### PR TITLE
Update dependent error handling AB#9707

### DIFF
--- a/Apps/Common/src/Constants/ErrorMessages.cs
+++ b/Apps/Common/src/Constants/ErrorMessages.cs
@@ -13,13 +13,23 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Medication.Constants
+namespace HealthGateway.Common.Constants
 {
     /// <summary>
     /// Common area for error messages.
     /// </summary>
     public static class ErrorMessages
     {
+        /// <summary>
+        /// Error message to return when patient has no hdid.
+        /// </summary>
+        public const string HdIdNotFound = "Please ensure you are using a current BC Services Card.";
+
+        /// <summary>
+        /// Error message to return patient data does not match request.
+        /// </summary>
+        public const string DataMismatch = "The information you entered does not match our records. Please try again.";
+    
         /// <summary>
         /// Error message to return when a Pharmanet record is protected.
         /// </summary>
@@ -43,6 +53,5 @@ namespace HealthGateway.Medication.Constants
         /// <summary>
         /// Error message to return when a patient phn was not found.
         /// </summary>
-        public const string PhnNotFoundErrorMessage = "PHN could not be retrieved";
-    }
+        public const string PhnNotFoundErrorMessage = "PHN could not be retrieved";}
 }

--- a/Apps/Common/src/Constants/ResultType.cs
+++ b/Apps/Common/src/Constants/ResultType.cs
@@ -21,7 +21,7 @@ namespace HealthGateway.Common.Constants
     public enum ResultType
     {
         /// <summary>
-        /// Represents an error condition.
+        /// Represents a system error condition.
         /// </summary>
         Error = 0,
 
@@ -31,8 +31,8 @@ namespace HealthGateway.Common.Constants
         Success = 1,
 
         /// <summary>
-        /// Represents that the transactions requires a protective word.
+        /// Represents that the request needs an user action.
         /// </summary>
-        Protected = 99,
+        ActionRequired = 2,
     }
 }

--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -221,8 +221,9 @@ namespace HealthGateway.Common.Delegates
 
                 PatientModel patient = new PatientModel() { FirstName = givenNames, LastName = lastNames, Birthdate = dob, Gender = gender, EmailAddress = string.Empty };
 
-                string personIdentifierType = ((II)retrievedPerson.identifiedPerson.id.GetValue(0)!).root;
-                string personIdentifier = ((II)retrievedPerson.identifiedPerson.id.GetValue(0)!).extension;
+                II? identifiedPersonId = (II?)retrievedPerson.identifiedPerson.id.GetValue(0);
+                string? personIdentifierType = identifiedPersonId?.root;
+                string personIdentifier = identifiedPersonId?.extension ?? string.Empty;
                 if (personIdentifierType == OIDType.HDID.ToString())
                 {
                     patient.HdId = personIdentifier;
@@ -233,18 +234,12 @@ namespace HealthGateway.Common.Delegates
                 }
                 else
                 {
-                    PatientModel emptyPatient = new PatientModel();
-                    this.logger.LogWarning($"Client Registry returned a person with a person identifier not recognized. No PHN was populated. {personIdentifier}");
-                    this.logger.LogDebug($"Finished getting patient. {JsonSerializer.Serialize(emptyPatient)}");
-                    return new RequestResult<PatientModel>()
-                    {
-                        ResultStatus = ResultType.Error,
-                        ResultError = new RequestResultError() { ResultMessage = "Client Registry returned a person with a person identifier not recognized.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.ClientRegistries) },
-                    };
+                    this.logger.LogWarning($"Client Registry returned a person with a person identifier not recognized. No PHN or HDID was populated.");
                 }
 
-                string subjectIdentifierType = ((II)retrievedPerson.id.GetValue(0)!).root;
-                string subjectIdentifier = ((II)retrievedPerson.id.GetValue(0)!).extension;
+                II? subjectId = (II?)retrievedPerson.id.GetValue(0);
+                string? subjectIdentifierType = subjectId?.root;
+                string subjectIdentifier = subjectId?.extension ?? string.Empty;
                 if (subjectIdentifierType == OIDType.HDID.ToString())
                 {
                     patient.HdId = subjectIdentifier;
@@ -255,14 +250,7 @@ namespace HealthGateway.Common.Delegates
                 }
                 else
                 {
-                    PatientModel emptyPatient = new PatientModel();
-                    this.logger.LogWarning($"Client Registry returned a person with a subject identifier not recognized. No PHN was populated. {subjectIdentifier}");
-                    this.logger.LogDebug($"Finished getting patient. {JsonSerializer.Serialize(emptyPatient)}");
-                    return new RequestResult<PatientModel>()
-                    {
-                        ResultStatus = ResultType.Error,
-                        ResultError = new RequestResultError() { ResultMessage = "Client Registry returned a person with a subject identifier not recognized. No PHN was populated", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.ClientRegistries) },
-                    };
+                    this.logger.LogWarning($"Client Registry returned a person with a subject identifier not recognized. No PHN or HDID was populated.");
                 }
 
                 return new RequestResult<PatientModel>()

