### PR TITLE
Add Sysdig OpenShift configuration for the team for AB#10002

### DIFF
--- a/Tools/Sysdig/README.md
+++ b/Tools/Sysdig/README.md
@@ -1,0 +1,6 @@
+
+# Sysdig
+
+[BC Government Setup Guide](https://developer.gov.bc.ca/OpenShift-User-Guide-to-Creating-and-Using-a-Sysdig-Team-for-Monitoring)
+
+[Sysdig Login](https://app.sysdigcloud.com/api/oauth/openid/bcdevops)

--- a/Tools/Sysdig/team.yaml
+++ b/Tools/Sysdig/team.yaml
@@ -1,0 +1,18 @@
+apiVersion: ops.gov.bc.ca/v1alpha1
+kind: SysdigTeam
+metadata:
+  name: 0bd5ad-sysdigteam
+spec:
+  team: 
+    description: The Sysdig Team for the Health Gateway Namespaces
+    users:
+    - name: nino.samson@gov.bc.ca
+      role: ROLE_TEAM_MANAGER
+    - name: stephen.laws@nomostech.com
+      role: ROLE_TEAM_MANAGER
+    - name: marobej@gmail.com
+      role: ROLE_TEAM_MANAGER
+    - name: mikelyttle@gmail.com
+      role: ROLE_TEAM_MANAGER
+    - name: tiago.graf@aot-technologies.com
+      role: ROLE_TEAM_MANAGER


### PR DESCRIPTION
# Fixes or Implements [AB#9783](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9783)

* [X] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Adds the configuration for OpenShift to enable Sysdig for the Health Gateway team.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
