### PR TITLE
Add resource HDID to Labs

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -195,7 +195,7 @@ namespace HealthGateway.Common.AspNetConfiguration
                 {
                     policy.AuthenticationSchemes.Add(JwtBearerDefaults.AuthenticationScheme);
                     policy.RequireAuthenticatedUser();
-                    policy.Requirements.Add(new FhirRequirement(FhirResource.Observation, FhirAccessType.Read));
+                    policy.Requirements.Add(new FhirRequirement(FhirResource.Observation, FhirAccessType.Read, FhirResourceLookup.Parameter));
                 });
                 options.AddPolicy(LaboratoryPolicy.Write, policy =>
                 {

--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -72,6 +72,7 @@ namespace HealthGateway.Laboratory.Controllers
         /// <summary>
         /// Gets a json list of laboratory orders.
         /// </summary>
+        /// <param name="hdid">The hdid resource to request the laboratory orders for.</param>
         /// <returns>A list of laboratory records wrapped in a request result.</returns>
         /// <response code="200">Returns the List of laboratory records.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -79,13 +80,12 @@ namespace HealthGateway.Laboratory.Controllers
         /// <response code="503">The service is unavailable for use.</response>
         [HttpGet]
         [Produces("application/json")]
-        [Authorize(Policy = UserPolicy.UserOnly)]
-        public async Task<IActionResult> GetLaboratoryOrders()
+        [Authorize(Policy = LaboratoryPolicy.Read)]
+        public async Task<IActionResult> GetLaboratoryOrders([FromQuery] string hdid)
         {
             this.logger.LogDebug($"Getting list of laboratory orders... ");
 
             ClaimsPrincipal user = this.httpContextAccessor.HttpContext.User;
-            string hdid = user.FindFirst("hdid").Value;
             string accessToken = await this.httpContextAccessor.HttpContext.GetTokenAsync("access_token").ConfigureAwait(true);
 
             RequestResult<IEnumerable<LaboratoryOrder>> result = await this.service.GetLaboratoryOrders(accessToken).ConfigureAwait(true);
@@ -98,6 +98,7 @@ namespace HealthGateway.Laboratory.Controllers
         /// Gets a a specific Laboratory report.
         /// </summary>
         /// <param name="reportId">The ID of the report belonging to the authenticated user to fetch.</param>
+        /// <param name="hdid">The requested HDID which owns the reportId.</param>
         /// <returns>A Laboratory PDF Report wrapped in a request result.</returns>
         /// <response code="200">Returns the specified PDF lab report.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -106,13 +107,12 @@ namespace HealthGateway.Laboratory.Controllers
         [HttpGet]
         [Produces("application/json")]
         [Route("{reportId}/Report")]
-        [Authorize(Policy = UserPolicy.UserOnly)]
-        public async Task<IActionResult> GetLaboratoryReport(Guid reportId)
+        [Authorize(Policy = LaboratoryPolicy.Read)]
+        public async Task<IActionResult> GetLaboratoryReport(Guid reportId, [FromQuery] string hdid)
         {
-            this.logger.LogDebug($"Getting PDF version of Laboratory Report... {1}");
+            this.logger.LogDebug($"Getting PDF version of Laboratory Report for hdid {hdid}");
 
             ClaimsPrincipal user = this.httpContextAccessor.HttpContext.User;
-            string hdid = user.FindFirst("hdid").Value;
             string accessToken = await this.httpContextAccessor.HttpContext.GetTokenAsync("access_token").ConfigureAwait(true);
 
             RequestResult<LaboratoryReport> result = await this.service.GetLabReport(reportId, accessToken).ConfigureAwait(true);

--- a/Apps/Laboratory/test/unit/Controllers/LaboratoryController_Test.cs
+++ b/Apps/Laboratory/test/unit/Controllers/LaboratoryController_Test.cs
@@ -88,7 +88,7 @@ namespace HealthGateway.LaboratoryTests
             LaboratoryController controller = new LaboratoryController(loggerFactory.CreateLogger<LaboratoryController>(),  svcMock.Object, httpContextAccessorMock.Object);
 
             // Act
-            IActionResult actual = await controller.GetLaboratoryOrders();
+            IActionResult actual = await controller.GetLaboratoryOrders(hdid);
 
             // Verify
             Assert.IsType<JsonResult>(actual);
@@ -155,7 +155,7 @@ namespace HealthGateway.LaboratoryTests
             LaboratoryController controller = new LaboratoryController(loggerFactory.CreateLogger<LaboratoryController>(), svcMock.Object, httpContextAccessorMock.Object);
 
             // Act
-            IActionResult actual = await controller.GetLaboratoryOrders();
+            IActionResult actual = await controller.GetLaboratoryOrders(hdid);
 
             // Verify
             Assert.IsType<JsonResult>(actual);
@@ -219,7 +219,7 @@ namespace HealthGateway.LaboratoryTests
             LaboratoryController controller = new LaboratoryController(loggerFactory.CreateLogger<LaboratoryController>(), svcMock.Object, httpContextAccessorMock.Object);
 
             // Act
-            IActionResult actual = await controller.GetLaboratoryReport(guid);
+            IActionResult actual = await controller.GetLaboratoryReport(guid, hdid);
 
             // Verify
             Assert.IsType<JsonResult>(actual);
@@ -287,7 +287,7 @@ namespace HealthGateway.LaboratoryTests
             LaboratoryController controller = new LaboratoryController(loggerFactory.CreateLogger<LaboratoryController>(), svcMock.Object, httpContextAccessorMock.Object);
 
             // Act
-            IActionResult actual = await controller.GetLaboratoryReport(guid);
+            IActionResult actual = await controller.GetLaboratoryReport(guid, hdid);
 
             // Verify
             Assert.IsType<JsonResult>(actual);

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
@@ -244,7 +244,7 @@ export default class LaboratoryTimelineComponent extends Vue {
   private getReport() {
     this.isLoadingDocument = true;
     this.laboratoryService
-        .getReportDocument(this.entry.id, this.user.hdid)
+      .getReportDocument(this.entry.id, this.user.hdid)
       .then((result) => {
         const link = document.createElement("a");
         let dateString = moment(this.entry.displayDate)

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
@@ -207,6 +207,7 @@ export default class LaboratoryTimelineComponent extends Vue {
   @Prop() entry!: LaboratoryTimelineEntry;
   @Prop() index!: number;
   @Prop() datekey!: string;
+  @Getter("user", { namespace: "user" }) user!: User;
 
   @Ref("messageModal")
   readonly messageModal!: MessageModalComponent;
@@ -243,7 +244,7 @@ export default class LaboratoryTimelineComponent extends Vue {
   private getReport() {
     this.isLoadingDocument = true;
     this.laboratoryService
-      .getReportDocument(this.entry.id)
+        .getReportDocument(this.entry.id, this.user.hdid)
       .then((result) => {
         const link = document.createElement("a");
         let dateString = moment(this.entry.displayDate)

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -66,7 +66,7 @@ export interface IMedicationService {
 export interface ILaboratoryService {
   initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
   getOrders(hdid: string): Promise<RequestResult<LaboratoryOrder[]>>;
-  getReportDocument(reportId: string): Promise<RequestResult<LaboratoryReport>>;
+  getReportDocument(reportId: string, hdid: string): Promise<RequestResult<LaboratoryReport>>;
 }
 
 export interface IConfigService {

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -66,7 +66,10 @@ export interface IMedicationService {
 export interface ILaboratoryService {
   initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
   getOrders(hdid: string): Promise<RequestResult<LaboratoryOrder[]>>;
-  getReportDocument(reportId: string, hdid: string): Promise<RequestResult<LaboratoryReport>>;
+  getReportDocument(
+    reportId: string,
+    hdid: string
+  ): Promise<RequestResult<LaboratoryReport>>;
 }
 
 export interface IConfigService {

--- a/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
@@ -35,7 +35,7 @@ export class RestLaboratoryService implements ILaboratoryService {
       }
       this.http
         .getWithCors<RequestResult<LaboratoryOrder[]>>(
-          `${this.baseUri}${this.LABORATORY_BASE_URI}/`
+          `${this.baseUri}${this.LABORATORY_BASE_URI}?hdid=${hdid}`
         )
         .then((requestResult) => {
           resolve(requestResult);
@@ -48,7 +48,8 @@ export class RestLaboratoryService implements ILaboratoryService {
   }
 
   public getReportDocument(
-    reportId: string
+    reportId: string,
+    hdid: string
   ): Promise<RequestResult<LaboratoryReport>> {
     return new Promise((resolve, reject) => {
       if (!this.isEnabled) {
@@ -64,7 +65,7 @@ export class RestLaboratoryService implements ILaboratoryService {
       }
       this.http
         .getWithCors<RequestResult<LaboratoryReport>>(
-          `${this.baseUri}${this.LABORATORY_BASE_URI}/${reportId}/Report/`
+          `${this.baseUri}${this.LABORATORY_BASE_URI}/${reportId}/Report?hdid=${hdid}`
         )
         .then((requestResult) => {
           resolve(requestResult);


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8507](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8507)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
Modified Lab controller to read the resource from the query to allow the authorization handler to secure the access.  The code still uses the bearer token of the authenticated user but this is a first step in allowing proper delegation.

## Testing
- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

### Steps to Reproduce:
Internal defect raised - not a reproducible issue.

### UI Changes
No

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
running npm run lint shows errors in a bunchy of .vue files which I didn't alter but application seems to run fine.  