### PR TITLE
Fixes reload of note after save

### DIFF
--- a/Apps/Database/src/Delegates/DBNoteDelegate.cs
+++ b/Apps/Database/src/Delegates/DBNoteDelegate.cs
@@ -47,13 +47,13 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc />
-        public DBResult<Note> GetNote(Guid noteId)
+        public DBResult<Note> GetNote(Guid noteId, string hdid)
         {
             DBResult<Note> result = new DBResult<Note>()
             {
                 Status = DBStatusCode.NotFound,
             };
-            result.Payload = this.dbContext.Note.Find(noteId);
+            result.Payload = this.dbContext.Note.Find(noteId, hdid);
             if (result.Payload != null)
             {
                 result.Status = DBStatusCode.Read;
@@ -93,7 +93,10 @@ namespace HealthGateway.Database.Delegates
                 {
                     this.dbContext.SaveChanges();
                     result.Status = DBStatusCode.Created;
-                    result.Payload = this.GetNote(note.Id).Payload;
+
+                    // Forces the refresh from the database.
+                    this.dbContext.Entry(note).State = EntityState.Detached;
+                    result.Payload = this.dbContext.Note.Find(note.Id, note.HdId);
                 }
                 catch (DbUpdateException e)
                 {

--- a/Apps/Database/src/Delegates/INoteDelegate.cs
+++ b/Apps/Database/src/Delegates/INoteDelegate.cs
@@ -29,8 +29,9 @@ namespace HealthGateway.Database.Delegates
         /// Gets a note from the DB using the noteId.
         /// </summary>
         /// <param name="noteId">The Note ID to retrieve.</param>
+        /// <param name="hdid">The user hdid.</param>
         /// <returns>The note wrapped in a DBResult.</returns>
-        DBResult<Note> GetNote(Guid noteId);
+        DBResult<Note> GetNote(Guid noteId, string hdid);
 
         /// <summary>
         /// Gets a list of notes ordered by the journal datetime for the given HdId.


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8671](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8671)
- [ ] Enhancement
- [x] Bug
- [ ] Documentation

## Description:
Fixes the reload of the note object after a save to the database.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required