### PR TITLE
Fixes dependent covid result tests AB#9652

### DIFF
--- a/Testing/functional/e2e/cypress/integration/dependent/dependents.js
+++ b/Testing/functional/e2e/cypress/integration/dependent/dependents.js
@@ -130,10 +130,11 @@ describe('dependents', () => {
         // Validate the tab and elements are present        
         cy.get('[data-testid=covid19TabTitle]').last().parent().click();
         cy.get('[data-testid=dependentCovidTestDate]').first().should('have.text', ' 2020-10-03 ');
-        cy.get('[data-testid=dependentCovidTestType]').first().should('have.text', ' BAL ');
-        cy.get('[data-testid=dependentCovidTestLocation]').first().should('have.text', ' Viha ');
+        cy.get('[data-testid=dependentCovidTestType]').first().should('have.text', ' Nasopharyngeal Swab ');
+        cy.get('[data-testid=dependentCovidTestLocation]').first().should('have.text', ' Fha ');
         cy.get('[data-testid=dependentCovidTestLabResult]').first().should('have.text', ' Positive ');
         cy.get('[data-testid=dependentCovidReportDownloadBtn]').first().click();
+
         cy.get('[data-testid=covid19TabTitle]').last().parent().click();
         cy.get('[data-testid=dependentCovidTestDate]').last().should('have.text', ' 2020-06-14 ');
         cy.get('[data-testid=dependentCovidTestType]').last().should('have.text', ' Nasopharyngeal Swab ');


### PR DESCRIPTION
# Fixes or Implements [AB#9652](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9652)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Fixes the dependent covid results functional test.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [x] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