--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -235,6 +235,11 @@ namespace HealthGateway.Common.Delegates
                 else
                 {
                     this.logger.LogWarning($"Client Registry returned a person with a person identifier not recognized. No PHN or HDID was populated.");
+                    return new RequestResult<PatientModel>()
+                    {
+                        ResultStatus = ResultType.ActionRequired,
+                        ResultError = ErrorTranslator.ActionRequired(ErrorMessages.HdIdNotFound, ActionType.NoHdId),
+                    };
                 }
 
                 II? subjectId = (II?)retrievedPerson.id.GetValue(0);
@@ -251,6 +256,11 @@ namespace HealthGateway.Common.Delegates
                 else
                 {
                     this.logger.LogWarning($"Client Registry returned a person with a subject identifier not recognized. No PHN or HDID was populated.");
+                    return new RequestResult<PatientModel>()
+                    {
+                        ResultStatus = ResultType.ActionRequired,
+                        ResultError = ErrorTranslator.ActionRequired(ErrorMessages.HdIdNotFound, ActionType.NoHdId),
+                    };
                 }
 
                 return new RequestResult<PatientModel>()

--- a/Apps/Common/src/ErrorHandling/ActionType.cs
+++ b/Apps/Common/src/ErrorHandling/ActionType.cs
@@ -1,0 +1,70 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.ErrorHandling
+{
+
+    /// <summary>
+    /// Enumerator that defines the different types of required actions.
+    /// </summary>
+    public class ActionType
+    {
+        private ActionType(string value)
+        {
+            this.Value = value;
+        }
+
+        /// <summary>
+        /// Gets the protected user error.
+        /// </summary>
+        public static ActionType Protected
+        {
+            get { return new ActionType("PROTECTED"); }
+        }
+
+        /// <summary>
+        /// Gets the missing hdid user error.
+        /// </summary>
+        public static ActionType NoHdId
+        {
+            get { return new ActionType("NOHDID"); }
+        }
+
+        /// <summary>
+        /// Gets the data mismatch user error.
+        /// </summary>
+        public static ActionType DataMismatch
+        {
+            get { return new ActionType("MISMATCH"); }
+        }
+
+        /// <summary>
+        /// Gets or sets the value that holds the internal representation of the ActionType.
+        /// </summary>
+        public string Value { get; set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            return this.Value == ((ActionType)obj!).Value;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return base.GetHashCode();
+        }
+    }
+}

--- a/Apps/Common/src/ErrorHandling/ErrorTranslator.cs
+++ b/Apps/Common/src/ErrorHandling/ErrorTranslator.cs
@@ -43,5 +43,20 @@ namespace HealthGateway.Common.ErrorHandling
             var applicationName = System.AppDomain.CurrentDomain.FriendlyName.ToString();
             return applicationName + "Server-" + errorType.Value;
         }
+
+        /// <summary>
+        /// Formats the error from the given error type.
+        /// </summary>
+        /// <param name="message">The user friendly message.</param>
+        /// <param name="actionType">Action type that caused the issue.</param>
+        /// <returns>A RequestResultError encapsulating the action required.</returns>
+        public static HealthGateway.Common.Models.RequestResultError ActionRequired(string message, ActionType actionType)
+        {
+            return new Models.RequestResultError() { 
+                ResultMessage = message,
+                ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState),
+                ActionCode = actionType,
+            };
+        }
     }
 }

--- a/Apps/Common/src/Models/RequestResultError.cs
+++ b/Apps/Common/src/Models/RequestResultError.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.Models
 {
     using System.Text.Json.Serialization;
+    using HealthGateway.Common.ErrorHandling;
 
     /// <summary>
     /// The RequestResultError model.
@@ -35,5 +36,25 @@ namespace HealthGateway.Common.Models
         /// </summary>
         [JsonPropertyName("errorCode")]
         public string ErrorCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the action code.
+        /// Will always be set when ResultType is ActionRequired.
+        /// </summary>
+        [JsonIgnore]
+        public ActionType? ActionCode { get; set; }
+
+        /// <summary>
+        /// Gets action code.
+        /// Will always be set when ResultType is ActionRequired.
+        /// </summary>
+        [JsonPropertyName("actionCode")]
+        public string? ActionCodeValue
+        {
+            get
+            {
+                return this.ActionCode?.Value;
+            }
+        }
     }
 }

--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegate_Test.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegate_Test.cs
@@ -138,7 +138,7 @@ namespace HealthGateway.CommonTests.Delegates
         }
 
         [Fact]
-        public async Task ShouldErrorIfInvalidIdentifier()
+        public async Task ShouldNotErrorIfInvalidIdentifier()
         {
             // Setup
             string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -233,7 +233,9 @@ namespace HealthGateway.CommonTests.Delegates
             RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHDIDAsync(hdid);
 
             // Verify
-            Assert.Equal(ResultType.Error, actual.ResultStatus);
+            Assert.Equal(ResultType.Success, actual.ResultStatus);
+            Assert.Empty(actual.ResourcePayload.PersonalHealthNumber);
+            Assert.NotEmpty(actual.ResourcePayload.HdId);
         }
 
         [Fact]

--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegate_Test.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegate_Test.cs
@@ -138,7 +138,7 @@ namespace HealthGateway.CommonTests.Delegates
         }
 
         [Fact]
-        public async Task ShouldNotErrorIfInvalidIdentifier()
+        public async Task ShouldErrorIfInvalidIdentifier()
         {
             // Setup
             string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -233,9 +233,8 @@ namespace HealthGateway.CommonTests.Delegates
             RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHDIDAsync(hdid);
 
             // Verify
-            Assert.Equal(ResultType.Success, actual.ResultStatus);
-            Assert.Empty(actual.ResourcePayload.PersonalHealthNumber);
-            Assert.NotEmpty(actual.ResourcePayload.HdId);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ErrorMessages.HdIdNotFound, actual.ResultError.ResultMessage);
         }
 
         [Fact]

--- a/Apps/Medication/src/Delegates/RestMedStatementDelegate.cs
+++ b/Apps/Medication/src/Delegates/RestMedStatementDelegate.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Medication.Delegates
     using System.Net.Mime;
     using System.Text.Json;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
@@ -31,8 +32,6 @@ namespace HealthGateway.Medication.Delegates
     using HealthGateway.Common.Utils;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models.Cacheable;
-    using HealthGateway.Medication.Constants;
-    using HealthGateway.Medication.Models;
     using HealthGateway.Medication.Models.ODR;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -170,8 +169,8 @@ namespace HealthGateway.Medication.Delegates
                 else
                 {
                     this.logger.LogInformation($"Invalid protected word");
-                    retVal.ResultStatus = Common.Constants.ResultType.Protected;
-                    retVal.ResultError = new RequestResultError() { ResultMessage = ErrorMessages.ProtectiveWordErrorMessage, ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.ODRRecords) };
+                    retVal.ResultStatus = ResultType.ActionRequired;
+                    retVal.ResultError = ErrorTranslator.ActionRequired(ErrorMessages.ProtectiveWordErrorMessage, ActionType.Protected);
                 }
 
                 return retVal;

--- a/Apps/Medication/src/Services/RestMedicationStatementService.cs
+++ b/Apps/Medication/src/Services/RestMedicationStatementService.cs
@@ -128,12 +128,8 @@ namespace HealthGateway.Medication.Services
                 else
                 {
                     this.logger.LogInformation($"Invalid protective word. {hdid}");
-                    result.ResultStatus = ResultType.Protected;
-                    result.ResultError = new RequestResultError()
-                    {
-                        ResultMessage = validationResult.Item2!,
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Patient),
-                    };
+                    result.ResultStatus = Common.Constants.ResultType.ActionRequired;
+                    result.ResultError = ErrorTranslator.ActionRequired(validationResult.Item2, ActionType.Protected);
                 }
 
                 this.logger.LogDebug($"Finished getting history of medication statements");

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegate_Test.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegate_Test.cs
@@ -22,10 +22,13 @@ namespace HealthGateway.Medication.Delegates.Test
     using Xunit;
     using System.Text.Json;
     using HealthGateway.Medication.Delegates;
+    using HealthGateway.Medication.Constants;
     using HealthGateway.Common.Services;
     using System.Net.Http;
     using Moq;
     using Microsoft.Extensions.Logging;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.ODR;
     using HealthGateway.Database.Delegates;
@@ -366,7 +369,9 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.True(response.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
+            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
         }
 
         [Fact]
@@ -593,7 +598,9 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.True(response.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
+            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
         }
 
         [Fact]
@@ -652,7 +659,9 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.True(response.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
+            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
         }
 
         [Fact]
@@ -711,7 +720,9 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.True(response.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
+            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
         }
 
         [Fact]

--- a/Apps/Medication/test/unit/Services/MedicationStatementService_Test.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementService_Test.cs
@@ -21,9 +21,11 @@ namespace HealthGateway.Medication.Services.Test
     using System.Collections.Generic;
     using System.Net;
     using System.Threading.Tasks;
-    using HealthGateway.Common.Delegates;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
+    using HealthGateway.Medication.Constants;
     using HealthGateway.Medication.Models;
     using HealthGateway.Medication.Services;
     using HealthGateway.Medication.Delegates;
@@ -104,43 +106,51 @@ namespace HealthGateway.Medication.Services.Test
 
             // Run and Verify protective word too long
             RequestResult<List<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(hdid, "TOOLONG4U");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordTooLong, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "SHORT");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordTooShort, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "SHORT|");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordInvalidChars, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "SHORT~");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordInvalidChars, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "SHORT^");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordInvalidChars, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "SHORT\\");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordInvalidChars, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "SHORT&");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
