### PR TITLE
Fix display of last login date AB#10404

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/profile.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/profile.vue
@@ -164,7 +164,10 @@ export default class ProfileView extends Vue {
                     );
                     this.userProfile = results[1];
                     this.lastLoginDateString = new DateWrapper(
-                        this.userProfile.lastLoginDateTime
+                        this.userProfile.lastLoginDateTime,
+                        {
+                            isUtc: true,
+                        }
                     ).format();
 
                     this.email = this.userProfile.email;


### PR DESCRIPTION
# Fixes [AB#10404](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10404)

* [ ] Enhancement
* [x] Bug
* [ ] Documentation

## Description

Corrects the display of the last logged in date to account for it being stored in UTC format.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

* [ ] Unit Tests Updated
* [ ] Functional Tests Updated
* [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

* [x] Chrome
* [ ] Safari
* [ ] Edge
* [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant.  Include any specialized deployment steps here.  
