### PR TITLE
Move note menu button AB#10167

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/note.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/note.vue
@@ -47,13 +47,6 @@ export default class NoteTimelineComponent extends Vue {
         return faEllipsisV;
     }
 
-    private get canShowDetails(): boolean {
-        return (
-            this.entry.text.length > 0 &&
-            this.entry.text !== this.entry.textSummary
-        );
-    }
-
     private handleDelete(): void {
         if (confirm("Are you sure you want to delete this note?")) {
             this.isSaving = true;
@@ -87,45 +80,50 @@ export default class NoteTimelineComponent extends Vue {
         :subtitle="entry.textSummary"
         :entry="entry"
         :allow-comment="false"
-        :can-show-details="canShowDetails"
         :is-mobile-details="isMobileDetails"
     >
-        <b-navbar-nav slot="header-menu">
-            <b-nav-item-dropdown
-                right
-                text=""
-                :no-caret="true"
-                :disabled="isSaving"
-            >
-                <!-- Using 'button-content' slot -->
-                <template slot="button-content">
-                    <font-awesome-icon
-                        data-testid="noteMenuBtn"
-                        class="noteMenu"
-                        :icon="menuIcon"
-                        size="1x"
-                    ></font-awesome-icon>
-                </template>
-                <b-dropdown-item
-                    data-testid="editNoteMenuBtn"
-                    class="menuItem"
-                    @click="handleEdit()"
-                >
-                    Edit
-                </b-dropdown-item>
-                <b-dropdown-item
-                    data-testid="deleteNoteMenuBtn"
-                    class="menuItem"
-                    @click="handleDelete()"
-                >
-                    Delete
-                </b-dropdown-item>
-            </b-nav-item-dropdown>
-        </b-navbar-nav>
-
-        <span slot="details-body">
-            {{ entry.text }}
-        </span>
+        <b-row slot="details-body" class="justify-content-between">
+            <b-col class="pt-1">
+                <span>
+                    {{ entry.text }}
+                </span>
+            </b-col>
+            <b-col class="col-1">
+                <b-navbar-nav class="justify-content-end">
+                    <b-nav-item-dropdown
+                        toggle-class="d-flex justify-content-end"
+                        right
+                        text=""
+                        :no-caret="true"
+                        :disabled="isSaving"
+                    >
+                        <!-- Using 'button-content' slot -->
+                        <template slot="button-content">
+                            <font-awesome-icon
+                                data-testid="noteMenuBtn"
+                                class="noteMenu"
+                                :icon="menuIcon"
+                                size="1x"
+                            ></font-awesome-icon>
+                        </template>
+                        <b-dropdown-item
+                            data-testid="editNoteMenuBtn"
+                            class="menuItem"
+                            @click="handleEdit()"
+                        >
+                            Edit
+                        </b-dropdown-item>
+                        <b-dropdown-item
+                            data-testid="deleteNoteMenuBtn"
+                            class="menuItem"
+                            @click="handleDelete()"
+                        >
+                            Delete
+                        </b-dropdown-item>
+                    </b-nav-item-dropdown>
+                </b-navbar-nav>
+            </b-col>
+        </b-row>
     </EntryCard>
 </template>
 

--- a/Testing/functional/e2e/cypress/integration/timeline/notes.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/notes.js
@@ -31,6 +31,9 @@ describe('Notes', () => {
     });
 
     it('Validate Edit', () => {
+        cy.get('[data-testid=timelineCard]')
+            .first()
+            .click();
         cy.get('[data-testid=noteMenuBtn]')
             .first()
             .click();
@@ -48,6 +51,9 @@ describe('Notes', () => {
     });
 
     it('Validate Delete', () => {
+        cy.get('[data-testid=timelineCard]')
+            .first()
+            .click();
         cy.get('[data-testid=noteMenuBtn]')
             .last()
             .click();


### PR DESCRIPTION
# Fixes or Implements [AB#10167](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10167)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Moves menu button from note card header to details body.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [x] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