-
-            // Run and Verify invalid char
-            actual = await service.GetMedicationStatementsHistory(hdid, "Test|");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordInvalidChars, actual.ResultError.ResultMessage);
 
             // Run and Verify invalid char
             actual = await service.GetMedicationStatementsHistory(hdid, "      ");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
-
-            // Run and Verify invalid char
-            actual = await service.GetMedicationStatementsHistory(hdid, "Test|string");
-            Assert.True(actual.ResultStatus == Common.Constants.ResultType.Protected);
+            Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
+            Assert.Equal(ActionType.Protected, actual.ResultError.ActionCode);
+            Assert.Equal(ErrorMessages.ProtectiveWordInvalidChars, actual.ResultError.ResultMessage);
         }
 
         [Fact]

--- a/Apps/WebClient/src/ClientApp/src/components/modal/newDependent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/newDependent.vue
@@ -9,13 +9,11 @@ import { Duration } from "luxon";
 import { IDependentService } from "@/services/interfaces";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
-import ErrorTranslator from "@/utility/errorTranslator";
-import BannerError from "@/models/bannerError";
-import { Action, Getter } from "vuex-class";
-import { ResultError } from "@/models/requestResult";
+import { Getter } from "vuex-class";
 import AddDependentRequest from "@/models/addDependentRequest";
 import type { WebClientConfiguration } from "@/models/configData";
 import User from "@/models/user";
