### PR TITLE
add cookies to cypress tests

### DIFF
--- a/Testing/functional/e2e/cypress/integration/timeline/filter.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/filter.js
@@ -92,7 +92,7 @@ describe("Filters", () => {
         cy.get("[data-testid=noTimelineEntriesText]").should("be.visible");
         cy.get("[data-testid=filterTextInput]").clear();
         cy.get("[data-testid=listViewToggle]").last().click();
-    }); 
+    });
 
     it("Filter Checkboxes are Visible", () => {
         cy.get("[data-testid=Medication-filter]")

--- a/Testing/functional/e2e/cypress/integration/timeline/filter.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/filter.js
@@ -13,7 +13,7 @@ function verifyActiveFilter(activeFilterCount) {
 
 describe("Filters", () => {  
     beforeEach(() => {
-        cy.restoreCookies();
+        cy.restoreAuthCookies();
     })
     before(() => {
         cy.login(

--- a/Testing/functional/e2e/cypress/integration/timeline/filter.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/filter.js
@@ -11,7 +11,10 @@ function verifyActiveFilter(activeFilterCount) {
     cy.get("[data-testid=filterDropdown]").focus().click({ force: true });
 }
 
-describe("Filters", () => {
+describe("Filters", () => {  
+    beforeEach(() => {
+        cy.restoreCookies();
+    })
     before(() => {
         cy.login(
             Cypress.env("keycloak.username"),
@@ -89,7 +92,7 @@ describe("Filters", () => {
         cy.get("[data-testid=noTimelineEntriesText]").should("be.visible");
         cy.get("[data-testid=filterTextInput]").clear();
         cy.get("[data-testid=listViewToggle]").last().click();
-    });
+    }); 
 
     it("Filter Checkboxes are Visible", () => {
         cy.get("[data-testid=Medication-filter]")

--- a/Testing/functional/e2e/cypress/support/commands.js
+++ b/Testing/functional/e2e/cypress/support/commands.js
@@ -8,7 +8,15 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 const { AuthMethod } = require("./constants");
-let storedCookies = [];
+const { globalStorage } = require("./globalStorage")
+
+function storeAuthCookies() {
+    cy.getCookies()
+        .then((cookies) => {
+            globalStorage.authCookies = cookies;
+        });
+}
+
 Cypress.Commands.add(
     "login",
     (username, password, authMethod = AuthMethod.BCSC, path = "/timeline") => {
@@ -74,7 +82,7 @@ Cypress.Commands.add(
                         // Wait for cookies are set before store them in cypress.
                         cy.get('[data-testid=logoutBtn]')
                             .should('be.visible')
-                        cy.storeCookies();
+                        storeAuthCookies();
                     })
             });
         }
@@ -223,15 +231,8 @@ Cypress.Commands.add("setupDownloads", () => {
   }
 });
 
-Cypress.Commands.add("storeCookies", () => {
-    cy.getCookies()
-        .then((cookies) => {
-            storedCookies = cookies;
-        });
-});
-
-Cypress.Commands.add("restoreCookies", () => {
-    storedCookies.forEach(cookie => {
+Cypress.Commands.add("restoreAuthCookies", () => {
+    globalStorage.authCookies.forEach(cookie => {
         cy.setCookie(cookie.name, cookie.value);
     });
 });

--- a/Testing/functional/e2e/cypress/support/commands.js
+++ b/Testing/functional/e2e/cypress/support/commands.js
@@ -8,7 +8,7 @@
 // https://on.cypress.io/custom-commands
 // ***********************************************
 const { AuthMethod } = require("./constants");
-let storedCookies = {};
+let storedCookies = [];
 Cypress.Commands.add(
     "login",
     (username, password, authMethod = AuthMethod.BCSC, path = "/timeline") => {

--- a/Testing/functional/e2e/cypress/support/globalStorage.js
+++ b/Testing/functional/e2e/cypress/support/globalStorage.js
@@ -1,0 +1,2 @@
+
+export var globalStorage = {authCookies: []};


### PR DESCRIPTION
# Fixes or Implements [AB#9985](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9985)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- Add common functions to store and restore cookies in cypress.
- Store cookies after login.
- Timeline Filter's tests work 100%
![image](https://user-images.githubusercontent.com/48332333/106957511-ed086f00-66ec-11eb-93c7-685eac557c53.png)

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [X] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
