### PR TITLE
Fix the covid modal

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/covid.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/covid.vue
@@ -108,19 +108,6 @@ export default class CovidModalComponent extends Vue {
         });
     }
 
-    private handleCancel(modalEvt: Event) {
-        // Prevent modal from closing
-        modalEvt.preventDefault();
-
-        // Trigger cancel handler
-        this.cancel();
-
-        // Hide the modal manually
-        this.$nextTick(() => {
-            this.isDismissed = true;
-        });
-    }
-
     @Emit()
     private submit() {
         return;
@@ -144,7 +131,7 @@ export default class CovidModalComponent extends Vue {
         footer-class="modal-footer"
         :no-close-on-backdrop="true"
         centered
-        @close="handleCancel"
+        @close="handleSubmit"
     >
         <form @submit.stop.prevent="handleSubmit">
             <b-row data-testid="covidModalText">

--- a/Apps/WebClient/src/ClientApp/src/components/modal/covid.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/covid.vue
@@ -108,6 +108,21 @@ export default class CovidModalComponent extends Vue {
         });
     }
 
+    private handleCancel(modalEvt: Event) {
+        // Prevent modal from closing
+        modalEvt.preventDefault();
+
+        this.updateCovidPreference();
+
+        // Trigger cancel handler
+        this.cancel();
+
+        // Hide the modal manually
+        this.$nextTick(() => {
+            this.isDismissed = true;
+        });
+    }
+
     @Emit()
     private submit() {
         return;
@@ -131,7 +146,7 @@ export default class CovidModalComponent extends Vue {
         footer-class="modal-footer"
         :no-close-on-backdrop="true"
         centered
-        @close="handleSubmit"
+        @close="handleCancel"
     >
         <form @submit.stop.prevent="handleSubmit">
             <b-row data-testid="covidModalText">

--- a/Testing/functional/e2e/cypress/integration/timeline/modals/covidModal.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/modals/covidModal.js
@@ -68,6 +68,16 @@ describe('Validate Modals Popup', () => {
         cy.get('[data-testid=covidModal] header:first')
           .find('button').should('have.text', '×').click()
         cy.get('[data-testid=covidModal]').should('not.exist')
+
+        // Verify that only COVID-19 Tests filter is selected. 
+        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=noteTitle]").should("not.exist");
+        cy.get("[data-testid=immunizationTitle]").should("not.exist");
+        cy.get("[data-testid=laboratoryTitle]").should("be.visible");
+        cy.get("[data-testid=medicationTitle]").should("not.exist");
+        cy.get('[data-testid=filterDropdown] > span').contains('1'); 
+
+        // Verify that Covid Modal doens't display after reload the timeline.
         cy.reload()
         cy.get('[data-testid=covidModal]').should('not.exist')
         cy.get('[data-testid=timelineLabel]').should('be.visible');

--- a/Testing/functional/e2e/cypress/integration/timeline/modals/covidModal.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/modals/covidModal.js
@@ -61,6 +61,14 @@ describe('Validate Modals Popup', () => {
         cy.get('[data-testid=covidModalText]').contains('Check the status of your COVID-19 test and view your result when it is available')
         cy.get('[data-testid=covidViewResultBtn]').should('be.visible').contains('View Result').click()
         cy.get('[data-testid=covidModal]').should('not.exist')
+        
+        // Verify that only COVID-19 Tests filter is selected.
+        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=noteTitle]").should("not.exist");
+        cy.get("[data-testid=immunizationTitle]").should("not.exist");
+        cy.get("[data-testid=laboratoryTitle]").should("be.visible");
+        cy.get("[data-testid=medicationTitle]").should("not.exist");
+        cy.get('[data-testid=filterDropdown] > span').contains('1');
     })
 
     it('Dismiss Covid Modal', () => {
@@ -69,13 +77,8 @@ describe('Validate Modals Popup', () => {
           .find('button').should('have.text', '×').click()
         cy.get('[data-testid=covidModal]').should('not.exist')
 
-        // Verify that only COVID-19 Tests filter is selected. 
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
-        cy.get("[data-testid=noteTitle]").should("not.exist");
-        cy.get("[data-testid=immunizationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("be.visible");
-        cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get('[data-testid=filterDropdown] > span').contains('1'); 
+        // Verify that only COVID-19 Tests filter is NOT selected.
+        cy.get('[data-testid=filterDropdown] > span').contains('0'); 
 
         // Verify that Covid Modal doens't display after reload the timeline.
         cy.reload()


### PR DESCRIPTION
# Fixes or Implements [AB#10198](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10198)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- Dismiss Covid modal by clicking x button also records the action in database.
- Update functional tests.

![image](https://user-images.githubusercontent.com/48332333/109567125-b595a400-7a99-11eb-9e04-dd4070c3a5c6.png)


If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [X] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
