### PR TITLE
Added padding to the phn before calling the HNClient

### DIFF
--- a/Apps/Medication/src/Parsers/TRPMessageParser.cs
+++ b/Apps/Medication/src/Parsers/TRPMessageParser.cs
@@ -43,6 +43,11 @@ namespace HealthGateway.Medication.Parsers
         /// <inheritdoc/>
         public HNMessage CreateRequestMessage(string phn, string userId, string ipAddress)
         {
+            if (phn.Length < 13)
+            {
+                phn = phn.PadLeft(13, '0');
+            }
+
             HNClientConfiguration hnClientConfig = new HNClientConfiguration();
             this.configuration.GetSection("HNClient").Bind(hnClientConfig);
 

--- a/Apps/Medication/test/unit/Parsers/TRPMessageParser_Test.cs
+++ b/Apps/Medication/test/unit/Parsers/TRPMessageParser_Test.cs
@@ -32,7 +32,7 @@ namespace HealthGateway.Medication.Test
     public class TRPMessageParser_Test
     {
         private readonly IHNMessageParser<MedicationStatement> parser;
-        private readonly string phn = "123456789";
+        private readonly string phn = "0000123456789";
         private readonly string userId = "test";
         private readonly string ipAddress = "127.0.0.1";
         private readonly string traceNumber = "101010";


### PR DESCRIPTION
The client registries returns a regular phn string but pharmanet requires 3 leading zeroes.
This PR fixes that.