### PR TITLE
Removed packages breaking Azure agent build for AB#10196

### DIFF
--- a/Tools/AzureAgent/docker/Dockerfile
+++ b/Tools/AzureAgent/docker/Dockerfile
@@ -49,8 +49,7 @@ ENV NODE_HOME=/opt/node-${NODE_VERSION}-linux-x64
 ENV PATH=$PATH:/opt/az/agent/bin:/opt/node-${NODE_VERSION}-linux-x64/bin:/opt/bin:$HOME/.local/bin/:$HOME/.dotnet/tools
 
 # Update the version of `npm` that came with the packages above
-# and install a few additional tools.
-RUN npm i -g npm@latest yarn@latest nsp@latest nodemon@latest && \
+RUN npm i -g npm@latest && \
     rm -rf ~/.npm && \
     node -v && \
     npm -v


### PR DESCRIPTION
# Fixes or Implements [AB#10196](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10196)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

While testing the new Kubernetes policies I found that the Azure agent build would not complete.  The offending line was installing npm and a few packages: nsp, yarn, and nodemon.  I removed the additional packages from the build and uninstall locally and tested the compilation of ClientApp for WebClient and AdminWebClient and they look alright.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

Run the Azure Agent build locally or via OpenShift
local: 
```console
cd Tools/AzureAgent/docker
docker build .
```

### UI Changes

No

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
