### PR TITLE
Fixes null pointer when no email invite exists for AB#8235

### DIFF
--- a/Apps/WebClient/src/Server/Controllers/UserEmailController.cs
+++ b/Apps/WebClient/src/Server/Controllers/UserEmailController.cs
@@ -114,14 +114,21 @@ namespace HealthGateway.WebClient.Controllers
             EmailInvite emailInvite = this.userEmailService.RetrieveLastInvite(hdid);
 
             // Check expiration and remove fields that contains sensitive information
-            if (emailInvite.ExpireDate < DateTime.UtcNow)
+            if (emailInvite != null)
             {
-                return new JsonResult(null);
+                if (emailInvite.ExpireDate < DateTime.UtcNow)
+                {
+                    return new JsonResult(null);
+                }
+                else
+                {
+                    UserEmailInvite result = UserEmailInvite.CreateFromDbModel(emailInvite);
+                    return new JsonResult(result);
+                }
             }
             else
             {
-                UserEmailInvite result = UserEmailInvite.CreateFromDbModel(emailInvite);
-                return new JsonResult(result);
+                return new JsonResult(null);
             }
         }
 


### PR DESCRIPTION
## Status
Ready

## Fixes or Implements [AB#8235](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8235)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
A null pointer was being thrown when no email invite exists.  Added a null check.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
Register a new user without an email.

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.
Tested manually 

## Notes/Additional Comments
