### PR TITLE
Fix NotificationSettingsJob for AB#8432

### DIFF
--- a/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
@@ -168,7 +168,7 @@ namespace HealthGateway.Common.Delegates
                         break;
                     case HttpStatusCode.BadRequest:
                         this.logger.LogError($"Error Details: {payload}");
-                        retVal.ResultMessage = $"Bad Request, HTTP Error {response.StatusCode}";
+                        retVal.ResultMessage = $"Bad Request, HTTP Error {response.StatusCode}\nDetails:\n{payload}";
                         break;
                     case HttpStatusCode.Forbidden:
                         this.logger.LogError($"Error Details: {payload}");

--- a/Apps/Common/src/Jobs/INotificationSettingsJob.cs
+++ b/Apps/Common/src/Jobs/INotificationSettingsJob.cs
@@ -25,8 +25,8 @@ namespace HealthGateway.Common.Jobs
         /// <summary>
         /// Sends an email immediately if Priority is standard or higher.
         /// </summary>
-        /// <param name="notificationSettings">The Notification settings to send to PHSA.</param>
+        /// <param name="notificationSettingsJSON">The Notification settings serialized to send to PHSA.</param>
         /// <param name="bearerToken">The bearer token of the authenticated user.</param>
-        void PushNotificationSettings(NotificationSettingsRequest notificationSettings, string bearerToken);
+        void PushNotificationSettings(string notificationSettingsJSON, string bearerToken);
     }
 }

--- a/Apps/Common/src/Services/NotificationSettingsService.cs
+++ b/Apps/Common/src/Services/NotificationSettingsService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Services
 {
     using System;
     using System.Globalization;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Hangfire;
     using HealthGateway.Common.Delegates;
@@ -49,7 +50,14 @@ namespace HealthGateway.Common.Services
         public void QueueNotificationSettings(NotificationSettingsRequest notificationSettings, string bearerToken)
         {
             this.logger.LogTrace($"Queueing Notification Settings push to PHSA...");
-            BackgroundJob.Enqueue<INotificationSettingsJob>(j => j.PushNotificationSettings(this.ValidateVerificationCode(notificationSettings), bearerToken));
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                IgnoreNullValues = true,
+                WriteIndented = true,
+            };
+            string json = JsonSerializer.Serialize(this.ValidateVerificationCode(notificationSettings), options);
+            BackgroundJob.Enqueue<INotificationSettingsJob>(j => j.PushNotificationSettings(json, bearerToken));
             this.logger.LogDebug($"Finished queueing Notification Settings push.");
         }
 

