### PR TITLE
refresh user profile after email verified AB#10533

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/validateEmail.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/validateEmail.vue
@@ -51,6 +51,9 @@ export default class ValidateEmailView extends Vue {
             .then((result) => {
                 this.validatedValue = result.resourcePayload;
                 this.resultStatus = result.resultStatus;
+                if (this.resultStatus == ResultType.Success) {
+                    this.checkRegistration();
+                }
             })
             .finally(() => {
                 this.isLoading = false;

--- a/Testing/functional/e2e/cypress/integration/user/emailValidation.js
+++ b/Testing/functional/e2e/cypress/integration/user/emailValidation.js
@@ -2,6 +2,7 @@ const { AuthMethod } = require("../../support/constants");
 
 describe("User Email Verification", () => {
     beforeEach(() => {
+        cy.enableModules([]);
         const baseUrl =
             "**/v1/api/UserProfile/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
         cy.intercept("GET", `${baseUrl}/email/validate/valid`, {
@@ -13,6 +14,8 @@ describe("User Email Verification", () => {
         cy.intercept("GET", `${baseUrl}/email/validate/expired`, {
             fixture: "WebClientService/EmailValidation/expired.json",
         });
+        cy.intercept('GET', '/v1/api/UserProfile/*')
+            .as('getUserProfile');
     });
 
     it("Check verified email invite", () => {
@@ -25,6 +28,10 @@ describe("User Email Verification", () => {
         cy.get("[data-testid=verifingInvite]").should("not.exist");
         cy.get("[data-testid=verifiedInvite]").should("be.visible");
         cy.get("[data-testid=continueButton]").click();
+        cy.wait('@getUserProfile')
+            .then((interception) => {
+                assert.equal(interception.response.statusCode, 200);
+            });
         cy.url().should("include", "/timeline");
     });
 


### PR DESCRIPTION
# Fixes or Implements [AB#10533](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10533)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Fixes bug where banner is still being displayed after email is verified, refreshing user profile fixes it.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
