### PR TITLE
Shrink background of loading animation to match icon size AB#10502

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/loading.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/loading.vue
@@ -134,15 +134,15 @@ export default class LoadingComponent extends Vue {
     display: block;
 }
 .spinner {
-    width: 100px;
-    height: 100px;
+    width: 60px;
+    height: 60px;
     position: absolute;
-    margin: 100px auto;
+    margin: 60px auto;
 
     top: 50%;
     left: 50%;
-    margin-top: -50px;
-    margin-left: -50px;
+    margin-top: -30px;
+    margin-left: -30px;
 }
 .text {
     color: $primary;


### PR DESCRIPTION
# Fixes or Implements [AB#10502](https://qslvic.visualstudio.com/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10502)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Reduces the diameter of the circle on the loading indicator so it doesn't dwarf the icon.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
