### PR TITLE
Updated to use system JWT for Queued Push to PHSA

### DIFF
--- a/Apps/Common/src/Jobs/INotificationSettingsJob.cs
+++ b/Apps/Common/src/Jobs/INotificationSettingsJob.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.Common.Jobs
         /// Sends an email immediately if Priority is standard or higher.
         /// </summary>
         /// <param name="notificationSettingsJSON">The Notification settings serialized to send to PHSA.</param>
-        /// <param name="bearerToken">The bearer token of the authenticated user.</param>
-        void PushNotificationSettings(string notificationSettingsJSON, string bearerToken);
+        void PushNotificationSettings(string notificationSettingsJSON);
     }
 }

--- a/Apps/Common/src/Models/NotificationSettingsBase.cs
+++ b/Apps/Common/src/Models/NotificationSettingsBase.cs
@@ -38,6 +38,7 @@ namespace HealthGateway.Common.Models
         /// <param name="notificationSettings">Initialize values from passed in object.</param>
         public NotificationSettingsBase(NotificationSettingsBase notificationSettings)
         {
+            this.SubjectHdid = notificationSettings.SubjectHdid;
             this.SMSEnabled = notificationSettings.SMSEnabled;
             this.SMSNumber = notificationSettings.SMSNumber;
             this.SMSVerified = notificationSettings.SMSVerified;
@@ -46,6 +47,12 @@ namespace HealthGateway.Common.Models
             this.EmailEnabled = notificationSettings.EmailEnabled;
             this.EmailScope = notificationSettings.EmailScope.ToList();
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating the subject HDID. This is an identifier person this notification is sent to.
+        /// </summary>
+        [JsonPropertyName("subjectHdid")]
+        public string? SubjectHdid { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether SMS notifications are enabled.

--- a/Apps/Common/src/Models/NotificationSettingsRequest.cs
+++ b/Apps/Common/src/Models/NotificationSettingsRequest.cs
@@ -50,6 +50,7 @@ namespace HealthGateway.Common.Models
         public NotificationSettingsRequest(UserProfile userProfile, string? emailAddress, string? smsNumber)
             : base()
         {
+            this.SubjectHdid = userProfile.HdId;
             this.EmailAddress = emailAddress;
             this.EmailEnabled = !string.IsNullOrWhiteSpace(emailAddress);
             this.SMSNumber = smsNumber;

--- a/Apps/Common/src/Services/INotificationSettingsService.cs
+++ b/Apps/Common/src/Services/INotificationSettingsService.cs
@@ -25,10 +25,10 @@ namespace HealthGateway.Common.Services
     {
         /// <summary>
         /// Queues pushing the Notification Settings to PHSA using our batch system.
+        /// Will use access_token acquired from system account authenication.
         /// </summary>
         /// <param name="notificationSettings">The Notification Settings Request object.</param>
-        /// <param name="bearerToken">The bearer token of the authenticated user.</param>
-        void QueueNotificationSettings(NotificationSettingsRequest notificationSettings, string bearerToken);
+        void QueueNotificationSettings(NotificationSettingsRequest notificationSettings);
 
         /// <summary>
         /// Sends the Notifications Settings to PHSA immediately.

--- a/Apps/Common/src/Services/NotificationSettingsService.cs
+++ b/Apps/Common/src/Services/NotificationSettingsService.cs
@@ -47,7 +47,7 @@ namespace HealthGateway.Common.Services
         }
 
         /// <inheritdoc />
-        public void QueueNotificationSettings(NotificationSettingsRequest notificationSettings, string bearerToken)
+        public void QueueNotificationSettings(NotificationSettingsRequest notificationSettings)
         {
             this.logger.LogTrace($"Queueing Notification Settings push to PHSA...");
             var options = new JsonSerializerOptions
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.Services
                 WriteIndented = true,
             };
             string json = JsonSerializer.Serialize(this.ValidateVerificationCode(notificationSettings), options);
-            BackgroundJob.Enqueue<INotificationSettingsJob>(j => j.PushNotificationSettings(json, bearerToken));
+            BackgroundJob.Enqueue<INotificationSettingsJob>(j => j.PushNotificationSettings(json));
             this.logger.LogDebug($"Finished queueing Notification Settings push.");
         }
 

--- a/Apps/WebClient/src/Server/Services/UserEmailService.cs
+++ b/Apps/WebClient/src/Server/Services/UserEmailService.cs
@@ -128,7 +128,7 @@ namespace HealthGateway.WebClient.Services
             RequestResult<NotificationSettingsResponse> response = await this.notificationSettingsService.SendNotificationSettings(request, bearerToken).ConfigureAwait(true);
             if (response.ResultStatus == ResultType.Error)
             {
-                this.notificationSettingsService.QueueNotificationSettings(request, bearerToken);
+                this.notificationSettingsService.QueueNotificationSettings(request);
             }
         }
     }

--- a/Apps/WebClient/src/Server/Services/UserProfileService.cs
+++ b/Apps/WebClient/src/Server/Services/UserProfileService.cs
@@ -331,7 +331,7 @@ namespace HealthGateway.WebClient.Services
             RequestResult<NotificationSettingsResponse> response = await this.notificationSettingsService.SendNotificationSettings(request, bearerToken).ConfigureAwait(true);
             if (response.ResultStatus == ResultType.Error)
             {
-                this.notificationSettingsService.QueueNotificationSettings(request, bearerToken);
+                this.notificationSettingsService.QueueNotificationSettings(request);
             }
 
             return request;

--- a/Apps/WebClient/src/Server/Services/UserSMSService.cs
+++ b/Apps/WebClient/src/Server/Services/UserSMSService.cs
@@ -123,7 +123,7 @@ namespace HealthGateway.WebClient.Services
             RequestResult<NotificationSettingsResponse> response = await this.notificationSettingsService.SendNotificationSettings(request, bearerToken).ConfigureAwait(true);
             if (response.ResultStatus == ResultType.Error)
             {
-                this.notificationSettingsService.QueueNotificationSettings(request, bearerToken);
+                this.notificationSettingsService.QueueNotificationSettings(request);
             }
 
             return request;

--- a/Apps/WebClient/test/unit/Services.Test/UserProfileService_Test.cs
+++ b/Apps/WebClient/test/unit/Services.Test/UserProfileService_Test.cs
@@ -189,7 +189,7 @@ namespace HealthGateway.WebClient.Test.Services
             Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
             notificationServiceMock.Setup(s => s.SendNotificationSettings(It.IsAny<NotificationSettingsRequest>(), "bearer_token"))
                 .ReturnsAsync(new RequestResult<NotificationSettingsResponse>() { ResultStatus = ResultType.Error });
-            notificationServiceMock.Setup(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>(), "bearer_token"));
+            notificationServiceMock.Setup(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()));
 
             Mock<IMessagingVerificationDelegate> messageVerificationDelegateMock = new Mock<IMessagingVerificationDelegate>();
 
@@ -206,7 +206,7 @@ namespace HealthGateway.WebClient.Test.Services
                 messageVerificationDelegateMock.Object);
 
             RequestResult<UserProfileModel> actualResult = await service.CreateUserProfile(new CreateUserRequest() { Profile = userProfile }, new System.Uri("http://localhost/"), "bearer_token");
-            notificationServiceMock.Verify(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>(), "bearer_token"), Times.Once());
+            notificationServiceMock.Verify(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()), Times.Once());
             Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
             Assert.True(actualResult.ResourcePayload.IsDeepEqual(expected));
         }


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements AB8450 NotificationSettings queued push to use system JWT
- [x] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
NotificationSettings queued push to use system JWT, but only when Queued, not direct.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### Steps to Reproduce:
The push notificiation should authenticate with PHSA endpoint, not using user JWT,
which is not available to job scheduler, as either expired or not set. This way the Job Scheduler will obtain JWT at time to delivery to PHSA endpoint, allowing for validation.
the JSON notification structure adds subjectHdid as now required.

### UI Changes
NO

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
We will need to update design notes to PHSA.
