### PR TITLE
Fix for two producs with cards. AB#10330

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/immunization.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/immunization.vue
@@ -56,28 +56,33 @@ export default class ImmunizationTimelineComponent extends Vue {
     >
         <b-row slot="details-body" class="justify-content-between">
             <b-col>
-                <b-row
-                    v-for="agent in entry.immunization.immunizationAgents"
-                    :key="agent.code"
-                    class="my-2"
-                >
+                <b-row>
                     <b-col>
-                        <div data-testid="immunizationProductTitle">
-                            <strong> Product: </strong>
-                            {{ agent.productName }}
-                        </div>
-                        <div data-testid="immunizationAgentNameTitle">
-                            <strong> Immunizing Agent: </strong>
-                            {{ agent.name }}
-                        </div>
-                        <div data-testid="immunizationProviderTitle">
-                            <strong> Provider / Clinic: </strong>
-                            {{ entry.immunization.providerOrClinic }}
-                        </div>
-                        <div data-testid="immunizationLotTitle">
-                            <strong> Lot Number: </strong>
-                            {{ agent.lotNumber }}
-                        </div>
+                        <b-row
+                            v-for="agent in entry.immunization
+                                .immunizationAgents"
+                            :key="agent.code"
+                            class="my-2"
+                        >
+                            <b-col>
+                                <div data-testid="immunizationProductTitle">
+                                    <strong> Product: </strong>
+                                    {{ agent.productName }}
+                                </div>
+                                <div data-testid="immunizationAgentNameTitle">
+                                    <strong> Immunizing Agent: </strong>
+                                    {{ agent.name }}
+                                </div>
+                                <div data-testid="immunizationProviderTitle">
+                                    <strong> Provider / Clinic: </strong>
+                                    {{ entry.immunization.providerOrClinic }}
+                                </div>
+                                <div data-testid="immunizationLotTitle">
+                                    <strong> Lot Number: </strong>
+                                    {{ agent.lotNumber }}
+                                </div>
+                            </b-col>
+                        </b-row>
                     </b-col>
                     <b-col
                         v-if="isCovidImmunization"

--- a/Testing/functional/e2e/cypress/fixtures/ImmunizationService/immunization.json
+++ b/Testing/functional/e2e/cypress/fixtures/ImmunizationService/immunization.json
@@ -67,6 +67,12 @@
                 "name": "DTaP-IPV",
                 "lotNumber": "123456",
                 "productName": "COVID"
+              },
+              {
+                "code": "777003004",
+                "name": "Another Agent",
+                "lotNumber": "1234567789",
+                "productName": "COVID 2"
               }
             ]
           },


### PR DESCRIPTION
# Fixes or Implements [AB#10330](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10330)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Fixes multiple covid cards shown when there are multiple products on an immunization