### PR TITLE
Add subject hdid into the header for AB#8524

### DIFF
--- a/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.Common.Delegates
     using System.Threading.Tasks;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Migrations;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 

--- a/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
@@ -26,6 +26,7 @@ namespace HealthGateway.Common.Delegates
     using System.Threading.Tasks;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
+    using HealthGateway.Database.Migrations;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -35,6 +36,7 @@ namespace HealthGateway.Common.Delegates
     public class RestNotificationSettingsDelegate : INotificationSettingsDelegate
     {
         private const string NotificationSettingsConfigSectionKey = "NotificationSettings";
+        private const string SubjectResourceHeader = "patient";
 
         private readonly ILogger logger;
         private readonly IHttpClientService httpClientService;
@@ -142,9 +144,11 @@ namespace HealthGateway.Common.Delegates
             this.logger.LogDebug($"Sending Notification Settings to PHSA...");
             this.logger.LogTrace($"Bearer token: {bearerToken}");
             using HttpClient client = this.httpClientService.CreateDefaultHttpClient();
+            client.DefaultRequestHeaders.Clear();
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", bearerToken);
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+            client.DefaultRequestHeaders.Add(SubjectResourceHeader, notificationSettings.SubjectHdid);
             try
             {
                 Uri endpoint = new Uri(this.nsConfig.Endpoint);


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8524](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8524)
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Adds the subject identifier for system calls to PHSA into the request headers.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
Since we were clearing the accept headers I cleared all of the other headers.
