### PR TITLE
Removed hard-coded start date

### DIFF
--- a/Apps/Medication/src/Services/RestMedicationStatementService.cs
+++ b/Apps/Medication/src/Services/RestMedicationStatementService.cs
@@ -114,13 +114,13 @@ namespace HealthGateway.Medication.Services
 
             // Retrieve the phn
             string jwtString = this.httpContextAccessor.HttpContext.Request.Headers["Authorization"][0];
-            string phn = await this.patientDelegate.GetPatientPHNAsync(hdid, jwtString).ConfigureAwait(true);
+            Patient patient = await this.patientDelegate.GetPatientAsync(hdid, jwtString).ConfigureAwait(true);
 
             MedicationHistoryQuery historyQuery = new MedicationHistoryQuery()
             {
-                StartDate = System.DateTime.Parse("1990/01/01"),
+                StartDate = patient.Birthdate,
                 EndDate = System.DateTime.Now,
-                PHN = phn,
+                PHN = patient.PersonalHealthNumber,
             };
             IPAddress address = this.httpContextAccessor.HttpContext.Connection.RemoteIpAddress;
             string ipv4Address = address.MapToIPv4().ToString();


### PR DESCRIPTION
## Status
**Ready/In Development/Hold/Abandoned**

## Fixes or Implements [AB#8096](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8096)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
This change moves the start date to retrieve the ODR data to be the birthdate

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
Setup the provider to be ODR and login to see the timeline. The records should be as early as the test user birthdate

### UI Changes
NO