### PR TITLE
Removed address from msp visits AB#10473

### DIFF
--- a/Apps/Encounter/src/Encounter.xml
+++ b/Apps/Encounter/src/Encounter.xml
@@ -123,41 +123,6 @@
             Gets or sets the Name.
             </summary>
         </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.AddressLine1">
-            <summary>
-            Gets or sets the Address Line 1.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.AddressLine2">
-            <summary>
-            Gets or sets the Address Line 2.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.AddressLine3">
-            <summary>
-            Gets or sets the Address Line 3.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.AddressLine4">
-            <summary>
-            Gets or sets the Address Line 4.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.City">
-            <summary>
-            Gets or sets the City.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.PostalCode">
-            <summary>
-            Gets or sets the Postal Code.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.Encounter.Models.Clinic.Province">
-            <summary>
-            Gets or sets the Province.
-            </summary>
-        </member>
         <member name="T:HealthGateway.Encounter.Models.DiagnosticCode">
             <summary>
             Represents a row in the Diagnostic Code.

--- a/Apps/Encounter/src/Models/Clinic.cs
+++ b/Apps/Encounter/src/Models/Clinic.cs
@@ -27,47 +27,5 @@ namespace HealthGateway.Encounter.Models
         /// </summary>
         [JsonPropertyName("name")]
         public string Name { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the Address Line 1.
-        /// </summary>
-        [JsonPropertyName("addressLine1")]
-        public string AddressLine1 { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the Address Line 2.
-        /// </summary>
-        [JsonPropertyName("addressLine2")]
-        public string AddressLine2 { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the Address Line 3.
-        /// </summary>
-        [JsonPropertyName("addressLine3")]
-        public string AddressLine3 { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the Address Line 4.
-        /// </summary>
-        [JsonPropertyName("addressLine4")]
-        public string AddressLine4 { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the City.
-        /// </summary>
-        [JsonPropertyName("city")]
-        public string City { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the Postal Code.
-        /// </summary>
-        [JsonPropertyName("postalCode")]
-        public string PostalCode { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the Province.
-        /// </summary>
-        [JsonPropertyName("province")]
-        public string Province { get; set; } = string.Empty;
     }
 }

--- a/Apps/Encounter/src/Models/EncounterModel.cs
+++ b/Apps/Encounter/src/Models/EncounterModel.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Encounter.Models
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Security.Cryptography;
     using System.Text;
     using System.Text.Json.Serialization;
@@ -69,7 +68,7 @@ namespace HealthGateway.Encounter.Models
             using var md5CryptoService = MD5.Create();
 #pragma warning restore SCS0006 // Weak hashing function
 #pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
-            StringBuilder sourceId = new StringBuilder();
+            StringBuilder sourceId = new ();
             sourceId.Append($"{model.ServiceDate:yyyyMMdd}");
             sourceId.Append($"{model.SpecialtyDesc}");
             sourceId.Append($"{model.PractitionerName}");
@@ -90,13 +89,6 @@ namespace HealthGateway.Encounter.Models
                 Clinic = new Clinic()
                 {
                     Name = model.LocationName,
-                    Province = model.LocationAddress.Province,
-                    City = model.LocationAddress.City,
-                    PostalCode = model.LocationAddress.PostalCode,
-                    AddressLine1 = model.LocationAddress.AddrLine1,
-                    AddressLine2 = model.LocationAddress.AddrLine2,
-                    AddressLine3 = model.LocationAddress.AddrLine3,
-                    AddressLine4 = model.LocationAddress.AddrLine4,
                 },
             };
         }
@@ -108,11 +100,11 @@ namespace HealthGateway.Encounter.Models
         /// <returns>A list of Encounter objects.</returns>
         public static IEnumerable<EncounterModel> FromODRClaimModelList(IEnumerable<Claim> models)
         {
-            List<EncounterModel> objects = new List<EncounterModel>();
-            HashSet<string> encounterIds = new HashSet<string>();
+            List<EncounterModel> objects = new ();
+            HashSet<string> encounterIds = new ();
             foreach (Claim claimModel in models)
             {
-                var encounter = EncounterModel.FromODRClaimModel(claimModel);
+                var encounter = FromODRClaimModel(claimModel);
                 if (!encounterIds.Contains(encounter.Id))
                 {
                     objects.Add(encounter);

--- a/Apps/Encounter/test/unit/Controllers/EncounterController_Test.cs
+++ b/Apps/Encounter/test/unit/Controllers/EncounterController_Test.cs
@@ -62,13 +62,6 @@ namespace HealthGateway.EncounterTests
                 Clinic = new Clinic()
                 {
                     Name = "LOCATION NAME",
-                    AddressLine1 = "address line 1",
-                    AddressLine2 = "address line 2",
-                    AddressLine3 = "address line 3",
-                    AddressLine4 = "address line 4",
-                    City = "Victoria",
-                    PostalCode = "V9V9V9",
-                    Province = "BC",
                 },
             });
             encounters.Add(new EncounterModel()
@@ -80,13 +73,6 @@ namespace HealthGateway.EncounterTests
                 Clinic = new Clinic()
                 {
                     Name = "LOCATION NAME",
-                    AddressLine1 = "address line 1",
-                    AddressLine2 = "address line 2",
-                    AddressLine3 = "address line 3",
-                    AddressLine4 = "address line 4",
-                    City = "Victoria",
-                    PostalCode = "V9V9V9",
-                    Province = "BC",
                 },
             });
             result.ResourcePayload = encounters;

--- a/Apps/Encounter/test/unit/Services/EncounterService_Test.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterService_Test.cs
@@ -119,17 +119,8 @@ namespace HealthGateway.Encounter.Test.Service
                 mockMSPDelegate.Object);
 
             var actualResult = service.GetEncounters(hdid).Result;
-            Assert.True(actualResult.ResultStatus == Common.Constants.ResultType.Success);
+            Assert.True(actualResult.ResultStatus == ResultType.Success);
             Assert.Equal(2, actualResult.ResourcePayload.Count()); // should return distint claims only.
-#pragma warning disable CA5351 // Do Not Use Broken Cryptographic Algorithms
-#pragma warning disable SCS0006 // Weak hashing function
-            using var md5CryptoService = MD5.Create();
-#pragma warning restore SCS0006 // Weak hashing function
-#pragma warning restore CA5351 // Do Not Use Broken Cryptographic Algorithms
-            var model = actualResult.ResourcePayload.First();
-            var generatedId = new Guid(md5CryptoService.ComputeHash(Encoding.Default.GetBytes($"{model.EncounterDate:yyyyMMdd}{model.SpecialtyDescription}{model.PractitionerName}{model.Clinic.Name}{model.Clinic.Province}{model.Clinic.City}{model.Clinic.PostalCode}{model.Clinic.AddressLine1}{model.Clinic.AddressLine2}{model.Clinic.AddressLine3}{model.Clinic.AddressLine4}")));
-            var expectedGeneratedId = new Guid(md5CryptoService.ComputeHash(Encoding.Default.GetBytes($"{this.sameClaim.ServiceDate:yyyyMMdd}{this.sameClaim.SpecialtyDesc}{this.sameClaim.PractitionerName}{this.sameClaim.LocationName}{this.sameClaim.LocationAddress.Province}{this.sameClaim.LocationAddress.City}{this.sameClaim.LocationAddress.PostalCode}{this.sameClaim.LocationAddress.AddrLine1}{this.sameClaim.LocationAddress.AddrLine2}{this.sameClaim.LocationAddress.AddrLine3}{this.sameClaim.LocationAddress.AddrLine4}")));
-            Assert.Equal(expectedGeneratedId, generatedId);
         }
 
         [Fact]

--- a/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
@@ -81,23 +81,6 @@ export default class MSPVisitsReportComponent extends Vue {
         return new DateWrapper(date).format();
     }
 
-    private formatAddress(encounter: Encounter): string {
-        var clinic = encounter.clinic;
-        return [
-            clinic.addressLine1,
-            clinic.addressLine2,
-            clinic.addressLine3,
-            clinic.addressLine4,
-        ].join(" ");
-    }
-
-    private formatCityProvince(encounter: Encounter): string {
-        var clinic = encounter.clinic;
-        return `${clinic.city || ""} ${clinic.province || ""}, ${
-            clinic.postalCode || ""
-        }`;
-    }
-
     public async generatePdf(): Promise<void> {
         this.logger.debug("generating Health Visits PDF...");
         this.isPreview = false;
@@ -128,7 +111,6 @@ export default class MSPVisitsReportComponent extends Vue {
                     <b-col>Specialty Description</b-col>
                     <b-col>Practitioner</b-col>
                     <b-col>Clinic/Practitioner</b-col>
-                    <b-col>Address</b-col>
                 </b-row>
                 <b-row
                     v-for="item in visibleRecords"
@@ -146,11 +128,6 @@ export default class MSPVisitsReportComponent extends Vue {
                     </b-col>
                     <b-col class="my-auto">
                         {{ item.clinic.name }}
-                    </b-col>
-                    <b-col class="my-auto">
-                        {{ formatAddress(item) }}
-                        <br />
-                        {{ formatCityProvince(item) }}
                     </b-col>
                 </b-row>
             </section>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/encounter.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/encounter.vue
@@ -8,7 +8,6 @@ import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 
 import EncounterTimelineEntry from "@/models/encounterTimelineEntry";
-import PhoneUtil from "@/utility/phoneUtil";
 
 import EntrycardTimelineComponent from "./entrycard.vue";
 
@@ -29,10 +28,6 @@ export default class EncounterTimelineComponent extends Vue {
 
     private get infoIcon(): IconDefinition {
         return faInfo;
-    }
-
-    private formatPhone(phoneNumber: string): string {
-        return PhoneUtil.formatPhone(phoneNumber);
     }
 }
 </script>
@@ -71,12 +66,6 @@ export default class EncounterTimelineComponent extends Vue {
                 </div>
                 <div data-testid="encounterClinicName">
                     {{ entry.clinic.name }}
-                </div>
-                <div data-testid="encounterClinicAddress">
-                    {{ entry.clinic.address }}
-                </div>
-                <div data-testid="encounterClinicPhone">
-                    {{ formatPhone(entry.clinic.phoneNumber) }}
                 </div>
             </b-col>
         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/models/clinic.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/clinic.ts
@@ -4,20 +4,4 @@ export default interface Clinic {
     clinicId: string;
     // Name.
     name: string;
-    // Address line 1.
-    addressLine1: string;
-    // Address line 2.
-    addressLine2: string;
-    // Address line 3.
-    addressLine3: string;
-    // Address line 4.
-    addressLine4: string;
-    // City.
-    city: string;
-    // Province.
-    province: string;
-    // Postal code.
-    postalCode: string;
-    // Phone number.
-    phoneNumber?: string;
 }

--- a/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
@@ -44,27 +44,9 @@ export default class EncounterTimelineEntry extends TimelineEntry {
 class ClinicViewModel {
     public id: string;
     public name: string;
-    public address: string;
-    public phoneNumber: string;
 
     constructor(model: Clinic) {
         this.id = model.clinicId || "";
         this.name = model.name;
-        this.phoneNumber = model.phoneNumber || "";
-
-        const addressArray = [
-            model.addressLine1,
-            model.addressLine2,
-            model.addressLine3,
-            model.addressLine4,
-        ];
-        this.address =
-            addressArray.filter((val) => val.length > 0).join(" ") +
-            ", " +
-            (model.city || "") +
-            " " +
-            (model.province || "") +
-            ", " +
-            (model.postalCode || "");
     }
 }

--- a/Testing/functional/e2e/cypress/integration/timeline/encounter.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/encounter.js
@@ -16,6 +16,5 @@ describe("MSP Visits", () => {
         cy.get("[data-testid=entryCardDetailsTitle").first().click();
         cy.get("[data-testid=encounterClinicLabel").should("be.visible");
         cy.get("[data-testid=encounterClinicName").should("be.visible");
-        cy.get("[data-testid=encounterClinicAddress").should("be.visible");
     });
 });

--- a/Testing/functional/e2e/cypress/integration/timeline/mobile/encounter.js
+++ b/Testing/functional/e2e/cypress/integration/timeline/mobile/encounter.js
@@ -26,8 +26,5 @@ describe("MSP Visits", () => {
         entryDetails
             .get("[data-testid=encounterClinicName")
             .should("be.visible");
-        entryDetails
-            .get("[data-testid=encounterClinicAddress")
-            .should("be.visible");
     });
 });


### PR DESCRIPTION
# Fixes or Implements [AB#10473](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10473)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Encounter data does not have address information anymore

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES 

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
