### PR TITLE
Bugs/8432

### DIFF
--- a/Apps/Common/src/Services/NotificationSettingsService.cs
+++ b/Apps/Common/src/Services/NotificationSettingsService.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.Common.Services
 
         private NotificationSettingsRequest ValidateVerificationCode(NotificationSettingsRequest notificationSettings)
         {
-            if (!notificationSettings.SMSVerified && string.IsNullOrEmpty(notificationSettings.SMSVerificationCode))
+            if (notificationSettings.SMSEnabled && string.IsNullOrEmpty(notificationSettings.SMSVerificationCode))
             {
                 // Create the SMS validation code if the SMS is not verified and the caller didn't set it.
                 Random generator = new Random();


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8432](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8432)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
Hangfire was exiting after the NotificationSettingsJob threw an exception.  It appears that Hangfire does not like async exceptions and removing it fixed the issue.

Another defect was found when created the SMS Validation code - fixed.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
Job has been manually tested.
