### PR TITLE
Disable months with no data on month picker 

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/monthYearPicker.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/monthYearPicker.vue
@@ -46,6 +46,10 @@
 .selectHide {
     display: none;
 }
+
+.no-data {
+    background-color: lightgray;
+}
 </style>
 <template>
     <div v-on-clickaway="close" class="select">
@@ -72,12 +76,12 @@
                 {{ selectedYear }}
             </b-col>
             <b-col
-                v-for="(month, i) of months"
+                v-for="(month, i) of monthsToDisplay"
                 :key="i"
-                class="item col-4"
+                :class="getDisplayMonthCss(month)"
                 @click="selectMonth(i)"
             >
-                {{ month }}
+                {{ month.Title }}
             </b-col>
         </b-row>
     </div>
@@ -89,6 +93,12 @@ import { Component, Prop, Watch, Emit } from "vue-property-decorator";
 import moment from "moment";
 import { directive as onClickaway } from "vue-clickaway";
 import { DateGroup } from "@/models/timelineEntry";
+import { mount } from "@vue/test-utils";
+
+class MonthToDisplay {
+    public Title: string = "";
+    public HasData: boolean = false;
+}
 
 @Component({
     directives: {
@@ -104,20 +114,36 @@ export default class MonthYearPickerComponent extends Vue {
     public selectedMonth: number = new Date().getMonth();
     private selectedDate: Date = new Date();
     private years: number[] = [];
-    private months: string[] = [
-        "Jan",
-        "Feb",
-        "Mar",
-        "Apr",
-        "May",
-        "Jun",
-        "Jul",
-        "Aug",
-        "Sep",
-        "Oct",
-        "Nov",
-        "Dec",
-    ];
+    private get monthsToDisplay() {
+        let availableMonthsOfSelectedYear = this.availableMonths.filter(
+            (m) => m.getFullYear() === this.selectedYear
+        );
+        let monthsToDisplay = [
+            { Title: "Jan", HasData: false },
+            { Title: "Feb", HasData: false },
+            { Title: "Mar", HasData: false },
+            { Title: "Apr", HasData: false },
+            { Title: "May", HasData: false },
+            { Title: "Jun", HasData: false },
+            { Title: "Jul", HasData: false },
+            { Title: "Aug", HasData: false },
+            { Title: "Sep", HasData: false },
+            { Title: "Oct", HasData: false },
+            { Title: "Nov", HasData: false },
+            { Title: "Dec", HasData: false },
+        ];
+        availableMonthsOfSelectedYear.forEach((date) => {
+            const month: number = date.getMonth();
+            monthsToDisplay[month].HasData = true;
+        });
+        debugger;
+        return monthsToDisplay;
+    }
+
+    private getDisplayMonthCss(displayMonth: MonthToDisplay) {
+        if (displayMonth.HasData) return "item col-4";
+        else return "item col-4 no-data";
+    }
 
     private get isOpen(): boolean {
         return this.isYearOpen || this.isMonthOpen;
@@ -133,10 +159,16 @@ export default class MonthYearPickerComponent extends Vue {
     }
 
     private selectMonth(month: number): void {
-        this.selectedMonth = month;
-        this.selectedDate = new Date(this.selectedYear, this.selectedMonth, 1);
-        this.dateChanged();
-        this.close();
+        if (this.monthsToDisplay[month].HasData) {
+            this.selectedMonth = month;
+            this.selectedDate = new Date(
+                this.selectedYear,
+                this.selectedMonth,
+                1
+            );
+            this.dateChanged();
+            this.close();
+        }
     }
 
     @Emit()

--- a/Apps/WebClient/src/ClientApp/src/components/monthYearPicker.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/monthYearPicker.vue
@@ -93,7 +93,6 @@ import { Component, Prop, Watch, Emit } from "vue-property-decorator";
 import moment from "moment";
 import { directive as onClickaway } from "vue-clickaway";
 import { DateGroup } from "@/models/timelineEntry";
-import { mount } from "@vue/test-utils";
 
 class MonthToDisplay {
     public Title: string = "";
@@ -136,7 +135,6 @@ export default class MonthYearPickerComponent extends Vue {
             const month: number = date.getMonth();
             monthsToDisplay[month].HasData = true;
         });
-        debugger;
         return monthsToDisplay;
     }
 


### PR DESCRIPTION
## Status
**Ready**

## Fixes or Implements [AB#8687](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/8687) & 8740
- [X] Enhancement
- [ ] Bug
- [ ] Documentation

## Description:
- Disabled months with no data on the calendar's month picker.
- This has fixed also the bug 8740.
- Calendar's years with no data are currently not displaying per Tiago's implementation in another task.
- Manually tested all scenarios including adding new note on calendar

## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

### Steps to Reproduce:
If this is a bug, please provide details on how to reproduce the code.

### UI Changes
YES
![image](https://user-images.githubusercontent.com/48332333/88587945-9c141180-d00b-11ea-92ac-5b9f997b3212.png)

### Browsers Tested
- [X] Chrome
- [ ] Safari
- [ ] Edge
- [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments
Any addtional notes or comments that may be relevant.  Include any specialized deployment steps here.
