### PR TITLE
Fix last month sometimes missing from health insight graph AB#10061

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/healthInsights.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/healthInsights.vue
@@ -109,13 +109,14 @@ export default class HealthInsightsView extends Vue {
         endDate: DateWrapper
     ): string[] {
         if (endDate.isBefore(startDate)) {
-            throw "End date must be greated than start date.";
+            throw "End date must be greater than start date.";
         }
 
+        var currentMonth = startDate.startOf("month");
         var result: string[] = [];
-        while (startDate.isBefore(endDate)) {
-            result.push(startDate.format("yyyy-LL-01"));
-            startDate = startDate.add({ months: 1 });
+        while (currentMonth.isBeforeOrSame(endDate)) {
+            result.push(currentMonth.format("yyyy-LL-01"));
+            currentMonth = currentMonth.add({ months: 1 });
         }
         return result;
     }


### PR DESCRIPTION
# Fixes or Implements [AB#10061](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10061)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Corrects the calculation of months to be displayed in health insight graph.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
