### PR TITLE
Handled failure in retrieving Patient Data

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
@@ -9,6 +9,7 @@ import { ResultType } from "@/constants/resulttype";
 import BannerError from "@/models/bannerError";
 import { DateWrapper } from "@/models/dateWrapper";
 import { LaboratoryOrder } from "@/models/laboratory";
+import PatientData from "@/models/patientData";
 import RequestResult from "@/models/requestResult";
 import User from "@/models/user";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
@@ -25,6 +26,7 @@ import ErrorTranslator from "@/utility/errorTranslator";
 export default class COVID19ReportComponent extends Vue {
     @Prop() private startDate?: string;
     @Prop() private endDate?: string;
+    @Prop() private patientData?: PatientData;
     @Getter("user", { namespace: "user" })
     private user!: User;
     @Action("addError", { namespace: "errorBanner" })
@@ -178,6 +180,7 @@ export default class COVID19ReportComponent extends Vue {
                     :start-date="startDate"
                     :end-date="endDate"
                     title="Health Gateway COVID-19 Test Result History"
+                    :patient-data="patientData"
                 />
                 <b-row
                     v-if="isEmpty && (!isLoading || !isPreview)"

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -11,6 +11,7 @@ import { ResultType } from "@/constants/resulttype";
 import BannerError from "@/models/bannerError";
 import { DateWrapper } from "@/models/dateWrapper";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
+import PatientData from "@/models/patientData";
 import RequestResult from "@/models/requestResult";
 import User from "@/models/user";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
@@ -28,6 +29,7 @@ import ErrorTranslator from "@/utility/errorTranslator";
 export default class MedicationHistoryReportComponent extends Vue {
     @Prop() private startDate?: string;
     @Prop() private endDate?: string;
+    @Prop() private patientData?: PatientData;
     @Getter("user", { namespace: "user" })
     private user!: User;
     @Action("getMedicationStatements", { namespace: "medication" })
@@ -229,6 +231,7 @@ export default class MedicationHistoryReportComponent extends Vue {
                     :start-date="startDate"
                     :end-date="endDate"
                     title="Health Gateway Medication History"
+                    :patient-data="patientData"
                 />
                 <b-row v-if="isEmpty && (!isLoading || !isPreview)">
                     <b-col>No records found.</b-col>

--- a/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
@@ -9,6 +9,7 @@ import { ResultType } from "@/constants/resulttype";
 import BannerError from "@/models/bannerError";
 import { DateWrapper } from "@/models/dateWrapper";
 import Encounter from "@/models/encounter";
+import PatientData from "@/models/patientData";
 import User from "@/models/user";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
@@ -25,6 +26,7 @@ import ErrorTranslator from "@/utility/errorTranslator";
 export default class MSPVisitsReportComponent extends Vue {
     @Prop() private startDate?: string;
     @Prop() private endDate?: string;
+    @Prop() private patientData?: PatientData;
     @Getter("user", { namespace: "user" })
     private user!: User;
     @Action("addError", { namespace: "errorBanner" })
@@ -172,6 +174,7 @@ export default class MSPVisitsReportComponent extends Vue {
                     :start-date="startDate"
                     :end-date="endDate"
                     title="Health Gateway MSP Visit History"
+                    :patient-data="patientData"
                 />
                 <b-row
                     v-if="isEmpty && (!isLoading || !isPreview)"

--- a/Apps/WebClient/src/ClientApp/src/eventbus.ts
+++ b/Apps/WebClient/src/ClientApp/src/eventbus.ts
@@ -17,4 +17,5 @@ export class EventMessageName {
     public static readonly TimelinePageUpdate = "timeline-page-update";
     public static readonly SelectedFilter = "filter-selected";
     public static readonly IsNoteBlank = "note-blank";
+    public static readonly PatientDataRetrieved = "patient-data-retrieved";
 }

--- a/Apps/WebClient/src/ClientApp/src/eventbus.ts
+++ b/Apps/WebClient/src/ClientApp/src/eventbus.ts
@@ -17,5 +17,4 @@ export class EventMessageName {
     public static readonly TimelinePageUpdate = "timeline-page-update";
     public static readonly SelectedFilter = "filter-selected";
     public static readonly IsNoteBlank = "note-blank";
-    public static readonly PatientDataRetrieved = "patient-data-retrieved";
 }

--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -11,6 +11,7 @@ import COVID19ReportComponent from "@/components/report/covid19.vue";
 import ImmunizationHistoryReportComponent from "@/components/report/immunizationHistory.vue";
 import MedicationHistoryReportComponent from "@/components/report/medicationHistory.vue";
 import MSPVisitsReportComponent from "@/components/report/mspVisits.vue";
+import EventBus, { EventMessageName } from "@/eventbus";
 import type { WebClientConfiguration } from "@/models/configData";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
@@ -43,7 +44,9 @@ export default class ReportsView extends Vue {
     @Ref("immunizationHistoryReport")
     readonly immunizationHistoryReport!: ImmunizationHistoryReportComponent;
 
+    private eventBus = EventBus;
     private isLoading = false;
+    private patientDataRetrieved = false;
     private isGeneratingReport = false;
     private logger!: ILogger;
     private reportType = "";
@@ -71,6 +74,12 @@ export default class ReportsView extends Vue {
                 text: "Immunizations",
             });
         }
+        this.eventBus.$on(
+            EventMessageName.PatientDataRetrieved,
+            (retrieved: boolean) => {
+                this.patientDataRetrieved = retrieved;
+            }
+        );
     }
 
     private clear() {
@@ -189,7 +198,9 @@ export default class ReportsView extends Vue {
                                                 data-testid="exportRecordBtn"
                                                 class="mb-1"
                                                 :disabled="
-                                                    !reportType || isLoading
+                                                    !reportType ||
+                                                    isLoading ||
+                                                    !patientDataRetrieved
                                                 "
                                                 @click="showConfirmationModal"
                                             >


### PR DESCRIPTION
# Fixes or Implements [AB#9940](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9940)
* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- Retry 3 time to get Patient Data in case of failure.
- Disable Download PDF if Patient Data is not available.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
