### PR TITLE
Fix bug with html2canvas AB#9882

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -85,6 +85,8 @@ export default class ReportsView extends Vue {
 
     private downloadPdf() {
         this.isGeneratingReport = true;
+        // Fixes a possible bug with html2canvas where if the page is scrolled it could cut off the image.
+        window.scrollTo(0, 0);
         let generatePromise: Promise<void>;
         switch (this.reportType) {
             case "MED":


### PR DESCRIPTION
# Fixes or Implements [AB#9882](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9882)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Fixes the report cutoff with a work around for a bug with html2canvas when the window is scrolled down.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