+import { ResultError } from "@/models/requestResult";
 
 @Component({
     components: {
@@ -25,15 +23,13 @@ import User from "@/models/user";
 export default class NewDependentComponent extends Vue {
     @Getter("user", { namespace: "user" }) user!: User;
 
-    @Action("addError", { namespace: "errorBanner" })
-    addError!: (error: BannerError) => void;
-
     @Getter("webClient", { namespace: "config" })
     webClientConfig!: WebClientConfiguration;
 
     private dependentService!: IDependentService;
     private isVisible = false;
     private isLoading = true;
+    private errorMessage = "";
     private dependent: AddDependentRequest = {
         firstName: "",
         lastName: "",
@@ -121,16 +117,11 @@ export default class NewDependentComponent extends Vue {
                 PHN: this.dependent.PHN.replace(/\D/g, ""),
             })
             .then(() => {
+                this.errorMessage = "";
                 this.handleSubmit();
             })
             .catch((err: ResultError) => {
-                this.addError(
-                    ErrorTranslator.toBannerError(
-                        "Error adding dependent. Please review fields and try again.",
-                        err
-                    )
-                );
-                this.handleSubmit();
+                this.errorMessage = err.resultMessage;
             })
             .finally(() => {
                 this.dependent = {
@@ -166,6 +157,19 @@ export default class NewDependentComponent extends Vue {
         header-text-variant="light"
         centered
     >
+        <b-alert
+            data-testid="dependentErrorBanner"
+            variant="danger"
+            dismissible
+            class="no-print"
+            :show="!!errorMessage"
+        >
+            <p data-testid="dependentErrorText">{{ errorMessage }}</p>
+            <span>
+                If you continue to have issues, please contact
+                HealthGateway@gov.bc.ca.
+            </span>
+        </b-alert>
         <b-row>
             <b-col>
                 <form>

--- a/Apps/WebClient/src/ClientApp/src/components/modal/newDependent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/newDependent.vue
@@ -122,25 +122,27 @@ export default class NewDependentComponent extends Vue {
             })
             .catch((err: ResultError) => {
                 this.errorMessage = err.resultMessage;
-            })
-            .finally(() => {
-                this.dependent = {
-                    firstName: "",
-                    lastName: "",
-                    dateOfBirth: "",
-                    PHN: "",
-                    testDate: "",
-                };
-                this.accepted = false;
             });
     }
 
     @Emit()
     private handleSubmit() {
+        this.clear();
         // Hide the modal manually
         this.$nextTick(() => {
             this.hideModal();
         });
+    }
+
+    private clear() {
+        this.dependent = {
+            firstName: "",
+            lastName: "",
+            dateOfBirth: "",
+            PHN: "",
+            testDate: "",
+        };
+        this.accepted = false;
     }
 }
 </script>

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -16,6 +16,7 @@ import { ResultType } from "@/constants/resulttype";
 import ErrorTranslator from "@/utility/errorTranslator";
 import PDFDefinition from "@/plugins/pdfDefinition";
 import LoadingComponent from "@/components/loading.vue";
+import { ActionType } from "@/constants/actionType";
 
 @Component({
     components: {
@@ -106,7 +107,10 @@ export default class MedicationHistoryReportComponent extends Vue {
                     // Required for the sample page
                     this.recordsPage = this.records.slice(0, 50);
                     this.sortEntries();
-                } else if (results.resultStatus == ResultType.Protected) {
+                } else if (
+                    results.resultStatus == ResultType.ActionRequired &&
+                    results.resultError?.actionCode == ActionType.Protected
+                ) {
                     this.protectiveWordModal.showModal();
                     this.protectiveWordAttempts++;
                 } else {

--- a/Apps/WebClient/src/ClientApp/src/constants/actionType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/actionType.ts
@@ -1,0 +1,5 @@
+export enum ActionType {
+    Protected = "PROTECTED",
+    NoHdId = "NOHDID",
+    DataMismatch = "MISMATCH",
+}

--- a/Apps/WebClient/src/ClientApp/src/constants/resulttype.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/resulttype.ts
@@ -1,5 +1,5 @@
 export enum ResultType {
     Error = 0,
     Success = 1,
-    Protected = 99,
+    ActionRequired = 2,
 }

--- a/Apps/WebClient/src/ClientApp/src/models/requestResult.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/requestResult.ts
@@ -1,3 +1,4 @@
+import { ActionType } from "@/constants/actionType";
 import { ResultType } from "@/constants/resulttype";
 
 export default interface RequestResult<T> {
@@ -16,8 +17,10 @@ export default interface RequestResult<T> {
 }
 
 export interface ResultError {
-    // The error code  associated to the request
+    // The error code associated to the request
     errorCode: string;
+    // The action code associated to the request
+    actionCode?: ActionType;
     // The message associated to the error request
     resultMessage: string;
 }

--- a/Apps/WebClient/src/ClientApp/src/views/healthInsights.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/healthInsights.vue
@@ -22,6 +22,7 @@ import LineChartComponent from "@/components/timeline/plot/lineChart.vue";
 import BannerError from "@/models/bannerError";
 import ErrorTranslator from "@/utility/errorTranslator";
 import { DateWrapper } from "@/models/dateWrapper";
+import { ActionType } from "@/constants/actionType";
 
 const namespace = "user";
 
@@ -107,7 +108,10 @@ export default class HealthInsightsView extends Vue {
                     ].date;
 
                     this.prepareMonthlyChart();
-                } else if (results.resultStatus == ResultType.Protected) {
+                } else if (
+                    results.resultStatus == ResultType.ActionRequired &&
+                    results.resultError?.actionCode == ActionType.Protected
+                ) {
                     this.protectiveWordModal.showModal();
                     this.protectiveWordAttempts++;
                 } else {

--- a/Apps/WebClient/src/ClientApp/src/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/timeline.vue
@@ -39,6 +39,7 @@ import EncounterTimelineEntry from "@/models/encounterTimelineEntry";
 import FilterComponent from "@/components/timeline/filters.vue";
 import { DateWrapper } from "@/models/dateWrapper";
 import TimelineFilter from "@/models/timelineFilter";
+import { ActionType } from "@/constants/actionType";
 
 const namespace = "user";
 
@@ -269,7 +270,10 @@ export default class TimelineView extends Vue {
                     }
                     this.sortEntries();
                     this.medicationCount = results.resourcePayload.length;
-                } else if (results.resultStatus == ResultType.Protected) {
+                } else if (
+                    results.resultStatus == ResultType.ActionRequired &&
+                    results.resultError?.actionCode == ActionType.Protected
+                ) {
                     if (!this.covidModal.show) {
                         this.protectiveWordModal.showModal();
                     }

--- a/Apps/WebClient/src/Server/Constants/RegistrationStatus.cs
+++ b/Apps/WebClient/src/Server/Constants/RegistrationStatus.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Constant
+namespace HealthGateway.WebClient.Constants
 {
     /// <summary>
     /// Registration status modes.

--- a/Apps/WebClient/src/Server/Models/AddDependentRequest.cs
+++ b/Apps/WebClient/src/Server/Models/AddDependentRequest.cs
@@ -47,46 +47,5 @@ namespace HealthGateway.WebClient.Models
         /// Gets or sets the TestDate.
         /// </summary>
         public DateTime TestDate { get; set; }
-
-        /// <summary>
-        /// Determines whether two specified System.String objects have the same value.
-        /// </summary>
-        /// <param name="patientModel">The Patient Model to compare, or null.</param>
-        /// <returns>true if the value of the AddDependentRequest is the same as the value of PatientModel; otherwise, false. If the
-        ///     PatientModel is null, the method returns false.</returns>
-        public bool Equals(PatientModel patientModel)
-        {
-            if (patientModel is null)
-            {
-                return false;
-            }
-
-            if (!patientModel.LastName.Equals(this.LastName, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            if (!patientModel.FirstName.Equals(this.FirstName, StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
-
-            if (patientModel.Birthdate.Year != this.DateOfBirth.Year)
-            {
-                return false;
-            }
-
-            if (patientModel.Birthdate.Month != this.DateOfBirth.Month)
-            {
-                return false;
-            }
-
-            if (patientModel.Birthdate.Day != this.DateOfBirth.Day)
-            {
-                return false;
-            }
-
-            return true;
-        }
     }
 }

--- a/Apps/WebClient/src/Server/Services/DependentService.cs
+++ b/Apps/WebClient/src/Server/Services/DependentService.cs
@@ -84,9 +84,9 @@ namespace HealthGateway.WebClient.Services
                     };
                 }
             }
-            this.logger.LogDebug("Getting dependent details...");
+            this.logger.LogTrace("Getting dependent details...");
             RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatient(addDependentRequest.PHN, PatientIdentifierType.PHN).ConfigureAwait(true)).Result;
-            if (patientResult.ResourcePayload == null)
+            if (patientResult.ResultStatus == ResultType.Error)
             {
                 return new RequestResult<DependentModel>()
                 {
@@ -95,53 +95,61 @@ namespace HealthGateway.WebClient.Services
                 };
             }
 
-            this.logger.LogError($"Getting dependent details...{JsonSerializer.Serialize(patientResult)}");
+            this.logger.LogDebug($"Finished getting dependent details...{JsonSerializer.Serialize(patientResult)}");
             // Verify dependent's details entered by user
-            if (!addDependentRequest.Equals(patientResult.ResourcePayload))
+            if (patientResult.ResourcePayload == null || !this.ValidateDependent(addDependentRequest, patientResult.ResourcePayload))
             {
-
+                this.logger.LogDebug($"Dependent information does not match request: {JsonSerializer.Serialize(addDependentRequest)} response: {JsonSerializer.Serialize(patientResult.ResourcePayload)}");
                 return new RequestResult<DependentModel>()
                 {
                     ResultStatus = ResultType.Error,
-                    ResultError = new RequestResultError() { ResultMessage = "The information you entered did not match. Please try again.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient) },
+                    ResultError = new RequestResultError() { ResultMessage = "The information you entered does not match our records. Please try again.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient) },
+                };
+            }
+
+            // Verify dependent has HDID
+            if (string.IsNullOrEmpty(patientResult.ResourcePayload.HdId))
+            {
+                return new RequestResult<DependentModel>()
+                {
+                    ResultStatus = ResultType.Error,
+                    ResultError = new RequestResultError() { ResultMessage = "Please ensure you are using a current BC Services Card.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient) },
+                };
+            }
+
+            string json = JsonSerializer.Serialize(addDependentRequest.TestDate, addDependentRequest.TestDate.GetType());
+            JsonDocument jsonDoc = JsonDocument.Parse(json);
+            // Insert Dependent to database
+            var dependent = new ResourceDelegate()
+            {
+                ResourceOwnerHdid = patientResult.ResourcePayload.HdId,
+                ProfileHdid = delegateHdId,
+                ReasonCode = ResourceDelegateReason.COVIDLab,
+                ReasonObjectType = addDependentRequest.TestDate.GetType().AssemblyQualifiedName,
+                ReasonObject = jsonDoc
+            };
+            DBResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Insert(dependent, true);
+
+            if (dbDependent.Status == DBStatusCode.Created)
+            {
+                this.logger.LogTrace("Finished adding dependent");
+                this.UpdateNotificationSettings(dependent.ResourceOwnerHdid, delegateHdId);
+
+                return new RequestResult<DependentModel>()
+                {
+                    ResourcePayload = DependentModel.CreateFromModels(dbDependent.Payload, patientResult.ResourcePayload),
+                    ResultStatus = ResultType.Success,
                 };
             }
             else
             {
-                string json = JsonSerializer.Serialize(addDependentRequest.TestDate, addDependentRequest.TestDate.GetType());
-                JsonDocument jsonDoc = JsonDocument.Parse(json);
-                // Insert Dependent to database
-                var dependent = new ResourceDelegate()
+                this.logger.LogError("Error adding dependent");
+                return new RequestResult<DependentModel>()
                 {
-                    ResourceOwnerHdid = patientResult.ResourcePayload.HdId,
-                    ProfileHdid = delegateHdId,
-                    ReasonCode = ResourceDelegateReason.COVIDLab,
-                    ReasonObjectType = addDependentRequest.TestDate.GetType().AssemblyQualifiedName,
-                    ReasonObject = jsonDoc
+                    ResourcePayload = new DependentModel(),
+                    ResultStatus = ResultType.Error,
+                    ResultError = new RequestResultError() { ResultMessage = dbDependent.Message, ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database) },
                 };
-                DBResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Insert(dependent, true);
-
-                if (dbDependent.Status == DBStatusCode.Created)
-                {
-                    this.logger.LogDebug("Finished adding dependent");
-                    this.UpdateNotificationSettings(dependent.ResourceOwnerHdid, delegateHdId);
-
-                    return new RequestResult<DependentModel>()
-                    {
-                        ResourcePayload = DependentModel.CreateFromModels(dbDependent.Payload, patientResult.ResourcePayload),
-                        ResultStatus = ResultType.Success,
-                    };
-                }
-                else
-                {
-                    this.logger.LogError("Error adding dependent");
-                    return new RequestResult<DependentModel>()
-                    {
-                        ResourcePayload = new DependentModel(),
-                        ResultStatus = ResultType.Error,
-                        ResultError = new RequestResultError() { ResultMessage = dbDependent.Message, ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database) },
-                    };
-                }
             }
         }
 
@@ -214,6 +222,36 @@ namespace HealthGateway.WebClient.Services
                 ResultError = dbDependent.Status == DBStatusCode.Deleted ? null : new RequestResultError() { ResultMessage = dbDependent.Message, ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database) },
             };
             return result;
+        }
+
+        private bool ValidateDependent(AddDependentRequest dependent, PatientModel patientModel)
+        {
+            if (patientModel is null)
+            {
+                return false;
+            }
+
+            if (!patientModel.LastName.Equals(dependent.LastName, StringComparison.OrdinalIgnoreCase))
+            {
+                this.logger.LogInformation("Validate Dependent: LastName mismatch.");
+                return false;
+            }
+
+            if (!patientModel.FirstName.Equals(dependent.FirstName, StringComparison.OrdinalIgnoreCase))
+            {
+                this.logger.LogInformation("Validate Dependent: FirstName mismatch.");
+                return false;
+            }
+
+            if (patientModel.Birthdate.Year != dependent.DateOfBirth.Year || 
+                patientModel.Birthdate.Month != dependent.DateOfBirth.Month || 
+                patientModel.Birthdate.Day != dependent.DateOfBirth.Day)
+            {
+                this.logger.LogInformation("Validate Dependent: DateOfBirth mismatch.");
+                return false;
+            }
+
+            return true;
         }
 
         private NotificationSettingsRequest UpdateNotificationSettings(string dependentHdid, string delegateHdid, bool isDelete = false)

--- a/Apps/WebClient/src/Server/Services/DependentService.cs
+++ b/Apps/WebClient/src/Server/Services/DependentService.cs
@@ -95,6 +95,15 @@ namespace HealthGateway.WebClient.Services
                 };
             }
 
+            if (patientResult.ResultStatus == ResultType.ActionRequired)
+            {
+                return new RequestResult<DependentModel>()
+                {
+                    ResultStatus = ResultType.ActionRequired,
+                    ResultError = patientResult.ResultError,
+                };
+            }
+
             this.logger.LogDebug($"Finished getting dependent details...{JsonSerializer.Serialize(patientResult)}");
             // Verify dependent's details entered by user
             if (patientResult.ResourcePayload == null || !this.ValidateDependent(addDependentRequest, patientResult.ResourcePayload))
@@ -102,8 +111,8 @@ namespace HealthGateway.WebClient.Services
                 this.logger.LogDebug($"Dependent information does not match request: {JsonSerializer.Serialize(addDependentRequest)} response: {JsonSerializer.Serialize(patientResult.ResourcePayload)}");
                 return new RequestResult<DependentModel>()
                 {
-                    ResultStatus = ResultType.Error,
-                    ResultError = new RequestResultError() { ResultMessage = "The information you entered does not match our records. Please try again.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient) },
+                    ResultStatus = ResultType.ActionRequired,
+                    ResultError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch),
                 };
             }
 
@@ -112,8 +121,8 @@ namespace HealthGateway.WebClient.Services
             {
                 return new RequestResult<DependentModel>()
                 {
-                    ResultStatus = ResultType.Error,
-                    ResultError = new RequestResultError() { ResultMessage = "Please ensure you are using a current BC Services Card.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient) },
+                    ResultStatus = ResultType.ActionRequired,
+                    ResultError = ErrorTranslator.ActionRequired(ErrorMessages.HdIdNotFound, ActionType.NoHdId),
                 };
             }
 

--- a/Apps/WebClient/src/Server/Services/UserProfileService.cs
+++ b/Apps/WebClient/src/Server/Services/UserProfileService.cs
@@ -29,7 +29,7 @@ namespace HealthGateway.WebClient.Services
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
-    using HealthGateway.WebClient.Constant;
+    using HealthGateway.WebClient.Constants;
     using HealthGateway.WebClient.Models;
     using Microsoft.Extensions.Logging;
 

--- a/Apps/WebClient/test/unit/Services.Test/DependentService_Test.cs
+++ b/Apps/WebClient/test/unit/Services.Test/DependentService_Test.cs
@@ -199,9 +199,9 @@ namespace HealthGateway.WebClient.Test.Services
             IDependentService service = SetupMockDependentService(addDependentRequest);
             RequestResult<DependentModel> actualResult = service.AddDependent(mockParentHdId, addDependentRequest);
 
-            Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
-            var serviceError = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient);
-            Assert.Equal(serviceError, actualResult.ResultError.ErrorCode);
+            var userError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
+            Assert.Equal(Common.Constants.ResultType.ActionRequired, actualResult.ResultStatus);
+            Assert.Equal(userError.ErrorCode, actualResult.ResultError.ErrorCode);
             Assert.Equal(mismatchedError, actualResult.ResultError.ResultMessage);
         }
 
@@ -213,10 +213,9 @@ namespace HealthGateway.WebClient.Test.Services
             IDependentService service = SetupMockDependentService(addDependentRequest);
             RequestResult<DependentModel> actualResult = service.AddDependent(mockParentHdId, addDependentRequest);
 
-            Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
-            var serviceError = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient);
-            Assert.Equal(serviceError, actualResult.ResultError.ErrorCode);
-
+            var userError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
+            Assert.Equal(Common.Constants.ResultType.ActionRequired, actualResult.ResultStatus);
+            Assert.Equal(userError.ErrorCode, actualResult.ResultError.ErrorCode);
             Assert.Equal(mismatchedError, actualResult.ResultError.ResultMessage);
         }
 
