### PR TITLE
Fix for not stacking the comments and buttons of the timeline cards on small screens/mobile

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/comment.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/comment.vue
@@ -3,7 +3,7 @@
 
 .comment-body {
     background-color: $lightGrey;
-    border-radius: 10px;
+    border-radius: 0px 0px 10px 10px;
 }
 
 .editing {
@@ -70,7 +70,7 @@
                     </b-dropdown>
                 </div>
             </b-row>
-            <b-row v-if="inputShowing" class="comment-body p-2 my-1">
+            <b-row v-if="inputShowing" class="comment-body p-2">
                 <b-col
                     v-if="isNewComment"
                     cols="auto"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/commentSection.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/commentSection.vue
@@ -4,70 +4,82 @@
 :not(.collapsed) > .when-closed {
     display: none;
 }
+
+.commentSection {
+    padding-left: 0px;
+    padding-right: 0px;
+}
 </style>
 <template>
-    <div>
-        <b-row class="pt-2">
-            <b-col>
-                <div v-if="hasComments" class="d-flex flex-row-reverse">
-                    <b-btn
-                        v-b-toggle="'entryComments-' + parentEntry.id"
-                        variant="link"
-                        class="px-0 py-2"
-                        @click="toggleComments()"
-                    >
-                        <span class="when-opened">
-                            <font-awesome-icon
-                                icon="chevron-up"
-                                aria-hidden="true"
-                            ></font-awesome-icon
-                        ></span>
-                        <span class="when-closed">
-                            <font-awesome-icon
-                                icon="chevron-down"
-                                aria-hidden="true"
-                            ></font-awesome-icon
-                        ></span>
-                        <span>
-                            {{
-                                comments.length > 1
-                                    ? comments.length + " comments"
-                                    : "1 comment"
-                            }}</span
-                        >
-                    </b-btn>
-                </div>
-            </b-col>
-        </b-row>
-        <b-row>
-            <b-col>
-                <Comment
-                    :comment="newComment"
-                    @on-comment-added="onAdd"
-                ></Comment>
-            </b-col>
-        </b-row>
-        <b-row>
-            <b-col>
-                <b-collapse :id="'entryComments-' + parentEntry.id">
-                    <div v-if="!isLoadingComments">
-                        <div v-for="comment in comments" :key="comment.id">
-                            <Comment
-                                :comment="comment"
-                                @needs-update="needsUpdate"
-                            ></Comment>
+    <b-row>
+        <b-col class="commentSection">
+            <div>
+                <b-row class="pt-2">
+                    <b-col>
+                        <div v-if="hasComments" class="d-flex flex-row-reverse">
+                            <b-btn
+                                v-b-toggle="'entryComments-' + parentEntry.id"
+                                variant="link"
+                                class="px-0 py-2"
+                                @click="toggleComments()"
+                            >
+                                <span class="when-opened">
+                                    <font-awesome-icon
+                                        icon="chevron-up"
+                                        aria-hidden="true"
+                                    ></font-awesome-icon
+                                ></span>
+                                <span class="when-closed">
+                                    <font-awesome-icon
+                                        icon="chevron-down"
+                                        aria-hidden="true"
+                                    ></font-awesome-icon
+                                ></span>
+                                <span>
+                                    {{
+                                        comments.length > 1
+                                            ? comments.length + " comments"
+                                            : "1 comment"
+                                    }}</span
+                                >
+                            </b-btn>
                         </div>
-                    </div>
-                    <div v-else>
-                        <div class="d-flex align-items-center">
-                            <strong>Loading...</strong>
-                            <b-spinner class="ml-5"></b-spinner>
-                        </div>
-                    </div>
-                </b-collapse>
-            </b-col>
-        </b-row>
-    </div>
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col>
+                        <Comment
+                            :comment="newComment"
+                            @on-comment-added="onAdd"
+                        ></Comment>
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col>
+                        <b-collapse :id="'entryComments-' + parentEntry.id">
+                            <div v-if="!isLoadingComments">
+                                <div
+                                    v-for="comment in comments"
+                                    :key="comment.id"
+                                >
+                                    <Comment
+                                        :comment="comment"
+                                        @needs-update="needsUpdate"
+                                    ></Comment>
+                                </div>
+                            </div>
+                            <div v-else>
+                                <div class="d-flex align-items-center">
+                                    <strong>Loading...</strong>
+                                    <b-spinner class="ml-5"></b-spinner>
+                                </div>
+                            </div>
+                        </b-collapse>
+                    </b-col>
+                </b-row>
+            </div>
+        </b-col>
+    </b-row>
 </template>
 <script lang="ts">
 import Vue from "vue";

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/immunization.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/immunization.vue
@@ -41,8 +41,8 @@ $radius: 15px;
 }
 
 .commentSection {
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 0px;
+    padding-right: 0px;
 }
 
 .collapsed > .when-opened,

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/immunization.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/immunization.vue
@@ -40,6 +40,11 @@ $radius: 15px;
     margin-top: 15px;
 }
 
