### PR TITLE
Add wait list card to admin module

### DIFF
--- a/Apps/AdminWebClient/src/AdminWebClient.xml
+++ b/Apps/AdminWebClient/src/AdminWebClient.xml
@@ -101,10 +101,19 @@
         </member>
         <member name="M:HealthGateway.Admin.Controllers.DashboardController.GetRegisteredUserCount">
             <summary>
-            Retrieves a list of user feedbacks.
+            Retrieves the count of registered users.
             </summary>
-            <returns>The list of user feedbacks.</returns>
-            <response code="200">Returns the list of user feedbacks.</response>
+            <returns>The count of registered users.</returns>
+            <response code="200">Returns the count of registered users.</response>
+            <response code="401">The client must authenticate itself to get the requested response.</response>
+            <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        </member>
+        <member name="M:HealthGateway.Admin.Controllers.DashboardController.GetWaitlistUserCount">
+            <summary>
+            Retrieves the count of waitlisted users.
+            </summary>
+            <returns>The count of waitlisted users.</returns>
+            <response code="200">Returns the count of waitlisted users.</response>
             <response code="401">The client must authenticate itself to get the requested response.</response>
             <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         </member>
@@ -467,13 +476,17 @@
         <member name="T:HealthGateway.Admin.Services.DashboardService">
             <inheritdoc />
         </member>
-        <member name="M:HealthGateway.Admin.Services.DashboardService.#ctor(HealthGateway.Database.Delegates.IProfileDelegate)">
+        <member name="M:HealthGateway.Admin.Services.DashboardService.#ctor(HealthGateway.Database.Delegates.IProfileDelegate,HealthGateway.Database.Delegates.IBetaRequestDelegate)">
             <summary>
             Initializes a new instance of the <see cref="T:HealthGateway.Admin.Services.DashboardService"/> class.
             </summary>
             <param name="userProfileDelegate">The user profile delegate to interact with the DB.</param>
+            <param name="betaRequestDelegate">The beta request delegate to interact with the DB.</param>
         </member>
         <member name="M:HealthGateway.Admin.Services.DashboardService.GetRegisteredUserCount">
+            <inheritdoc />
+        </member>
+        <member name="M:HealthGateway.Admin.Services.DashboardService.GetWaitlistUserCount">
             <inheritdoc />
         </member>
         <member name="T:HealthGateway.Admin.Services.IAuthenticationService">
@@ -540,6 +553,12 @@
             Retrieves the count of registered users.
             </summary>
             <returns>The count of user profiles that accepted the terms of service.</returns>
+        </member>
+        <member name="M:HealthGateway.Admin.Services.IDashboardService.GetWaitlistUserCount">
+            <summary>
+            Retrieves the count of waitlisted users.
+            </summary>
+            <returns>The count of users waiting for an invite.</returns>
         </member>
         <member name="T:HealthGateway.Admin.Services.IUserFeedbackService">
             <summary>