--- a/Apps/Common/test/unit/Delegates/NotificationSettingsDelegate_Test.cs
+++ b/Apps/Common/test/unit/Delegates/NotificationSettingsDelegate_Test.cs
@@ -251,10 +251,11 @@ namespace HealthGateway.CommonTests.Delegates
         [Fact]
         public void ValidateSetNotificationSettings400()
         {
+            string errMsg = "Mocked Error";
             RequestResult<NotificationSettingsResponse> expected = new RequestResult<NotificationSettingsResponse>()
             {
                 ResultStatus = Common.Constants.ResultType.Error,
-                ResultMessage = "Bad Request, HTTP Error BadRequest",
+                ResultMessage = $"Bad Request, HTTP Error BadRequest\nDetails:\n{errMsg}",
             };
             NotificationSettingsRequest notificationSettings = new NotificationSettingsRequest()
             {
@@ -282,7 +283,7 @@ namespace HealthGateway.CommonTests.Delegates
                .ReturnsAsync(new HttpResponseMessage()
                {
                    StatusCode = HttpStatusCode.BadRequest,
-                   Content = new StringContent(string.Empty),
+                   Content = new StringContent(errMsg),
                })
                .Verifiable();
             using var loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());

--- a/Apps/JobScheduler/src/Jobs/NotificationSettingsJob.cs
+++ b/Apps/JobScheduler/src/Jobs/NotificationSettingsJob.cs
@@ -18,6 +18,7 @@ namespace Healthgateway.JobScheduler.Jobs
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.Contracts;
+    using System.Text.Json;
     using Hangfire;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Jobs;
@@ -48,13 +49,20 @@ namespace Healthgateway.JobScheduler.Jobs
 
         /// <inheritdoc />
         [DisableConcurrentExecution(ConcurrencyTimeout)]
-        public async void PushNotificationSettings(NotificationSettingsRequest notificationSettings, string bearerToken)
+        public async void PushNotificationSettings(string notificationSettingsJSON, string bearerToken)
         {
             this.logger.LogTrace($"Queueing Notification Settings push to PHSA...");
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                IgnoreNullValues = true,
+                WriteIndented = true,
+            };
+            NotificationSettingsRequest notificationSettings = JsonSerializer.Deserialize<NotificationSettingsRequest>(notificationSettingsJSON, options);
             RequestResult<NotificationSettingsResponse> retVal = await this.notificationSettingsDelegate.SetNotificationSettings(notificationSettings, bearerToken).ConfigureAwait(true);
             if (retVal.ResultStatus != HealthGateway.Common.Constants.ResultType.Success)
             {
-                throw new ApplicationException($"Unable to send Notification Settings to PHSA, Error: {retVal.ResultMessage}");
+                throw new ApplicationException($"Unable to send Notification Settings to PHSA, Error:\n{retVal.ResultMessage}");
             }
 
             this.logger.LogDebug($"Finished queueing Notification Settings push.");

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -29,6 +29,7 @@ namespace HealthGateway.JobScheduler
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.Authorization.Admin;
+    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.FileDownload;
     using HealthGateway.Common.Jobs;
     using HealthGateway.Common.Services;
@@ -50,6 +51,7 @@ namespace HealthGateway.JobScheduler
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.IdentityModel.Tokens;
+
 
     /// <summary>
     /// The startup class.
@@ -89,10 +91,8 @@ namespace HealthGateway.JobScheduler
                     this.configuration.GetConnectionString("GatewayConnection"),
                     b => b.MigrationsAssembly(nameof(Database))));
 
-            services.AddTransient<IEmailDelegate, DBEmailDelegate>();
-            services.AddTransient<IEmailJob, EmailJob>();
 
-            // DB Maintainer Services
+            // Add Delegates and services for jobs
             services.AddTransient<IFileDownloadService, FileDownloadService>();
             services.AddTransient<IDrugProductParser, FederalDrugProductParser>();
             services.AddTransient<IPharmaCareDrugParser, PharmaCareDrugParser>();
@@ -102,14 +102,18 @@ namespace HealthGateway.JobScheduler
             services.AddTransient<IEmailDelegate, DBEmailDelegate>();
             services.AddTransient<IMessagingVerificationDelegate, DBMessagingVerificationDelegate>();
             services.AddTransient<IEmailQueueService, EmailQueueService>();
+            services.AddTransient<INotificationSettingsDelegate, RestNotificationSettingsDelegate>();
 
             // Add injection for KeyCloak User Admin
             services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
             services.AddTransient<IUserAdminDelegate, KeycloakUserAdminDelegate>();
 
-            // Add app
+            // Add Jobs
             services.AddTransient<FedDrugJob>();
             services.AddTransient<ProvincialDrugJob>();
+            services.AddTransient<IEmailJob, EmailJob>();
+            services.AddTransient<INotificationSettingsJob, NotificationSettingsJob>();
+
 
             // Enable Hangfire
             services.AddHangfire(x => x.UsePostgreSqlStorage(this.configuration.GetConnectionString("GatewayConnection")));


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8432](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8432)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
The NotificationSettings job was not instantiating as it and its delegate were not declared in startup.
The queuing service using newtonsoft json was duplicating the scopes.  I updated the Job to take a serialized request and serialized/deserialized myself using System.text.JSON
Added detail to return error message.

## Testing
- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.
Manual Tests run and unit tests verified.

## Notes/Additional Comments
On email = false, we currently send an empty string.  PHSA is validating that and responding with a bad request.  Brad and Nino to take this forward to them.