+.commentSection {
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
 .collapsed > .when-opened,
 :not(.collapsed) > .when-closed {
     display: none;
@@ -59,8 +64,7 @@ $radius: 15px;
                 {{ entry.immunization.name }}
             </b-col>
         </b-row>
-        <b-row class="my-2">
-            <b-col class="leftPane"></b-col>
+        <b-row class="commentSection">
             <b-col>
                 <CommentSection :parent-entry="entry"></CommentSection>
             </b-col>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/immunization.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/immunization.vue
@@ -40,11 +40,6 @@ $radius: 15px;
     margin-top: 15px;
 }
 
-.commentSection {
-    padding-left: 0px;
-    padding-right: 0px;
-}
-
 .collapsed > .when-opened,
 :not(.collapsed) > .when-closed {
     display: none;
@@ -64,11 +59,7 @@ $radius: 15px;
                 {{ entry.immunization.name }}
             </b-col>
         </b-row>
-        <b-row class="commentSection">
-            <b-col>
-                <CommentSection :parent-entry="entry"></CommentSection>
-            </b-col>
-        </b-row>
+        <CommentSection :parent-entry="entry"></CommentSection>
     </b-col>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
@@ -39,6 +39,11 @@ $radius: 15px;
     margin-top: 15px;
 }
 
+.commentSection {
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
 .commentButton {
     border-radius: $radius;
 }
@@ -196,6 +201,10 @@ $radius: 15px;
                         </b-collapse>
                     </b-col>
                 </b-row>
+            </b-col>
+        </b-row>
+        <b-row>
+            <b-col class="commentSection">
                 <CommentSection :parent-entry="entry"></CommentSection>
             </b-col>
         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
@@ -40,8 +40,8 @@ $radius: 15px;
 }
 
 .commentSection {
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 0px;
+    padding-right: 0px;
 }
 
 .commentButton {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/laboratory.vue
@@ -39,11 +39,6 @@ $radius: 15px;
     margin-top: 15px;
 }
 
-.commentSection {
-    padding-left: 0px;
-    padding-right: 0px;
-}
-
 .commentButton {
     border-radius: $radius;
 }
@@ -203,11 +198,7 @@ $radius: 15px;
                 </b-row>
             </b-col>
         </b-row>
-        <b-row>
-            <b-col class="commentSection">
-                <CommentSection :parent-entry="entry"></CommentSection>
-            </b-col>
-        </b-row>
+        <CommentSection :parent-entry="entry"></CommentSection>
         <MessageModalComponent
             ref="messageModal"
             title="Sensitive Document Download"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/medication.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/medication.vue
@@ -41,8 +41,8 @@ $radius: 15px;
 }
 
 .commentSection {
-    padding-left: 2px;
-    padding-right: 2px;
+    padding-left: 0px;
+    padding-right: 0px;
 }
 
 .commentButton {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/medication.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/medication.vue
@@ -40,11 +40,6 @@ $radius: 15px;
     margin-top: 15px;
 }
 
-.commentSection {
-    padding-left: 0px;
-    padding-right: 0px;
-}
-
 .commentButton {
     border-radius: $radius;
 }
@@ -201,11 +196,7 @@ $radius: 15px;
                 </b-row>
             </b-col>
         </b-row>
-        <b-row>
-            <b-col class="commentSection">
-                <CommentSection :parent-entry="entry"></CommentSection>
-            </b-col>
-        </b-row>
+        <CommentSection :parent-entry="entry"></CommentSection>
     </b-col>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/medication.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/medication.vue
@@ -40,6 +40,11 @@ $radius: 15px;
     margin-top: 15px;
 }
 
+.commentSection {
+    padding-left: 2px;
+    padding-right: 2px;
+}
+
 .commentButton {
     border-radius: $radius;
 }
@@ -194,6 +199,10 @@ $radius: 15px;
                         </b-collapse>
                     </b-col>
                 </b-row>
+            </b-col>
+        </b-row>
+        <b-row>
+            <b-col class="commentSection">
                 <CommentSection :parent-entry="entry"></CommentSection>
             </b-col>
         </b-row>


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8544](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8544)
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
- Fix to not stack the comments and buttons of the timeline cards on small screens/mobile.
- Changes have been added to Medication, Laboratory and Immunization vues.
- Finally I got it working, yeah !
![image](https://user-images.githubusercontent.com/48332333/86070377-6cd0ab80-ba31-11ea-9e7a-335add8bbbbb.png)

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
N/A

### UI Changes
YES

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
N/A
