### PR TITLE
Display Type if Title is empty

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/entrycard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/entrycard.vue
@@ -22,6 +22,14 @@ export default class EntrycardTimelineComponent extends Vue {
     @Prop({ default: true }) allowComment!: boolean;
     @Prop({ default: true }) showDetailsButton!: boolean;
 
+    private get displayTitle(): string {
+        if (this.title === "") {
+            return this.entry.type.toString();
+        } else {
+            return this.title;
+        }
+    }
+
     private detailsVisible = false;
 
     private get dateString(): string {
@@ -65,9 +73,9 @@ export default class EntrycardTimelineComponent extends Vue {
                                 class="detailsButton text-left"
                                 @click="toggleDetails()"
                             >
-                                <strong>{{ title }}</strong>
+                                <strong>{{ displayTitle }}</strong>
                             </b-btn>
-                            <strong v-else>{{ title }}</strong>
+                            <strong v-else>{{ displayTitle }}</strong>
                         </b-col>
                         <b-col cols="4" class="text-right">
                             <span


### PR DESCRIPTION
# Fixes or Implements [AB#10097](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10097)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description
- Display entry's type if entry's title is blank.
![image](https://user-images.githubusercontent.com/48332333/108287983-9a916e80-7140-11eb-83a7-e9205fd7fe3c.png)


If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
