### PR TITLE
Webclient & Admin run from commandline

### DIFF
--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -143,6 +143,8 @@ namespace HealthGateway.AdminWebClient
                 app.UseResponseCompression();
             }
 
+            bool debugerAttached = System.Diagnostics.Debugger.IsAttached;
+
             app.UseEndpoints(endpoints =>
                 {
                     endpoints.MapControllers();
@@ -150,12 +152,12 @@ namespace HealthGateway.AdminWebClient
                         name: "default",
                         pattern: "{controller}/{action=Index}/{id?}");
 
-                    if (env.IsDevelopment())
+                    if (env.IsDevelopment() && debugerAttached)
                     {
                         endpoints.MapToVueCliProxy(
                             "{*path}",
                             new SpaOptions { SourcePath = "ClientApp" },
-                            npmScript: System.Diagnostics.Debugger.IsAttached ? "serve" : null,
+                            npmScript: "serve",
                             regex: "Compiled successfully",
                             forceKill: true);
                     }
@@ -164,6 +166,11 @@ namespace HealthGateway.AdminWebClient
             app.UseSpa(spa =>
             {
                 spa.Options.SourcePath = "ClientApp";
+                if (env.IsDevelopment() && !debugerAttached)
+                {
+                    // change this to whatever webpack dev server says it's running on
+                    spa.UseProxyToSpaDevelopmentServer("http://localhost:8080");
+                }
             });
         }
 

--- a/Apps/HealthGateway.code-workspace
+++ b/Apps/HealthGateway.code-workspace
@@ -45,10 +45,6 @@
       "path": "WebClient"
     },
     {
-      "name": "Dolphin",
-      "path": "/home/dev/Development/HealthGateway/Tools/Dolphin"
-    },
-    {
       "path": "Laboratory"
     }
   ],

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -153,6 +153,8 @@ namespace HealthGateway.WebClient
                 app.UseResponseCompression();
             }
 
+            bool debugerAttached = System.Diagnostics.Debugger.IsAttached;
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapRazorPages();
@@ -163,15 +165,25 @@ namespace HealthGateway.WebClient
                     name: "default",
                     pattern: "{controller}/{action=Index}/{id?}");
 
-                if (env.IsDevelopment())
+                if (env.IsDevelopment() && debugerAttached)
                 {
                     endpoints.MapToVueCliProxy(
                         "{*path}",
                         new SpaOptions { SourcePath = "ClientApp" },
-                        npmScript: System.Diagnostics.Debugger.IsAttached ? "serve" : null,
+                        npmScript: "serve",
                         port:8585,
                         regex: "Compiled successfully",
                         forceKill: true);
+                }
+            });
+
+            app.UseSpa(spa =>
+            {
+                spa.Options.SourcePath = "ClientApp";
+                if (env.IsDevelopment() && !debugerAttached)
+                {
+                    // change this to whatever webpack dev server says it's running on
+                    spa.UseProxyToSpaDevelopmentServer("http://localhost:8080");
                 }
             });
 


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8616](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8616)
- [x] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Server can be run from command line and connect to an already running node server
dotnet run
npm run serve

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

### UI Changes
NO