### PR TITLE
Fix long list query bug for AB#8252

### DIFF
--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -10,7 +10,7 @@
     "Enabled": "false"
   },
   "OpenIdConnect": {
-    "Audience": "healthgateway-local",
+    "Audience": "healthgateway",
     "Authority": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/ff09qn3f",
     "ClientId": "healthgateway-local",
     "RequireHttpsMetadata": "false"

--- a/Apps/Laboratory/src/appsettings.Development.json
+++ b/Apps/Laboratory/src/appsettings.Development.json
@@ -10,7 +10,7 @@
     "Enabled": "false"
   },
   "OpenIdConnect": {
-    "Audience": "healthgateway-local",
+    "Audience": "healthgateway",
     "Authority": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/ff09qn3f",
     "ClientId": "healthgateway-local",
     "RequireHttpsMetadata": "false"

--- a/Apps/Medication/src/appsettings.Development.json
+++ b/Apps/Medication/src/appsettings.Development.json
@@ -2,6 +2,7 @@
   "Logging": {
     "LogLevel": {
       "HealthGateway.Common.Instrumentation": "Trace",
+      "Microsoft.EntityFrameworkCore.Database.Command": "Information",
       "Default": "Error",
       "System": "Information",
       "Microsoft": "Error"
@@ -13,7 +14,7 @@
   "OpenIdConnect": {
     "Authority": "https://sso-dev.pathfinder.gov.bc.ca/auth/realms/ff09qn3f",
     "RequireHttpsMetadata": "false",
-    "Audience": "healthgateway-local",
+    "Audience": "healthgateway",
     "ClientId": "healthgateway-local"
   },
   "HNClient": {

--- a/Apps/Medication/test/unit/Controllers/MedicationController_Test.cs
+++ b/Apps/Medication/test/unit/Controllers/MedicationController_Test.cs
@@ -54,7 +54,7 @@ namespace HealthGateway.Medication.Test
             serviceMock.Setup(s => s.GetMedications(It.IsAny<List<string>>())).Returns(new Dictionary<string, MedicationResult>());
 
             List<string> drugIdentifiers = new List<string>() { "000001", "000003", "000003" };
-            List<string> paddedDinList = drugIdentifiers.Select(x => x.PadLeft(8, '0')).ToList();
+            List<string> paddedDinList = drugIdentifiers.Select(x => x.PadLeft(8, '0')).Distinct().ToList();
             MedicationController controller = new MedicationController(serviceMock.Object);
 
             // Act

--- a/Apps/Medication/test/unit/Controllers/MedicationController_Test.cs
+++ b/Apps/Medication/test/unit/Controllers/MedicationController_Test.cs
@@ -54,7 +54,7 @@ namespace HealthGateway.Medication.Test
             serviceMock.Setup(s => s.GetMedications(It.IsAny<List<string>>())).Returns(new Dictionary<string, MedicationResult>());
 
             List<string> drugIdentifiers = new List<string>() { "000001", "000003", "000003" };
-            List<string> paddedDinList = drugIdentifiers.Select(x => x.PadLeft(8, '0')).Distinct().ToList();
+            List<string> paddedDinList = drugIdentifiers.Select(x => x.PadLeft(8, '0')).ToList();
             MedicationController controller = new MedicationController(serviceMock.Object);
 
             // Act

--- a/Apps/Patient/src/appsettings.json
+++ b/Apps/Patient/src/appsettings.json
@@ -10,7 +10,7 @@
         "KnownProxies": []
     },
     "OpenIdConnect": {
-        "Audience": "healthgateway-local"
+        "Audience": "healthgateway"
     },
     "SwaggerSettings": {
         "RoutePrefix": "swagger",


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8252](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8252)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
Queries to fetch drug information with lists were not normalizing the list before running the query.
Updated the queries to use the distinct list.

Updated AppSettings.Development.json to use the healthgateway audience as keycloak is not returning that for the local client.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
Not visible via UI, data being returned to UI should be smaller and may have some performance gain.

### UI Changes
No

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.
Manually tested the App which appear to be working normally.

## Notes/Additional Comments
N/A