### PR TITLE
Fix verify button spacing on profile page AB#10384

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/profile.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/profile.vue
@@ -701,24 +701,20 @@ export default class ProfileView extends Vue {
                                                             : false
                                                     "
                                                 />
-                                                <div
+                                                <b-button
                                                     v-if="
                                                         !smsVerified &&
                                                         !isSMSEditable &&
                                                         smsNumber
                                                     "
+                                                    id="verifySMS"
+                                                    data-testid="verifySMSBtn"
+                                                    variant="outline-primary"
                                                     class="ml-3"
+                                                    @click="verifySMS()"
                                                 >
-                                                    <b-button
-                                                        id="verifySMS"
-                                                        data-testid="verifySMSBtn"
-                                                        variant="outline-primary"
-                                                        class="ml-3"
-                                                        @click="verifySMS()"
-                                                    >
-                                                        Verify
-                                                    </b-button>
-                                                </div>
+                                                    Verify
+                                                </b-button>
                                             </div>
                                             <b-form-invalid-feedback
                                                 :state="$v.smsNumber.sms"


### PR DESCRIPTION
# Fixes [AB#10384](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10384)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Remove extra margin on Verify button for mobile notifications on the User Profile page.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

* [x] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
