### PR TITLE
Remove obsolete test for common AB#9844

### DIFF
--- a/Apps/Common/test/unit/Services/HttpClientService_Test.cs
+++ b/Apps/Common/test/unit/Services/HttpClientService_Test.cs
@@ -19,13 +19,7 @@ namespace HealthGateway.CommonTests.Services
     using System.Collections.Generic;
     using System.Net.Http;
     using Microsoft.Extensions.Configuration;
-    using DeepEqual.Syntax;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Constants;
-    using HealthGateway.Database.Delegates;
-    using HealthGateway.Database.Models;
-    using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
 
@@ -49,9 +43,6 @@ namespace HealthGateway.CommonTests.Services
             using HttpClient client = service.CreateDefaultHttpClient();
 
             Assert.True(client is HttpClient && client.Timeout.TotalSeconds == timeout);
-
-            using HttpClient untrustedClient = service.CreateUntrustedHttpClient();
-            Assert.True(untrustedClient is HttpClient && client.Timeout.TotalSeconds == timeout);
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#9844](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9844)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

Previous PR removed the UntrustedHTTPClient but didn't remove the associated Test which caused compilation errors.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [X] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
