### PR TITLE
Add logs to lab report and error out when no content

### DIFF
--- a/Apps/Laboratory/test/functional/README.md
+++ b/Apps/Laboratory/test/functional/README.md
@@ -1,1 +1,0 @@
-Functional tests to go here.

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -147,7 +147,7 @@ namespace HealthGateway.LaboratoryTests
                 mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
                 ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), mockHttpClientService.Object, this.configuration);
                 RequestResult<IEnumerable<LaboratoryOrder>> actualResult = Task.Run(async () => await labDelegate.GetLaboratoryOrders(string.Empty).ConfigureAwait(true)).Result;
-                Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
+                Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
                 Assert.Empty(actualResult.ResourcePayload);
             }
             finally

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -147,7 +147,7 @@ namespace HealthGateway.LaboratoryTests
                 mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
                 ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), mockHttpClientService.Object, this.configuration);
                 RequestResult<IEnumerable<LaboratoryOrder>> actualResult = Task.Run(async () => await labDelegate.GetLaboratoryOrders(string.Empty).ConfigureAwait(true)).Result;
-                Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
+                Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
                 Assert.Empty(actualResult.ResourcePayload);
             }
             finally
@@ -259,7 +259,7 @@ namespace HealthGateway.LaboratoryTests
                 mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
                 ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), mockHttpClientService.Object, this.configuration);
                 RequestResult<LaboratoryReport> actualResult = Task.Run(async () => await labDelegate.GetLabReport(Guid.NewGuid(), string.Empty).ConfigureAwait(true)).Result;
-                Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
+                Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
             }
             finally
             {


### PR DESCRIPTION
# Fixes or Implements [AB#9676](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9676)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Add logs to lab report and error out when no content.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
