### PR TITLE
Fix for showing notes on correct date

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/calendar/header.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/calendar/header.vue
@@ -101,9 +101,9 @@ export default class CalendarComponent extends Vue {
     }
 
     private dispatchEvent() {
-        this.title = moment(this.currentDate).format(this.titleFormat);
         let startDate = DateUtil.getMonthFirstDate(this.headerDate);
         this.$emit("update:currentDate", startDate);
+        this.title = moment(startDate).format(this.titleFormat);
     }
 }
 </script>

--- a/Apps/WebClient/src/ClientApp/src/components/calendar/header.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/calendar/header.vue
@@ -76,6 +76,12 @@ export default class CalendarComponent extends Vue {
     @Prop() titleFormat!: string;
 
     private headerDate: Date = new Date();
+    private leftIcon: string = "chevron-left";
+    private rightIcon: string = "chevron-right";
+
+    public get title(): string {
+        return moment(this.currentDate).format(this.titleFormat);
+    }
 
     @Watch("currentDate")
     public onCurrentDateChange(currentDate: Date) {
@@ -85,10 +91,6 @@ export default class CalendarComponent extends Vue {
     private created() {
         this.dispatchEvent();
     }
-
-    private title: string = "";
-    private leftIcon: string = "chevron-left";
-    private rightIcon: string = "chevron-right";
 
     private previousMonth() {
         this.headerDate = DateUtil.changeMonth(this.currentDate, -1);
@@ -103,7 +105,6 @@ export default class CalendarComponent extends Vue {
     private dispatchEvent() {
         let startDate = DateUtil.getMonthFirstDate(this.headerDate);
         this.$emit("update:currentDate", startDate);
-        this.title = moment(startDate).format(this.titleFormat);
     }
 }
 </script>


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8608](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8608)
- [] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
- Fixed the broken left (<--) & right (-->) navigation which displays the wrong month title on the Calendar vue.
![image](https://user-images.githubusercontent.com/48332333/86491777-8703d580-bd20-11ea-82fe-66677c60cea4.png)

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
- Open Timeline vue.
- Add a new note for a specific date.
- Make sure that the note icon displays for that date on the Month vue.

### UI Changes
YES

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [X] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
N/A
