### PR TITLE
Fix prevent close on edit

### DIFF
--- a/Apps/WebClient/src/ClientApp/app/assets/scss/bcgov/_overrides.scss
+++ b/Apps/WebClient/src/ClientApp/app/assets/scss/bcgov/_overrides.scss
@@ -9,6 +9,10 @@
   text-decoration: none;
 }
 
+.dropdown-item {
+  text-decoration: none;
+}
+
 // Highlight focused links
 a:not(.btn):focus {
   color: $link-hover-color;

--- a/Apps/WebClient/src/ClientApp/app/components/timeline/entrycard.vue
+++ b/Apps/WebClient/src/ClientApp/app/components/timeline/entrycard.vue
@@ -31,6 +31,8 @@
       :index="index"
       @on-note-updated="onChange"
       @on-note-deleted="onRemove"
+      @on-edit-started="onEdit"
+      @on-edit-close="onClose"
     />
   </b-row>
 </template>
@@ -68,6 +70,16 @@ export default class EntrycardTimelineComponent extends Vue {
 
   @Emit()
   public onRemove(object: any) {
+    return object;
+  }
+
+  @Emit()
+  public onEdit(object: any) {
+    return object;
+  }
+
+  @Emit()
+  public onClose(object: any) {
     return object;
   }
 }

--- a/Apps/WebClient/src/ClientApp/app/components/timeline/note.vue
+++ b/Apps/WebClient/src/ClientApp/app/components/timeline/note.vue
@@ -60,6 +60,10 @@ $radius: 15px;
   padding-left: 30px;
   padding-right: 20px;
 }
+
+.noteMenu {
+  color: $soft_text;
+}
 </style>
 
 <template>
@@ -86,10 +90,10 @@ $radius: 15px;
                       size="1x"
                     ></font-awesome-icon>
                   </template>
-                  <b-dropdown-item @click="editNote()">
+                  <b-dropdown-item class="menuItem" @click="editNote()">
                     Edit
                   </b-dropdown-item>
-                  <b-dropdown-item @click="deleteNote()">
+                  <b-dropdown-item class="menuItem" @click="deleteNote()">
                     Delete
                   </b-dropdown-item>
                 </b-nav-item-dropdown>
@@ -269,6 +273,7 @@ export default class NoteTimelineComponent extends Vue {
       .toISOString()
       .slice(0, 10);
     this.isEditMode = true;
+    this.onEditStarted(this.entry);
   }
 
   private deleteNote(): void {
@@ -280,13 +285,18 @@ export default class NoteTimelineComponent extends Vue {
   }
 
   private onReset(): void {
-    this.close();
+    this.onEditClose(this.entry);
     this.isEditMode = false;
   }
 
   @Emit()
-  public close() {
-    return;
+  public onEditClose(note: NoteTimelineEntry) {
+    return note;
+  }
+
+  @Emit()
+  public onEditStarted(note: NoteTimelineEntry) {
+    return note;
   }
 
   @Emit()

--- a/Apps/WebClient/src/ClientApp/app/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/app/views/timeline.vue
@@ -158,7 +158,7 @@
               <b-col>
                 <NoteTimelineComponent
                   :is-add-mode="true"
-                  @close="isAddingNote = false"
+                  @on-edit-close="isAddingNote = false"
                   @on-note-added="onNoteAdded"
                 />
               </b-col>
@@ -178,6 +178,8 @@
                 :index="index"
                 @on-change="onCardUpdated"
                 @on-remove="onCardRemoved"
+                @on-edit="onCardEdit"
+                @on-close="onCardClose"
               />
             </b-row>
           </div>
@@ -261,6 +263,7 @@ export default class TimelineComponent extends Vue {
   private sortDesc: boolean = true;
   private protectiveWordAttempts: number = 0;
   private isAddingNote: boolean = false;
+  private editIdList: string[] = [];
   private unsavedChangesText: string =
     "You have unsaved changes. Are you sure you want to leave?";
 
@@ -276,14 +279,17 @@ export default class TimelineComponent extends Vue {
   }
 
   beforeRouteLeave(to, from, next) {
-    if (this.isAddingNote && !confirm(this.unsavedChangesText)) {
+    if (
+      (this.isAddingNote || this.editIdList.length > 0) &&
+      !confirm(this.unsavedChangesText)
+    ) {
       return;
     }
     next();
   }
 
   private onBrowserClose(event: BeforeUnloadEvent) {
-    if (this.isAddingNote) {
+    if (this.isAddingNote || this.editIdList.length > 0) {
       event.returnValue = this.unsavedChangesText;
     }
   }
@@ -415,6 +421,15 @@ export default class TimelineComponent extends Vue {
   private onCardRemoved(entry: TimelineEntry) {
     const index = this.timelineEntries.findIndex(e => e.id == entry.id);
     this.timelineEntries.splice(index, 1);
+  }
+
+  private onCardEdit(entry: TimelineEntry) {
+    this.editIdList.push(entry.id);
+  }
+
+  private onCardClose(entry: TimelineEntry) {
+    const index = this.editIdList.findIndex(e => e == entry.id);
+    this.editIdList.splice(index, 1);
   }
 
   private onCardUpdated(entry: TimelineEntry) {


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8060](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8060)
- [ ] Enhancement
- [x] Bug
- [ ] Documentation

## Description:
Fixes the warning message not being displayed when the user closes the tab while editing a note.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### Steps to Reproduce:
In the timeline page start edit a note.
Refresh or navigate to a link.
The page should warn that changes won't be saved. (No warning is displayed)

### UI Changes
YES

### Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox