### PR TITLE
Fixes admin site not retrieving feedback

### DIFF
--- a/Apps/Database/src/Delegates/DBFeedbackDelegate.cs
+++ b/Apps/Database/src/Delegates/DBFeedbackDelegate.cs
@@ -114,10 +114,13 @@ namespace HealthGateway.Database.Delegates
 
             foreach (UserFeedbackAdmin feedbackAdmin in feedback)
             {
-                string? email;
-                if (profileEmails.TryGetValue(feedbackAdmin.UserProfileId, out email))
+                if (!string.IsNullOrWhiteSpace(feedbackAdmin.UserProfileId))
                 {
-                    feedbackAdmin.Email = email != null ? email : string.Empty;
+                    string? email;
+                    if (profileEmails.TryGetValue(feedbackAdmin.UserProfileId, out email))
+                    {
+                        feedbackAdmin.Email = email != null ? email : string.Empty;
+                    }
                 }
             }
 

--- a/Apps/Database/src/Models/Comment.cs
+++ b/Apps/Database/src/Models/Comment.cs
@@ -40,7 +40,7 @@ namespace HealthGateway.Database.Models
         public string UserProfileId { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets the UerProfile associated to this comment.
+        /// Gets or sets the UserProfile associated to this comment.
         /// </summary>
         public virtual UserProfile? UserProfile { get; set; }
 


### PR DESCRIPTION
# Fixes or Implements [AB#9881](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9881)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

The admin site was failing to retrieve feedback data if the user was no longer in the DB and had made a comment

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

User has a validated email
User makes a feedback comment.
User removes its account
JobScheduler runs the close account job
Open Admin user-feedback section.

