### PR TITLE
Add documentation for missing robots.txt for AB#10088

### DIFF
--- a/Apps/WebClient/src/WebClient.csproj
+++ b/Apps/WebClient/src/WebClient.csproj
@@ -52,7 +52,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Views\DumpHeaders\" />
-    <Folder Include="Views\Robots\" />
   </ItemGroup>
   <Target Name="CleanDistFolder" AfterTargets="CoreClean">
     <RemoveDir Directories="wwwroot\dist" />

--- a/Tools/BaseBuild/README.md
+++ b/Tools/BaseBuild/README.md
@@ -89,6 +89,25 @@ oc process -f ./adminWebClientSecrets.yaml -p OIDC_SECRET=[Client OIDC Secret]
 oc set env --from=secret/adminwebclient-secrets dc/adminwebclient
 ```
 
+### WebClient Production Only Robots.txt Configuration
+
+Health Gateway has a configurable [robots.txt](../../Apps/WebClient/src/Server/Controllers/RobotsController.cs) that is based on the HealthGateway_Robots.txdt environment variable.  Our default is to have all Robots disallowed in non-Production environments.
+
+Create a ConfigMap for the Robots file
+
+```console
+oc create configmap robots.txt --from-file=HealthGateway_Robots.txt=robots.txt
+```
+
+Once complete manually add the configmap to the webclient deployment config using the name HealthGateway_Robots.txt
+
+The following should work from CLI but DOES NOT as it forces the environment name to uppercase and replaces the . with a _
+e.g. HEALTHGATEWAY_ROBOTS_TXT - investigating but not critical and so documenting.
+
+```console
+oc set env --from=configmap/robots.txt dc/webclient
+```
+
 ### Routes
 
 Once the services have been deployed, you will need to create endpoint routes.  Certificates are required for this step and you can download the HealthgatewayPrivateKey.pem, wildcard.healthgateway.gov.bc.ca.pem and the caCertificate.pem from the Health Gateway Secure Documentation under Certificates 2020.

--- a/Tools/BaseBuild/README.md
+++ b/Tools/BaseBuild/README.md
@@ -91,7 +91,7 @@ oc set env --from=secret/adminwebclient-secrets dc/adminwebclient
 
 ### WebClient Production Only Robots.txt Configuration
 
-Health Gateway has a configurable [robots.txt](../../Apps/WebClient/src/Server/Controllers/RobotsController.cs) that is based on the HealthGateway_Robots.txdt environment variable.  Our default is to have all Robots disallowed in non-Production environments.
+Health Gateway has a configurable [robots.txt](../../Apps/WebClient/src/Server/Controllers/RobotsController.cs) that is based on the HealthGateway_Robots.txt environment variable.  Our default is to have all Robots disallowed in non-Production environments.
 
 Create a ConfigMap for the Robots file
 

--- a/Tools/BaseBuild/robots.txt
+++ b/Tools/BaseBuild/robots.txt
@@ -1,0 +1,5 @@
+#Production Robots as of Feb 17, 2021
+User-agent: *
+Disallow: /ValidateEmail/
+Disallow: /registrationInfo
+Disallow: /api/


### PR DESCRIPTION
# Fixes or Implements [AB#10088](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10088)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

During the OpenShift 4 migration the Production robots override was not applied and was not documented.  This PR updates the documentation.

I removed an obsolete folder in the WebClient codebase related to Robots.

I have already run the steps against the Production deployment config.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

Verify the Production robots.txt file by visiting https:///www.healthgateway.gov.bc.ca/robots.txt default will display a non-prod comment.  

### UI Changes

No

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
