### PR TITLE
Added call to getLoggedInUsersCount

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/views/Dashboard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Dashboard.vue
@@ -65,6 +65,7 @@ export default class Dashboard extends Vue {
   mounted() {
     this.dashboardService = container.get(SERVICE_IDENTIFIER.DashboardService);
     this.getRegisteredUserCount();
+    this.getLoggedInUsersCount();
     this.getUnregisteredInvitedUserCount();
     this.getWaitlistedUserCount();
   }


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements AB#????
- [ ] Enhancement
- [x] Bug
- [ ] Documentation

## Description:
Added call to getLoggedInUsersCount in admin dashboard so the card would display the number of logged in users today and not 0.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### UI Changes
NO

### Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Manual testing completed. Logged in as three different users (hthgtwy11, hthgtwy13, hthgtwy14) and observed that after each login into the healthgateway portal, the number in the admin dashboard increased by 1.