### PR TITLE
Implement Notes delete AB#8018

### DIFF
--- a/Apps/Database/src/Delegates/INoteDelegate.cs
+++ b/Apps/Database/src/Delegates/INoteDelegate.cs
@@ -63,5 +63,13 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">if true the transaction is persisted immediately.</param>
         /// <returns>A Note wrapped in a DBResult.</returns>
         public DBResult<Note> UpdateNote(Note note, bool commit = true);
+
+        /// <summary>
+        /// Deletes the supplied note.
+        /// </summary>
+        /// <param name="note">The note to be deleted in the backend.</param>
+        /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <returns>A Note wrapped in a DBResult.</returns>
+        public DBResult<Note> DeleteNote(Note note, bool commit = true);
     }
 }

--- a/Apps/WebClient/src/Server/Controllers/NoteController.cs
+++ b/Apps/WebClient/src/Server/Controllers/NoteController.cs
@@ -119,6 +119,33 @@ namespace HealthGateway.WebClient.Controllers
         }
 
         /// <summary>
+        /// Deletes a note from the database.
+        /// </summary>
+        /// <returns>The deleted Note wrapped in a RequestResult.</returns>
+        /// <param name="note">The patient note.</param>
+        /// <response code="200">The note was deleted.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        [HttpDelete]
+        [Authorize(Policy = "PatientOnly")]
+        public async Task<IActionResult> DeleteNote([FromBody] Note note)
+        {
+            // Validate the hdid to be a patient.
+            ClaimsPrincipal user = this.httpContextAccessor.HttpContext.User;
+            string userHdid = user.FindFirst("hdid").Value;
+            AuthorizationResult isAuthorized = await this.authorizationService
+                .AuthorizeAsync(user, userHdid, PolicyNameConstants.UserIsPatient)
+                .ConfigureAwait(true);
+            if (!isAuthorized.Succeeded)
+            {
+                return new ForbidResult();
+            }
+
+            RequestResult<Note> result = this.noteService.DeleteNote(note);
+            return new JsonResult(result);
+        }
+
+        /// <summary>
         /// Gets all notes for the specified user.
         /// </summary>
         /// <returns>The list of notes model wrapped in a request result.</returns>

--- a/Apps/WebClient/src/Server/Services/INoteService.cs
+++ b/Apps/WebClient/src/Server/Services/INoteService.cs
@@ -47,5 +47,12 @@ namespace HealthGateway.WebClient.Services
         /// <param name="note">The note to update.</param>
         /// <returns>The updated Note.</returns>
         public RequestResult<Note> UpdateNote(Note note);
+
+        /// <summary>
+        /// Deletes the given note from the backend.
+        /// </summary>
+        /// <param name="note">The note to delete.</param>
+        /// <returns>The deleted note wrapped in a RequestResult.</returns>
+        public RequestResult<Note> DeleteNote(Note note);
     }
 }

--- a/Apps/WebClient/src/Server/Services/NoteService.cs
+++ b/Apps/WebClient/src/Server/Services/NoteService.cs
@@ -83,5 +83,18 @@ namespace HealthGateway.WebClient.Services
             };
             return result;
         }
+
+        /// <inheritdoc />
+        public RequestResult<Note> DeleteNote(Note note)
+        {
+            DBResult<Note> dbResult = this.noteDelegate.DeleteNote(note);
+            RequestResult<Note> result = new RequestResult<Note>()
+            {
+                ResourcePayload = dbResult.Payload,
+                ResultStatus = dbResult.Status == Database.Constant.DBStatusCode.Deleted ? Common.Constants.ResultType.Success : Common.Constants.ResultType.Error,
+                ResultMessage = dbResult.Message,
+            };
+            return result;
+        }
     }
 }

--- a/Apps/WebClient/src/WebClient.xml
+++ b/Apps/WebClient/src/WebClient.xml
@@ -143,6 +143,16 @@
             <response code="401">The client must authenticate itself to get the requested response.</response>
             <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         </member>
+        <member name="M:HealthGateway.WebClient.Controllers.NoteController.DeleteNote(HealthGateway.Database.Models.Note)">
+            <summary>
+            Deletes a note from the database.
+            </summary>
+            <returns>The deleted Note wrapped in a RequestResult.</returns>
+            <param name="note">The patient note.</param>
+            <response code="200">The note was deleted.</response>
+            <response code="401">The client must authenticate itself to get the requested response.</response>
+            <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        </member>
         <member name="M:HealthGateway.WebClient.Controllers.NoteController.GetAll">
             <summary>
             Gets all notes for the specified user.
@@ -701,6 +711,13 @@
             <param name="note">The note to update.</param>
             <returns>The updated Note.</returns>
         </member>
+        <member name="M:HealthGateway.WebClient.Services.INoteService.DeleteNote(HealthGateway.Database.Models.Note)">
+            <summary>
+            Deletes the given note from the backend.
+            </summary>
+            <param name="note">The note to delete.</param>
+            <returns>The deleted note wrapped in a RequestResult.</returns>
+        </member>
         <member name="T:HealthGateway.WebClient.Services.IUserEmailService">
             <summary>
             The User Email service.
@@ -803,6 +820,9 @@
             <inheritdoc />
         </member>
         <member name="M:HealthGateway.WebClient.Services.NoteService.UpdateNote(HealthGateway.Database.Models.Note)">
+            <inheritdoc />
+        </member>
+        <member name="M:HealthGateway.WebClient.Services.NoteService.DeleteNote(HealthGateway.Database.Models.Note)">
             <inheritdoc />
         </member>
         <member name="T:HealthGateway.WebClient.Services.UserEmailService">


### PR DESCRIPTION
## Status
**Ready/In Development/Hold/Abandoned**

## Fixes or Implements [AB#8018](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8018)
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Updates the WebClient Note controller, service and delegate to support deleting notes.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.
Testing to be done in a subsequent ticket. 

## Notes/Additional Comments
Any addtional notes or comments that may be relevant.  Include any specialized deployment steps here.
