### PR TITLE
Deceased person error

### DIFF
--- a/Apps/Patient/src/Services/SoapPatientService.cs
+++ b/Apps/Patient/src/Services/SoapPatientService.cs
@@ -106,6 +106,16 @@ namespace HealthGateway.PatientService
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson retrievedPerson = reply.HCIM_IN_GetDemographicsResponse.controlActProcess.subject[0].target;
 
+            // If the deceased indicator is set and true, return an empty person.
+            bool deceasedInd = retrievedPerson.identifiedPerson.deceasedInd?.value == true;
+            if (deceasedInd)
+            {
+                retVal = new Patient();
+                this.logger.LogWarning($"Client Registry returned a person with the deceasedIndicator set to true. No PHN was populated.");
+                this.logger.LogDebug($"Finished getting patient. {JsonConvert.SerializeObject(retVal)}");
+                return retVal;
+            }
+
             // Extract the subject names
             List<string> givenNameList = new List<string>();
             List<string> lastNameList = new List<string>();

--- a/Apps/WebClient/src/ClientApp/app/components/timeline/medication.vue
+++ b/Apps/WebClient/src/ClientApp/app/components/timeline/medication.vue
@@ -31,6 +31,7 @@ $radius: 15px;
 
 .leftPane {
   width: 60px;
+  max-width: 60px;
 }
 
 .detailsButton {
@@ -51,7 +52,7 @@ $radius: 15px;
   <b-row class="entryCard">
     <b-col>
       <b-row class="entryHeading">
-        <b-col class="icon leftPane" cols="0">
+        <b-col class="icon leftPane">
           <i :class="'fas fa-2x ' + getEntryIcon(entry)"></i>
         </b-col>
         <b-col class="entryTitle">
@@ -59,7 +60,7 @@ $radius: 15px;
         </b-col>
       </b-row>
       <b-row>
-        <b-col class="leftPane" cols="0"> </b-col>
+        <b-col class="leftPane"></b-col>
         <b-col>
           <b-row>
             <b-col>

--- a/Apps/WebClient/src/ClientApp/app/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/app/views/timeline.vue
@@ -2,7 +2,7 @@
 @import "@/assets/scss/_variables.scss";
 
 .column-wrapper {
-  border: 1px;
+  border: 1px; //red solid;
 }
 
 #pageTitle {
@@ -28,9 +28,9 @@
 <template>
   <div>
     <LoadingComponent :is-loading="isLoading"></LoadingComponent>
-    <b-row class="my-3">
+    <b-row class="my-3 fluid justify-content-md-center">
       <b-col class="col-3 column-wrapper"> </b-col>
-      <b-col id="timeline" class="col-6 column-wrapper">
+      <b-col id="timeline" class="col-12 col-lg-6 column-wrapper">
         <b-alert :show="hasErrors" dismissible variant="danger">
           <h4>Error</h4>
           <span>An unexpected error occured while processing the request.</span>


### PR DESCRIPTION
Fixed timeline on small screens. Persons with the indicator of deceased no longer retrieve a valid PHN
[AB#7729](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/7729)