### PR TITLE
Fix ODR error forcing protected word for AB#10405

### DIFF
--- a/Apps/Common/src/omnisharp.json
+++ b/Apps/Common/src/omnisharp.json
@@ -1,0 +1,5 @@
+{
+    "RoslynExtensionsOptions": {
+        "enableAnalyzersSupport": true
+    }
+}

--- a/Apps/Medication/src/Delegates/SalesforeceDelegate.cs
+++ b/Apps/Medication/src/Delegates/SalesforeceDelegate.cs
@@ -75,7 +75,7 @@ namespace HealthGateway.Medication.Delegates
         {
             using (Source.StartActivity("GetMedicationRequestsAsync"))
             {
-                RequestResult<IList<MedicationRequest>> retVal = new()
+                RequestResult<IList<MedicationRequest>> retVal = new ()
                 {
                     ResultStatus = Common.Constants.ResultType.Error,
                 };

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegate_Test.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegate_Test.cs
@@ -603,13 +603,11 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
-            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
-            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
+            Assert.Equal(ResultType.Error, response.ResultStatus);
         }
 
         [Fact]
-        public void ValidateGetProtectiveWordParseError()
+        public void ValidateGetProtectiveWordJSONParseError()
         {
             string PHN = "9735361219";
             ODRHistoryQuery query = new ODRHistoryQuery()
@@ -664,9 +662,7 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
-            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
-            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
+            Assert.Equal(ResultType.Error, response.ResultStatus);
         }
 
         [Fact]
@@ -725,9 +721,7 @@ namespace HealthGateway.Medication.Delegates.Test
                                                                                 string.Empty,
                                                                                 string.Empty,
                                                                                 string.Empty).ConfigureAwait(true)).Result;
-            Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
-            Assert.Equal(ActionType.Protected, response.ResultError.ActionCode);
-            Assert.Equal(ErrorMessages.ProtectiveWordErrorMessage, response.ResultError.ResultMessage);
+            Assert.Equal(ResultType.Error, response.ResultStatus);
         }
 
         [Fact]

--- a/Apps/Medication/test/unit/Delegates/SalesforceDelegate_Test.cs
+++ b/Apps/Medication/test/unit/Delegates/SalesforceDelegate_Test.cs
@@ -34,7 +34,7 @@ namespace HealthGateway.Medication.Delegates.Test
     using Moq.Protected;
     using Xunit;
 
-    public class SalesforceDelegate_Test
+    public class SalesforceDelegateTest
     {
         [Fact]
         public void ShouldRetrieveMedicationRequests()
@@ -307,7 +307,7 @@ namespace HealthGateway.Medication.Delegates.Test
 
             var jwt = JsonSerializer.Deserialize<JWTModel>(json, options);
 
-            return jwt ?? new();
+            return jwt ?? new ();
         }
 
         private static Mock<IHttpClientService> CreateHttpClient(HttpResponseMessage stubResponse, string expectedPHN, string authorizationToken)


### PR DESCRIPTION
# Fixes or Implements [AB#10405](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10405)

* [ ] Enhancement
* [X] Bug
* [ ] Documentation

## Description

Should resolve the issue where a problem with the ODR service caused a protective word prompt.  I removed the exception handling in the validate protectiveWord and moved the try/catch block in the parent.

I also did minor smell cleanup.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [X] Unit Tests Updated
* [ ] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

N/A

### UI Changes

No

### Browsers Tested

* [X] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Functional tests were run to validate behaviour.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
