### PR TITLE
Update landing to get only communication type banner

### DIFF
--- a/Apps/Database/src/Delegates/DBCommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/DBCommunicationDelegate.cs
@@ -45,7 +45,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc />
-        public DBResult<Communication> GetActive()
+        public DBResult<Communication> GetActiveBanner()
         {
             this.logger.LogTrace($"Getting active Communication from DB...");
             DBResult<Communication> result = new DBResult<Communication>()
@@ -54,7 +54,7 @@ namespace HealthGateway.Database.Delegates
             };
             result.Payload = this.dbContext.Communication
                 .OrderByDescending(c => c.CreatedDateTime)
-                .FirstOrDefault(c => c.CommunicationTypeCode == CommunicationType.Email || (DateTime.UtcNow >= c.EffectiveDateTime && DateTime.UtcNow <= c.ExpiryDateTime));
+                .FirstOrDefault(c => c.CommunicationTypeCode == CommunicationType.Banner && (DateTime.UtcNow >= c.EffectiveDateTime && DateTime.UtcNow <= c.ExpiryDateTime));
 
             if (result.Payload != null)
             {

--- a/Apps/Database/src/Delegates/ICommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/ICommunicationDelegate.cs
@@ -25,10 +25,10 @@ namespace HealthGateway.Database.Delegates
     public interface ICommunicationDelegate
     {
         /// <summary>
-        /// Gets the active communication from the DB.
+        /// Gets the active communication banner from the DB.
         /// </summary>
         /// <returns>The Communication wrapped in a DBResult.</returns>
-        DBResult<Communication> GetActive();
+        DBResult<Communication> GetActiveBanner();
 
         /// <summary>
         /// Add the given communication.

--- a/Apps/WebClient/src/Server/Controllers/CommunicationController.cs
+++ b/Apps/WebClient/src/Server/Controllers/CommunicationController.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.WebClient.Controllers
         [HttpGet]
         public IActionResult Get()
         {
-            RequestResult<Communication> result = this.communicationService.GetActive();
+            RequestResult<Communication> result = this.communicationService.GetActiveBanner();
             return new JsonResult(result);
         }
     }

--- a/Apps/WebClient/src/Server/Services/CommunicationService.cs
+++ b/Apps/WebClient/src/Server/Services/CommunicationService.cs
@@ -42,9 +42,9 @@ namespace HealthGateway.WebClient.Services
         }
 
         /// <inheritdoc />
-        public RequestResult<Communication> GetActive()
+        public RequestResult<Communication> GetActiveBanner()
         {
-            DBResult<Communication> dbComm = this.communicationDelegate.GetActive();
+            DBResult<Communication> dbComm = this.communicationDelegate.GetActiveBanner();
             RequestResult<Communication> result = new RequestResult<Communication>()
             {
                 ResourcePayload = dbComm.Payload,

--- a/Apps/WebClient/src/Server/Services/ICommunicationService.cs
+++ b/Apps/WebClient/src/Server/Services/ICommunicationService.cs
@@ -25,9 +25,9 @@ namespace HealthGateway.WebClient.Services
     public interface ICommunicationService
     {
         /// <summary>
-        /// Gets the active communication from the backend.
+        /// Gets the active communication banner from the backend.
         /// </summary>
         /// <returns>The active communication wrapped in a RequestResult.</returns>
-        public RequestResult<Communication> GetActive();
+        public RequestResult<Communication> GetActiveBanner();
     }
 }

--- a/Apps/WebClient/test/unit/Services.Test/CommunicationService_Test.cs
+++ b/Apps/WebClient/test/unit/Services.Test/CommunicationService_Test.cs
@@ -46,13 +46,13 @@ namespace HealthGateway.WebClient.Test.Services
             };
 
             Mock<ICommunicationDelegate> communicationDelegateMock = new Mock<ICommunicationDelegate>();
-            communicationDelegateMock.Setup(s => s.GetActive()).Returns(dbResult);
+            communicationDelegateMock.Setup(s => s.GetActiveBanner()).Returns(dbResult);
 
             ICommunicationService service = new CommunicationService(
                 new Mock<ILogger<CommunicationService>>().Object,
                 communicationDelegateMock.Object
             );
-            RequestResult<Communication> actualResult = service.GetActive();
+            RequestResult<Communication> actualResult = service.GetActiveBanner();
 
             Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
             Assert.True(actualResult.ResourcePayload.IsDeepEqual(communication));


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8637](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8637)
- [x] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
Update webclient to display only communication type "banner"

## Testing
- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
 NO

### Browsers Tested
- [ ] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
Any addtional notes or comments that may be relevant.  Include any specialized deployment steps here.
