### PR TITLE
Fix timezone issue

### DIFF
--- a/Apps/Medication/src/Parsers/TRPMessageParser.cs
+++ b/Apps/Medication/src/Parsers/TRPMessageParser.cs
@@ -66,8 +66,11 @@ namespace HealthGateway.Medication.Parsers
             Message m = new Message();
 
             // MSH - Message Header
+            DateTime utc = DateTime.UtcNow;
+            TimeZoneInfo localtz = TimeZoneInfo.FindSystemTimeZoneById("America/Vancouver");
+            DateTime local = TimeZoneInfo.ConvertTimeFromUtc(utc, localtz);
             m.AddSegmentMSH(hnClientConfig.SendingApplication, hnClientConfig.SendingFacility, hnClientConfig.ReceivingApplication, hnClientConfig.ReceivingFacility, $"{userId}:{ipAddress}", $"{HNClientConfiguration.PATIENT_PROFILE_MESSAGE_TYPE}^00", TRACE, hnClientConfig.ProcessingID, hnClientConfig.MessageVersion);
-            m.SetValue("MSH.7", string.Format(culture, "{0:yyyy/MM/dd HH:mm:ss}", DateTime.Now)); // HNClient specific date format
+            m.SetValue("MSH.7", string.Format(culture, "{0:yyyy/MM/dd HH:mm:ss}", local)); // HNClient specific date format
             m.SetValue("MSH.9", HNClientConfiguration.PATIENT_PROFILE_MESSAGE_TYPE); // HNClient doesn't recognize event types (removes ^00 from message type)
 
             // ZZZ - Transaction Control


### PR DESCRIPTION
The current TRP request is using the system date when sending which causes errors when deployed to OpenShift as it uses UTC.  We likely need a larger fix (common code) but this should resolve the problem for our demo.

Unable to test complete code locally but have confirmed the additional code returns local time.