### PR TITLE
Add title to resource centre menu AB#10568

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/resourceCentre.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/resourceCentre.vue
@@ -46,6 +46,11 @@ export default class ResourceCentreComponent extends Vue {
                     class="rounded-circle bg-white shadow p-3"
                 />
             </template>
+            <b-dropdown-text
+                text-class="hg-resource-centre-title font-weight-bold"
+                >Resource Centre</b-dropdown-text
+            >
+            <b-dropdown-divider />
             <b-dropdown-item-button
                 :disabled="covidImmunizations.length === 0"
                 data-testid="hg-resource-centre-covid-card"
@@ -59,12 +64,14 @@ export default class ResourceCentreComponent extends Vue {
 </template>
 
 <style lang="scss">
-// deliberately unscoped to affect button styling in dropdown
-
 @import "@/assets/scss/_variables.scss";
 
 .hg-resource-centre {
     bottom: 0;
+
+    .hg-resource-centre-title {
+        cursor: default;
+    }
 
     button.dropdown-toggle {
         color: $hg-button-resource-centre-text;

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -11,8 +11,10 @@ import "@/plugins/registerComponentHooks";
 import {
     BBadge,
     BDropdown,
+    BDropdownDivider,
     BDropdownItem,
     BDropdownItemButton,
+    BDropdownText,
     BFormTag,
     BFormTags,
     BPopover,
@@ -63,8 +65,10 @@ import { RootState } from "./store/types";
 Vue.component("BPopover", BPopover);
 Vue.component("BBadge", BBadge);
 Vue.component("BDropdown", BDropdown);
+Vue.component("BDropdownDivider", BDropdownDivider);
 Vue.component("BDropdownItem", BDropdownItem);
 Vue.component("BDropdownItemButton", BDropdownItemButton);
+Vue.component("BDropdownText", BDropdownText);
 Vue.component("BFormTags", BFormTags);
 Vue.component("BFormTag", BFormTag);
 Vue.component("HgButton", HgButtonComponent);


### PR DESCRIPTION
# Fixes [AB#10568](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10568)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Adds "Resource Centre" title to top of resource centre menu.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
