### PR TITLE
Fix filters menu cut off by header

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/filters.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/filters.vue
@@ -199,6 +199,7 @@ export default class FilterComponent extends Vue {
                 data-testid="filterDropdown"
                 text="Filter"
                 class="w-100"
+                no-flip
                 :toggle-class="{ 'filter-selected': hasFilterSelected }"
                 menu-class="z-index-large w-100"
                 variant="outline-primary"


### PR DESCRIPTION
# Fixes or Implements [AB#9756](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9756)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

Removed the auto-flip feature of b-dropdown that was causing the dropdown to be overlapped by the header. Now the dropdown does not flip.

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

Open filters on short screen. See it does not flip and become cut off.

### UI Changes

NO

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox