### PR TITLE
Fix logout and navigation issues when resizing timeline AB#10412

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/entryDetails.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/entryDetails.vue
@@ -57,7 +57,7 @@ export default class EntryDetailsComponent extends Vue {
 
     @Watch("isMobile")
     private onIsMobile() {
-        if (!this.isMobile) {
+        if (this.isVisible && !this.isMobile) {
             this.handleClose();
         }
     }


### PR DESCRIPTION
# Fixes or Implements [AB#10412](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10412)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Prevents an unintended browser navigation from triggering when resizing the timeline page from mobile to desktop view without having a timeline entry details pane open.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