--- a/Apps/AdminWebClient/src/ClientApp/src/services/dashboardService.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/services/dashboardService.ts
@@ -13,7 +13,21 @@ export class DashboardService implements IDashboardService {
   public getRegisteredUsersCount(): Promise<number> {
     return new Promise((resolve, reject) => {
       this.http
-        .get<number>(`${this.BASE_URI}`)
+        .get<number>(`${this.BASE_URI}/RegisteredCount`)
+        .then(requestResult => {
+          resolve(requestResult);
+        })
+        .catch(err => {
+          console.log(err);
+          return reject(err);
+        });
+    });
+  }
+
+  public getWaitlistedUsersCount(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.http
+        .get<number>(`${this.BASE_URI}/WaitlistCount`)
         .then(requestResult => {
           resolve(requestResult);
         })

--- a/Apps/AdminWebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/services/interfaces.ts
@@ -32,6 +32,7 @@ export interface IUserFeedbackService {
 export interface IDashboardService {
   initialize(http: IHttpDelegate): void;
   getRegisteredUsersCount(): Promise<number>;
+  getWaitlistedUsersCount(): Promise<number>;
 }
 
 export interface IHttpDelegate {

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Dashboard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Dashboard.vue
@@ -22,6 +22,14 @@
               {{registeredUserCount}}</h1>
         </v-card>
       </v-col>
+      <v-col class="col-lg-3 col-md-6 col-sm-12">
+        <v-card class="text-center">
+          <h3>Waitlisted Users</h3>
+          <h1>
+              {{waitlistedUserCount}}
+          </h1>
+        </v-card>
+      </v-col>
     </v-row>
   </v-layout>
 </template>
@@ -33,18 +41,30 @@ import container from "@/plugins/inversify.config";
 @Component
 export default class Dashboard extends Vue {
   private registeredUserCount: number = 0;
+  private waitlistedUserCount: number = 0;
   private dashboardService!: IDashboardService;
+
   mounted() {
     this.dashboardService = container.get(
       SERVICE_IDENTIFIER.DashboardService
     );
     this.getRegisteredUserCount();
+    this.getWaitlistedUserCount();
   }
+
   private getRegisteredUserCount() {
     this.dashboardService
       .getRegisteredUsersCount()
       .then(count => {
         this.registeredUserCount = count;
+      });
+  }
+
+  private getWaitlistedUserCount() {
+    this.dashboardService
+      .getWaitlistedUsersCount()
+      .then(count => {
+        this.waitlistedUserCount = count;
       });
   }
 }

--- a/Apps/AdminWebClient/src/Server/Controllers/DashboardController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/DashboardController.cs
@@ -45,16 +45,31 @@ namespace HealthGateway.Admin.Controllers
         }
 
         /// <summary>
-        /// Retrieves a list of user feedbacks.
+        /// Retrieves the count of registered users.
         /// </summary>
-        /// <returns>The list of user feedbacks.</returns>
-        /// <response code="200">Returns the list of user feedbacks.</response>
+        /// <returns>The count of registered users.</returns>
+        /// <response code="200">Returns the count of registered users.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpGet]
+        [Route("RegisteredCount")]
         public IActionResult GetRegisteredUserCount()
         {
             return new JsonResult(this.dashboardService.GetRegisteredUserCount());
+        }
+
+        /// <summary>
+        /// Retrieves the count of waitlisted users.
+        /// </summary>
+        /// <returns>The count of waitlisted users.</returns>
+        /// <response code="200">Returns the count of waitlisted users.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        [HttpGet]
+        [Route("WaitlistCount")]
+        public IActionResult GetWaitlistUserCount()
+        {
+            return new JsonResult(this.dashboardService.GetWaitlistUserCount());
         }
     }
 }

--- a/Apps/AdminWebClient/src/Server/Services/DashboardService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/DashboardService.cs
@@ -21,20 +21,31 @@ namespace HealthGateway.Admin.Services
     public class DashboardService : IDashboardService
     {
         private readonly IProfileDelegate userProfileDelegate;
+        private readonly IBetaRequestDelegate betaRequestDelegate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DashboardService"/> class.
         /// </summary>
         /// <param name="userProfileDelegate">The user profile delegate to interact with the DB.</param>
-        public DashboardService(IProfileDelegate userProfileDelegate)
+        /// <param name="betaRequestDelegate">The beta request delegate to interact with the DB.</param>
+        public DashboardService(
+            IProfileDelegate userProfileDelegate,
+            IBetaRequestDelegate betaRequestDelegate)
         {
             this.userProfileDelegate = userProfileDelegate;
+            this.betaRequestDelegate = betaRequestDelegate;
         }
 
         /// <inheritdoc />
         public int GetRegisteredUserCount()
         {
             return this.userProfileDelegate.GetRegisteredUsersCount();
+        }
+
+        /// <inheritdoc />
+        public int GetWaitlistUserCount()
+        {
+            return this.betaRequestDelegate.GetWaitlistCount();
         }
     }
 }

--- a/Apps/AdminWebClient/src/Server/Services/IDashboardService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/IDashboardService.cs
@@ -25,5 +25,11 @@ namespace HealthGateway.Admin.Services
         /// </summary>
         /// <returns>The count of user profiles that accepted the terms of service.</returns>
         int GetRegisteredUserCount();
+
+        /// <summary>
+        /// Retrieves the count of waitlisted users.
+        /// </summary>
+        /// <returns>The count of users waiting for an invite.</returns>
+        int GetWaitlistUserCount();
     }
 }

--- a/Apps/Database/src/Delegates/DBBetaRequestDelegate.cs
+++ b/Apps/Database/src/Delegates/DBBetaRequestDelegate.cs
@@ -113,5 +113,13 @@ namespace HealthGateway.Database.Delegates
             this.logger.LogDebug($"Finished getting pending beta request from DB. {JsonSerializer.Serialize(result)}");
             return result;
         }
+
+        /// <inheritdoc />
+        public int GetWaitlistCount()
+        {
+            int result = this.dbContext.BetaRequest
+                .Count(b => !this.dbContext.EmailInvite.Any(e => e.HdId == b.HdId));
+            return result;
+        }
     }
 }

--- a/Apps/Database/src/Delegates/IBetaRequestDelegate.cs
+++ b/Apps/Database/src/Delegates/IBetaRequestDelegate.cs
@@ -52,5 +52,11 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
         DBResult<List<BetaRequest>> GetPendingBetaRequest();
+
+        /// <summary>
+        /// Returns the count of waitlisted users from the database.
+        /// </summary>
+        /// <returns>The count of users waiting for an invite.</returns>
+        int GetWaitlistCount();
     }
 }


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8080](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8080)
- [x] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Adds a widget card to admin module displaying the count of waitlisted users.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### UI Changes
YES 

### Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox