### PR TITLE
Fixes disabled modules showing up on reports page AB#9685

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -9,6 +9,8 @@ import MessageModalComponent from "@/components/modal/genericMessage.vue";
 import MedicationHistoryReportComponent from "@/components/report/medicationHistory.vue";
 import MSPVisitsReportComponent from "@/components/report/mspVisits.vue";
 import { IAuthenticationService } from "@/services/interfaces";
+import type { WebClientConfiguration } from "@/models/configData";
+import { Getter } from "vuex-class";
 
 @Component({
     components: {
@@ -19,6 +21,9 @@ import { IAuthenticationService } from "@/services/interfaces";
     },
 })
 export default class ReportsView extends Vue {
+    @Getter("webClient", { namespace: "config" })
+    config!: WebClientConfiguration;
+
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
     @Ref("medicationHistoryReport")
@@ -29,11 +34,18 @@ export default class ReportsView extends Vue {
     private fullName = "";
     private logger!: ILogger;
     private reportType = "";
-    private reportTypeOptions = [
-        { value: "", text: "Select a service" },
-        { value: "MED", text: "Medications" },
-        { value: "MSP", text: "MSP Visits" },
-    ];
+    private reportTypeOptions = [{ value: "", text: "Select a service" }];
+
+    private mounted() {
+        this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        if (this.config.modules["Medication"]) {
+            this.reportTypeOptions.push({ value: "MED", text: "Medications" });
+        }
+        if (this.config.modules["Encounter"]) {
+            this.reportTypeOptions.push({ value: "MSP", text: "MSP Visits" });
+        }
+        this.loadName();
+    }
 
     private showConfirmationModal() {
         this.messageModal.showModal();
@@ -48,11 +60,6 @@ export default class ReportsView extends Vue {
                 this.mspVisitsReport.generatePdf();
                 break;
         }
-    }
-
-    private mounted() {
-        this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-        this.loadName();
     }
 
     private loadName(): void {

--- a/Testing/functional/e2e/cypress/integration/report/report.js
+++ b/Testing/functional/e2e/cypress/integration/report/report.js
@@ -4,6 +4,7 @@ describe('Reports', () => {
     let sensitiveDocText = ' The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off. ';
     before(() => {
         cy.readConfig().as("config").then(config => {
+            config.webClient.modules.Encounter = true
             cy.server();
             cy.route('GET', '/v1/api/configuration/', config);
             cy.login(Cypress.env('keycloak.username'), Cypress.env('keycloak.password'), AuthMethod.KeyCloak, "/reports");


### PR DESCRIPTION
# Fixes or Implements [AB#9685](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9685)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

MSP Vistis and Medication report types are now configurable.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
