### PR TITLE
Add resource centre to nav pages AB#10535

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/app.vue
+++ b/Apps/WebClient/src/ClientApp/src/app.vue
@@ -157,7 +157,7 @@ export default class App extends Vue {
         <NavHeader />
         <b-row>
             <NavSidebar class="no-print sticky-top vh-100" />
-            <main class="col fill-height">
+            <main class="col fill-height d-flex flex-column">
                 <ErrorCard
                     title="Whoops!"
                     description="An error occurred."

--- a/Apps/WebClient/src/ClientApp/src/assets/scss/_variables.scss
+++ b/Apps/WebClient/src/ClientApp/src/assets/scss/_variables.scss
@@ -105,3 +105,6 @@ $hg-button-nav-disabled: none;
 $hg-button-nav-disabled-text: #546f8a;
 $hg-button-nav-selected: #0092f1;
 $hg-button-nav-selected-text: white;
+
+$hg-button-resource-centre-text: $hg-brand-secondary;
+$hg-button-resource-centre-hover-text: $hg-brand-secondary;

--- a/Apps/WebClient/src/ClientApp/src/components/modal/immunizationCard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/immunizationCard.vue
@@ -44,8 +44,8 @@ export default class ImmunizationCardComponent extends Vue {
     @Getter("patientData", { namespace: "user" })
     patientData!: PatientData;
 
-    @Getter("immunizations", { namespace: "immunization" })
-    immunizations!: ImmunizationEvent[];
+    @Getter("covidImmunizations", { namespace: "immunization" })
+    covidImmunizations!: ImmunizationEvent[];
 
     private eventBus = EventBus;
 
@@ -65,26 +65,14 @@ export default class ImmunizationCardComponent extends Vue {
     @Ref("cardModal")
     readonly cardModal!: Vue;
 
-    @Watch("immunizations", { deep: true })
+    @Watch("covidImmunizations", { deep: true })
     private onImmunizationsChange() {
         this.doses = [];
-        const covidImmunizations = this.immunizations
-            .filter((x) => x.targetedDisease?.toLowerCase().includes("covid"))
-            .sort((a, b) => {
-                const firstDate = new DateWrapper(a.dateOfImmunization);
-                const secondDate = new DateWrapper(b.dateOfImmunization);
 
-                return firstDate.isAfter(secondDate)
-                    ? 1
-                    : firstDate.isBefore(secondDate)
-                    ? -1
-                    : 0;
-            });
-
-        for (let index = 0; index < covidImmunizations.length; index++) {
-            const element = covidImmunizations[index];
-            const agent =
-                covidImmunizations[index].immunization.immunizationAgents[0];
+        for (let index = 0; index < this.covidImmunizations.length; index++) {
+            const element = this.covidImmunizations[index];
+            const agent = this.covidImmunizations[index].immunization
+                .immunizationAgents[0];
             this.doses.push({
                 product: agent.productName,
                 date: DateWrapper.format(element.dateOfImmunization),

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/sidebar.vue
@@ -5,7 +5,6 @@ import {
     faChartLine,
     faClipboardList,
     faEdit,
-    faQuestion,
     faStream,
     faUserFriends,
 } from "@fortawesome/free-solid-svg-icons";
@@ -28,7 +27,6 @@ library.add(
     faChartLine,
     faClipboardList,
     faEdit,
-    faQuestion,
     faStream,
     faUserFriends
 );
@@ -249,10 +247,6 @@ export default class SidebarComponent extends Vue {
     private get isDependents(): boolean {
         return this.$route.path == "/dependents";
     }
-
-    private get isFAQ(): boolean {
-        return this.$route.path == "/faq";
-    }
 }
 </script>
 
@@ -461,25 +455,6 @@ export default class SidebarComponent extends Vue {
                             </b-col>
                             <b-col v-show="isOpen" class="button-text">
                                 <span>Health Insights</span>
-                            </b-col>
-                        </b-row>
-                    </hg-button>
-
-                    <!-- FAQ button -->
-                    <hg-button
-                        id="menuBtnFAQ"
-                        data-testid="menuBtnFAQ"
-                        to="/faq"
-                        class="my-3"
-                        variant="nav"
-                        :class="{ selected: isFAQ }"
-                    >
-                        <b-row class="align-items-center name-wrappe">
-                            <b-col title="FAQ" :class="{ 'col-3': isOpen }">
-                                <hg-icon icon="question" size="large" />
-                            </b-col>
-                            <b-col v-show="isOpen" class="button-text">
-                                <span>FAQ</span>
                             </b-col>
                         </b-row>
                     </hg-button>

--- a/Apps/WebClient/src/ClientApp/src/components/resourceCentre.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/resourceCentre.vue
@@ -1,0 +1,75 @@
+<script lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faQuestion } from "@fortawesome/free-solid-svg-icons";
+
+import EventBus, { EventMessageName } from "@/eventbus";
+
+library.add(faQuestion);
+
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import { Getter } from "vuex-class";
+
+import { ImmunizationEvent } from "@/models/immunizationModel";
+
+@Component
+export default class ResourceCentreComponent extends Vue {
+    @Getter("covidImmunizations", { namespace: "immunization" })
+    covidImmunizations!: ImmunizationEvent[];
+
+    private eventBus = EventBus;
+
+    private showCovidCard(): void {
+        this.eventBus.$emit(EventMessageName.TimelineCovidCard);
+    }
+}
+</script>
+
+<template>
+    <div class="hg-resource-centre position-sticky p-3 mt-auto align-self-end">
+        <b-dropdown
+            dropup
+            :popper-opts="{
+                placement: 'top-end',
+            }"
+            no-caret
+            variant="link"
+        >
+            <template #button-content>
+                <hg-icon
+                    icon="question"
+                    size="large"
+                    square
+                    class="rounded-circle bg-white shadow p-3"
+                />
+            </template>
+            <b-dropdown-item-button
+                :disabled="covidImmunizations.length === 0"
+                @click="showCovidCard()"
+                >COVID-19 Card</b-dropdown-item-button
+            >
+            <b-dropdown-item to="/faq">FAQ</b-dropdown-item>
+            <b-dropdown-item to="/release-notes">Release Notes</b-dropdown-item>
+        </b-dropdown>
+    </div>
+</template>
+
+<style lang="scss">
+// deliberately unscoped to affect button styling in dropdown
+
+@import "@/assets/scss/_variables.scss";
+
+.hg-resource-centre {
+    bottom: 0;
+
+    button.dropdown-toggle {
+        color: $hg-button-resource-centre-text;
+
+        &:hover:not([disabled]),
+        &:active:not([disabled]),
+        &:focus:not([disabled]) {
+            color: $hg-button-resource-centre-hover-text;
+        }
+    }
+}
+</style>

--- a/Apps/WebClient/src/ClientApp/src/components/shared/hgIcon.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/hgIcon.vue
@@ -13,17 +13,17 @@ export default class HgIconComponent extends Vue {
     @Prop({ required: false, default: false }) square!: boolean;
 
     private get classes(): string[] {
-        let result = [];
+        const result = ["hg-icon"];
 
         switch (this.size) {
             case "small":
-                result.push("hg-icon", "hg-small");
+                result.push("hg-small");
                 break;
             case "medium":
-                result.push("hg-icon", "hg-medium");
+                result.push("hg-medium");
                 break;
             case "large":
-                result.push("hg-icon", "hg-large");
+                result.push("hg-large");
                 break;
             default:
                 return [];

--- a/Apps/WebClient/src/ClientApp/src/components/shared/hgIcon.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/hgIcon.vue
@@ -10,18 +10,30 @@ import { Component, Prop } from "vue-property-decorator";
 })
 export default class HgIconComponent extends Vue {
     @Prop({ required: false, default: "medium" }) size!: string;
+    @Prop({ required: false, default: false }) square!: boolean;
 
     private get classes(): string[] {
+        let result = [];
+
         switch (this.size) {
             case "small":
-                return ["hg-icon", "hg-small"];
+                result.push("hg-icon", "hg-small");
+                break;
             case "medium":
-                return ["hg-icon", "hg-medium"];
+                result.push("hg-icon", "hg-medium");
+                break;
             case "large":
-                return ["hg-icon", "hg-large"];
+                result.push("hg-icon", "hg-large");
+                break;
             default:
                 return [];
         }
+
+        if (this.square === true) {
+            result.push("hg-square");
+        }
+
+        return result;
     }
 }
 </script>
@@ -45,6 +57,9 @@ export default class HgIconComponent extends Vue {
     }
     &.hg-large {
         font-size: 1.5rem;
+    }
+    &.hg-square {
+        width: 1em;
     }
 }
 </style>

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -8,7 +8,15 @@ import "bootstrap-vue/dist/bootstrap-vue.css";
 import "@/assets/scss/bcgov/bootstrap-theme.scss";
 import "@/plugins/registerComponentHooks";
 
-import { BBadge, BFormTag, BFormTags, BPopover } from "bootstrap-vue";
+import {
+    BBadge,
+    BDropdown,
+    BDropdownItem,
+    BDropdownItemButton,
+    BFormTag,
+    BFormTags,
+    BPopover,
+} from "bootstrap-vue";
 import IdleVue from "idle-vue";
 import Vue from "vue";
 import VueContentPlaceholders from "vue-content-placeholders";
@@ -54,6 +62,9 @@ import { RootState } from "./store/types";
 
 Vue.component("BPopover", BPopover);
 Vue.component("BBadge", BBadge);
+Vue.component("BDropdown", BDropdown);
+Vue.component("BDropdownItem", BDropdownItem);
+Vue.component("BDropdownItemButton", BDropdownItemButton);
 Vue.component("BFormTags", BFormTags);
 Vue.component("BFormTag", BFormTag);
 Vue.component("HgButton", HgButtonComponent);

--- a/Apps/WebClient/src/ClientApp/src/store/modules/immunization/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/immunization/getters.ts
@@ -1,3 +1,4 @@
+import { DateWrapper } from "@/models/dateWrapper";
 import { ImmunizationEvent, Recommendation } from "@/models/immunizationModel";
 import { LoadStatus } from "@/models/storeOperations";
 
@@ -6,6 +7,20 @@ import { ImmunizationGetters, ImmunizationState } from "./types";
 export const getters: ImmunizationGetters = {
     immunizations(state: ImmunizationState): ImmunizationEvent[] {
         return state.immunizations;
+    },
+    covidImmunizations(state: ImmunizationState): ImmunizationEvent[] {
+        return state.immunizations
+            .filter((x) => x.targetedDisease?.toLowerCase().includes("covid"))
+            .sort((a, b) => {
+                const firstDate = new DateWrapper(a.dateOfImmunization);
+                const secondDate = new DateWrapper(b.dateOfImmunization);
+
+                return firstDate.isAfter(secondDate)
+                    ? 1
+                    : firstDate.isBefore(secondDate)
+                    ? -1
+                    : 0;
+            });
     },
     recomendations(state: ImmunizationState): Recommendation[] {
         return state.recommendations;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/immunization/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/immunization/types.ts
@@ -23,6 +23,7 @@ export interface ImmunizationState {
 export interface ImmunizationGetters
     extends GetterTree<ImmunizationState, RootState> {
     immunizations(state: ImmunizationState): ImmunizationEvent[];
+    covidImmunizations(state: ImmunizationState): ImmunizationEvent[];
     recomendations(state: ImmunizationState): Recommendation[];
     immunizationCount(state: ImmunizationState): number;
     isDeferredLoad(state: ImmunizationState): boolean;

--- a/Apps/WebClient/src/ClientApp/src/views/dependents.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/dependents.vue
@@ -8,6 +8,7 @@ import { Action, Getter } from "vuex-class";
 import DependentCardComponent from "@/components/dependentCard.vue";
 import LoadingComponent from "@/components/loading.vue";
 import NewDependentComponent from "@/components/modal/newDependent.vue";
+import ResourceCentreComponent from "@/components/resourceCentre.vue";
 import BannerError from "@/models/bannerError";
 import type { WebClientConfiguration } from "@/models/configData";
 import type { Dependent } from "@/models/dependent";
@@ -24,6 +25,7 @@ library.add(faUserPlus);
         LoadingComponent,
         DependentCardComponent,
         NewDependentComponent,
+        "resource-centre": ResourceCentreComponent,
     },
 })
 export default class DependentsView extends Vue {
@@ -84,7 +86,7 @@ export default class DependentsView extends Vue {
 }
 </script>
 <template>
-    <div class="m-3">
+    <div class="m-3 flex-grow-1 d-flex flex-column">
         <LoadingComponent :is-loading="isLoading"></LoadingComponent>
         <b-row>
             <b-col class="col-12 col-lg-9 column-wrapper">
@@ -139,6 +141,7 @@ export default class DependentsView extends Vue {
                 </b-row>
             </b-col>
         </b-row>
+        <resource-centre />
         <NewDependentComponent
             ref="newDependentModal"
             @show="showModal"

--- a/Apps/WebClient/src/ClientApp/src/views/healthInsights.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/healthInsights.vue
@@ -7,6 +7,7 @@ import ErrorCardComponent from "@/components/errorCard.vue";
 import LoadingComponent from "@/components/loading.vue";
 import ProtectiveWordComponent from "@/components/modal/protectiveWord.vue";
 import LineChartComponent from "@/components/plot/lineChart.vue";
+import ResourceCentreComponent from "@/components/resourceCentre.vue";
 import { DateWrapper } from "@/models/dateWrapper";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
 import MedicationTimelineEntry from "@/models/medicationTimelineEntry";
@@ -23,6 +24,7 @@ import { ILogger } from "@/services/interfaces";
         ProtectiveWordComponent,
         ErrorCard: ErrorCardComponent,
         LineChart: LineChartComponent,
+        "resource-centre": ResourceCentreComponent,
     },
 })
 export default class HealthInsightsView extends Vue {
@@ -176,7 +178,7 @@ export default class HealthInsightsView extends Vue {
 </script>
 
 <template>
-    <div class="m-3">
+    <div class="m-3 flex-grow-1 d-flex flex-column">
         <LoadingComponent v-if="isLoading" :is-custom="true"></LoadingComponent>
         <b-row>
             <b-col
@@ -230,6 +232,7 @@ export default class HealthInsightsView extends Vue {
                 </div>
             </b-col>
         </b-row>
+        <resource-centre />
         <ProtectiveWordComponent :is-loading="isLoading" />
     </div>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -14,6 +14,7 @@ import ImmunizationHistoryReportComponent from "@/components/report/immunization
 import MedicationHistoryReportComponent from "@/components/report/medicationHistory.vue";
 import MedicationRequestReportComponent from "@/components/report/medicationRequest.vue";
 import MSPVisitsReportComponent from "@/components/report/mspVisits.vue";
+import ResourceCentreComponent from "@/components/resourceCentre.vue";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
@@ -32,6 +33,7 @@ import ReportFilter, { ReportFilterBuilder } from "@/models/reportFilter";
         MedicationRequestReportComponent,
         "hg-date-picker": DatePickerComponent,
         MultiSelectComponent,
+        "resource-centre": ResourceCentreComponent,
     },
 })
 export default class ReportsView extends Vue {
@@ -204,7 +206,7 @@ export default class ReportsView extends Vue {
 </script>
 
 <template>
-    <div class="m-3">
+    <div class="m-3 flex-grow-1 d-flex flex-column">
         <div>
             <b-row>
                 <b-col class="col-12 col-md-10 col-lg-9 column-wrapper">
@@ -453,6 +455,7 @@ export default class ReportsView extends Vue {
                 </b-col>
             </b-row>
         </div>
+        <resource-centre />
         <message-modal
             ref="messageModal"
             data-testid="messageModal"

--- a/Apps/WebClient/src/ClientApp/src/views/timeline.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/timeline.vue
@@ -10,6 +10,7 @@ import LoadingComponent from "@/components/loading.vue";
 import CovidModalComponent from "@/components/modal/covid.vue";
 import NoteEditComponent from "@/components/modal/noteEdit.vue";
 import ProtectiveWordComponent from "@/components/modal/protectiveWord.vue";
+import ResourceCentreComponent from "@/components/resourceCentre.vue";
 import CalendarTimelineComponent from "@/components/timeline/calendarTimeline.vue";
 import EntryDetailsComponent from "@/components/timeline/entryCard/entryDetails.vue";
 import FilterComponent from "@/components/timeline/filters.vue";
@@ -48,6 +49,7 @@ library.add(faSearch);
         CalendarTimeline: CalendarTimelineComponent,
         ErrorCard: ErrorCardComponent,
         Filters: FilterComponent,
+        "resource-centre": ResourceCentreComponent,
     },
 })
 export default class TimelineView extends Vue {
@@ -320,7 +322,7 @@ export default class TimelineView extends Vue {
 </script>
 
 <template>
-    <div>
+    <div class="flex-grow-1 d-flex flex-column">
         <LoadingComponent v-if="isLoading" :is-custom="true"></LoadingComponent>
         <b-row class="my-2 fluid">
             <b-col id="timeline" class="col-12 col-lg-9 column-wrapper">
@@ -475,6 +477,7 @@ export default class TimelineView extends Vue {
                 </b-row>
             </b-col>
         </b-row>
+        <resource-centre />
         <CovidModalComponent :is-loading="isLoading" />
         <ProtectiveWordComponent :is-loading="isLoading" />
         <NoteEditComponent :is-loading="isLoading" />

--- a/Apps/WebClient/src/ClientApp/test/stubs/store/immunizationStub.ts
+++ b/Apps/WebClient/src/ClientApp/test/stubs/store/immunizationStub.ts
@@ -21,6 +21,9 @@ const immunizationGetters: ImmunizationGetters = {
     immunizations(): ImmunizationEvent[] {
         return [];
     },
+    covidImmunizations(): ImmunizationEvent[] {
+        return [];
+    },
     recomendations(): Recommendation[] {
         return [];
     },


### PR DESCRIPTION
# Fixes or Implements [AB#10535](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10535)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Adds a button in the bottom-right corner of all pages that are included in the left navigation (Timeline, Dependents, Export Records, Health Insights). This button opens the resource centre menu, containing links to the FAQ and Release Notes and a button to display the COVID-19 Card.

Also removes the FAQ link from the left-hand navigation, refactors the filtering for COVID-19 immunizations to a getter, and adds a property to the HgIcon component that can force icons to be square.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
