### PR TITLE
Fixes protective word modal not showing

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/covid.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/covid.vue
@@ -56,7 +56,7 @@ export default class CovidModalComponent extends Vue {
   @Prop({ default: false }) isLoading!: boolean;
 
   public isVisible: boolean = false;
-  private show: boolean = false;
+  public show: boolean = false;
 
   public showModal() {
     this.show = true;

--- a/Apps/WebClient/src/ClientApp/src/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/timeline.vue
@@ -423,7 +423,7 @@ export default class TimelineView extends Vue {
           this.sortEntries();
           this.applyTimelineFilter();
         } else if (results.resultStatus == ResultType.Protected) {
-          if (this.covidModal.isVisible) {
+          if (!this.covidModal.show) {
             this.protectiveWordModal.showModal();
           }
           this.protectiveWordAttempts++;


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8527](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8527)
- [ ] Enhancement
- [x] Bug
- [ ] Documentation

## Description:
Fixes protective word modal not showing when no results from lab/covid.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### Steps to Reproduce:
login with protected user.
If no covid results protected word modal does not show up.
modal should show up.