@@ -228,10 +227,9 @@ namespace HealthGateway.WebClient.Test.Services
             IDependentService service = SetupMockDependentService(addDependentRequest);
             RequestResult<DependentModel> actualResult = service.AddDependent(mockParentHdId, addDependentRequest);
 
-            Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
-            var serviceError = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient);
-            Assert.Equal(serviceError, actualResult.ResultError.ErrorCode);
-
+            var userError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
+            Assert.Equal(Common.Constants.ResultType.ActionRequired, actualResult.ResultStatus);
+            Assert.Equal(userError.ErrorCode, actualResult.ResultError.ErrorCode);
             Assert.Equal(mismatchedError, actualResult.ResultError.ResultMessage);
         }
 
@@ -253,9 +251,9 @@ namespace HealthGateway.WebClient.Test.Services
             IDependentService service = SetupMockDependentService(addDependentRequest, patientResult: patientResult);
             RequestResult<DependentModel> actualResult = service.AddDependent(mockParentHdId, addDependentRequest);
 
-            Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
-            var serviceError = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient);
-            Assert.Equal(serviceError, actualResult.ResultError.ErrorCode);
+            var userError = ErrorTranslator.ActionRequired(ErrorMessages.HdIdNotFound, ActionType.NoHdId);
+            Assert.Equal(Common.Constants.ResultType.ActionRequired, actualResult.ResultStatus);
+            Assert.Equal(userError.ErrorCode, actualResult.ResultError.ErrorCode);
             Assert.Equal(noHdIdError, actualResult.ResultError.ResultMessage);
         }
 

