### PR TITLE
Adds config for AB#8288 and AB#8291

### DIFF
--- a/Apps/WebClient/src/appsettings.Development.json
+++ b/Apps/WebClient/src/appsettings.Development.json
@@ -24,14 +24,15 @@
           "LogoutRedirect": "5000"
       },    
       "RegistrationStatus": "open",
-      "Modules": {
-        "Immunization": "true",
-        "Medication": "false",
-        "MedicationHistory": "true",
-        "Lab": "false",
-        "Encounter": "false",
-        "Note": "true",
-        "Comment": "true"
+    "Modules": {
+      "Immunization": "true",
+      "Medication": "false",
+      "MedicationHistory": "true",
+      "Lab": "false",
+      "Encounter": "false",
+      "Note": "true",
+      "Comment": "true",
+      "CovidLabResults": "true"
     }
   },
   "ServiceEndpoints": {

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -52,7 +52,7 @@
       "Encounter": "false",
       "Note": "false",
       "Comment": "false",
-      "CovidLabResults": "true"
+      "CovidLabResults": "false"
     },
     "HoursForDeletion": 720
   },

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -41,7 +41,8 @@
     },
     "ExternalURLs": {
       "HealthLinkImmunizationSchedule": "https://www.healthlinkbc.ca/tools-videos/bc-immunization-schedules",
-      "HealthLinkVaccineSearch": "https://www.healthlinkbc.ca/search/"
+      "HealthLinkVaccineSearch": "https://www.healthlinkbc.ca/search/",
+      "CovidLabResults": "https://www.change.me"
     },
     "Modules": {
       "Immunization": "false",
@@ -50,7 +51,8 @@
       "Lab": "false",
       "Encounter": "false",
       "Note": "false",
-      "Comment": "false"
+      "Comment": "false",
+      "CovidLabResults": "true"
     },
     "HoursForDeletion": 720
   },


### PR DESCRIPTION
## Status
Ready

## Fixes or Implements [AB#8288](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8288) and [AB#8291](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8291)
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Adds the External URL and Module for CovidLabResults.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
N/A

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
We are getting a lot of modules disabled by default.