### PR TITLE
Fixed expiry hours display format

### DIFF
--- a/Apps/Common/src/Services/EmailQueueService.cs
+++ b/Apps/Common/src/Services/EmailQueueService.cs
@@ -152,8 +152,8 @@ namespace HealthGateway.Common.Services
 
             keyValues.Add(INVITE_KEY_VARIABLE, invite.InviteKey.ToString());
             keyValues.Add(ACTIVATION_HOST_VARIABLE, hostUrl);
-            decimal verificationExpiryHours = this.emailVerificationExpirySeconds / 3600;
-            keyValues.Add(EMAIL_TEMPLATE_EXPIRY_HOURS, verificationExpiryHours.ToString("C2", CultureInfo.CurrentCulture));
+            float verificationExpiryHours = this.emailVerificationExpirySeconds / 3600;
+            keyValues.Add(EMAIL_TEMPLATE_EXPIRY_HOURS, verificationExpiryHours.ToString("0", CultureInfo.CurrentCulture));
 
             invite.Email = this.ProcessTemplate(toEmail, this.GetEmailTemplate(EmailTemplateName.RegistrationTemplate), keyValues);
             this.QueueNewInviteEmail(invite);

--- a/Apps/WebClient/src/Server/Services/UserEmailService.cs
+++ b/Apps/WebClient/src/Server/Services/UserEmailService.cs
@@ -78,10 +78,12 @@ namespace HealthGateway.WebClient.Services
                     emailInvite.VerificationAttempts++;
                     this.messageVerificationDelegate.Update(emailInvite);
                 }
+
                 retVal.ResultStatus = ResultType.Error;
-                retVal.ResultError = new RequestResultError() { 
+                retVal.ResultError = new RequestResultError()
+                {
                     ResultMessage = "Invalid Email Invite",
-                    ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState) 
+                    ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState),
                 };
             }
             else if (emailInvite.VerificationAttempts >= MaxVerificationAttempts ||


### PR DESCRIPTION
# Fixes or Implements [AB#10048](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10048)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description
- Fix for display format of the expiry hours.
- Manually Tested scenarios
 i. Same Email --> same Account Verification link.
ii. New Email --> different link.
iii. Expired link
![image](https://user-images.githubusercontent.com/48332333/107824046-a5f62b80-6d35-11eb-90df-e05c34fbca46.png)
![image](https://user-images.githubusercontent.com/48332333/107824053-a8588580-6d35-11eb-80f4-69357046ab35.png)

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
