### PR TITLE
Features/8119

### DIFF
--- a/Apps/Common/src/Delegates/AESCryptoDelegate.cs
+++ b/Apps/Common/src/Delegates/AESCryptoDelegate.cs
@@ -1,0 +1,130 @@
+﻿//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Common.Delegates
+{
+    using System;
+    using System.IO;
+    using System.Security.Cryptography;
+    using HealthGateway.Common.Models;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Delegate to encrypt/decrypt using AES.
+    /// </summary>
+    public class AESCryptoDelegate
+    {
+        private const string ConfigKey = "AESCrypto";
+        private readonly ILogger<AESCryptoDelegate> logger;
+        private readonly IConfiguration configuration;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AESCryptoDelegate"/> class.
+        /// </summary>
+        /// <param name="logger">Injected Logger Provider.</param>
+        /// <param name="configuration">The injected configuration provider.</param>
+        public AESCryptoDelegate(
+            ILogger<AESCryptoDelegate> logger,
+            IConfiguration configuration)
+        {
+            this.logger = logger;
+            this.configuration = configuration;
+            this.AesConfig = new AESCryptoDelegateConfig();
+            this.configuration.Bind(ConfigKey, this.AesConfig);
+        }
+
+        /// <summary>
+        /// Gets or sets the instance configuration.
+        /// </summary>
+        public AESCryptoDelegateConfig AesConfig { get; set; }
+
+        /// <summary>
+        /// Encrypts the plaintext using the key supplied.
+        /// </summary>
+        /// <param name="key">The base64 encoded encryption key.</param>
+        /// <param name="plainText">The text to encrypt.</param>
+        /// <returns>The encrypted text.</returns>
+        public string Encrypt(string key, string plainText)
+        {
+            return this.Encrypt(key, null, plainText);
+        }
+
+        /// <summary>
+        /// Encrypts the plaintext using the key and initialization vector supplied.
+        /// </summary>
+        /// <param name="key">The base64 encoded encryption key.</param>
+        /// <param name="iv">The base64 encoded initialization vector.</param>
+        /// <param name="plainText">The text to encrypt.</param>
+        /// <returns>The encrypted text.</returns>
+        public string Encrypt(string key, string? iv, string plainText)
+        {
+            using Aes aes = Aes.Create();
+            aes.KeySize = this.AesConfig.KeySize;
+            aes.Key = Convert.FromBase64String(key);
+            aes.IV = iv != null ? Convert.FromBase64String(iv) : new byte[16];
+            ICryptoTransform encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+            using MemoryStream msEncrypt = new MemoryStream();
+            using CryptoStream csEncrypt = new CryptoStream(msEncrypt, encryptor, CryptoStreamMode.Write);
+            using StreamWriter swEncrypt = new StreamWriter(csEncrypt);
+            swEncrypt.Write(plainText);
+            swEncrypt.Close();
+            byte[] encryptedBytes = msEncrypt.ToArray();
+            return Convert.ToBase64String(encryptedBytes);
+        }
+
+        /// <summary>
+        /// Decrypts the encrypted text using the key supplied.
+        /// </summary>
+        /// <param name="key">The base64 encoded encryption key.</param>
+        /// <param name="encryptedText">The text to decrypt.</param>
+        /// <returns>The decrypted text.</returns>
+        public string Decrypt(string key, string encryptedText)
+        {
+            return this.Decrypt(key, null, encryptedText);
+        }
+
+        /// <summary>
+        /// Decrypts the encrypted text using the key and initialization vector supplied.
+        /// </summary>
+        /// <param name="key">The base64 encoded encryption key.</param>
+        /// <param name="iv">The base64 encoded initialization vector.</param>
+        /// <param name="encryptedText">The text to decrypt.</param>
+        /// <returns>The decrypted text.</returns>
+        public string Decrypt(string key, string? iv, string encryptedText)
+        {
+            string? plaintext = null;
+            byte[] encryptedBytes = Convert.FromBase64String(encryptedText);
+            using Aes aes = Aes.Create();
+            aes.KeySize = this.AesConfig.KeySize;
+            aes.Key = Convert.FromBase64String(key);
+            aes.IV = iv != null ? Convert.FromBase64String(iv) : new byte[16];
+            ICryptoTransform decryptor = aes.CreateDecryptor(aes.Key, aes.IV);
+            using MemoryStream msDecrypt = new MemoryStream(encryptedBytes);
+            using CryptoStream csDecrypt = new CryptoStream(msDecrypt, decryptor, CryptoStreamMode.Read);
+            using StreamReader srDecrypt = new StreamReader(csDecrypt);
+            plaintext = srDecrypt.ReadToEnd();
+            return plaintext;
+        }
+
+        public string GenerateKey()
+        {
+            using Aes aes = Aes.Create();
+            aes.KeySize = this.AesConfig.KeySize;
+            aes.GenerateKey();
+            return Convert.ToBase64String(aes.Key);
+        }
+    }
+}