--- a/Apps/WebClient/test/unit/Services.Test/DependentService_Test.cs
+++ b/Apps/WebClient/test/unit/Services.Test/DependentService_Test.cs
@@ -43,7 +43,8 @@ namespace HealthGateway.WebClient.Test.Services
         private DateTime mockDateOfBirth = new DateTime(2010, 10, 10);
         private const string mockGender = "Male";
         private const string mockHdId = "MockHdId";
-        private const string mismatchedError = "The information you entered did not match. Please try again.";
+        private const string mismatchedError = "The information you entered does not match our records. Please try again.";
+        private const string noHdIdError = "Please ensure you are using a current BC Services Card.";
 
         private IDependentService SetupCommonMocks(Mock<IResourceDelegateDelegate> mockDependentDelegate, Mock<IPatientService> mockPatientService)
         {
@@ -232,6 +233,30 @@ namespace HealthGateway.WebClient.Test.Services
             Assert.Equal(serviceError, actualResult.ResultError.ErrorCode);
 
             Assert.Equal(mismatchedError, actualResult.ResultError.ResultMessage);
+        }
+
+        [Fact]
+        public void ValidateDependentWithNoHdId()
+        {
+            RequestResult<PatientModel> patientResult = new RequestResult<PatientModel>();
+            patientResult.ResultStatus = Common.Constants.ResultType.Success;
+            patientResult.ResourcePayload = new PatientModel()
+            {
+                HdId = string.Empty,
+                PersonalHealthNumber = mockPHN,
+                FirstName = mockFirstName,
+                LastName = mockLastName,
+                Birthdate = mockDateOfBirth,
+                Gender = mockGender,
+            };
+            AddDependentRequest addDependentRequest = SetupMockInput();
+            IDependentService service = SetupMockDependentService(addDependentRequest, patientResult: patientResult);
+            RequestResult<DependentModel> actualResult = service.AddDependent(mockParentHdId, addDependentRequest);
+
+            Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
+            var serviceError = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Patient);
+            Assert.Equal(serviceError, actualResult.ResultError.ErrorCode);
+            Assert.Equal(noHdIdError, actualResult.ResultError.ResultMessage);
         }
 
         [Fact]

--- a/Apps/WebClient/test/unit/Services.Test/UserProfileService_Test.cs
+++ b/Apps/WebClient/test/unit/Services.Test/UserProfileService_Test.cs
@@ -29,7 +29,7 @@ namespace HealthGateway.WebClient.Test.Services
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
-    using HealthGateway.WebClient.Constant;
+    using HealthGateway.WebClient.Constants;
     using HealthGateway.WebClient.Models;
     using HealthGateway.WebClient.Services;
     using Microsoft.Extensions.Logging;


### PR DESCRIPTION
# Fixes or Implements [AB#9707](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9707)

* [x] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Updated vue to display dependent errors in-modal.
Updated patient delegate to not error if hdid/phn not found.
Updated dependent to return graceful error if no hdid/data mismatch.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [x] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
