### PR TITLE
Add tuto. popover for Export Records

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -74,7 +74,8 @@ export default class SidebarComponent extends Vue {
     private name = "";
     private windowWidth = 0;
 
-    private isTutorialEnabled = false;
+    private isTutorialEnabledForNotes = false;
+    private isTutorialEnabledForExportRecords = false;
 
     @Watch("oidcIsAuthenticated")
     private onPropertyChanged() {
@@ -91,7 +92,8 @@ export default class SidebarComponent extends Vue {
 
     @Watch("isOpen")
     private onIsOpen() {
-        this.isTutorialEnabled = false;
+        this.isTutorialEnabledForNotes = false;
+        this.isTutorialEnabledForExportRecords = false;
     }
 
     private mounted() {
@@ -114,7 +116,8 @@ export default class SidebarComponent extends Vue {
                 return;
             }
 
-            this.isTutorialEnabled = true;
+            this.isTutorialEnabledForNotes = true;
+            this.isTutorialEnabledForExportRecords = true;
 
             document.querySelectorAll(".button-title").forEach((button) => {
                 if (transition?.classList.contains("collapsed")) {
@@ -152,7 +155,8 @@ export default class SidebarComponent extends Vue {
                     oidcUser.family_name
                 );
             }
-            this.isTutorialEnabled = true;
+            this.isTutorialEnabledForNotes = true;
+            this.isTutorialEnabledForExportRecords = true;
         });
     }
 
@@ -171,30 +175,44 @@ export default class SidebarComponent extends Vue {
         this.eventBus.$emit(EventMessageName.TimelineCreateNote);
     }
 
-    private dismissTutorial() {
-        this.logger.debug("Dismissing tutorial...");
-        if (
-            this.user.preferences.tutorialPopover != undefined &&
-            this.user.preferences.tutorialPopover.hdId != undefined
-        ) {
-            this.user.preferences.tutorialPopover.value = "false";
+    private dismissTutorial(
+        preference: string,
+        userPreference: UserPreference
+    ) {
+        this.logger.debug(`Dismissing tutorial ${preference}...`);
+        if (userPreference != undefined && userPreference.hdId != undefined) {
+            userPreference.value = "false";
             this.updateUserPreference({
                 hdid: this.user.hdid,
-                userPreference: this.user.preferences.tutorialPopover,
+                userPreference: userPreference,
             });
         } else {
-            this.user.preferences.tutorialPopover = {
+            userPreference = {
                 hdId: this.user.hdid,
-                preference: "tutorialPopover",
-                value: "true",
+                preference: preference,
+                value: "false",
                 version: 0,
                 createdDateTime: new DateWrapper().toISO(),
             };
             this.createUserPreference({
                 hdid: this.user.hdid,
-                userPreference: this.user.preferences.tutorialPopover,
+                userPreference: userPreference,
             });
         }
+    }
+
+    private dismissTutorialForNotes() {
+        this.dismissTutorial(
+            "tutorialPopover",
+            this.user.preferences.tutorialPopover
+        );
+    }
+
+    private dismissTutorialForExportRecords() {
+        this.dismissTutorial(
+            "tutorialPopoverExportRecords",
+            this.user.preferences.tutorialPopoverExportRecords
+        );
     }
 
     private printView() {
@@ -206,23 +224,41 @@ export default class SidebarComponent extends Vue {
         this.windowWidth = window.innerWidth;
     }
 
-    private get showTutorialPopover(): boolean {
+    private showTutorialPopover(
+        tutorialPopover: UserPreference,
+        isTutorialEnabled: boolean
+    ): boolean {
         if (this.isMobileWidth) {
             return (
-                this.isTutorialEnabled &&
-                this.user.preferences.tutorialPopover?.value === "true" &&
+                isTutorialEnabled &&
+                tutorialPopover?.value === "true" &&
                 this.isOpen
             );
         } else {
-            return (
-                this.isTutorialEnabled &&
-                this.user.preferences.tutorialPopover?.value === "true"
-            );
+            return isTutorialEnabled && tutorialPopover?.value === "true";
         }
     }
 
-    private set showTutorialPopover(value: boolean) {
-        this.isTutorialEnabled = value;
+    private get showTutorialPopoverNotes(): boolean {
+        return this.showTutorialPopover(
+            this.user.preferences.tutorialPopover,
+            this.isTutorialEnabledForNotes
+        );
+    }
+
+    private set showTutorialPopoverNotes(value: boolean) {
+        this.isTutorialEnabledForNotes = value;
+    }
+
+    private get showTutorialPopoverExportRecords(): boolean {
+        return this.showTutorialPopover(
+            this.user.preferences.tutorialPopoverExportRecords,
+            this.isTutorialEnabledForExportRecords
+        );
+    }
+
+    private set showTutorialPopoverExportRecords(value: boolean) {
+        this.isTutorialEnabledForExportRecords = value;
     }
 
     private get isOverlayVisible() {
@@ -383,7 +419,7 @@ export default class SidebarComponent extends Vue {
                         <b-popover
                             ref="popover"
                             triggers="manual"
-                            :show.sync="showTutorialPopover"
+                            :show.sync="showTutorialPopoverNotes"
                             target="add-a-note-row"
                             class="popover"
                             fallback-placement="clockwise"
@@ -394,7 +430,7 @@ export default class SidebarComponent extends Vue {
                             <div>
                                 <b-button
                                     class="pop-over-close"
-                                    @click="dismissTutorial"
+                                    @click="dismissTutorialForNotes"
                                     >x</b-button
                                 >
                             </div>
@@ -470,6 +506,7 @@ export default class SidebarComponent extends Vue {
                         class="my-4"
                     >
                         <b-row
+                            id="export-records-row"
                             class="align-items-center name-wrapper my-4 button-container"
                             :class="{ selected: isReports }"
                         >
@@ -496,6 +533,32 @@ export default class SidebarComponent extends Vue {
                                 <span>Export Records</span>
                             </b-col>
                         </b-row>
+                        <b-popover
+                            ref="popover"
+                            triggers="manual"
+                            :show.sync="showTutorialPopoverExportRecords"
+                            target="export-records-row"
+                            class="popover"
+                            fallback-placement="clockwise"
+                            placement="right"
+                            variant="dark"
+                            boundary="viewport"
+                        >
+                            <div>
+                                <b-button
+                                    class="pop-over-close"
+                                    @click="dismissTutorialForExportRecords"
+                                    >x</b-button
+                                >
+                            </div>
+                            <div
+                                data-testid="exportRecordsPopover"
+                                class="popover-content"
+                            >
+                                Download a pdf of your records. e.g. COVID-19
+                                test proof for employers.
+                            </div>
+                        </b-popover>
                     </router-link>
                     <!-- Health Insights button -->
                     <router-link
@@ -791,6 +854,9 @@ export default class SidebarComponent extends Vue {
 @media (max-width: 470px) {
     .popover-content {
         max-width: 8rem;
+    }
+    .bs-popover-right {
+        margin-left: 220px !important;
     }
 }
 </style>

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -527,6 +527,7 @@ export default class SidebarComponent extends Vue {
                             </b-col>
                             <b-col
                                 v-show="isOpen"
+                                id="export-records-col"
                                 cols="7"
                                 class="button-title"
                             >
@@ -534,7 +535,7 @@ export default class SidebarComponent extends Vue {
                             </b-col>
                         </b-row>
                         <b-popover
-                            ref="popover"
+                            ref="popover-export-records"
                             triggers="manual"
                             :show.sync="showTutorialPopoverExportRecords"
                             target="export-records-row"
@@ -849,14 +850,10 @@ export default class SidebarComponent extends Vue {
     max-width: 20rem;
     color: black;
 }
-
 /* Small Devices*/
 @media (max-width: 470px) {
     .popover-content {
         max-width: 8rem;
-    }
-    .bs-popover-right {
-        margin-left: 220px !important;
     }
 }
 </style>

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -193,16 +193,6 @@ export default class SidebarComponent extends Vue {
         }
     }
 
-    private dismissTutorialForNotes() {
-        this.dismissTutorial(this.user.preferences.tutorialPopover);
-    }
-
-    private dismissTutorialForExportRecords() {
-        this.dismissTutorial(
-            this.user.preferences.tutorialPopoverExportRecords
-        );
-    }
-
     private printView() {
         this.clearOverlay();
         this.eventBus.$emit(EventMessageName.TimelinePrintView);
@@ -418,7 +408,11 @@ export default class SidebarComponent extends Vue {
                             <div>
                                 <b-button
                                     class="pop-over-close"
-                                    @click="dismissTutorialForNotes"
+                                    @click="
+                                        dismissTutorial(
+                                            user.preferences.tutorialPopover
+                                        )
+                                    "
                                     >x</b-button
                                 >
                             </div>
@@ -536,7 +530,12 @@ export default class SidebarComponent extends Vue {
                             <div>
                                 <b-button
                                     class="pop-over-close"
-                                    @click="dismissTutorialForExportRecords"
+                                    @click="
+                                        dismissTutorial(
+                                            user.preferences
+                                                .tutorialPopoverExportRecords
+                                        )
+                                    "
                                     >x</b-button
                                 >
                             </div>

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -12,7 +12,6 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faStream } from "@fortawesome/free-solid-svg-icons";
 import User from "@/models/user";
 import type { UserPreference } from "@/models/userPreference";
-import { DateWrapper } from "@/models/dateWrapper";
 library.add(faStream);
 
 const auth = "auth";
@@ -175,25 +174,18 @@ export default class SidebarComponent extends Vue {
         this.eventBus.$emit(EventMessageName.TimelineCreateNote);
     }
 
-    private dismissTutorial(
-        preference: string,
-        userPreference: UserPreference
-    ) {
-        this.logger.debug(`Dismissing tutorial ${preference}...`);
-        if (userPreference != undefined && userPreference.hdId != undefined) {
-            userPreference.value = "false";
+    private dismissTutorial(userPreference: UserPreference) {
+        this.logger.debug(
+            `Dismissing tutorial ${userPreference.preference}...`
+        );
+        userPreference.value = "false";
+        if (userPreference.hdId != undefined) {
             this.updateUserPreference({
                 hdid: this.user.hdid,
                 userPreference: userPreference,
             });
         } else {
-            userPreference = {
-                hdId: this.user.hdid,
-                preference: preference,
-                value: "false",
-                version: 0,
-                createdDateTime: new DateWrapper().toISO(),
-            };
+            userPreference.hdId = this.user.hdid;
             this.createUserPreference({
                 hdid: this.user.hdid,
                 userPreference: userPreference,
@@ -202,15 +194,11 @@ export default class SidebarComponent extends Vue {
     }
 
     private dismissTutorialForNotes() {
-        this.dismissTutorial(
-            "tutorialPopover",
-            this.user.preferences.tutorialPopover
-        );
+        this.dismissTutorial(this.user.preferences.tutorialPopover);
     }
 
     private dismissTutorialForExportRecords() {
         this.dismissTutorial(
-            "tutorialPopoverExportRecords",
             this.user.preferences.tutorialPopoverExportRecords
         );
     }

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -45,6 +45,18 @@ export const actions: ActionTree<UserState, RootState> = {
                                 createdDateTime: new DateWrapper().toISO(),
                             };
                         }
+                        if (
+                            userProfile.preferences
+                                .tutorialPopoverExportRecords === undefined
+                        ) {
+                            userProfile.preferences.tutorialPopoverExportRecords = {
+                                hdId: userProfile.hdid,
+                                preference: "tutorialPopoverExportRecords",
+                                value: "true",
+                                version: 0,
+                                createdDateTime: new DateWrapper().toISO(),
+                            };
+                        }
                     } else {
                         isRegistered = false;
                     }


### PR DESCRIPTION
# Fixes or Implements [AB#9858](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9858)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description
- add Popover to "Export Records" menu item with the Text: "Download a pdf of your records. e.g. COVID-19 test proof for employers." 
- show once until dismissed
![image](https://user-images.githubusercontent.com/48332333/104654279-ae910e80-5670-11eb-9282-35c53324a188.png)

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
