### PR TITLE
Rename MSP Visits to Health Visits AB#10340

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
@@ -96,10 +96,10 @@ export default class MSPVisitsReportComponent extends Vue {
     }
 
     public async generatePdf(): Promise<void> {
-        this.logger.debug("generating MSP Visits PDF...");
+        this.logger.debug("generating Health Visits PDF...");
         this.isPreview = false;
 
-        PDFUtil.generatePdf("HealthGateway_MSPVisits.pdf", this.report).then(
+        PDFUtil.generatePdf("HealthGateway_HealthVisits.pdf", this.report).then(
             () => {
                 this.isPreview = true;
             }
@@ -116,16 +116,17 @@ export default class MSPVisitsReportComponent extends Vue {
                     v-show="!isPreview"
                     :start-date="startDate"
                     :end-date="endDate"
-                    title="Health Gateway MSP Visit History"
+                    title="Health Gateway Health Visit History"
                 />
                 <b-row v-if="isEmpty && (!isLoading || !isPreview)">
                     <b-col>No records found.</b-col>
                 </b-row>
                 <b-row v-else-if="!isEmpty" class="py-3 header">
                     <b-col>Date</b-col>
-                    <b-col>Provider Name</b-col>
                     <b-col>Specialty Description</b-col>
-                    <b-col>Clinic Location</b-col>
+                    <b-col>Practitioner</b-col>
+                    <b-col>Clinic/Practitioner</b-col>
+                    <b-col>Address</b-col>
                 </b-row>
                 <b-row
                     v-for="item in visibleRecords"
@@ -136,14 +137,16 @@ export default class MSPVisitsReportComponent extends Vue {
                         {{ formatDate(item.encounterDate) }}
                     </b-col>
                     <b-col class="my-auto">
-                        {{ item.practitionerName }}
-                    </b-col>
-                    <b-col class="my-auto">
                         {{ item.specialtyDescription }}
                     </b-col>
                     <b-col class="my-auto">
-                        <p>{{ item.clinic.name }}</p>
-                        <p>{{ item.clinic.address }}</p>
+                        {{ item.practitionerName }}
+                    </b-col>
+                    <b-col class="my-auto">
+                        {{ item.clinic.name }}
+                    </b-col>
+                    <b-col class="my-auto">
+                        {{ item.clinic.address }}
                     </b-col>
                 </b-row>
             </section>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/encounter.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/encounter.vue
@@ -1,5 +1,9 @@
 <script lang="ts">
-import { faUserMd, IconDefinition } from "@fortawesome/free-solid-svg-icons";
+import {
+    faInfo,
+    faUserMd,
+    IconDefinition,
+} from "@fortawesome/free-solid-svg-icons";
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 
@@ -23,6 +27,10 @@ export default class EncounterTimelineComponent extends Vue {
         return faUserMd;
     }
 
+    private get infoIcon(): IconDefinition {
+        return faInfo;
+    }
+
     private formatPhone(phoneNumber: string): string {
         return PhoneUtil.formatPhone(phoneNumber);
     }
@@ -33,18 +41,33 @@ export default class EncounterTimelineComponent extends Vue {
     <EntryCard
         :card-id="index + '-' + datekey"
         :entry-icon="entryIcon"
-        :title="entry.practitionerName"
+        :title="entry.specialtyDescription"
+        :subtitle="entry.practitionerName"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
     >
-        <div slot="header-description">
-            {{ entry.specialtyDescription }}
-        </div>
-
         <b-row slot="details-body">
             <b-col>
-                <div data-testid="encounterClinicLabel">
+                <div class="d-inline-flex" data-testid="encounterClinicLabel">
                     <strong>Clinic/Practitioner:</strong>
+                    <div
+                        :id="`tooltip-info${index}-${datekey}`"
+                        class="infoIcon ml-2 mt-1"
+                        tabindex="0"
+                    >
+                        <font-awesome-icon :icon="infoIcon" />
+                    </div>
+                    <b-tooltip
+                        variant="secondary"
+                        :target="`tooltip-info${index}-${datekey}`"
+                        placement="top"
+                        triggers="hover focus"
+                    >
+                        Information is from the billing claim and may show a
+                        different practitioner or clinic from the one you
+                        visited. For more information, visit the
+                        <router-link to="/faq">FAQ</router-link> page.
+                    </b-tooltip>
                 </div>
                 <div data-testid="encounterClinicName">
                     {{ entry.clinic.name }}
@@ -61,6 +84,8 @@ export default class EncounterTimelineComponent extends Vue {
 </template>
 
 <style lang="scss" scoped>
+@import "@/assets/scss/_variables.scss";
+
 .col {
     padding: 0px;
     margin: 0px;
@@ -68,5 +93,14 @@ export default class EncounterTimelineComponent extends Vue {
 .row {
     padding: 0;
     margin: 0px;
+}
+.infoIcon {
+    background-color: $aquaBlue;
+    color: $primary_text;
+    text-align: center;
+    border-radius: 50%;
+    height: 15px;
+    width: 15px;
+    font-size: 0.5em;
 }
 </style>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/filters.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/filters.vue
@@ -99,7 +99,7 @@ export default class FilterComponent extends Vue {
             },
             {
                 type: EntryType.Encounter,
-                display: "MSP Visits",
+                display: "Health Visits",
                 isEnabled: this.config.modules[EntryType.Encounter],
                 numEntries: this.encounterCount,
             },

--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -74,7 +74,10 @@ export default class ReportsView extends Vue {
             this.reportTypeOptions.push({ value: "MED", text: "Medications" });
         }
         if (this.config.modules["Encounter"]) {
-            this.reportTypeOptions.push({ value: "MSP", text: "MSP Visits" });
+            this.reportTypeOptions.push({
+                value: "MSP",
+                text: "Health Visits",
+            });
         }
         if (this.config.modules["Laboratory"]) {
             this.reportTypeOptions.push({


### PR DESCRIPTION
# Fixes or Implements AB#10340

* [x] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Rename MSP Visits to Health Visits.
Adds tooltip to Encounter card.
Reorder columns in Encounter report.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

* [ ] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
