### PR TITLE
Split Dependent name similar to Patient for AB#9669

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/dependentCard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependentCard.vue
@@ -44,7 +44,9 @@ export default class DependentCardComponent extends Vue {
 
     private message =
         "Are you sure you want to remove " +
-        this.dependent.dependentInformation.name +
+        this.dependent.dependentInformation.firstname +
+        " " +
+        this.dependent.dependentInformation.lastname +
         " from your list of dependents?";
 
     private isLoading = false;
@@ -128,7 +130,7 @@ export default class DependentCardComponent extends Vue {
                 const link = document.createElement("a");
                 let report: LaboratoryReport = result.resourcePayload;
                 link.href = `data:${report.mediaType};${report.encoding},${report.data}`;
-                link.download = `COVID_Result_${this.dependent.dependentInformation.name}_${labResult.collectedDateTime}.pdf`;
+                link.download = `COVID_Result_${this.dependent.dependentInformation.firstname}${this.dependent.dependentInformation.lastname}_${labResult.collectedDateTime}.pdf`;
                 link.click();
                 URL.revokeObjectURL(link.href);
             })

--- a/Apps/WebClient/src/ClientApp/src/models/dependent.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/dependent.ts
@@ -15,9 +15,14 @@ export interface DependentInformation {
     PHN: string;
 
     /**
-     * The dependent name.
+     * The dependent first name.
      */
-    name: string;
+    firstname: string;
+
+    /**
+     * The dependent last name.
+     */
+    lastname: string;
 
     /**
      * The dependent birth date.

--- a/Apps/WebClient/src/Server/Models/DependentInformation.cs
+++ b/Apps/WebClient/src/Server/Models/DependentInformation.cs
@@ -31,10 +31,16 @@ namespace HealthGateway.WebClient.Models
         public string HdId { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the name of the dependent.
+        /// Gets or sets the patient first name.
         /// </summary>
-        [JsonPropertyName("name")]
-        public string Name { get; set; } = string.Empty;
+        [JsonPropertyName("firstname")]
+        public string FirstName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the patient last name.
+        /// </summary>
+        [JsonPropertyName("lastname")]
+        public string LastName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the Masked PHN of the dependent.
@@ -62,7 +68,8 @@ namespace HealthGateway.WebClient.Models
             DependentInformation result = new DependentInformation()
             {
                 HdId = patientModel.HdId,
-                Name = $"{patientModel.FirstName} {patientModel.LastName} ",
+                FirstName = patientModel.FirstName,
+                LastName = patientModel.LastName,
                 PHN = patientModel.PersonalHealthNumber,
                 Gender = patientModel.Gender,
                 DateOfBirth = patientModel.Birthdate,

--- a/Apps/WebClient/test/unit/Controllers.Test/DependentController_Test.cs
+++ b/Apps/WebClient/test/unit/Controllers.Test/DependentController_Test.cs
@@ -37,7 +37,8 @@ namespace HealthGateway.WebClient.Test.Controllers
         private const string hdid = "mockedHdId";
         private const string token = "Fake Access Token";
         private const string userId = "mockedUserId";
-        private const string dependentName = "mockedDependentName";
+        private const string firstName = "mocked";
+        private const string lastname = "DependentName";
 
         [Fact]
         public void ShouldGetDependents()
@@ -77,7 +78,8 @@ namespace HealthGateway.WebClient.Test.Controllers
                 {
                     DateOfBirth = new DateTime(1980, 1, 1),
                     Gender = "Female",
-                    Name = $"dependentName"
+                    FirstName = firstName,
+                    LastName = lastname,
                 }
             };
             RequestResult<DependentModel> expectedResult = new RequestResult<DependentModel>()
@@ -170,7 +172,8 @@ namespace HealthGateway.WebClient.Test.Controllers
                         PHN = $"{dependentModels}-{i}",
                         DateOfBirth = new DateTime(1980 + i, 1, 1),
                         Gender = "Female",
-                        Name = $"{dependentName}-{i}"
+                        FirstName = "first",
+                        LastName = "last-{i}"
                     }
                 });
             }


### PR DESCRIPTION
# Fixes or Implements [AB#9669](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9669)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

As requested by PHSA, split the dependent name into the first name and last name using the same names as the Patient service.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [X] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Tested in Chrome adding dependent and ran the unit tests.  Looks ok.