### PR TITLE
Fix cypress failure when downloading file for dependents for AB#9883

### DIFF
--- a/Testing/functional/e2e/cypress/integration/dependent/dependents.js
+++ b/Testing/functional/e2e/cypress/integration/dependent/dependents.js
@@ -1,6 +1,7 @@
 const { AuthMethod } = require("../../support/constants")
 
 describe('dependents', () => {
+
     const validDependent = {
         firstName: "Sam",
         lastName: "Testfive",
@@ -20,6 +21,8 @@ describe('dependents', () => {
     }
 
     before(() => {
+
+        cy.setupDownloads();
         cy.enableModules(["CovidLabResults", "Laboratory", "Dependent"]);
         cy.login(
             Cypress.env('keycloak.username'), 

--- a/Testing/functional/e2e/cypress/integration/dependent/dependents.js
+++ b/Testing/functional/e2e/cypress/integration/dependent/dependents.js
@@ -21,7 +21,6 @@ describe('dependents', () => {
     }
 
     before(() => {
-
         cy.setupDownloads();
         cy.enableModules(["CovidLabResults", "Laboratory", "Dependent"]);
         cy.login(

--- a/Testing/functional/e2e/cypress/integration/report/immunizationReport.js
+++ b/Testing/functional/e2e/cypress/integration/report/immunizationReport.js
@@ -1,9 +1,9 @@
 const { AuthMethod } = require("../../support/constants")
 describe('Immunization History Report', () => {
-    const downloadsFolder = 'cypress/downloads'
     let sensitiveDocText = ' The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off. ';
     
     before(() => {
+        cy.setupDownloads();
         let isLoading = false;  
         cy.enableModules("Immunization");
         cy.intercept('GET', "**/v1/api/Immunization/*", (req) => { 
@@ -16,21 +16,6 @@ describe('Immunization History Report', () => {
             isLoading = !isLoading;
           })
         });
-
-        // The next command allow downloads in Electron, Chrome, and Edge
-        // without any users popups or file save dialogs.
-        if (!Cypress.isBrowser('firefox')) {
-          // since this call returns a promise, must tell Cypress to wait for it to be resolved
-          cy.log('Page.setDownloadBehavior')
-          cy.wrap(
-            Cypress.automation('remote:debugger:protocol',
-              {
-                command: 'Page.setDownloadBehavior',
-                params: { behavior: 'allow', downloadPath: downloadsFolder },
-              }),
-            { log: false }
-          )
-        }
         cy.login(Cypress.env('keycloak.username'), Cypress.env('keycloak.password'), AuthMethod.KeyCloak, "/reports");
     })
 

--- a/Testing/functional/e2e/cypress/integration/report/report.js
+++ b/Testing/functional/e2e/cypress/integration/report/report.js
@@ -1,26 +1,11 @@
 const { AuthMethod } = require("../../support/constants")
 
 describe('Reports', () => {
-    const downloadsFolder = 'cypress/downloads'
     let sensitiveDocText = ' The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off. ';
     before(() => {
+        cy.setupDownloads();
         cy.enableModules(["Encounter", "Medication", "Laboratory"]);
         cy.login(Cypress.env('keycloak.username'), Cypress.env('keycloak.password'), AuthMethod.KeyCloak, "/reports");
-
-        // The next command allow downloads in Electron, Chrome, and Edge
-        // without any users popups or file save dialogs.
-        if (!Cypress.isBrowser('firefox')) {
-          // since this call returns a promise, must tell Cypress to wait for it to be resolved
-          cy.log('Page.setDownloadBehavior')
-          cy.wrap(
-            Cypress.automation('remote:debugger:protocol',
-              {
-                command: 'Page.setDownloadBehavior',
-                params: { behavior: 'allow', downloadPath: downloadsFolder },
-              }),
-            { log: false }
-          )
-        }
     })
 
     it('Validate Date Filter Exists', () => {       

--- a/Testing/functional/e2e/cypress/support/commands.js
+++ b/Testing/functional/e2e/cypress/support/commands.js
@@ -199,3 +199,21 @@ Cypress.Commands.add("enableModules", (modules) => {
         });
     });
 });
+
+Cypress.Commands.add("setupDownloads", () => {
+  const downloadsFolder = 'cypress/downloads'
+  // The next command allow downloads in Electron, Chrome, and Edge
+  // without any users popups or file save dialogs.
+  if (!Cypress.isBrowser('firefox')) {
+    // since this call returns a promise, must tell Cypress to wait for it to be resolved
+    cy.log('Page.setDownloadBehavior')
+    cy.wrap(
+      Cypress.automation('remote:debugger:protocol',
+        {
+          command: 'Page.setDownloadBehavior',
+          params: { behavior: 'allow', downloadPath: downloadsFolder },
+        }),
+      { log: false }
+    )
+  }
+});


### PR DESCRIPTION
# Fixes or Implements [AB#9883](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9883)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

When downloading files using Cypress and the Electron browser on the command line the Test Runner will fail if you attempted to download a file without setting up a default download folder.  

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [X] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

Run the dependents test from the command line:

```
npx cypress run --spec cypress/integration/dependent/dependents.js
```

This will fail with 
### UI Changes

No

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
