### PR TITLE
Implement dynamic OneTime job for AB#8520

### DIFF
--- a/Apps/JobScheduler/src/JobScheduler.csproj
+++ b/Apps/JobScheduler/src/JobScheduler.csproj
@@ -50,7 +50,6 @@
   </ItemGroup>  
   <ItemGroup>
     <Folder Include="Context\" />
-    <Folder Include="Jobs\" />
     <Folder Include="Utils\" />
     <Folder Include="Views\" />
     <Folder Include="Views\DumpHeaders\" />

--- a/Apps/JobScheduler/src/Jobs/OneTimeJob.cs
+++ b/Apps/JobScheduler/src/Jobs/OneTimeJob.cs
@@ -1,0 +1,123 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace Healthgateway.JobScheduler.Jobs
+{
+    using System;
+    using Hangfire;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Context;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using Healthgateway.JobScheduler.Tasks;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The OneTimeJob will run arbitrary IOneTimeTask (configurable) once.
+    /// </summary>
+    public class OneTimeJob
+    {
+        private const string JobKey = "OneTime";
+        private const string OneTimeClassKey = "TaskClass";
+        private const int ConcurrencyTimeout = 5 * 60; // 5 Minutes
+
+        private readonly IServiceProvider serviceProvider;
+        private readonly IConfiguration configuration;
+        private readonly IConfiguration jobConfig;
+        private readonly ILogger<OneTimeJob> logger;
+        private readonly IApplicationSettingsDelegate applicationSettingsDelegate;
+
+        private readonly GatewayDbContext dbContext;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OneTimeJob"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The dotnet service provider.</param>
+        /// <param name="configuration">The configuration to use.</param>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="dbContext">The db context to use.</param>
+        /// <param name="applicationSettingsDelegate">The job settings in the DB.</param>
+        public OneTimeJob(
+            IServiceProvider serviceProvider,
+            IConfiguration configuration,
+            ILogger<OneTimeJob> logger,
+            GatewayDbContext dbContext,
+            IApplicationSettingsDelegate applicationSettingsDelegate)
+        {
+            this.serviceProvider = serviceProvider;
+            this.configuration = configuration;
+            this.logger = logger;
+            this.dbContext = dbContext;
+            this.applicationSettingsDelegate = applicationSettingsDelegate;
+            this.jobConfig = this.configuration.GetSection($"{JobKey}");
+        }
+
+        /// <summary>
+        /// Reads
+        /// </summary>
+        [DisableConcurrentExecution(ConcurrencyTimeout)]
+        public void Process()
+        {
+            this.logger.LogInformation("OneTimeJob Starting");
+            string? className = this.jobConfig.GetValue<string>(OneTimeClassKey);
+            if (className != null)
+            {
+                Type? taskType = Type.GetType(className);
+                if (taskType != null)
+                {
+                    this.logger.LogInformation($"OneTimeJob will invoke {taskType.Name}");
+                    ApplicationSetting hasRunAppSetting = this.applicationSettingsDelegate.GetApplicationSetting(
+                            ApplicationType.JobScheduler,
+                            this.GetType().Name,
+                            className);
+                    if (hasRunAppSetting == null)
+                    {
+                        this.logger.LogInformation($"OneTimeJob is invoking {className}");
+                        Type? type = Type.GetType(className);
+                        IOneTimeTask task = (IOneTimeTask)ActivatorUtilities.CreateInstance(this.serviceProvider, type);
+                        task.Run();
+                        this.logger.LogInformation($"OneTimeJob is marking class {taskType.Name} as invoked");
+                        hasRunAppSetting = new ApplicationSetting()
+                        {
+                            Application = ApplicationType.JobScheduler,
+                            Component = this.GetType().Name,
+                            Key = className,
+                            Value = true.ToString(),
+                        };
+                        this.applicationSettingsDelegate.AddApplicationSetting(hasRunAppSetting);
+                        this.logger.LogInformation($"OneTimeJob is commiting DB changes");
+                        this.dbContext.SaveChanges();
+                    }
+                    else
+                    {
+                        this.logger.LogInformation($"OneTimeJob has invoked {taskType.Name} before and will exit");
+                    }
+                }
+                else
+                {
+                    throw new TypeLoadException($"Unable to find Task Type {className}");
+                }
+            }
+            else
+            {
+                this.logger.LogInformation($"OneTime job is not configured to run anything");
+            }
+            this.logger.LogInformation($"OneTimeJob Finished running");
+        }
+}
+}

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -101,6 +101,7 @@ namespace HealthGateway.JobScheduler
             services.AddTransient<IMessagingVerificationDelegate, DBMessagingVerificationDelegate>();
             services.AddTransient<IEmailQueueService, EmailQueueService>();
             services.AddTransient<INotificationSettingsDelegate, RestNotificationSettingsDelegate>();
+            services.AddTransient<INotificationSettingsService, NotificationSettingsService>();
 
             // Add injection for KeyCloak User Admin
             services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
@@ -156,6 +157,7 @@ namespace HealthGateway.JobScheduler
             SchedulerHelper.ScheduleDrugLoadJob<ProvincialDrugJob>(this.configuration, "PharmaCareDrugFile");
             SchedulerHelper.ScheduleJob<NotifyUpdatedLegalAgreementsJob>(this.configuration, "NotifyUpdatedLegalAgreements", j => j.Process());
             SchedulerHelper.ScheduleJob<CloseAccountJob>(this.configuration, "CloseAccounts", j => j.Process());
+            SchedulerHelper.ScheduleJob<OneTimeJob>(this.configuration, "OneTime", j => j.Process());
 
             app.UseStaticFiles(new StaticFileOptions
             {

--- a/Apps/JobScheduler/src/Tasks/IOneTimeTask.cs
+++ b/Apps/JobScheduler/src/Tasks/IOneTimeTask.cs
@@ -1,0 +1,29 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace Healthgateway.JobScheduler.Tasks
+{
+    /// <summary>
+    /// A task that should be invoked only once from the OneTimeJob.
+    /// Any DB access should not commit and should defer to the Job to do so.
+    /// </summary>
+    public interface IOneTimeTask
+    {
+        /// <summary>
+        /// Runs the task that needs to be done for the IOneTimeTask.
+        /// </summary>
+        void Run();
+    }
+}

--- a/Apps/JobScheduler/src/Tasks/SendValidatedUsersToPHSA.cs
+++ b/Apps/JobScheduler/src/Tasks/SendValidatedUsersToPHSA.cs
@@ -1,0 +1,83 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace Healthgateway.JobScheduler.Tasks
+{
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using HealthGateway.Database.Context;
+    using HealthGateway.Database.Models;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Queries the Health Gateway DB for all current users with emails.
+    /// Queues NotificationSettings job for each.
+    /// </summary>
+    public class SendValidatedUsersToPHSA : IOneTimeTask
+    {
+        private readonly IConfiguration configuration;
+        private readonly ILogger<SendValidatedUsersToPHSA> logger;
+        private readonly GatewayDbContext dbContext;
+        private readonly INotificationSettingsService notificationSettingsService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SendValidatedUsersToPHSA"/> class.
+        /// </summary>
+        /// <param name="configuration">The configuration to use.</param>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="dbContext">The db context to use.</param>
+        /// <param name="notificationSettingsService">The notification settings service.</param>
+        public SendValidatedUsersToPHSA(
+                IConfiguration configuration,
+                ILogger<SendValidatedUsersToPHSA> logger,
+                GatewayDbContext dbContext,
+                INotificationSettingsService notificationSettingsService)
+        {
+            this.configuration = configuration;
+            this.logger = logger;
+            this.dbContext = dbContext;
+            this.notificationSettingsService = notificationSettingsService;
+        }
+
+        /// <summary>
+        /// Runs the task that needs to be done for the IOneTimeTask.
+        /// </summary>
+        public void Run()
+        {
+            this.logger.LogInformation($"Performing Task {this.GetType().Name}");
+            IEnumerable<UserProfile> users = this.dbContext.UserProfile.Where(q => !string.IsNullOrEmpty(q.Email)).ToList();
+            this.logger.LogInformation($"Queueing NotificationSettings for {users.Count()} users");
+            foreach (UserProfile user in users)
+            {
+                NotificationSettingsRequest nsr = new NotificationSettingsRequest()
+                {
+                    SubjectHdid = user.HdId,
+                    EmailAddress = user.Email,
+                    EmailEnabled = true,
+                };
+
+                // Queue each push to PHSA in the Job Scheduler
+                this.notificationSettingsService.QueueNotificationSettings(nsr);
+            }
+
+            this.logger.LogInformation($"Task {this.GetType().Name} has completed");
+        }
+    }
+}

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -1,7 +1,9 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "ForwardProxies": {
@@ -151,5 +153,11 @@
     "ResponseType": "code",
     "Scope": "openid",
     "RequireHttpsMetadata": "false"
+  },
+  "OneTime": {
+    "Id": "Onetime Task Runner",
+    "Schedule": "20 0 * * *",
+    "Immediate": "false",
+    "Delay": 60,
   }
 }

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -1,7 +1,9 @@
 ﻿{
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
   "ForwardProxies": {


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8520](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8520)
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
A generic facility to run one time tasks for Health Gateway.
First task created is to push PHSA Notification Settings for all existing users with a valid email.

Fixed logging issue in WebClient and Hangfire.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
N/A

### UI Changes
No

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
The default configuration will not run any job, we will have to add an OpenShift configuration to add the specific for: 
  "OneTime": {
    "TaskClass": "Healthgateway.JobScheduler.Tasks.SendValidatedUsersToPHSA"
  }