--- a/Apps/Common/src/Delegates/AESCryptoDelegate.cs
+++ b/Apps/Common/src/Delegates/AESCryptoDelegate.cs
@@ -25,7 +25,7 @@ namespace HealthGateway.Common.Delegates
     /// <summary>
     /// Delegate to encrypt/decrypt using AES.
     /// </summary>
-    public class AESCryptoDelegate
+    public class AESCryptoDelegate : ICryptoDelegate
     {
         private const string ConfigKey = "AESCrypto";
         private readonly ILogger<AESCryptoDelegate> logger;
@@ -51,15 +51,10 @@ namespace HealthGateway.Common.Delegates
         /// </summary>
         public AESCryptoDelegateConfig AesConfig { get; set; }
 
-        /// <summary>
-        /// Encrypts the plaintext using the key supplied.
-        /// </summary>
-        /// <param name="key">The base64 encoded encryption key.</param>
-        /// <param name="plainText">The text to encrypt.</param>
-        /// <returns>The encrypted text.</returns>
+        /// <inheritdoc />
         public string Encrypt(string key, string plainText)
         {
-            return this.Encrypt(key, null, plainText);
+            return this.Encrypt(key, this.AesConfig.IV, plainText);
         }
 
         /// <summary>
@@ -85,15 +80,10 @@ namespace HealthGateway.Common.Delegates
             return Convert.ToBase64String(encryptedBytes);
         }
 
-        /// <summary>
-        /// Decrypts the encrypted text using the key supplied.
-        /// </summary>
-        /// <param name="key">The base64 encoded encryption key.</param>
-        /// <param name="encryptedText">The text to decrypt.</param>
-        /// <returns>The decrypted text.</returns>
+        /// <inheritdoc />
         public string Decrypt(string key, string encryptedText)
         {
-            return this.Decrypt(key, null, encryptedText);
+            return this.Decrypt(key, this.AesConfig.IV, encryptedText);
         }
 
         /// <summary>
@@ -119,6 +109,7 @@ namespace HealthGateway.Common.Delegates
             return plaintext;
         }
 
+        /// <inheritdoc />
         public string GenerateKey()
         {
             using Aes aes = Aes.Create();

--- a/Apps/Common/src/Delegates/ICryptoDelegate.cs
+++ b/Apps/Common/src/Delegates/ICryptoDelegate.cs
@@ -40,9 +40,9 @@ namespace HealthGateway.Common.Delegates
         public string Decrypt(string key, string encryptedText);
 
         /// <summary>
-        /// 
+        /// Generates a suitable key for use in the implementation Encrypt/Decrypt methods.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>A Base64 encoded key.</returns>
         public string GenerateKey();
     }
 }

--- a/Apps/Common/src/Delegates/ICryptoDelegate.cs
+++ b/Apps/Common/src/Delegates/ICryptoDelegate.cs
@@ -1,0 +1,48 @@
+﻿//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Common.Delegates
+{
+    using HealthGateway.Database.Models.Cacheable;
+
+    /// <summary>
+    /// A delegate to encrypted and decrypt text.
+    /// </summary>
+    public interface ICryptoDelegate
+    {
+        /// <summary>
+        /// Encrypts the plaintext using the key supplied.
+        /// </summary>
+        /// <param name="key">The base64 encoded encryption key.</param>
+        /// <param name="plainText">The text to encrypt.</param>
+        /// <returns>The encrypted text.</returns>
+        public string Encrypt(string key, string plainText);
+
+        /// <summary>
+        /// Decrypts the encrypted text using the key supplied.
+        /// </summary>
+        /// <param name="key">The base64 encoded encryption key.</param>
+        /// <param name="encryptedText">The text to decrypt.</param>
+        /// <returns>The decrypted text.</returns>
+        public string Decrypt(string key, string encryptedText);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        public string GenerateKey();
+    }
+}

