### PR TITLE
Change popover trigger from focus to click to resolve AB#9957

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/filters.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/filters.vue
@@ -178,7 +178,7 @@ export default class FilterComponent extends Vue {
             </b-button>
             <b-popover
                 target="filterBtn"
-                triggers="focus"
+                triggers="click"
                 text="Filter"
                 class="w-100"
                 data-testid="filterContainer"


### PR DESCRIPTION
# Fixes or Implements [AB#9957](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9957)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

It appears that popover focus triggers are broken on MacOS/Safari as multiple hits found on Google including
https://github.com/bootstrap-vue/bootstrap-vue/issues/1547

I changed the tigger to be click based and the filter works correctly on Safari.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

* [X] Chrome
* [X] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.
Manual testing confirmed expected behaviour, may need to investigate BrowserStack for this.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
