### PR TITLE
Fix for Note Popover

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -547,6 +547,8 @@ export default class SidebarComponent extends Vue {
                 transitionEvent.propertyName !== "max-width"
             ) {
                 return;
+            } else {
+                self.isTutorialEnabled = false;
             }
 
             self.isTutorialEnabled = true;
@@ -649,7 +651,10 @@ export default class SidebarComponent extends Vue {
     }
 
     private get isTimeline(): boolean {
-        return this.$route.path == "/timeline";
+        let isTimeLine = this.$route.path == "/timeline";
+        if (isTimeLine && !this.isTutorialEnabled)
+            this.isTutorialEnabled = true;
+        return isTimeLine;
     }
 
     private get isProfile(): boolean {


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8715](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8715)
- [ ] Enhancement
- [X] Bug
- [ ] Documentation

## Description:
- Issue: Popover doesn't display right after user login or when user switches to User Profile page then comes back to the Timeline page.
- The fix manages the Tutorial flag for these 2 scenarios.
- Tested for all the scenarios including the above 2 scenarios and also resizing/mobile/opening sidebar ...

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
YES

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
Any addtional notes or comments that may be relevant.  Include any specialized deployment steps here.
