### PR TITLE
Fixes the SMS being different between registration and DB

### DIFF
--- a/Apps/Common/src/Common.xml
+++ b/Apps/Common/src/Common.xml
@@ -2394,15 +2394,6 @@
             Will use access_token acquired from system account authenication.
             </summary>
             <param name="notificationSettings">The Notification Settings Request object.</param>
-            <returns>The notification settings request queued.</returns>
-        </member>
-        <member name="M:HealthGateway.Common.Services.INotificationSettingsService.SendNotificationSettings(HealthGateway.Common.Models.NotificationSettingsRequest,System.String)">
-            <summary>
-            Sends the Notifications Settings to PHSA immediately.
-            </summary>
-            <param name="notificationSettings">The Notification Settings Request object.</param>
-            <param name="bearerToken">The bearer token of the authenticated user.</param>
-            <returns>A Notification Settings Response object mapped in a RequestResult.</returns>
         </member>
         <member name="T:HealthGateway.Common.Services.IPatientService">
             <summary>
@@ -2496,25 +2487,15 @@
             A simple service to queue and send email.
             </summary>
         </member>
-        <member name="M:HealthGateway.Common.Services.NotificationSettingsService.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.Common.Services.NotificationSettingsService},Hangfire.IBackgroundJobClient,HealthGateway.Common.Delegates.INotificationSettingsDelegate,HealthGateway.Database.Delegates.IResourceDelegateDelegate)">
+        <member name="M:HealthGateway.Common.Services.NotificationSettingsService.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.Common.Services.NotificationSettingsService},Hangfire.IBackgroundJobClient,HealthGateway.Database.Delegates.IResourceDelegateDelegate)">
             <summary>
             Initializes a new instance of the <see cref="T:HealthGateway.Common.Services.NotificationSettingsService"/> class.
             </summary>
             <param name="logger">The injected logger provider.</param>
             <param name="jobClient">The JobScheduler queue client.</param>
-            <param name="notificationSettingsDelegate">Notification Settings delegate to be used.</param>
             <param name="resourceDelegateDelegate">The injected db user delegate delegate.</param>
         </member>
-        <member name="M:HealthGateway.Common.Services.NotificationSettingsService.CreateVerificationCode">
-            <summary>
-            Creates a new 6 digit verification code.
-            </summary>
-            <returns>The verification code.</returns>
-        </member>
         <member name="M:HealthGateway.Common.Services.NotificationSettingsService.QueueNotificationSettings(HealthGateway.Common.Models.NotificationSettingsRequest)">
-            <inheritdoc />
-        </member>
-        <member name="M:HealthGateway.Common.Services.NotificationSettingsService.SendNotificationSettings(HealthGateway.Common.Models.NotificationSettingsRequest,System.String)">
             <inheritdoc />
         </member>
         <member name="T:HealthGateway.Common.Services.PatientService">

--- a/Apps/Common/src/Services/INotificationSettingsService.cs
+++ b/Apps/Common/src/Services/INotificationSettingsService.cs
@@ -15,7 +15,6 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Services
 {
-    using System.Threading.Tasks;
     using HealthGateway.Common.Models;
 
     /// <summary>
@@ -28,15 +27,6 @@ namespace HealthGateway.Common.Services
         /// Will use access_token acquired from system account authenication.
         /// </summary>
         /// <param name="notificationSettings">The Notification Settings Request object.</param>
-        /// <returns>The notification settings request queued.</returns>
-        NotificationSettingsRequest QueueNotificationSettings(NotificationSettingsRequest notificationSettings);
-
-        /// <summary>
-        /// Sends the Notifications Settings to PHSA immediately.
-        /// </summary>
-        /// <param name="notificationSettings">The Notification Settings Request object.</param>
-        /// <param name="bearerToken">The bearer token of the authenticated user.</param>
-        /// <returns>A Notification Settings Response object mapped in a RequestResult.</returns>
-        Task<RequestResult<NotificationSettingsResponse>> SendNotificationSettings(NotificationSettingsRequest notificationSettings, string bearerToken);
+        void QueueNotificationSettings(NotificationSettingsRequest notificationSettings);
     }
 }

--- a/Apps/WebClient/src/Server/Services/IUserSMSService.cs
+++ b/Apps/WebClient/src/Server/Services/IUserSMSService.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.WebClient.Services
 {
+    using HealthGateway.Database.Models;
+
     /// <summary>
     /// The User SMS service.
     /// </summary>
@@ -34,7 +36,7 @@ namespace HealthGateway.WebClient.Services
         /// <param name="hdid">The user hdid.</param>
         /// <param name="sms">SMS number to be set for the user.</param>
         /// <returns>returns true if the sms number was sucessfully created.</returns>
-        bool CreateUserSMS(string hdid, string sms);
+        MessagingVerification CreateUserSMS(string hdid, string sms);
 
         /// <summary>
         /// Updates the user SMS number.

--- a/Apps/WebClient/src/Server/Services/UserProfileService.cs
+++ b/Apps/WebClient/src/Server/Services/UserProfileService.cs
@@ -218,6 +218,8 @@ namespace HealthGateway.WebClient.Services
                 string? requestedSMSNumber = createProfileRequest.Profile.SMSNumber;
                 string? requestedEmail = createProfileRequest.Profile.Email;
 
+                NotificationSettingsRequest notificationRequest = new (createdProfile, requestedEmail, requestedSMSNumber);
+
                 // Add email verification
                 if (!string.IsNullOrWhiteSpace(requestedEmail))
                 {
@@ -227,10 +229,11 @@ namespace HealthGateway.WebClient.Services
                 // Add SMS verification
                 if (!string.IsNullOrWhiteSpace(requestedSMSNumber))
                 {
-                    this.userSMSService.CreateUserSMS(hdid, requestedSMSNumber);
+                    MessagingVerification smsVerification = this.userSMSService.CreateUserSMS(hdid, requestedSMSNumber);
+                    notificationRequest.SMSVerificationCode = smsVerification.SMSValidationCode;
                 }
 
-                this.notificationSettingsService.QueueNotificationSettings(new NotificationSettingsRequest(createdProfile, requestedEmail, requestedSMSNumber));
+                this.notificationSettingsService.QueueNotificationSettings(notificationRequest);
 
                 this.logger.LogDebug($"Finished creating user profile. {JsonSerializer.Serialize(insertResult)}");
                 return new RequestResult<UserProfileModel>()


### PR DESCRIPTION
# Fixes or Implements [AB#10476](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10476)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Fixes SMS validation not working on reigstration

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