--- a/Apps/Common/src/Models/AESCryptoDelegateConfig.cs
+++ b/Apps/Common/src/Models/AESCryptoDelegateConfig.cs
@@ -29,5 +29,10 @@ namespace HealthGateway.Common.Models
         /// Gets or sets the key size for AES crypto functions.
         /// </summary>
         public int KeySize { get; set; } = DefaultKeySize;
+
+        /// <summary>
+        /// Gets or sets the Initialization Vector.
+        /// </summary>
+        public string? IV { get; set; }
     }
 }

--- a/Apps/Common/src/Models/AESCryptoDelegateConfig.cs
+++ b/Apps/Common/src/Models/AESCryptoDelegateConfig.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Models
+{
+    /// <summary>
+    /// The configuration for the AESCrypto delegate
+    /// </summary>
+    public class AESCryptoDelegateConfig
+    {
+        /// <summary>
+        /// The default key size used for key AES crypto functions.
+        /// </summary>
+        public const int DefaultKeySize = 256;
+
+        /// <summary>
+        /// Gets or sets the key size for AES crypto functions.
+        /// </summary>
+        public int KeySize { get; set; } = DefaultKeySize;
+    }
+}

--- a/Apps/Common/test/unit/CommonTests.csproj
+++ b/Apps/Common/test/unit/CommonTests.csproj
@@ -6,6 +6,12 @@
     <RootNamespace>HealthGateway.CommonTests</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.msbuild" Version="2.7.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Apps/Common/test/unit/Delegates/AesCryptoDelegate_Test.cs
+++ b/Apps/Common/test/unit/Delegates/AesCryptoDelegate_Test.cs
@@ -1,0 +1,202 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Delegates
+{
+    using System.Collections.Generic;
+    using DeepEqual.Syntax;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using Xunit;
+    using HealthGateway.Common.Delegates;
+    using HealthGateway.Common.Models;
+    using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+    using System;
+    using System.Text.Json;
+    using HealthGateway.Database.Models.Cacheable;
+    using System.Text;
+
+    public class AesCryptoDelegate_Test
+    {
+        [Fact]
+        public void VerifyConfigurationBinding()
+        {
+            AESCryptoDelegateConfig expectedConfig = new AESCryptoDelegateConfig()
+            {
+                KeySize = 256,
+            };
+
+            var myConfiguration = new Dictionary<string, string>
+            {
+                {"AESCrypto:KeySize", expectedConfig.KeySize.ToString()},
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            Assert.True(expectedConfig.IsDeepEqual(aesDelegate.AesConfig));
+        }
+
+        [Fact]
+        public void VerifyDefaultConfigurationBinding()
+        {
+            AESCryptoDelegateConfig expectedConfig = new AESCryptoDelegateConfig()
+            {
+                KeySize = AESCryptoDelegateConfig.DefaultKeySize,
+            };
+
+            var myConfiguration = new Dictionary<string, string>
+            {
+                //test empty configuration
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            Assert.True(expectedConfig.IsDeepEqual(aesDelegate.AesConfig));
+        }
+
+        [Fact]
+        public void VerifyKeyGeneration()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+                {"AESCrypto:KeySize", "128"},
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            string key = aesDelegate.GenerateKey();
+            byte[] keyBytes = Convert.FromBase64String(key);
+
+            Assert.True(keyBytes.Length == aesDelegate.AesConfig.KeySize / 8);
+        }
+
+        [Fact]
+        public void VerifyEncryption()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            string key = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
+
+            string plainText = "Hello World";
+            string expectedStr = "m8zvM4eT5e4Wn1cJvbo+WQ==";
+            string encryptedStr = aesDelegate.Encrypt(key, plainText);
+
+            Assert.True(expectedStr == encryptedStr);
+        }
+
+        [Fact]
+        public void VerifyDecryption()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            string key = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
+
+            string cipherText = "m8zvM4eT5e4Wn1cJvbo+WQ==";
+            string expectedStr = "Hello World";
+            string decryptedStr = aesDelegate.Decrypt(key, cipherText);
+
+            Assert.True(expectedStr == decryptedStr);
+        }
+
+        [Fact]
+        public void VerifyEncryptionwithIV()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            string key = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
+            string iv = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEF"));
+
+            string plainText = "Hello World";
+            string expectedStr = "ct9piIgrLBasmnfNPLcHRA==";
+            string encryptedStr = aesDelegate.Encrypt(key, iv, plainText);
+
+            Assert.True(expectedStr == encryptedStr);
+        }
+
+        [Fact]
+        public void VerifyDecryptionwithIV()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+            };
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+
+            AESCryptoDelegate aesDelegate = new AESCryptoDelegate(
+                new Mock<ILogger<AESCryptoDelegate>>().Object,
+                configuration);
+
+            string key = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEFGHIJKLMNOPQRSTUV"));
+            string iv = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEF"));
+
+            string cipherText = "ct9piIgrLBasmnfNPLcHRA==";
+            string expectedStr = "Hello World";
+            string decryptedStr = aesDelegate.Decrypt(key, iv, cipherText);
+
+            Assert.True(expectedStr == decryptedStr);
+        }
+    }
+}

--- a/Apps/Common/test/unit/Delegates/AesCryptoDelegate_Test.cs
+++ b/Apps/Common/test/unit/Delegates/AesCryptoDelegate_Test.cs
@@ -37,11 +37,13 @@ namespace HealthGateway.CommonTests.Delegates
             AESCryptoDelegateConfig expectedConfig = new AESCryptoDelegateConfig()
             {
                 KeySize = 256,
+                IV = Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEF")),
             };
 
             var myConfiguration = new Dictionary<string, string>
             {
                 {"AESCrypto:KeySize", expectedConfig.KeySize.ToString()},
+                {"AESCrypto:IV", Convert.ToBase64String(Encoding.ASCII.GetBytes("0123456789ABCDEF"))},
             };
 
             var configuration = new ConfigurationBuilder()

--- a/Apps/Immunization/src/Properties/launchSettings.json
+++ b/Apps/Immunization/src/Properties/launchSettings.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:3001"
+      "applicationUrl": "http://localhost:3001",
+      "sslPort": 0
     }
   },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "HealthGateway.Immunization": {
       "commandName": "Project",
-      "launchBrowser": true,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/Apps/Medication/src/Properties/launchSettings.json
+++ b/Apps/Medication/src/Properties/launchSettings.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:3003"
+      "applicationUrl": "http://localhost:3003",
+      "sslPort": 0
     }
   },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "HealthGateway.Medication": {
       "commandName": "Project",
-      "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Apps/Patient/src/Properties/launchSettings.json
+++ b/Apps/Patient/src/Properties/launchSettings.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "http://json.schemastore.org/launchsettings.json",
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:3002"
+      "applicationUrl": "http://localhost:3002",
+      "sslPort": 0
     }
   },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
   "profiles": {
     "HealthGateway.Patient": {
       "commandName": "Project",
-      "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -1,5 +1,5 @@
 //-------------------------------------------------------------------------
-// Copyright © 2020 Province of British Columbia
+// Copyright © 2019 Province of British Columbia
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ namespace HealthGateway.WebClient
     using Hangfire.PostgreSql;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
     using HealthGateway.WebClient.Services;
@@ -88,6 +89,7 @@ namespace HealthGateway.WebClient
             services.AddTransient<IBetaRequestDelegate, DBBetaRequestDelegate>();
             services.AddTransient<ILegalAgreementDelegate, DBLegalAgreementDelegate>();
             services.AddTransient<INoteDelegate, DBNoteDelegate>();
+            services.AddTransient<ICryptoDelegate, AESCryptoDelegate>();
 
             services.Configure<ApiBehaviorOptions>(options =>
             {

--- a/Tools/BaseBuild/odrproxy-deploy.json
+++ b/Tools/BaseBuild/odrproxy-deploy.json
@@ -212,20 +212,20 @@
       "displayName": "Source Name",
       "name": "SOURCE_NAME",
       "required": true,
-      "value": "healthgateproxy"
+      "value": "odrproxy"
     },
     {
       "description": "The name assigned to all of the openshift objects defined in this template. It is also the name of runtime image you want.",
       "displayName": "Name",
       "name": "NAME",
       "required": true,
-      "value": "healthgateproxy"
+      "value": "odrproxy"
     },
     {
       "description": "The exposed hostname that will route to the service, e.g., myappname.pathfinder.gov.bc.ca, if left blank a value will be defaulted.",
       "displayName": "Application Hostname",
       "name": "APPLICATION_DOMAIN",
-      "value": "dev-odrproxy.pathfinder.gov.bc.ca"
+      "value": "test-odrproxy.pathfinder.gov.bc.ca"
     },
 
     {
@@ -233,13 +233,13 @@
       "displayName": "Image Namespace",
       "name": "IMAGE_NAMESPACE",
       "required": true,
-      "value": "xx-tools"
+      "value": "q6qfzk-tools"
     },
     {
       "description": "The TAG name for this environment, e.g., dev, test, prod",
       "displayName": "Env TAG name",
       "name": "TAG_NAME",
-      "value": "dev"
+      "value": "test"
     },
     {
       "description": "URL of Digital Experience MSP Service",
@@ -252,70 +252,70 @@
       "description": "User name : password for the Digital Experience MSP Service",
       "displayName": "TARGET_USERNAME_PASSWORD",
       "name": "TARGET_USERNAME_PASSWORD",
-      "required": true,
+      "required": false,
       "value": ""
     },
     {
       "description": "Private key of the MSP-Service for the Mutual TLS negotiation",
       "displayName": "MUTUAL_TLS_PEM_KEY_BASE64",
       "name": "MUTUAL_TLS_PEM_KEY_BASE64",
-      "required": true,
+      "required": false,
       "value": ""
     },
     {
       "description": "Passphrase for the private key of the MSP-Service",
       "displayName": "MUTUAL_TLS_PEM_KEY_PASSPHRASE",
       "name": "MUTUAL_TLS_PEM_KEY_PASSPHRASE",
-      "required": true,
+      "required": false,
       "value": ""
     },
     {
       "description": "Public Certificate of the Digital Experience MSP Service to be trusted",
       "displayName": "MUTUAL_TLS_PEM_CERT",
       "name": "MUTUAL_TLS_PEM_CERT",
-      "required": true,
+      "required": false,
       "value": ""
     },
     {
       "description": "Use SSL",
       "displayName": "SECURE_MODE",
       "name": "SECURE_MODE",
-      "required": true,
+      "required": false,
       "value": "true"
     },
     {
       "description": "Use Mutual SSL",
       "displayName": "USE_MUTUAL_TLS",
       "name": "USE_MUTUAL_TLS",
-      "required": true,
+      "required": false,
       "value": "true"
     },
     {
       "description": "Authentication Key used in all SSL",
       "displayName": "AUTH_TOKEN_KEY",
       "name": "AUTH_TOKEN_KEY",
-      "required": true,
+      "required": false,
       "value": ""
     },
     {
       "description": "Use Auth Token in all SSL",
       "displayName": "USE_AUTH_TOKEN",
       "name": "USE_AUTH_TOKEN",
-      "required": true,
+      "required": false,
       "value": "true"
     },
     {
       "description": "Host name for the Splunk Forwarder",
       "displayName": "LOGGER_HOST",
       "name": "LOGGER_HOST",
-      "required": true,
+      "required": false,
       "value": "splunk-forwarder"
     },
     {
       "description": "Port for the Splunk Forwarder",
       "displayName": "LOGGER_PORT",
       "name": "LOGGER_PORT",
-      "required": true,
+      "required": false,
       "value": "8080"
     },
     {


### PR DESCRIPTION
## Status
Ready

## Fixes or Implements [AB#8119](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8119)
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Create an Encryption delegate that utilizes AES to support the encryption of Notes.

## Testing
- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

### Steps to Reproduce:
N/A

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
I disabled the browser auto-launch of Patient, Meds, and Immunization.
I also checked in the copy of the json that I used to deploy the ODR Proxy.
