### PR TITLE
Add functional tests for attachment icons AB#10394

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratory.vue
@@ -115,7 +115,7 @@ export default class LaboratoryTimelineComponent extends Vue {
         </div>
 
         <div slot="details-body">
-            <div v-if="reportAvailable">
+            <div v-if="reportAvailable" data-testid="laboratoryReportAvailable">
                 <b-spinner v-if="isLoadingDocument"></b-spinner>
                 <span v-else data-testid="laboratoryReport">
                     <strong>Report:</strong>

--- a/Testing/functional/e2e/cypress/fixtures/LaboratoryService/laboratory.json
+++ b/Testing/functional/e2e/cypress/fixtures/LaboratoryService/laboratory.json
@@ -95,7 +95,7 @@
       "messageDateTime": "2020-10-04T21:08:00+00:00",
       "messageId": "20000001442319514",
       "additionalData": "Positive for COVID-19 (SARS-CoV-2) RNA by molecular assay\u003Cbr\u003Emethod.\u003Cbr\u003E\u003Cbr\u003EThis assay targets the E and ORF1/a gene regions of the\u003Cbr\u003ECOVID-19 (SARS-CoV-2) virus.\u003Cbr\u003E\u003Cbr\u003EA copy of the result has been sent to Infection Prevention\u003Cbr\u003Eand Control.\u003Cbr\u003E\u003Cbr\u003EAs required by the regulation for the control of\u003Cbr\u003Ecommunicable disease, this case will be reported to the\u003Cbr\u003EMedical Health Officer.\u003Cbr\u003E\u003Cbr\u003E",
-      "reportAvailable": true,
+      "reportAvailable": false,
       "labResults": [
         {
           "id": "40a6e571-62b6-4cb3-89ed-afe7a322ccb2",

--- a/Testing/functional/e2e/cypress/integration/timeline/immunization.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/immunization.js
@@ -28,6 +28,22 @@ describe('Immunization', () => {
         .should('be.visible')
     })
 
+    it('Validate COVID-19 Immunization Attachment Icons', () => {
+      cy.log('All COVID-19 immunizations should have attachment icons.')
+      cy.get('[data-testid=cardBtn]')
+        .closest('[data-testid=timelineCard]')
+        .each((card) => {
+          cy.wrap(card).find('[data-testid=attachmentIcon]').should('exist')
+        })
+
+      cy.log('All cards with attachment icons should be COVID-19 immunizations.')
+      cy.get('[data-testid=attachmentIcon]')
+        .closest('[data-testid=timelineCard]')
+        .each((card) => {
+          cy.wrap(card).find('[data-testid=cardBtn]').should('exist')
+        })
+    })
+
     it('Validate Card Details', () => {
       cy.get('[data-testid=timelineCard')
         .first()

--- a/Testing/functional/e2e/cypress/integration/timeline/mobile/laboratory.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/mobile/laboratory.js
@@ -132,4 +132,22 @@ describe("Laboratory", () => {
         });
       });
   });
+
+  it("Validate Report Attachment Icons", () => {
+    cy.log("All cards with reports should have attachment icons.");
+    cy.get("[data-testid=laboratoryReportAvailable]")
+      .closest("[data-testid=timelineCard]")
+      .each((card) => {
+        cy.wrap(card).find("[data-testid=attachmentIcon]").should("exist");
+      });
+
+    cy.log("All cards with attachment icons should have reports.");
+    cy.get("[data-testid=attachmentIcon]")
+      .closest("[data-testid=timelineCard]")
+      .each((card) => {
+        cy.wrap(card)
+          .find("[data-testid=laboratoryReportAvailable]")
+          .should("exist");
+      });
+  });
 });


### PR DESCRIPTION
# Implements [AB#10394](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10394)

* [x] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Adds functional tests for the attachment icons that display when immunization or laboratory results have a card or report available to download.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [x] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [x] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
