### PR TITLE
fix for displaying notes popove

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -234,6 +234,12 @@ export default class SidebarComponent extends Vue {
     }
 
     private get isTimeline(): boolean {
+        if (
+            !this.isMobileWidth &&
+            this.user.preferences.tutorialPopover?.value === "true"
+        ) {
+            this.showTutorialPopover = true;
+        }
         return this.$route.path == "/timeline";
     }
 


### PR DESCRIPTION
# Fixes or Implements [AB#9887](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9887)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- Fix for displaying Notes's popoever when login or when selecting Timeline from Profile menu.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
