### PR TITLE
Renable blocked IDIR test for AB#10314

### DIFF
--- a/Testing/functional/e2e/cypress/integration/authentication/auth.js
+++ b/Testing/functional/e2e/cypress/integration/authentication/auth.js
@@ -58,27 +58,27 @@ describe('Authentication', () => {
         }
     })
 
-    // it('IDIR Blocked', () => {
-    //     if (Cypress.config().baseUrl != localDevUri) {
-    //         cy.visit('/login');
-    //         cy.log(`Authenticating as IDIR user ${Cypress.env('idir.username')}`);
-    //         cy.get('[data-testid=IDIRBtn]')
-    //             .should('be.visible')
-    //             .should('not.be.disabled')
-    //             .click();
-    //         cy.get('#user')
-    //             .type(Cypress.env('idir.username'));
-    //         cy.get('#password')
-    //             .type(Cypress.env('idir.password'));
-    //         cy.get('input[name="btnSubmit"')
-    //             .click();
-    //         // cy.contains('h1', '403');
-    //         // cy.contains('h2', 'IDIR Login');
-    //     }
-    //     else {
-    //         cy.log("Skipped Logout Test as running locally")
-    //     }
-    // })
+    it('IDIR Blocked', () => {
+        if (Cypress.config().baseUrl != localDevUri) {
+            cy.visit('/login');
+            cy.log(`Authenticating as IDIR user ${Cypress.env('idir.username')}`);
+            cy.get('[data-testid=IDIRBtn]')
+                .should('be.visible')
+                .should('not.be.disabled')
+                .click();
+            cy.get('#user')
+                .type(Cypress.env('idir.username'));
+            cy.get('#password')
+                .type(Cypress.env('idir.password'));
+            cy.get('input[name="btnSubmit"')
+                .click();
+            // cy.contains('h1', '403');
+            // cy.contains('h2', 'IDIR Login');
+        }
+        else {
+            cy.log("Skipped Logout Test as running locally")
+        }
+    })
 
     it('KeyCloak Login', () => {
         cy.login(Cypress.env('keycloak.username'), Cypress.env('keycloak.password'), AuthMethod.KeyCloak)


### PR DESCRIPTION
# Fixes or Implements [AB#10314](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10314)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

Re-enable disabled functional test on blocked IDIRs.

Please note:  If you're running locally you will need to update the password from the secure documentation.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [X] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
