### PR TITLE
Added the user management identity to the DB when closing an account

### DIFF
--- a/Apps/WebClient/src/Server/Controllers/UserProfileController.cs
+++ b/Apps/WebClient/src/Server/Controllers/UserProfileController.cs
@@ -163,7 +163,10 @@ namespace HealthGateway.WebClient.Controllers
                 .Referer?
                 .GetLeftPart(UriPartial.Authority);
 
-            RequestResult<UserProfileModel> result = this.userProfileService.CloseUserProfile(hdid, referer);
+            // Retrieve the user identity id from the claims
+            Guid userId = new Guid(user.FindFirst(ClaimTypes.NameIdentifier).Value);
+
+            RequestResult<UserProfileModel> result = this.userProfileService.CloseUserProfile(hdid, userId, referer);
             return new JsonResult(result);
         }
 

--- a/Apps/WebClient/src/Server/Services/IUserProfileService.cs
+++ b/Apps/WebClient/src/Server/Services/IUserProfileService.cs
@@ -44,9 +44,10 @@ namespace HealthGateway.WebClient.Services
         /// Closed the user profile.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
+        /// <param name="userId">The user id.</param>
         /// <param name="hostUrl">The host of the email validation endpoint.</param>
         /// <returns>The wrapped user profile.</returns>
-        RequestResult<UserProfileModel> CloseUserProfile(string hdid, string hostUrl);
+        RequestResult<UserProfileModel> CloseUserProfile(string hdid, Guid userId, string hostUrl);
 
         /// <summary>
         /// Recovers the user profile.

--- a/Apps/WebClient/src/Server/Services/UserProfileService.cs
+++ b/Apps/WebClient/src/Server/Services/UserProfileService.cs
@@ -196,9 +196,8 @@ namespace HealthGateway.WebClient.Services
         }
 
         /// <inheritdoc />
-        public RequestResult<UserProfileModel> CloseUserProfile(string hdid, string hostUrl)
+        public RequestResult<UserProfileModel> CloseUserProfile(string hdid, Guid userId, string hostUrl)
         {
-            //Contract.Requires(hdid != null && hostUri != null);
             this.logger.LogTrace($"Closing user profile... {hdid}");
 
             string registrationStatus = this.configurationService.GetConfiguration().WebClient.RegistrationStatus;
@@ -219,7 +218,8 @@ namespace HealthGateway.WebClient.Services
                 }
 
                 profile.ClosedDateTime = DateTime.Now;
-                DBResult<UserProfile> updateResult = profileDelegate.UpdateUserProfile(profile);
+                profile.IdentityManagementId = userId;
+                DBResult<UserProfile> updateResult = this.profileDelegate.UpdateUserProfile(profile);
                 if (!string.IsNullOrWhiteSpace(profile.Email))
                 {
                     Dictionary<string, string> keyValues = new Dictionary<string, string>();
@@ -238,7 +238,6 @@ namespace HealthGateway.WebClient.Services
         /// <inheritdoc />
         public RequestResult<UserProfileModel> RecoverUserProfile(string hdid, string hostUrl)
         {
-            //Contract.Requires(hdid != null && hostUri != null);
             this.logger.LogTrace($"Recovering user profile... {hdid}");
 
             string registrationStatus = this.configurationService.GetConfiguration().WebClient.RegistrationStatus;
@@ -258,8 +257,10 @@ namespace HealthGateway.WebClient.Services
                     return requestResult;
                 }
 
+                // Remove values set for deletion
                 profile.ClosedDateTime = null;
-                DBResult<UserProfile> updateResult = profileDelegate.UpdateUserProfile(profile);
+                profile.IdentityManagementId = null;
+                DBResult<UserProfile> updateResult = this.profileDelegate.UpdateUserProfile(profile);
                 if (!string.IsNullOrWhiteSpace(profile.Email))
                 {
                     Dictionary<string, string> keyValues = new Dictionary<string, string>();

--- a/Apps/WebClient/src/WebClient.xml
+++ b/Apps/WebClient/src/WebClient.xml
@@ -667,11 +667,12 @@
             <param name="hostUri">The host of the email validation endpoint.</param>
             <returns>The wrapped user profile.</returns>
         </member>
-        <member name="M:HealthGateway.WebClient.Services.IUserProfileService.CloseUserProfile(System.String,System.String)">
+        <member name="M:HealthGateway.WebClient.Services.IUserProfileService.CloseUserProfile(System.String,System.Guid,System.String)">
             <summary>
             Closed the user profile.
             </summary>
             <param name="hdid">The requested user hdid.</param>
+            <param name="userId">The user id.</param>
             <param name="hostUrl">The host of the email validation endpoint.</param>
             <returns>The wrapped user profile.</returns>
         </member>
@@ -744,7 +745,7 @@
         <member name="M:HealthGateway.WebClient.Services.UserProfileService.CreateUserProfile(HealthGateway.WebClient.Models.CreateUserRequest,System.Uri)">
             <inheritdoc />
         </member>
-        <member name="M:HealthGateway.WebClient.Services.UserProfileService.CloseUserProfile(System.String,System.String)">
+        <member name="M:HealthGateway.WebClient.Services.UserProfileService.CloseUserProfile(System.String,System.Guid,System.String)">
             <inheritdoc />
         </member>
         <member name="M:HealthGateway.WebClient.Services.UserProfileService.RecoverUserProfile(System.String,System.String)">


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#7998](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/7998)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
Adds the user ID to the db

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
Close an account. Check that the user id is populated on the user profile

### UI Changes
NO

