### PR TITLE
Fix Covid Card cutoff

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/immunizationCard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/immunizationCard.vue
@@ -105,6 +105,7 @@ export default class ImmunizationCardComponent extends Vue {
     private created() {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         this.eventBus.$on(EventMessageName.TimelineCovidCard, this.showModal);
+        this.onImmunizationsChange();
     }
 
     public showModal(): void {


### PR DESCRIPTION
# Fixes or Implements AB#10289

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description
- Re-populate Doses list on creation of COVID-card view

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
