### PR TITLE
Designed and Implemented DB Model and DB Delegate for Communication from Admin Module to Gateway Users

### DIFF
--- a/Apps/Database/src/Constants/EmailTo.cs
+++ b/Apps/Database/src/Constants/EmailTo.cs
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Database.Constants
+{
+    /// <summary>
+    /// Represents the To of emails.
+    /// </summary>
+    public static class EmailTo
+    {
+        /// <summary>
+        /// Constant value to represent undisclosed-recipients of the To field of the email.
+        /// </summary>
+        public const string UndisclosedRecipients = "undisclosed-recipients";
+    }
+}

--- a/Apps/Database/src/Delegates/DBEmailDelegate.cs
+++ b/Apps/Database/src/Delegates/DBEmailDelegate.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
 //  Copyright © 2019 Province of British Columbia
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -89,6 +89,17 @@ namespace HealthGateway.Database.Delegates
 
             this.logger.LogDebug($"Finished inserting email to DB. {JsonSerializer.Serialize(email)}");
             return email.Id;
+        }
+
+        /// <inheritdoc />
+        public Guid InsertBatchEmail(Email email, bool shouldCommit = true)
+        {
+            this.logger.LogTrace($"Inserting batch email to DB... {email}");
+            email.To = EmailTo.UndisclosedRecipients;
+            var retValue = this.InsertEmail(email, shouldCommit);
+
+            this.logger.LogDebug($"Finished inserting batch email to DB. {JsonSerializer.Serialize(email)}");
+            return retValue;
         }
 
         /// <inheritdoc />

--- a/Apps/Database/src/Delegates/IEmailDelegate.cs
+++ b/Apps/Database/src/Delegates/IEmailDelegate.cs
@@ -1,4 +1,4 @@
-﻿// -------------------------------------------------------------------------
+// -------------------------------------------------------------------------
 //  Copyright © 2019 Province of British Columbia
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,6 +58,14 @@ namespace HealthGateway.Database.Delegates
         /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
         /// <returns>Returns the guid of the saved email.</returns>
         Guid InsertEmail(Email email, bool shouldCommit = true);
+
+        /// <summary>
+        /// Inserts an batch email using a populated Email object.
+        /// </summary>
+        /// <param name="email">The populated batch email to save.</param>
+        /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
+        /// <returns>Returns the guid of the saved email.</returns>
+        Guid InsertBatchEmail(Email email, bool shouldCommit = true);
 
         /// <summary>
         /// Updates an email using a populated Email object.


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8635](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8635) & 8636
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description: 
**Important notes** for the design, Leo would like to review this design on Monday to make sure.
Design:
- to send the same message to a batch of recipients message.To.Add (new GroupAddress ("undisclosed-recipients")); // <https://github.com/jstedfast/MailKit/issues/830> 
- We will also need to add a bunch of recipients to the Bcc header and use the normal Send(MimeMessage) (or SendAsync) method.
- Please note that there may be a limitation of around 25-50 recipients for a single message in use by some SMTP servers)

Batch email definition​
- To field always contains the "undisclosed-recipients" value.​
- Bcc field doesn't contain data (or empty)​
How to process a batch email?​
- Batch email will be inserted by different components (i.e. AdminWebClient for Comm email) via a DBEmailDelegate's 

InsertBatchEmail method​
- A batch jobs will pick up these batch emails based on To field above and email's priority.​
- Batch job will create and several emails with the same details of the batch email with the BCC fields popolated with max 25 recipients (per recommendation). I.e. batch job will create 100k users / 25 recipients = 400 emails in the db.​
- Batch job will send these newly created emails.

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
NO

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
N/A
