### PR TITLE
 Add functional tests for medication exclusions on reports AB#10373

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -155,6 +155,7 @@ export default class MedicationHistoryReportComponent extends Vue {
                     v-for="item in visibleRecords"
                     :key="item.prescriptionIdentifier + item.dispensedDate"
                     class="item py-1"
+                    data-testid="medicationReportEntry"
                 >
                     <b-col class="col-1 my-auto text-nowrap">
                         {{ formatDate(item.dispensedDate) }}
@@ -162,7 +163,10 @@ export default class MedicationHistoryReportComponent extends Vue {
                     <b-col class="col-1 my-auto">
                         {{ item.medicationSummary.din }}
                     </b-col>
-                    <b-col class="col-2 my-auto">
+                    <b-col
+                        class="col-2 my-auto"
+                        data-testid="medicationReportEntryBrandName"
+                    >
                         {{ item.medicationSummary.brandName }}
                     </b-col>
                     <b-col class="col-2 my-auto">

--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -282,6 +282,7 @@ export default class ReportsView extends Vue {
                                     reportFilter.hasMedicationsFilter() &&
                                     reportType == 'MED'
                                 "
+                                data-testid="medicationFilter"
                             >
                                 <div><strong>Exclude</strong></div>
                                 <b-form-tag
@@ -332,6 +333,7 @@ export default class ReportsView extends Vue {
                                         v-model="selectedMedicationOptions"
                                         placeholder="Choose a medication"
                                         :options="medicationOptions"
+                                        data-testid="medicationExclusionFilter"
                                     ></MultiSelectComponent>
                                 </b-col>
                             </b-row>

--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -150,7 +150,7 @@ export default class ReportsView extends Vue {
 
     private cancelFilter() {
         this.selectedStartDate = this.reportFilter.startDate;
-        this.selectedEndDate = this.reportFilter.startDate;
+        this.selectedEndDate = this.reportFilter.endDate;
         this.selectedMedicationOptions = this.reportFilter.medications;
     }
 

--- a/Testing/functional/e2e/cypress/fixtures/MedicationService/medicationStatement.json
+++ b/Testing/functional/e2e/cypress/fixtures/MedicationService/medicationStatement.json
@@ -1,0 +1,167 @@
+{
+  "resourcePayload": [
+    {
+      "prescriptionIdentifier": "9529523",
+      "prescriptionStatus": "\u0000",
+      "dispensedDate": "2019-12-30T00:00:00",
+      "practitionerSurname": "PZVVPS",
+      "directions": ".. SHAKE WELL .. DRINK 50MLS CARRY 80MLS DAILY DAILY  MAY BE POISONOUS TO OTHERS",
+      "dateEntered": null,
+      "pharmacyId": "",
+      "medicationSummary": {
+        "din": "66999990",
+        "brandName": "Methadone (Maintenance) 1mg/Ml",
+        "genericName": "",
+        "quantity": 390,
+        "maxDailyDosage": 0,
+        "drugDiscontinuedDate": null,
+        "form": "",
+        "manufacturer": "",
+        "strength": "",
+        "strengthUnit": "",
+        "isPin": true
+      },
+      "dispensingPharmacy": {
+        "pharmacyId": "BC00007912",
+        "name": "DJOPXNCCHKDTAPPALZCDV",
+        "addressLine1": "GRRJJQOBCUUUHZW",
+        "addressLine2": "",
+        "city": "KAMLOOPS",
+        "province": "BC",
+        "postalCode": "JTAEKA",
+        "countryCode": "CAN",
+        "phoneNumber": "250-5095824",
+        "faxNumber": "250-5073852"
+      }
+    },
+    {
+      "prescriptionIdentifier": "133920",
+      "prescriptionStatus": "\u0000",
+      "dispensedDate": "2019-12-29T00:00:00",
+      "practitionerSurname": "PLJDDRV",
+      "directions": "TAKE 2 TABLETS AT BEDTIME",
+      "dateEntered": null,
+      "pharmacyId": "",
+      "medicationSummary": {
+        "din": "2391724",
+        "brandName": "MINT-ZOPICLONE",
+        "genericName": "ZOPICLONE",
+        "quantity": 30,
+        "maxDailyDosage": 0,
+        "drugDiscontinuedDate": null,
+        "form": "TABLET",
+        "manufacturer": "MINT PHARMACEUTICALS INC",
+        "strength": "7.5",
+        "strengthUnit": "MG",
+        "isPin": false
+      },
+      "dispensingPharmacy": {
+        "pharmacyId": "BC00006638",
+        "name": "VQJWMQUFRYKPT",
+        "addressLine1": "ZBFKMFYUDPJAFJUPPFXNEQ",
+        "addressLine2": "",
+        "city": "MAPLE RIDGE",
+        "province": "BC",
+        "postalCode": "FOHCYQ",
+        "countryCode": "CAN",
+        "phoneNumber": "604-5842313",
+        "faxNumber": "604-9092387"
+      }
+    },
+    {
+      "prescriptionIdentifier": "6787902",
+      "prescriptionStatus": "\u0000",
+      "dispensedDate": "2019-12-25T00:00:00",
+      "practitionerSurname": "PZVVPS",
+      "directions": "TAKE 2 TABLETS AT BEDTIME (DISPENSE WITH METHADONE MON/THURS)",
+      "dateEntered": null,
+      "pharmacyId": "",
+      "medicationSummary": {
+        "din": "2391724",
+        "brandName": "MINT-ZOPICLONE",
+        "genericName": "ZOPICLONE",
+        "quantity": 8,
+        "maxDailyDosage": 0,
+        "drugDiscontinuedDate": null,
+        "form": "TABLET",
+        "manufacturer": "MINT PHARMACEUTICALS INC",
+        "strength": "7.5",
+        "strengthUnit": "MG",
+        "isPin": false
+      },
+      "dispensingPharmacy": {
+        "pharmacyId": "BC00007912",
+        "name": "DJOPXNCCHKDTAPPALZCDV",
+        "addressLine1": "GRRJJQOBCUUUHZW",
+        "addressLine2": "",
+        "city": "KAMLOOPS",
+        "province": "BC",
+        "postalCode": "JTAEKA",
+        "countryCode": "CAN",
+        "phoneNumber": "250-5095824",
+        "faxNumber": "250-5073852"
+      }
+    },
+    {
+      "prescriptionIdentifier": "9528727",
+      "prescriptionStatus": "\u0000",
+      "dispensedDate": "2019-12-25T00:00:00",
+      "practitionerSurname": "PZVVPS",
+      "directions": ".. SHAKE WELL .. DRINK 50MLS CARRY 80MLS DAILY DAILY  MAY BE POISONOUS TO OTHERS",
+      "dateEntered": null,
+      "pharmacyId": "",
+      "medicationSummary": {
+        "din": "66999990",
+        "brandName": "Methadone (Maintenance) 1mg/Ml",
+        "genericName": "",
+        "quantity": 520,
+        "maxDailyDosage": 0,
+        "drugDiscontinuedDate": null,
+        "form": "",
+        "manufacturer": "",
+        "strength": "",
+        "strengthUnit": "",
+        "isPin": true
+      },
+      "dispensingPharmacy": {
+        "pharmacyId": "BC00007912",
+        "name": "DJOPXNCCHKDTAPPALZCDV",
+        "addressLine1": "GRRJJQOBCUUUHZW",
+        "addressLine2": "",
+        "city": "KAMLOOPS",
+        "province": "BC",
+        "postalCode": "JTAEKA",
+        "countryCode": "CAN",
+        "phoneNumber": "250-5095824",
+        "faxNumber": "250-5073852"
+      }
+    },
+    {
+      "prescriptionIdentifier": "6784060",
+      "prescriptionStatus": "\u0000",
+      "dispensedDate": "2019-12-22T00:00:00",
+      "practitionerSurname": "PZVVPS",
+      "directions": "TAKE 2 TABLETS AT BEDTIME (DISPENSE WITH METHADONE MON/THURS)",
+      "dateEntered": null,
+      "pharmacyId": "",
+      "medicationSummary": {
+        "din": "2391724",
+        "brandName": "MINT-ZOPICLONE",
+        "genericName": "ZOPICLONE",
+        "quantity": 6,
+        "maxDailyDosage": 0,
+        "drugDiscontinuedDate": null,
+        "form": "TABLET",
+        "manufacturer": "MINT PHARMACEUTICALS INC",
+        "strength": "7.5",
+        "strengthUnit": "MG",
+        "isPin": false
+      }
+    }
+  ],
+  "totalResultCount": 5,
+  "pageIndex": 1,
+  "pageSize": 20000,
+  "resultStatus": 1,
+  "resultError": null
+}

--- a/Testing/functional/e2e/cypress/integration/report/report.js
+++ b/Testing/functional/e2e/cypress/integration/report/report.js
@@ -8,68 +8,6 @@ describe('Reports', () => {
         cy.login(Cypress.env('keycloak.username'), Cypress.env('keycloak.password'), AuthMethod.KeyCloak, "/reports");
     })
 
-    it('Validate Advanced - Dates, Cancel and Apply', () => {    
-        cy.get('[data-testid=advancedPanel]')
-            .should('not.be.visible');
-    
-        cy.get('[data-testid=advancedBtn]')
-            .should('be.enabled', 'be.visible')
-            .click();
-
-        cy.get('[data-testid=startDateInput] input')
-        .should('be.enabled', 'be.visible')
-        .should('have.value','')
-        .click()
-        .focus()
-        .type("2021-FEB-03")
-    
-        cy.get('[data-testid=endDateInput] input')
-        .should('be.enabled', 'be.visible')
-        .should('have.value','')
-        .click()
-        .focus()
-        .type("2021-FEB-05")
-        .focus()
-
-        cy.get('[data-testid=applyFilterBtn]')
-            .click()
-        cy.get('[data-testid=selectedDatesFilter]')
-            .contains('From 2021-Feb-03 To 2021-Feb-05')
-
-        // Validate filters - Cancel  button
-        cy.get('[data-testid=advancedBtn]')
-            .click();
-        
-        // Cancel button should not set the newly entered values
-        cy.get('[data-testid=startDateInput] input')
-            .type("2020-FEB-03")
-        cy.get('[data-testid=endDateInput] input')
-            .type("2020-FEB-05")
-        cy.get('[data-testid=clearBtn]')
-            .should('be.enabled', 'be.visible')
-            .click();
-        cy.get('[data-testid=startDateInput] input')
-            .should('have.value','2021-FEB-03')
-        cy.get('[data-testid=endDateInput] input')
-            .should('have.value','2021-FEB-05')
-
-        cy.get('[data-testid=clearBtn]')
-            .should('not.be.visible')
-        cy.get('[data-testid=applyFilterBtn]')
-            .should('not.be.visible')
-        cy.get('[data-testid=startDateInput] input')
-            .should('not.be.visible')        
-        cy.get('[data-testid=endDateInput] input')
-            .should('not.be.visible')
-        
-        cy.get('[data-testid=clearFilter] button')
-            .should('be.visible')
-            .click();
-        
-        cy.get('[data-testid=clearFilter] button')
-            .should('not.exist');
-    })
-
     it('Validate Service Selection', () => {
         cy.get('[data-testid=exportRecordBtn]')
             .should('be.disabled', 'be.visible')

--- a/Testing/functional/e2e/cypress/integration/report/reportFiltering.js
+++ b/Testing/functional/e2e/cypress/integration/report/reportFiltering.js
@@ -1,0 +1,139 @@
+const { AuthMethod } = require("../../support/constants");
+
+describe("Report Filtering", () => {
+  beforeEach(() => {
+    cy.enableModules("Medication");
+    cy.intercept("GET", "**/v1/api/MedicationStatement/*", {
+      fixture: "MedicationService/medicationStatement.json",
+    });
+    cy.login(
+      Cypress.env("keycloak.username"),
+      Cypress.env("keycloak.password"),
+      AuthMethod.KeyCloak,
+      "/reports"
+    );
+  });
+
+  it("Validate Dates, Cancel and Apply", () => {
+    cy.get("[data-testid=advancedPanel]").should("not.be.visible");
+
+    cy.get("[data-testid=advancedBtn]")
+      .should("be.enabled", "be.visible")
+      .click();
+
+    cy.get("[data-testid=startDateInput] input")
+      .should("be.enabled", "be.visible")
+      .should("have.value", "")
+      .click()
+      .focus()
+      .type("2021-FEB-03");
+
+    cy.get("[data-testid=endDateInput] input")
+      .should("be.enabled", "be.visible")
+      .should("have.value", "")
+      .click()
+      .focus()
+      .type("2021-FEB-05")
+      .focus();
+
+    cy.get("[data-testid=applyFilterBtn]").click();
+    cy.get("[data-testid=selectedDatesFilter]").contains(
+      "From 2021-Feb-03 To 2021-Feb-05"
+    );
+
+    // Validate filters - Cancel  button
+    cy.get("[data-testid=advancedBtn]").click();
+
+    // Cancel button should not set the newly entered values
+    cy.get("[data-testid=startDateInput] input").clear().type("2020-FEB-03");
+    cy.get("[data-testid=endDateInput] input").clear().type("2020-FEB-05");
+    cy.get("[data-testid=clearBtn]").focus();
+    cy.get("[data-testid=startDateInput] input").should(
+      "have.value",
+      "2020-FEB-03"
+    );
+    cy.get("[data-testid=endDateInput] input").should(
+      "have.value",
+      "2020-FEB-05"
+    );
+    cy.get("[data-testid=clearBtn]").should("be.enabled", "be.visible").click();
+
+    cy.get("[data-testid=advancedBtn]").click();
+    cy.get("[data-testid=startDateInput] input").should(
+      "have.value",
+      "2021-FEB-03"
+    );
+    cy.get("[data-testid=endDateInput] input").should(
+      "have.value",
+      "2021-FEB-05"
+    );
+
+    cy.get("[data-testid=clearFilter] button").should("be.visible").click();
+    cy.get("[data-testid=clearFilter] button").should("not.exist");
+  });
+
+  it("Validate Medication Exclusions", () => {
+    cy.get("[data-testid=reportType]")
+      .should("be.enabled", "be.visible")
+      .select("MED");
+
+    cy.get("[data-testid=advancedPanel]").should("not.be.visible");
+
+    cy.get("[data-testid=advancedBtn]")
+      .should("be.enabled", "be.visible")
+      .click();
+
+    cy.get("[data-testid=medicationExclusionFilter]").should("be.visible");
+
+    cy.get("[data-testid=medicationReportEntry]")
+      .should("be.visible")
+      .first()
+      .find("[data-testid=medicationReportEntryBrandName]")
+      .then(($brandName) => {
+        const brandText = $brandName.text().trim();
+
+        cy.get("[data-testid=medicationExclusionFilter] select")
+          .should("be.visible")
+          .focus()
+          .select(brandText);
+
+        cy.get("[data-testid=applyFilterBtn]").click();
+
+        cy.get(
+          "[data-testid=medicationFilter] .b-form-tag-content span"
+        ).should("contain", brandText);
+
+        cy.get("[data-testid=medicationReportEntry]")
+          .should("be.visible")
+          .first()
+          .find("[data-testid=medicationReportEntryBrandName]")
+          .then(($filteredBrandName) => {
+            const filteredBrandText = $filteredBrandName.text().trim();
+            expect(filteredBrandText).to.not.equal(brandText);
+          });
+
+        cy.get("[data-testid=advancedBtn]").click();
+
+        cy.get(
+          `[data-testid=medicationExclusionFilter] [title=${brandText}] button`
+        )
+          .should("be.enabled", "be.visible")
+          .click();
+
+        cy.get("[data-testid=applyFilterBtn]").click();
+
+        cy.get("[data-testid=medicationFilter] .b-form-tag-content").should(
+          "not.exist"
+        );
+
+        cy.get("[data-testid=medicationReportEntry]")
+          .should("be.visible")
+          .first()
+          .find("[data-testid=medicationReportEntryBrandName]")
+          .then(($unfilteredBrandName) => {
+            const unfilteredBrandText = $unfilteredBrandName.text().trim();
+            expect(unfilteredBrandText).to.equal(brandText);
+          });
+      });
+  });
+});


### PR DESCRIPTION
# Implements [AB#10373](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10373)

* [x] Enhancement
* [ ] Bug
* [ ] Documentation

## Description

Adds functional tests to apply and remove medication exclusions on the reports page.  Also fixes a bug where the clear button in the filter would not reset the value for the end date input.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [x] Functional Tests Updated
* [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [x] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
