### PR TITLE
Fix modal headers

### DIFF
--- a/Apps/WebClient/src/ClientApp/app/components/modal/idle.vue
+++ b/Apps/WebClient/src/ClientApp/app/components/modal/idle.vue
@@ -1,17 +1,5 @@
 ﻿<style lang="scss" scoped>
 @import "@/assets/scss/_variables.scss";
-.text-large {
-  font-size: 250%;
-}
-.modal-header {
-  background-color: $primary;
-  color: $primary_text;
-
-  button,
-  button:hover {
-    color: #fff;
-  }
-}
 .modal-footer {
   justify-content: flex-start;
 }
@@ -20,8 +8,8 @@
   <b-modal
     ref="idle-modal"
     v-model="visible"
-    header-class="modal-header"
-    footer-class="modal-footer"
+    header-bg-variant="primary"
+    header-text-variant="light"
     :ok-only="true"
     title="Are you still there?"
     ok-title="I'm here!"

--- a/Apps/WebClient/src/ClientApp/app/components/modal/protectiveWord.vue
+++ b/Apps/WebClient/src/ClientApp/app/components/modal/protectiveWord.vue
@@ -1,17 +1,5 @@
 ﻿<style lang="scss" scoped>
 @import "@/assets/scss/_variables.scss";
-.text-large {
-  font-size: 250%;
-}
-.modal-header {
-  background-color: $primary;
-  color: $primary_text;
-
-  button,
-  button:hover {
-    color: #fff;
-  }
-}
 .modal-footer {
   justify-content: flex-start;
   button {
@@ -24,8 +12,8 @@
   <b-modal
     id="protective-word-modal"
     title="Restricted PharmaNet Records"
-    header-class="modal-header"
-    footer-class="modal-footer"
+    header-bg-variant="primary"
+    header-text-variant="light"
     centered
   >
     <b-row>


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8375](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8375)
- [ ] Enhancement
- [x] Bug
- [ ] Documentation

## Description:
Fixed modal headers not using correct colours.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### Steps to Reproduce:
Login with protected user and wait for protective word modal, header is white while it should be blue.

### UI Changes
YES

### Browsers Tested
- [x] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox