### PR TITLE
Enable delete old emails job AB#9658

### DIFF
--- a/Apps/Database/src/Delegates/DBEmailDelegate.cs
+++ b/Apps/Database/src/Delegates/DBEmailDelegate.cs
@@ -172,6 +172,8 @@ namespace HealthGateway.Database.Delegates
             List<Email> oldIds = this.dbContext.Email
                                 .Where(email => email.EmailStatusCode == EmailStatus.Processed &&
                                                 email.CreatedDateTime.Date <= DateTime.UtcNow.AddDays(daysAgo * -1).Date)
+                                .Where(email => !this.dbContext.CommunicationEmail.Any(commEmail => commEmail.EmailId == email.Id))
+                                .Where(email => !this.dbContext.MessagingVerification.Any(msgVerification => msgVerification.EmailId == email.Id))
                                 .Select(email => new Email { Id = email.Id, Version = email.Version })
                                 .Take(maxRows)
                                 .ToList();

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -196,8 +196,7 @@ namespace HealthGateway.JobScheduler
             SchedulerHelper.ScheduleJob<CloseAccountJob>(this.configuration, "CloseAccounts", j => j.Process());
             SchedulerHelper.ScheduleJob<OneTimeJob>(this.configuration, "OneTime", j => j.Process());
             SchedulerHelper.ScheduleJob<CleanCacheJob>(this.configuration, "CleanCache", j => j.Process());
-
-            // SchedulerHelper.ScheduleJob<DeleteEmailJob>(this.configuration, "DeleteEmailJob", j => j.DeleteOldEmails());
+            SchedulerHelper.ScheduleJob<DeleteEmailJob>(this.configuration, "DeleteEmailJob", j => j.DeleteOldEmails());
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#9658](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9658)

* [x] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Enable delete old emails job.
Fixes job to delete only emails not tied on a FK with Communications and MessagingVerification tables.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
