### PR TITLE
Dependants menu button does not show on closed accounts

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -430,7 +430,7 @@ export default class SidebarComponent extends Vue {
                         </b-row>
                     </div>
                     <router-link
-                        v-show="isDependentEnabled"
+                        v-show="isDependentEnabled && isActiveProfile"
                         id="menuBtnDependents"
                         data-testid="menuBtnDependentsLink"
                         to="/dependents"


### PR DESCRIPTION
# Fixes or Implements [AB#9655](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9655)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Fixed the Dependents button showing on closed accounts
