### PR TITLE
Display lab result outcome AB#10239

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/dependentCard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependentCard.vue
@@ -13,7 +13,11 @@ import BannerError from "@/models/bannerError";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
 import type { Dependent } from "@/models/dependent";
-import { LaboratoryOrder, LaboratoryReport } from "@/models/laboratory";
+import {
+    LaboratoryOrder,
+    LaboratoryReport,
+    LaboratoryUtil,
+} from "@/models/laboratory";
 import { LaboratoryResult } from "@/models/laboratory";
 import { ResultError } from "@/models/requestResult";
 import User from "@/models/user";
@@ -199,7 +203,7 @@ export default class DependentCardComponent extends Vue {
     }
 
     private checkResultReady(labResult: LaboratoryResult): boolean {
-        return labResult.testStatus == "Final";
+        return LaboratoryUtil.isTestResultReady(labResult.testStatus);
     }
 
     private formatResult(labResult: LaboratoryResult): string {

--- a/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
@@ -5,7 +5,7 @@ import { Action, Getter } from "vuex-class";
 
 import ReportHeaderComponent from "@/components/report/header.vue";
 import { DateWrapper } from "@/models/dateWrapper";
-import { LaboratoryOrder } from "@/models/laboratory";
+import { LaboratoryOrder, LaboratoryUtil } from "@/models/laboratory";
 import PatientData from "@/models/patientData";
 import User from "@/models/user";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
@@ -96,6 +96,10 @@ export default class COVID19ReportComponent extends Vue {
         });
     }
 
+    private checkResultReady(testStatus: string | null): boolean {
+        return LaboratoryUtil.isTestResultReady(testStatus);
+    }
+
     private formatDate(date: string): string {
         return new DateWrapper(date).format("yyyy-MM-dd");
     }
@@ -151,7 +155,12 @@ export default class COVID19ReportComponent extends Vue {
                         {{ item.location }}
                     </b-col>
                     <b-col data-testid="covid19ItemResult" class="my-auto">
-                        {{ item.labResults[0].labResultOutcome }}
+                        <span
+                            v-if="
+                                checkResultReady(item.labResults[0].testStatus)
+                            "
+                            >{{ item.labResults[0].labResultOutcome }}</span
+                        >
                     </b-col>
                 </b-row>
             </section>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
@@ -109,7 +109,11 @@ export default class LaboratoryTimelineComponent extends Vue {
                 <b-spinner v-if="isLoadingDocument"></b-spinner>
                 <span v-else>
                     <strong>Report:</strong>
-                    <b-btn variant="link" @click="showConfirmationModal()">
+                    <b-btn
+                        v-if="entry.isTestResultReady"
+                        variant="link"
+                        @click="showConfirmationModal()"
+                    >
                         <font-awesome-icon
                             icon="file-download"
                             aria-hidden="true"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
@@ -96,7 +96,7 @@ export default class LaboratoryTimelineComponent extends Vue {
         :is-mobile-details="isMobileDetails"
     >
         <div slot="header-description">
-            <strong v-show="entry.isStatusFinal">
+            <strong v-show="entry.isTestResultReady">
                 Result:
                 <span :class="entry.labResultOutcome"
                     >{{ entry.labResultOutcome }}

--- a/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
@@ -38,7 +38,10 @@ export interface LaboratoryReport {
 
 export abstract class LaboratoryUtil {
     public static isTestResultReady(testStatus: string | null): boolean {
-        if (testStatus == null) return false;
-        else return ["Final", "Corrected", "Amended"].includes(testStatus);
+        if (testStatus == null) {
+            return false;
+        } else {
+            return ["Final", "Corrected", "Amended"].includes(testStatus);
+        }
     }
 }

--- a/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
@@ -35,3 +35,10 @@ export interface LaboratoryReport {
     encoding: string;
     data: string;
 }
+
+export abstract class LaboratoryUtil {
+    public static isTestResultReady(testStatus: string | null): boolean {
+        if (testStatus == null) return false;
+        else return ["Final", "Corrected", "Amended"].includes(testStatus);
+    }
+}

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryTimelineEntry.ts
@@ -1,5 +1,9 @@
 import { DateWrapper } from "@/models/dateWrapper";
-import { LaboratoryOrder, LaboratoryResult } from "@/models/laboratory";
+import {
+    LaboratoryOrder,
+    LaboratoryResult,
+    LaboratoryUtil,
+} from "@/models/laboratory";
 import TimelineEntry, { EntryType } from "@/models/timelineEntry";
 import { UserComment } from "@/models/userComment";
 
@@ -12,7 +16,7 @@ export default class LaboratoryTimelineEntry extends TimelineEntry {
     public labResultOutcome: string | null;
     public displayDate: DateWrapper;
     public reportAvailable: boolean;
-    public isStatusFinal: boolean;
+    public isTestResultReady: boolean;
 
     public summaryTitle: string;
     public summaryDescription: string;
@@ -53,7 +57,10 @@ export default class LaboratoryTimelineEntry extends TimelineEntry {
         this.summaryTitle = firstResult.loincName || "";
         this.summaryDescription = firstResult.testType || "";
         this.summaryStatus = firstResult.testStatus || "";
-        this.isStatusFinal = this.summaryStatus == "Final";
+        this.isTestResultReady = LaboratoryUtil.isTestResultReady(
+            this.summaryStatus
+        );
+        console.log(`isTestResultReady: ${this.isTestResultReady}`);
         this.labResultOutcome = firstResult.labResultOutcome;
 
         this.getComments = getComments;

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryTimelineEntry.ts
@@ -60,7 +60,6 @@ export default class LaboratoryTimelineEntry extends TimelineEntry {
         this.isTestResultReady = LaboratoryUtil.isTestResultReady(
             this.summaryStatus
         );
-        console.log(`isTestResultReady: ${this.isTestResultReady}`);
         this.labResultOutcome = firstResult.labResultOutcome;
 
         this.getComments = getComments;


### PR DESCRIPTION
# Fixes or Implements [AB#10239](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10239)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description
- Add logic to show Results for "Amended", "Corrected" and "Final" on (1) Timeline (2) Dependent and (3) Export pages.
![image](https://user-images.githubusercontent.com/48332333/109893021-cd0e9180-7c3f-11eb-80ec-e7e7d3c6494b.png)

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
