### PR TITLE
Fixes Bug AB#7856 which prevented loading of new drug files.

### DIFF
--- a/Apps/DBMaintainer/Apps/BCProvDrugDBApp.cs
+++ b/Apps/DBMaintainer/Apps/BCProvDrugDBApp.cs
@@ -44,9 +44,9 @@ namespace HealthGateway.DrugMaintainer.Apps
                 throw new ApplicationException($"The zip file contained {files.Length} CSV files, very confused.");
             }
             this.logger.LogInformation("Parsing Provincial PharmaCare file");
-            this.drugDbContext.AddRange(this.parser.ParsePharmaCareDrugFile(files[0], downloadedFile));
-            this.AddFileToDB(downloadedFile);
             this.RemoveOldFiles(downloadedFile);
+            this.AddFileToDB(downloadedFile);
+            this.drugDbContext.AddRange(this.parser.ParsePharmaCareDrugFile(files[0], downloadedFile));
             this.logger.LogInformation("Saving PharmaCare Drugs");
             this.drugDbContext.SaveChanges();
         }

--- a/Apps/DBMaintainer/Apps/BaseDrugApp.cs
+++ b/Apps/DBMaintainer/Apps/BaseDrugApp.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.DrugMaintainer.Apps
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.IO.Compression;
     using System.Linq;
@@ -139,10 +140,12 @@ namespace HealthGateway.DrugMaintainer.Apps
         /// <param name="downloadedFile">Search for all download files not matching this one.</param>
         protected void RemoveOldFiles(FileDownload downloadedFile)
         {
-            var oldIds = this.drugDbContext.FileDownload.Where(p => p.ProgramCode == downloadedFile.ProgramCode &&
-                                          p.Hash != downloadedFile.Hash).Select(f => f.Id).ToList();
+            List<FileDownload> oldIds = this.drugDbContext.FileDownload
+                                            .Where(p => p.ProgramCode == downloadedFile.ProgramCode && p.Hash != downloadedFile.Hash)
+                                            .Select(f => new FileDownload{ Id = f.Id, Version = f.Version})
+                                            .ToList();
             oldIds.ForEach(s => logger.LogInformation($"Deleting old Download file with hash: {s}"));
-            this.drugDbContext.RemoveRange(oldIds.Select(id => new FileDownload { Id = id }));
+            this.drugDbContext.RemoveRange(oldIds);
         }
 
         /// <summary>

--- a/Apps/JobScheduler/src/appsettings.Development.json
+++ b/Apps/JobScheduler/src/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
     "Logging": {
         "LogLevel": {
-            "Default": "Debug"
+            "Default": "Information"
         }
     },
     "ForwardProxies": {


### PR DESCRIPTION
## Status
Ready

## Fixes or Implements AB#????
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
The drug loader programs were not loading new drug files due to a constraint violation.  The issue appears to be that the delete for the FileDownload file was failing due to concurrency check as the Version was not loaded. 

Added backup/restore Postgres scripts.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
Using an old backup, run the loader program which will cause the program to download a new file and attempt to load which fails.

### UI Changes
NO

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Manual testing of the load programs has been done in my local environment and will be done in Development.

## Notes/Additional Comments
N/A
