### PR TITLE
Add divider to sidebar

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -540,13 +540,14 @@ export default class SidebarComponent extends Vue {
             <b-row class="sidebar-footer m-0 p-0">
                 <b-col class="m-0 p-0">
                     <!-- Collapse Button -->
+                    <hr />
                     <b-row
                         class="align-items-center my-4 d-sm-block"
                         :class="[isOpen ? 'mx-4' : 'button-container']"
                     >
                         <b-col
                             :title="`${isOpen ? 'Collapse' : 'Expand'} Menu`"
-                            :class="{ 'ml-auto col-4': isOpen }"
+                            :class="{ 'ml-auto col-2': isOpen }"
                         >
                             <font-awesome-icon
                                 data-testid="sidebarToggle"
@@ -575,6 +576,11 @@ export default class SidebarComponent extends Vue {
 
 <style lang="scss" scoped>
 @import "@/assets/scss/_variables.scss";
+
+.sidebarDivider {
+    border-top: 10px solid;
+    color: white;
+}
 
 .wrapper {
     display: flex;
@@ -705,7 +711,9 @@ export default class SidebarComponent extends Vue {
 }
 
 #sidebar hr {
-    border-top: 1px solid $soft_text;
+    border-top: 2px solid white;
+    margin-left: 10px;
+    margin-right: 10px;
 }
 
 #sidebar.collapsed .arrow-icon {
@@ -755,6 +763,7 @@ export default class SidebarComponent extends Vue {
     position: sticky;
     bottom: 0rem;
     align-self: flex-end;
+    background-color: $primary;
 }
 
 .popover-body {


### PR DESCRIPTION
# Fixes or Implements [AB#9740](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9740)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

Added divider to sidebar to prevent overlap between icons

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

Collapse website down to small size and see that collapse button persists overtop of icons in its own floating section.

### UI Changes

YES

![collapsemenu2](https://user-images.githubusercontent.com/35615145/102554656-0fc9c000-407a-11eb-83a1-1261010b0a44.PNG)
![collapsemenu1](https://user-images.githubusercontent.com/35615145/102554657-10625680-407a-11eb-9ec4-8b9f4f0ee0d8.PNG)

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox
