### PR TITLE
revert Hsts

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -605,11 +605,6 @@ namespace HealthGateway.Common.AspNetConfiguration
                 app.UseDeveloperExceptionPage();
             }
 
-            if (!this.environment.IsDevelopment())
-            {
-                app.UseHttpsRedirection();
-            }
-
             app.UseStaticFiles();
             app.UseRouting();
 

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -108,7 +108,6 @@ namespace HealthGateway.Common.AspNetConfiguration
             services.AddResponseCompression(options =>
             {
                 options.Providers.Add<GzipCompressionProvider>();
-                options.EnableForHttps = true;
             });
 
             services.AddHttpClient<IHttpClientService, HttpClientService>();

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -134,13 +134,6 @@ namespace HealthGateway.Common.AspNetConfiguration
                 {
                     options.JsonSerializerOptions.WriteIndented = true;
                 });
-
-            services.AddHsts(options =>
-            {
-                options.Preload = true;
-                options.IncludeSubDomains = true;
-                options.MaxAge = TimeSpan.FromDays(180);
-            });
         }
 
         /// <summary>
@@ -610,12 +603,6 @@ namespace HealthGateway.Common.AspNetConfiguration
             if (this.environment.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-            }
-            else
-            {
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                this.Logger.LogInformation("Using HSTS, which sets Strict-Transport-Security Header");
-                app.UseHsts();
             }
 
             if (!this.environment.IsDevelopment())

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -28,7 +28,6 @@ namespace HealthGateway.WebClient
     using HealthGateway.WebClient.Services;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Rewrite;
     using Microsoft.AspNetCore.SpaServices;
@@ -119,19 +118,6 @@ namespace HealthGateway.WebClient
             // Configure SPA
             services.AddControllersWithViews();
 
-            services.AddHsts(options =>
-            {
-                options.IncludeSubDomains = true;
-                options.MaxAge = TimeSpan.FromDays(365);
-                options.Preload = true;
-            });
-            // Configure HTTPS redirection
-            services.AddHttpsRedirection(options =>
-            {
-                options.RedirectStatusCode = StatusCodes.Status301MovedPermanently;
-                options.HttpsPort = 443;
-            });
-
             // In production, the Vue files will be served from this directory
             services.AddSpaStaticFiles(configuration =>
             {
@@ -164,9 +150,6 @@ namespace HealthGateway.WebClient
 
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
-
-                // Redirect http to https
-                app.UseHttpsRedirection();
             }
 
             if (!env.IsDevelopment())

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -147,9 +147,6 @@ namespace HealthGateway.WebClient
             else
             {
                 app.UseExceptionHandler("/Home/Error");
-
-                // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
-                app.UseHsts();
             }
 
             if (!env.IsDevelopment())

--- a/Tools/BaseBuild/route.sh
+++ b/Tools/BaseBuild/route.sh
@@ -13,7 +13,9 @@ then
   redirect=Redirect
   echo Creating base route dnd HTTP redirect set to $redirect
   oc create route edge "$route"-https --ca-cert="./caCertificate.pem" --cert="./wildcard.healthgateway.gov.bc.ca.pem" --key="./HealthGatewayPrivateKey.pem" --hostname="$env.healthgateway.gov.bc.ca" --service="$service" --insecure-policy="$redirect"
+  oc annotate route "$route"-https haproxy.router.openshift.io/hsts_header="max-age=31536000;includeSubDomains;preload"
 else
   echo Creating route with path $routePath and HTTP redirect set to $redirect
   oc create route edge "$route"-https --ca-cert="./caCertificate.pem" --cert="./wildcard.healthgateway.gov.bc.ca.pem" --key="./HealthGatewayPrivateKey.pem" --hostname="$env.healthgateway.gov.bc.ca" --path="$routePath" --service="$service" --insecure-policy="$redirect"
+  oc annotate route "$route"-https haproxy.router.openshift.io/hsts_header="max-age=31536000;includeSubDomains;preload"
 fi


### PR DESCRIPTION
# Fixes or Implements [AB#9616](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9616)-revert

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- The HSTS redirection that was put into place is forcing a redirect and the pods are not coming online due to not ready.
- HSTS and HTTPS shouldn't be application level code as we deploy into OpenShift.  We've reverted the changes and removed related config as well as updated the route creation script to annotate the OpenShift routes properly for HSTS.  Ticket [AB#9616](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9616) has been updated with before and after the route changes.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
