### PR TITLE
Hotfix for bug involving accessing length of undefined

### DIFF
--- a/Apps/WebClient/src/ClientApp/app/components/modal/protectiveWord.vue
+++ b/Apps/WebClient/src/ClientApp/app/components/modal/protectiveWord.vue
@@ -22,18 +22,15 @@
 
 <template>
   <b-modal
-    ref="protectiveWord-modal"
+    id="protective-word-modal"
     title="Restricted PharmaNet Records"
     header-class="modal-header"
     footer-class="modal-footer"
     centered
-    @ok="handleOk"
-    @close="cancel"
-    @hide="reset"
   >
     <b-row>
       <b-col>
-        <form ref="form" @submit.stop.prevent="handleSubmit">
+        <form @submit.stop.prevent="handleSubmit">
           <b-row>
             <b-col cols="8">
               <label for="protectiveWord-input">Protective Word </label>
@@ -55,7 +52,7 @@
         </form>
       </b-col>
     </b-row>
-    <template v-slot:modal-footer="{ ok, cancel, hide }">
+    <template v-slot:modal-footer>
       <b-row>
         <b-col>
           <b-row>
@@ -64,7 +61,7 @@
                 size="lg"
                 variant="primary"
                 :disabled="!protectiveWord"
-                @click="ok()"
+                @click="handleOk($event)"
               >
                 Continue
               </b-button>
@@ -98,35 +95,46 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Ref, Emit, Prop, Component } from "vue-property-decorator";
+import { Emit, Prop, Component, Watch } from "vue-property-decorator";
 
 @Component
 export default class ProtectiveWordComponent extends Vue {
-  @Ref("protectiveWord-modal") readonly modal!: HTMLElement;
-  @Ref("form") readonly form!: HTMLElement;
   @Prop() error!: boolean;
-  private protectiveWord!: string = "";
+  @Prop({ default: false }) isLoading!: boolean;
 
-  @Emit()
+  private isShowing: boolean = false;
+  private protectiveWord: string = "";
+  private readonly modalId: string = "protective-word-modal";
+
   public showModal() {
-    this.modal.show();
+    this.isShowing = true;
+  }
+
+  public hideModal() {
+    this.isShowing = false;
+    this.$bvModal.hide(this.modalId);
+  }
+
+  @Watch("isLoading")
+  private onIsLoading() {
+    if (!this.isLoading && this.isShowing) {
+      this.$bvModal.show(this.modalId);
+    }
   }
 
   @Emit()
-  public submit() {
+  private submit() {
+    this.isShowing = false;
     return this.protectiveWord;
   }
 
   @Emit()
-  public cancel() {
+  private cancel() {
+    this.isShowing = false;
     return;
   }
 
-  private reset() {
-    this.protectiveWord = "";
-  }
-
-  private handleOk(bvModalEvt) {
+  private handleOk(bvModalEvt: Event) {
     // Prevent modal from closing
     bvModalEvt.preventDefault();
 
@@ -139,7 +147,7 @@ export default class ProtectiveWordComponent extends Vue {
 
     // Hide the modal manually
     this.$nextTick(() => {
-      this.modal.hide();
+      this.hideModal();
     });
   }
 }

--- a/Apps/WebClient/src/ClientApp/app/models/timelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/app/models/timelineEntry.ts
@@ -10,9 +10,9 @@ export enum EntryType {
 export default abstract class TimelineEntry {
   public readonly id: string;
   public readonly type: EntryType;
-  public readonly date?: Date;
+  public readonly date: Date;
 
-  public constructor(id: string, type: EntryType, date?: Date) {
+  public constructor(id: string, type: EntryType, date: Date) {
     this.id = id;
     this.type = type;
     this.date = date;

--- a/Apps/WebClient/src/ClientApp/app/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/app/views/timeline.vue
@@ -215,6 +215,7 @@
     <ProtectiveWordComponent
       ref="protectiveWordModal"
       :error="protectiveWordAttempts > 1"
+      :is-loading="isLoading"
       @submit="onProtectiveWordSubmit"
       @cancel="onProtectiveWordCancel"
     />

--- a/Apps/WebClient/src/ClientApp/app/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/app/views/timeline.vue
@@ -604,7 +604,11 @@ export default class TimelineComponent extends Vue {
       // Set it to new final page
       this.currentPage = result.length;
     }
-    this.visibleTimelineEntries = result[this.currentPage - 1];
+    if (result.length === 0) {
+      this.visibleTimelineEntries = [];
+    } else {
+      this.visibleTimelineEntries = result[this.currentPage - 1];
+    }
   }
 
   private get dateGroups(): DateGroup[] {

--- a/Apps/WebClient/src/ClientApp/app/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/app/views/timeline.vue
@@ -276,14 +276,13 @@ export default class TimelineComponent extends Vue {
 
   private filterText: string = "";
   private timelineEntries: TimelineEntry[] = [];
+  private filteredTimelineEntries: TimelineEntry[] = [];
   private visibleTimelineEntries: TimelineEntry[] = [];
-  private timelinePages: TimelineEntry[][] = [];
   private isMedicationLoading: boolean = false;
   private isImmunizationLoading: boolean = false;
   private isNoteLoading: boolean = false;
   private windowWidth: number = 0;
   private currentPage: number = 1;
-  private filteredEntriesLength = 0;
   private hasErrors: boolean = false;
   private protectiveWordAttempts: number = 0;
   private isAddingNote: boolean = false;
@@ -296,12 +295,12 @@ export default class TimelineComponent extends Vue {
   @Ref("protectiveWordModal")
   readonly protectiveWordModal!: ProtectiveWordComponent;
 
-  created() {
+  private created() {
     window.addEventListener("resize", this.handleResize);
     this.handleResize();
   }
 
-  mounted() {
+  private mounted() {
     this.initializeFilters();
     this.fetchMedicationStatements();
     this.fetchImmunizations();
@@ -318,7 +317,7 @@ export default class TimelineComponent extends Vue {
     });
   }
 
-  beforeRouteLeave(to, from, next) {
+  private beforeRouteLeave(to, from, next) {
     if (
       (this.isAddingNote || this.editIdList.length > 0) &&
       !confirm(this.unsavedChangesText)
@@ -327,7 +326,8 @@ export default class TimelineComponent extends Vue {
     }
     next();
   }
-  destroyed() {
+
+  private destroyed() {
     window.removeEventListener("handleResize", this.handleResize);
   }
 
@@ -380,7 +380,7 @@ export default class TimelineComponent extends Vue {
     return this.config.modules["Note"];
   }
 
-  private get getNumberOfEntriesPerPage(): number {
+  private get numberOfEntriesPerPage(): number {
     if (this.windowWidth < 576) {
       // xs
       return 7;
@@ -399,28 +399,13 @@ export default class TimelineComponent extends Vue {
 
   private get numberOfPages(): number {
     let result = Math.ceil(
-      this.filteredEntriesLength / this.getNumberOfEntriesPerPage
+      this.filteredTimelineEntries.length / this.numberOfEntriesPerPage
     );
     if (result < 1) {
       return 1;
     } else {
       return result;
     }
-  }
-
-  private getPages(entries: TimelineEntry[]): TimelineEntry[][] {
-    let index = 0;
-    let result: TimelineEntry[][] = [];
-    this.sortGroup(entries);
-    for (
-      index = 0;
-      index < entries.length;
-      index += this.getNumberOfEntriesPerPage
-    ) {
-      let chunk = entries.slice(index, index + this.getNumberOfEntriesPerPage);
-      result.push(chunk);
-    }
-    return result;
   }
 
   private initializeFilters(): void {
@@ -465,6 +450,7 @@ export default class TimelineComponent extends Vue {
           for (let result of results.resourcePayload) {
             this.timelineEntries.push(new MedicationTimelineEntry(result));
           }
+          this.sortEntries();
           this.applyTimelineFilter();
         } else if (results.resultStatus == ResultType.Protected) {
           this.protectiveWordModal.showModal();
@@ -499,6 +485,7 @@ export default class TimelineComponent extends Vue {
           for (let result of results.resourcePayload) {
             this.timelineEntries.push(new ImmunizationTimelineEntry(result));
           }
+          this.sortEntries();
           this.applyTimelineFilter();
         } else {
           console.log(
@@ -530,6 +517,7 @@ export default class TimelineComponent extends Vue {
           for (let result of results.resourcePayload) {
             this.timelineEntries.push(new NoteTimelineEntry(result));
           }
+          this.sortEntries();
           this.applyTimelineFilter();
         } else {
           console.log(
@@ -551,6 +539,7 @@ export default class TimelineComponent extends Vue {
     this.isAddingNote = false;
     if (note) {
       this.timelineEntries.push(new NoteTimelineEntry(note));
+      this.sortEntries();
       this.applyTimelineFilter();
     }
   }
@@ -590,25 +579,31 @@ export default class TimelineComponent extends Vue {
 
   @Watch("filterText")
   @Watch("filterTypes")
-  @Watch("currentPage")
-  @Watch("getNumberOfEntriesPerPage")
   private applyTimelineFilter() {
-    let filtered = this.timelineEntries.filter(entry =>
+    this.filteredTimelineEntries = this.timelineEntries.filter(entry =>
       entry.filterApplies(this.filterText, this.filterTypes)
     );
-    // Adjust number of pages depending on filters
-    this.filteredEntriesLength = filtered.length;
-    let result = this.getPages(filtered);
-    // Check if access to out-of-bounds page is attempted after resize
-    if (this.currentPage > result.length && result.length > 0) {
-      // Set it to new final page
-      this.currentPage = result.length;
+  }
+
+  @Watch("currentPage")
+  @Watch("numberOfEntriesPerPage")
+  @Watch("filteredTimelineEntries")
+  private calculateVisibleEntries() {
+    // Handle the current page being beyond the max number of pages
+    if (this.currentPage > this.numberOfPages) {
+      this.currentPage = this.numberOfPages;
     }
-    if (result.length === 0) {
-      this.visibleTimelineEntries = [];
-    } else {
-      this.visibleTimelineEntries = result[this.currentPage - 1];
-    }
+
+    // Get the section of the array that contains the paginated section
+    let lowerIndex = (this.currentPage - 1) * this.numberOfEntriesPerPage;
+    let upperIndex = Math.min(
+      this.currentPage * this.numberOfEntriesPerPage,
+      this.filteredTimelineEntries.length
+    );
+    this.visibleTimelineEntries = this.filteredTimelineEntries.slice(
+      lowerIndex,
+      upperIndex
+    );
   }
 
   private get dateGroups(): DateGroup[] {
@@ -655,6 +650,12 @@ export default class TimelineComponent extends Vue {
 
   private getTotalCount(): number {
     return this.timelineEntries.length;
+  }
+
+  private sortEntries() {
+    this.timelineEntries.sort((a, b) =>
+      a.date > b.date ? -1 : a.date < b.date ? 1 : 0
+    );
   }
 
   private printRecords() {

--- a/Apps/WebClient/src/ClientApp/app/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/app/views/timeline.vue
@@ -398,14 +398,13 @@ export default class TimelineComponent extends Vue {
   }
 
   private get numberOfPages(): number {
-    let result = Math.ceil(
-      this.filteredTimelineEntries.length / this.numberOfEntriesPerPage
-    );
-    if (result < 1) {
-      return 1;
-    } else {
-      return result;
+    let result = 1;
+    if (this.filteredTimelineEntries.length > this.numberOfEntriesPerPage) {
+      result = Math.ceil(
+        this.filteredTimelineEntries.length / this.numberOfEntriesPerPage
+      );
     }
+    return result;
   }
 
   private initializeFilters(): void {


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements AB#8326
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
Tried to access index of empty array < 0 without a check. This led to an attempt to access the length of undefined which led to an endless spinning wheel for all users who had no timeline entries. Fixed by implementing a quick check if the user had no timeline entries.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
Run the user timeline and uncheck all filters so you see no entries on the page. This should render an empty page rather than throwing an error.

### UI Changes
NO

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox
