### PR TITLE
Switchover to Kubernetes Network policies for AB#10178

### DIFF
--- a/Tools/BaseBuild/README.md
+++ b/Tools/BaseBuild/README.md
@@ -7,15 +7,10 @@ Documents our OpenShift Build and Deployment process templates.
 A Network Security Policy needs to be deployed into each namespace prior to anything being executed.  In order to create this, please execute the following:
 
 ```console
-oc project 0bd5ad-tools
-oc process -f ./nsp.yaml -p NAMESPACE=0bd5ad-tools | oc apply -f -
-oc project 0bd5ad-dev
-oc process -f ./nsp.yaml -p NAMESPACE=0bd5ad-dev | oc apply -f -
-oc project 0bd5ad-test
-oc process -f ./nsp.yaml -p NAMESPACE=0bd5ad-test | oc apply -f -
-oc project 0bd5ad-prod
-oc process -f ./nsp.yaml -p NAMESPACE=0bd5ad-prod | oc apply -f -
-```
+oc process -f ./nsp.yaml -p NAMESPACE_PREFIX=0bd5ad -p ENVIRONMENT=tools | oc apply -f -
+oc process -f ./nsp.yaml -p NAMESPACE_PREFIX=0bd5ad -p ENVIRONMENT=dev | oc apply -f -
+oc process -f ./nsp.yaml -p NAMESPACE_PREFIX=0bd5ad -p ENVIRONMENT=test | oc apply -f -
+oc process -f ./nsp.yaml -p NAMESPACE_PREFIX=0bd5ad -p ENVIRONMENT=prod | oc apply -f -```
 
 Please ensure that the AzureAgents have been deployed into the OpenShift tools namespace.
 

--- a/Tools/BaseBuild/nsp.yaml
+++ b/Tools/BaseBuild/nsp.yaml
@@ -1,42 +1,86 @@
-  apiVersion: template.openshift.io/v1
-  kind: Template
-  objects:
-    - apiVersion: security.devops.gov.bc.ca/v1alpha1
-      kind: NetworkSecurityPolicy
-      metadata:
-        name: egress-internet
-      spec:
-        description: "allow ${NAMESPACE} namespace to talk to the internet."
-        source:
-          - - $namespace=${NAMESPACE}
-        destination:
-          - - ext:network=any
-
-    - apiVersion: security.devops.gov.bc.ca/v1alpha1
-      kind: NetworkSecurityPolicy
-      metadata:
-        name: intra-namespace-comms
-      spec:
-        description: "allow ${NAMESPACE} namespace to talk to itself"
-        source:
-          - - $namespace=${NAMESPACE}
-        destination:
-          - - $namespace=${NAMESPACE}
-
-    - apiVersion: security.devops.gov.bc.ca/v1alpha1
-      kind: NetworkSecurityPolicy
-      metadata:
-        name: int-cluster-k8s-api-comms
-      spec:
-        description: "allow ${NAMESPACE} pods to talk to the k8s api"
-        destination:
-        - - int:network=internal-cluster-api-endpoint
-        source:
-        - - $namespace=${NAMESPACE}
-        
-  parameters:
-    - name: NAMESPACE
+---
+apiVersion: template.openshift.io/v1
+kind: Template
+labels:
+  template: quickstart-network-security-policy
+metadata:
+  name: quickstart-network-security-policy
+objects:
+  - kind: NetworkPolicy
+    apiVersion: networking.k8s.io/v1
+    metadata:
+      name: deny-by-default
+    spec:
+      # The default posture for a security first namespace is to
+      # deny all traffic. If not added this rule will be added
+      # by Platform Services during environment cut-over.
+      podSelector: {}
+      ingress: []
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-from-openshift-ingress
+    spec:
+      # This policy allows any pod with a route & service combination
+      # to accept traffic from the OpenShift router pods. This is
+      # required for things outside of OpenShift (like the Internet)
+      # to reach your pods.
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  network.openshift.io/policy-group: ingress
+      podSelector: {}
+      policyTypes:
+        - Ingress
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: allow-all-internal
+    spec:
+      # Allow all pods within the current namespace to communicate
+      # to one another.
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  environment: ${ENVIRONMENT}
+                  name: ${NAMESPACE_PREFIX}
+      podSelector: {}
+      policyTypes:
+        - Ingress
+  - apiVersion: security.devops.gov.bc.ca/v1alpha1
+    kind: NetworkSecurityPolicy
+    metadata:
+      name: any-to-any
+    spec:
       description: |
-        The the name of the namespace the policy is being
-        deployed to.
-      required: true
+        allow all pods to communicate
+      source:
+        - - "$namespace=${NAMESPACE_PREFIX}-${ENVIRONMENT}"
+      destination:
+        - - "$namespace=*"
+  - apiVersion: security.devops.gov.bc.ca/v1alpha1
+    kind: NetworkSecurityPolicy
+    metadata:
+      name: any-to-external
+    spec:
+      description: |
+        Allow all pods to talk to external systems
+      source:
+        - - "$namespace=${NAMESPACE_PREFIX}-${ENVIRONMENT}"
+      destination:
+        - - "ext:network=any"
+parameters:
+  - name: NAMESPACE_PREFIX
+    displayName: Namespace Prefix
+    description: |
+      The prefix (a.k.a license plate) of the namespace this policy
+      is being deployed to;
+    required: true
+  - name: ENVIRONMENT
+    displayName: Environment Name
+    description: |
+      The environment (i.e dev/test/prod/tools) this policy is 
+      being deployed to.
+    required: true


### PR DESCRIPTION
# Fixes or Implements [AB#10125](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10125)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Updates our Network Security policy to use Kubernetes instead of Aporeto.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
