### PR TITLE
Fix download pdf on safari AB#10278

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
@@ -74,25 +74,14 @@ export default class LaboratoryTimelineComponent extends Vue {
                 fetch(
                     `data:${report.mediaType};${report.encoding},${report.data}`
                 )
-                    .then((res) => res.blob())
-                    .then((b) => {
+                    .then((response) => response.blob())
+                    .then((blob) => {
                         // It is necessary to create a new blob object with mime-type explicitly set
                         // otherwise only Chrome works like it should
-                        var newBlob = new Blob([b], {
+                        var newBlob = new Blob([blob], {
                             type: "application/pdf",
                         });
 
-                        // IE doesn't allow using a blob object directly as link href
-                        // instead it is necessary to use msSaveOrOpenBlob
-                        if (
-                            window.navigator &&
-                            window.navigator.msSaveOrOpenBlob
-                        ) {
-                            window.navigator.msSaveOrOpenBlob(newBlob);
-                            return;
-                        }
-
-                        // For other browsers:
                         // Create a link pointing to the ObjectURL containing the blob.
                         const data = window.URL.createObjectURL(newBlob);
                         var link = document.createElement("a");

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
@@ -67,15 +67,43 @@ export default class LaboratoryTimelineComponent extends Vue {
         this.laboratoryService
             .getReportDocument(this.entry.id, this.user.hdid)
             .then((result) => {
-                const link = document.createElement("a");
                 let dateString = this.entry.displayDate.format(
                     "YYYY_MM_DD-HH_mm"
                 );
                 let report: LaboratoryReport = result.resourcePayload;
-                link.href = `data:${report.mediaType};${report.encoding},${report.data}`;
-                link.download = `COVID_Result_${dateString}.pdf`;
-                link.click();
-                URL.revokeObjectURL(link.href);
+                fetch(
+                    `data:${report.mediaType};${report.encoding},${report.data}`
+                )
+                    .then((res) => res.blob())
+                    .then((b) => {
+                        // It is necessary to create a new blob object with mime-type explicitly set
+                        // otherwise only Chrome works like it should
+                        var newBlob = new Blob([b], {
+                            type: "application/pdf",
+                        });
+
+                        // IE doesn't allow using a blob object directly as link href
+                        // instead it is necessary to use msSaveOrOpenBlob
+                        if (
+                            window.navigator &&
+                            window.navigator.msSaveOrOpenBlob
+                        ) {
+                            window.navigator.msSaveOrOpenBlob(newBlob);
+                            return;
+                        }
+
+                        // For other browsers:
+                        // Create a link pointing to the ObjectURL containing the blob.
+                        const data = window.URL.createObjectURL(newBlob);
+                        var link = document.createElement("a");
+                        link.href = data;
+                        link.download = `COVID_Result_${dateString}.pdf`;
+                        link.click();
+                        setTimeout(function () {
+                            // For Firefox it is necessary to delay revoking the ObjectURL
+                            window.URL.revokeObjectURL(data);
+                        }, 100);
+                    });
             })
             .catch((err) => {
                 this.logger.error(err);


### PR DESCRIPTION
# Fixes or Implements [AB#10278](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10278)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Attempts to fix download pdf issue on safari.
Pending testing on mobile.
Needs refactoring if working.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
