### PR TITLE
Added hash to the chunk to avoid catching the wrong filename

### DIFF
--- a/Apps/WebClient/src/ClientApp/webpack.config.js
+++ b/Apps/WebClient/src/ClientApp/webpack.config.js
@@ -81,7 +81,7 @@ module.exports = (env, argv) => {
       output: {
         path: path.resolve(__dirname, bundleOutputDir),
         filename: "[name].bundle.js",
-        chunkFilename: "[name].chunk.js",
+        chunkFilename: "[name].chunk.[contenthash].js",
         publicPath: "/dist/"
       },
       plugins: [


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements AB#????
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
Adding a hash to the chunks will hopefully prevent caching and retrieving of the wrong file version.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

No testing required since change relates to the deployment of the code.

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
- [ ] Yes
- [X] No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

## Notes/Additional Comments

