### PR TITLE
fix notes popover for mobile

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -792,5 +792,8 @@ export default class SidebarComponent extends Vue {
     .popover-content {
         max-width: 8rem;
     }
+    .bs-popover-right {
+        margin-left: 14rem !important;
+    }
 }
 </style>


### PR DESCRIPTION
# Fixes or Implements [AB#9888](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9888)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- Adjusted the margin-left for mobile.
RESULTS
![image](https://user-images.githubusercontent.com/48332333/104783831-bcf82c80-573b-11eb-9f5b-f7c516390121.png)


If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
