### PR TITLE
Add traceId to request result error AB#10021

### DIFF
--- a/Apps/Common/src/Models/RequestResultError.cs
+++ b/Apps/Common/src/Models/RequestResultError.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Common.Models
 {
+    using System.Diagnostics;
     using System.Text.Json.Serialization;
     using HealthGateway.Common.ErrorHandling;
 
@@ -23,6 +24,14 @@ namespace HealthGateway.Common.Models
     /// </summary>
     public class RequestResultError
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RequestResultError"/> class.
+        /// </summary>
+        public RequestResultError()
+        {
+            this.TraceId = Activity.Current?.TraceId.ToString() ?? string.Empty;
+        }
+
         /// <summary>
         /// Gets or sets the message depending on the result type.
         /// Will always be set when ResultType is Error.
@@ -36,6 +45,13 @@ namespace HealthGateway.Common.Models
         /// </summary>
         [JsonPropertyName("errorCode")]
         public string ErrorCode { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the error code.
+        /// Will always be set when ResultType is Error.
+        /// </summary>
+        [JsonPropertyName("traceId")]
+        public string TraceId { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the action code.

--- a/Apps/Common/src/Models/RequestResultError.cs
+++ b/Apps/Common/src/Models/RequestResultError.cs
@@ -47,8 +47,7 @@ namespace HealthGateway.Common.Models
         public string ErrorCode { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the error code.
-        /// Will always be set when ResultType is Error.
+        /// Gets or sets the trace id associated with the request.
         /// </summary>
         [JsonPropertyName("traceId")]
         public string TraceId { get; set; } = string.Empty;


### PR DESCRIPTION
# Fixes or Implements [AB#10021](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10021)

* [x] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Adds TraceId to Request Result Error.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
