### PR TITLE
Add retrieval of single immunization | Tasks/10581

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -206,7 +206,11 @@ namespace HealthGateway.Common.AspNetConfiguration
                 {
                     policy.AuthenticationSchemes.Add(JwtBearerDefaults.AuthenticationScheme);
                     policy.RequireAuthenticatedUser();
-                    policy.Requirements.Add(new FhirRequirement(FhirResource.Immunization, FhirAccessType.Read));
+                    policy.Requirements.Add(new FhirRequirement(
+                        FhirResource.Immunization,
+                        FhirAccessType.Read,
+                        FhirResourceLookup.Parameter,
+                        supportsUserDelegation: false));
                 });
                 options.AddPolicy(ImmunizationPolicy.Write, policy =>
                 {

--- a/Apps/Immunization/src/Delegates/IImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/IImmunizationDelegate.cs
@@ -26,12 +26,18 @@ namespace HealthGateway.Immunization.Delegates
     public interface IImmunizationDelegate
     {
         /// <summary>
+        /// Returns the matching immunization for the given id.
+        /// </summary>
+        /// <param name="immunizationId">The id of the immunization to retrieve.</param>
+        /// <returns>The immunization that matches the given id.</returns>
+        Task<RequestResult<PHSAResult<ImmunizationViewResponse>>> GetImmunization(string immunizationId);
+
+        /// <summary>
         /// Returns a PHSA Result including the load state and a List of Immunizations for the authenticated user.
         /// It has a collection of one or more Immunizations.
         /// </summary>
-        /// <param name="bearerToken">The security token representing the authenticated user.</param>
         /// <param name="pageIndex">The page index to return.</param>
         /// <returns>The PHSAResult including the load state and the list of Immunizations available for the user identified by the bearerToken.</returns>
-        Task<RequestResult<PHSAResult<ImmunizationResponse>>> GetImmunizations(string bearerToken, int pageIndex = 0);
+        Task<RequestResult<PHSAResult<ImmunizationResponse>>> GetImmunizations(int pageIndex = 0);
     }
 }

--- a/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
@@ -25,12 +25,15 @@ namespace HealthGateway.Immunization.Delegates
     using System.Net.Mime;
     using System.Text.Json;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Constants;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Models.PHSA;
+    using Microsoft.AspNetCore.Authentication;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.WebUtilities;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -41,10 +44,14 @@ namespace HealthGateway.Immunization.Delegates
     public class RestImmunizationDelegate : IImmunizationDelegate
     {
         private const string ImmunizationConfigSectionKey = "Immunization";
-
         private readonly ILogger logger;
         private readonly IHttpClientService httpClientService;
         private readonly ImmunizationConfig immunizationConfig;
+
+        /// <summary>
+        /// Gets or sets the http context accessor.
+        /// </summary>
+        private readonly IHttpContextAccessor httpContextAccessor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RestImmunizationDelegate"/> class.
@@ -52,13 +59,16 @@ namespace HealthGateway.Immunization.Delegates
         /// <param name="logger">Injected Logger Provider.</param>
         /// <param name="httpClientService">The injected http client service.</param>
         /// <param name="configuration">The injected configuration provider.</param>
+        /// <param name="httpContextAccessor">The Http Context accessor.</param>
         public RestImmunizationDelegate(
             ILogger<RestImmunizationDelegate> logger,
             IHttpClientService httpClientService,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            IHttpContextAccessor httpContextAccessor)
         {
             this.logger = logger;
             this.httpClientService = httpClientService;
+            this.httpContextAccessor = httpContextAccessor;
             this.immunizationConfig = new ImmunizationConfig();
             configuration.Bind(ImmunizationConfigSectionKey, this.immunizationConfig);
         }
@@ -66,81 +76,120 @@ namespace HealthGateway.Immunization.Delegates
         private static ActivitySource Source { get; } = new ActivitySource(nameof(RestImmunizationDelegate));
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PHSAResult<ImmunizationResponse>>> GetImmunizations(string bearerToken, int pageIndex = 0)
+        public async Task<RequestResult<PHSAResult<ImmunizationViewResponse>>> GetImmunization(string immunizationId)
         {
-            using (Source.StartActivity("GetDemographicsByHDIDAsync"))
+            using Activity? activity = Source.StartActivity("GetImmunization");
+            this.logger.LogDebug($"Getting immunization {immunizationId}...");
+
+            string endpointString = string.Format(CultureInfo.InvariantCulture, "{0}/{1}", this.immunizationConfig.Endpoint, immunizationId);
+            RequestResult<PHSAResult<ImmunizationViewResponse>> retVal = await this.ParsePHSAResult<ImmunizationViewResponse>(new Uri(endpointString)).ConfigureAwait(true);
+            this.logger.LogDebug($"Finished getting Immunization {immunizationId}");
+
+            return retVal;
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<PHSAResult<ImmunizationResponse>>> GetImmunizations(int pageIndex = 0)
+        {
+            using Activity? activity = Source.StartActivity("GetImmunizations");
+            this.logger.LogDebug($"Getting immunizations...");
+
+            Dictionary<string, string?> query = new ()
             {
-                RequestResult<PHSAResult<ImmunizationResponse>> retVal = new RequestResult<PHSAResult<ImmunizationResponse>>()
+                ["limit"] = this.immunizationConfig.FetchSize,
+            };
+            Uri endpoint = new Uri(QueryHelpers.AddQueryString(this.immunizationConfig.Endpoint, query));
+            RequestResult<PHSAResult<ImmunizationResponse>> retVal = await this.ParsePHSAResult<ImmunizationResponse>(endpoint).ConfigureAwait(true);
+            this.logger.LogDebug($"Finished getting Immunizations");
+
+            return retVal;
+        }
+
+        private async Task<RequestResult<PHSAResult<T>>> ParsePHSAResult<T>(Uri endpoint)
+        {
+            HttpContext? httpContext = this.httpContextAccessor.HttpContext;
+            if (httpContext != null)
+            {
+                string? bearerToken = await httpContext.GetTokenAsync("access_token").ConfigureAwait(true);
+                if (bearerToken != null)
                 {
-                    ResultStatus = Common.Constants.ResultType.Error,
-                    PageIndex = pageIndex,
-                };
-                this.logger.LogDebug($"Getting immunizations...");
-                using HttpClient client = this.httpClientService.CreateDefaultHttpClient();
-                client.DefaultRequestHeaders.Accept.Clear();
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", bearerToken);
-                client.DefaultRequestHeaders.Accept.Add(
-                new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
-                Dictionary<string, string?> query = new Dictionary<string, string?>
-                {
-                    ["limit"] = this.immunizationConfig.FetchSize,
-                };
-                try
-                {
-                    Uri endpoint = new Uri(QueryHelpers.AddQueryString(this.immunizationConfig.Endpoint, query));
-                    HttpResponseMessage response = await client.GetAsync(endpoint).ConfigureAwait(true);
-                    string payload = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-                    this.logger.LogTrace($"Response: {response}");
-                    switch (response.StatusCode)
+                    RequestResult<PHSAResult<T>> retVal = new ()
                     {
-                        case HttpStatusCode.OK:
-                            var options = new JsonSerializerOptions
-                            {
-                                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                                IgnoreNullValues = true,
-                                WriteIndented = true,
-                            };
-                            this.logger.LogTrace($"Response payload: {payload}");
-                            PHSAResult<ImmunizationResponse>? phsaResult = JsonSerializer.Deserialize<PHSAResult<ImmunizationResponse>>(payload, options);
-                            if (phsaResult != null && phsaResult.Result != null)
-                            {
+                        ResultStatus = ResultType.Error,
+                        PageIndex = 0,
+                    };
+
+                    try
+                    {
+                        using HttpClient client = this.httpClientService.CreateDefaultHttpClient();
+                        client.DefaultRequestHeaders.Accept.Clear();
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("bearer", bearerToken);
+                        client.DefaultRequestHeaders.Accept.Add(
+                        new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+                        HttpResponseMessage response = await client.GetAsync(endpoint).ConfigureAwait(true);
+                        string payload = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+                        this.logger.LogTrace($"Response: {response}");
+
+                        switch (response.StatusCode)
+                        {
+                            case HttpStatusCode.OK:
+                                var options = new JsonSerializerOptions
+                                {
+                                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                                    IgnoreNullValues = true,
+                                    WriteIndented = true,
+                                };
+                                this.logger.LogTrace($"Response payload: {payload}");
+                                PHSAResult<T>? phsaResult = JsonSerializer.Deserialize<PHSAResult<T>>(payload, options);
+                                if (phsaResult != null && phsaResult.Result != null)
+                                {
+                                    retVal.ResultStatus = Common.Constants.ResultType.Success;
+                                    retVal.ResourcePayload = phsaResult;
+                                    retVal.TotalResultCount = 1;
+                                    retVal.PageSize = int.Parse(this.immunizationConfig.FetchSize, CultureInfo.InvariantCulture);
+                                }
+                                else
+                                {
+                                    retVal.ResultError = new RequestResultError() { ResultMessage = "Error with JSON data", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+                                }
+
+                                break;
+                            case HttpStatusCode.NoContent: // No Immunizations exits for this user
                                 retVal.ResultStatus = Common.Constants.ResultType.Success;
-                                retVal.ResourcePayload = phsaResult;
-                                retVal.TotalResultCount = 1;
+                                retVal.ResourcePayload = new PHSAResult<T>();
+                                retVal.TotalResultCount = 0;
                                 retVal.PageSize = int.Parse(this.immunizationConfig.FetchSize, CultureInfo.InvariantCulture);
-                            }
-                            else
-                            {
-                                retVal.ResultError = new RequestResultError() { ResultMessage = "Error with JSON data", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
-                            }
-
-                            break;
-                        case HttpStatusCode.NoContent: // No Immunizations exits for this user
-                            retVal.ResultStatus = Common.Constants.ResultType.Success;
-                            retVal.ResourcePayload = new PHSAResult<ImmunizationResponse>();
-                            retVal.TotalResultCount = 0;
-                            retVal.PageSize = int.Parse(this.immunizationConfig.FetchSize, CultureInfo.InvariantCulture);
-                            break;
-                        case HttpStatusCode.Forbidden:
-                            retVal.ResultError = new RequestResultError() { ResultMessage = $"DID Claim is missing or can not resolve PHN, HTTP Error {response.StatusCode}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
-                            break;
-                        default:
-                            retVal.ResultError = new RequestResultError() { ResultMessage = $"Unable to connect to Immunizations Endpoint, HTTP Error {response.StatusCode}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
-                            this.logger.LogError($"Unable to connect to endpoint {endpoint}, HTTP Error {response.StatusCode}\n{payload}");
-                            break;
+                                break;
+                            case HttpStatusCode.Forbidden:
+                                retVal.ResultError = new RequestResultError() { ResultMessage = $"DID Claim is missing or can not resolve PHN, HTTP Error {response.StatusCode}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+                                break;
+                            default:
+                                retVal.ResultError = new RequestResultError() { ResultMessage = $"Unable to connect to Immunizations Endpoint, HTTP Error {response.StatusCode}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+                                this.logger.LogError($"Unable to connect to endpoint {endpoint}, HTTP Error {response.StatusCode}\n{payload}");
+                                break;
+                        }
                     }
-                }
 #pragma warning disable CA1031 // Do not catch general exception types
-                catch (Exception e)
+                    catch (Exception e)
 #pragma warning restore CA1031 // Do not catch general exception types
-                {
-                    retVal.ResultError = new RequestResultError() { ResultMessage = $"Exception getting Immunizations: {e}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
-                    this.logger.LogError($"Unexpected exception in Get Immunizations {e}");
-                }
+                    {
+                        retVal.ResultError = new RequestResultError() { ResultMessage = $"Exception getting Immunization data: {e}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+                        this.logger.LogError($"Unexpected exception retrieving Immunization data {e}");
+                    }
 
-                this.logger.LogDebug($"Finished getting Immunizations");
-                return retVal;
+                    return retVal;
+                }
             }
+
+            return new RequestResult<PHSAResult<T>>()
+            {
+                ResultStatus = ResultType.Error,
+                ResultError = new RequestResultError()
+                {
+                    ResultMessage = "Error retrieving bearer token",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Immunization),
+                },
+            };
         }
     }
 }

--- a/Apps/Immunization/src/Immunization.xml
+++ b/Apps/Immunization/src/Immunization.xml
@@ -14,18 +14,24 @@
             Gets or sets the immunization data service.
             </summary>
         </member>
-        <member name="F:HealthGateway.Immunization.Controllers.ImmunizationController.httpContextAccessor">
-            <summary>
-            Gets or sets the http context accessor.
-            </summary>
-        </member>
-        <member name="M:HealthGateway.Immunization.Controllers.ImmunizationController.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.Immunization.Controllers.ImmunizationController},HealthGateway.Immunization.Services.IImmunizationService,Microsoft.AspNetCore.Http.IHttpContextAccessor)">
+        <member name="M:HealthGateway.Immunization.Controllers.ImmunizationController.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.Immunization.Controllers.ImmunizationController},HealthGateway.Immunization.Services.IImmunizationService)">
             <summary>
             Initializes a new instance of the <see cref="T:HealthGateway.Immunization.Controllers.ImmunizationController"/> class.
             </summary>
             <param name="logger">Injected Logger Provider.</param>
             <param name="svc">The immunization data service.</param>
-            <param name="httpContextAccessor">The Http Context accessor.</param>
+        </member>
+        <member name="M:HealthGateway.Immunization.Controllers.ImmunizationController.GetImmunization(System.String,System.String)">
+            <summary>
+            Gets an immunization record for the given id.
+            </summary>
+            <param name="hdid">The hdid patient id.</param>
+            <param name="immunizationId">The immunization id.</param>
+            <returns>a list of immunization records.</returns>
+            <response code="200">Returns the List of Immunization records.</response>
+            <response code="401">The client must authenticate itself to get the requested response.</response>
+            <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+            <response code="503">The service is unavailable for use.</response>
         </member>
         <member name="M:HealthGateway.Immunization.Controllers.ImmunizationController.GetImmunizations(System.String)">
             <summary>
@@ -43,12 +49,18 @@
             Interface that defines a delegate to retrieve immunization information.
             </summary>
         </member>
-        <member name="M:HealthGateway.Immunization.Delegates.IImmunizationDelegate.GetImmunizations(System.String,System.Int32)">
+        <member name="M:HealthGateway.Immunization.Delegates.IImmunizationDelegate.GetImmunization(System.String)">
+            <summary>
+            Returns the matching immunization for the given id.
+            </summary>
+            <param name="immunizationId">The id of the immunization to retrieve.</param>
+            <returns>The immunization that matches the given id.</returns>
+        </member>
+        <member name="M:HealthGateway.Immunization.Delegates.IImmunizationDelegate.GetImmunizations(System.Int32)">
             <summary>
             Returns a PHSA Result including the load state and a List of Immunizations for the authenticated user.
             It has a collection of one or more Immunizations.
             </summary>
-            <param name="bearerToken">The security token representing the authenticated user.</param>
             <param name="pageIndex">The page index to return.</param>
             <returns>The PHSAResult including the load state and the list of Immunizations available for the user identified by the bearerToken.</returns>
         </member>
@@ -57,15 +69,24 @@
             Implementation that uses HTTP to retrieve immunization information.
             </summary>
         </member>
-        <member name="M:HealthGateway.Immunization.Delegates.RestImmunizationDelegate.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.Immunization.Delegates.RestImmunizationDelegate},HealthGateway.Common.Services.IHttpClientService,Microsoft.Extensions.Configuration.IConfiguration)">
+        <member name="F:HealthGateway.Immunization.Delegates.RestImmunizationDelegate.httpContextAccessor">
+            <summary>
+            Gets or sets the http context accessor.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Immunization.Delegates.RestImmunizationDelegate.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.Immunization.Delegates.RestImmunizationDelegate},HealthGateway.Common.Services.IHttpClientService,Microsoft.Extensions.Configuration.IConfiguration,Microsoft.AspNetCore.Http.IHttpContextAccessor)">
             <summary>
             Initializes a new instance of the <see cref="T:HealthGateway.Immunization.Delegates.RestImmunizationDelegate"/> class.
             </summary>
             <param name="logger">Injected Logger Provider.</param>
             <param name="httpClientService">The injected http client service.</param>
             <param name="configuration">The injected configuration provider.</param>
+            <param name="httpContextAccessor">The Http Context accessor.</param>
         </member>
-        <member name="M:HealthGateway.Immunization.Delegates.RestImmunizationDelegate.GetImmunizations(System.String,System.Int32)">
+        <member name="M:HealthGateway.Immunization.Delegates.RestImmunizationDelegate.GetImmunization(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:HealthGateway.Immunization.Delegates.RestImmunizationDelegate.GetImmunizations(System.Int32)">
             <inheritdoc/>
         </member>
         <member name="T:HealthGateway.Immunization.Models.ImmunizationAgent">
@@ -391,6 +412,11 @@
         <member name="T:HealthGateway.Immunization.Models.PHSA.ImmunizationResponse">
             <summary>
             Represents Immunization Response.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Immunization.Models.PHSA.ImmunizationResponse.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:HealthGateway.Immunization.Models.PHSA.ImmunizationResponse"/> class.
             </summary>
         </member>
         <member name="M:HealthGateway.Immunization.Models.PHSA.ImmunizationResponse.#ctor(System.Collections.Generic.IList{HealthGateway.Immunization.Models.PHSA.ImmunizationViewResponse},System.Collections.Generic.IList{HealthGateway.Immunization.Models.PHSA.Recommendation.ImmunizationRecommendationResponse})">
@@ -741,11 +767,17 @@
             The Immunization data service.
             </summary>
         </member>
-        <member name="M:HealthGateway.Immunization.Services.IImmunizationService.GetImmunizations(System.String,System.Int32)">
+        <member name="M:HealthGateway.Immunization.Services.IImmunizationService.GetImmunization(System.String)">
+            <summary>
+            Gets the ImmunizationEvent for the given id.
+            </summary>
+            <param name="immunizationId">The security token representing the authenticated user.</param>
+            <returns>Returns a list of immunizations.</returns>
+        </member>
+        <member name="M:HealthGateway.Immunization.Services.IImmunizationService.GetImmunizations(System.Int32)">
             <summary>
             Gets the ImmunizationResult inluding load state and a list of immunization records.
             </summary>
-            <param name="bearerToken">The security token representing the authenticated user.</param>
             <param name="pageIndex">The page index to return.</param>
             <returns>Returns a list of immunizations.</returns>
         </member>
@@ -760,7 +792,10 @@
             </summary>
             <param name="immunizationDelegate">The factory to create immunization delegates.</param>
         </member>
-        <member name="M:HealthGateway.Immunization.Services.ImmunizationService.GetImmunizations(System.String,System.Int32)">
+        <member name="M:HealthGateway.Immunization.Services.ImmunizationService.GetImmunization(System.String)">
+            <inheritdoc/>
+        </member>
+        <member name="M:HealthGateway.Immunization.Services.ImmunizationService.GetImmunizations(System.Int32)">
             <inheritdoc/>
         </member>
         <member name="T:HealthGateway.Immunization.Startup">

--- a/Apps/Immunization/src/Models/ImmunizationEvent.cs
+++ b/Apps/Immunization/src/Models/ImmunizationEvent.cs
@@ -76,7 +76,7 @@ namespace HealthGateway.Immunization.Models
         {
             return new ImmunizationEvent()
             {
-                Id = model.SourceSystemId,
+                Id = model.Id.ToString(),
                 DateOfImmunization = model.OccurrenceDateTime,
                 TargetedDisease = model.TargetedDisease,
                 ProviderOrClinic = model.ProviderOrClinic,

--- a/Apps/Immunization/src/Models/PHSA/ImmunizationResponse.cs
+++ b/Apps/Immunization/src/Models/PHSA/ImmunizationResponse.cs
@@ -27,6 +27,15 @@ namespace HealthGateway.Immunization.Models.PHSA
         /// <summary>
         /// Initializes a new instance of the <see cref="ImmunizationResponse"/> class.
         /// </summary>
+        public ImmunizationResponse()
+        {
+            this.ImmunizationViews = new List<ImmunizationViewResponse>();
+            this.Recommendations = new List<ImmunizationRecommendationResponse>();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ImmunizationResponse"/> class.
+        /// </summary>
         /// <param name="immunizationViews">The list of immunization view response.</param>
         /// <param name="recommendations">The list of immunization recommendation response.</param>
         [JsonConstructor]

--- a/Apps/Immunization/src/Services/IImmunizationService.cs
+++ b/Apps/Immunization/src/Services/IImmunizationService.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Services
 {
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Common.Models;
     using HealthGateway.Immunization.Models;
@@ -26,11 +25,17 @@ namespace HealthGateway.Immunization.Services
     public interface IImmunizationService
     {
         /// <summary>
+        /// Gets the ImmunizationEvent for the given id.
+        /// </summary>
+        /// <param name="immunizationId">The security token representing the authenticated user.</param>
+        /// <returns>Returns a list of immunizations.</returns>
+        Task<RequestResult<ImmunizationEvent>> GetImmunization(string immunizationId);
+
+        /// <summary>
         /// Gets the ImmunizationResult inluding load state and a list of immunization records.
         /// </summary>
-        /// <param name="bearerToken">The security token representing the authenticated user.</param>
         /// <param name="pageIndex">The page index to return.</param>
         /// <returns>Returns a list of immunizations.</returns>
-        Task<RequestResult<ImmunizationResult>> GetImmunizations(string bearerToken, int pageIndex = 0);
+        Task<RequestResult<ImmunizationResult>> GetImmunizations(int pageIndex = 0);
     }
 }

--- a/Apps/Immunization/src/Services/ImmunizationService.cs
+++ b/Apps/Immunization/src/Services/ImmunizationService.cs
@@ -41,9 +41,34 @@ namespace HealthGateway.Immunization.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<ImmunizationResult>> GetImmunizations(string bearerToken, int pageIndex = 0)
+        public async Task<RequestResult<ImmunizationEvent>> GetImmunization(string immunizationId)
         {
-            RequestResult<PHSAResult<ImmunizationResponse>> delegateResult = await this.immunizationDelegate.GetImmunizations(bearerToken, pageIndex).ConfigureAwait(true);
+            RequestResult<PHSAResult<ImmunizationViewResponse>> delegateResult = await this.immunizationDelegate.GetImmunization(immunizationId).ConfigureAwait(true);
+            if (delegateResult.ResultStatus == ResultType.Success)
+            {
+                return new RequestResult<ImmunizationEvent>()
+                {
+                    ResultStatus = delegateResult.ResultStatus,
+                    ResourcePayload = ImmunizationEvent.FromPHSAModel(delegateResult.ResourcePayload!.Result),
+                    PageIndex = delegateResult.PageIndex,
+                    PageSize = delegateResult.PageSize,
+                    TotalResultCount = delegateResult.TotalResultCount,
+                };
+            }
+            else
+            {
+                return new RequestResult<ImmunizationEvent>()
+                {
+                    ResultStatus = delegateResult.ResultStatus,
+                    ResultError = delegateResult.ResultError,
+                };
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<ImmunizationResult>> GetImmunizations(int pageIndex = 0)
+        {
+            RequestResult<PHSAResult<ImmunizationResponse>> delegateResult = await this.immunizationDelegate.GetImmunizations(pageIndex).ConfigureAwait(true);
             if (delegateResult.ResultStatus == ResultType.Success)
             {
                 return new RequestResult<ImmunizationResult>()

--- a/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
@@ -17,15 +17,11 @@ namespace HealthGateway.Immunization.Test.Controllers
 {
     using System;
     using System.Collections.Generic;
-    using System.Security.Claims;
     using System.Threading.Tasks;
     using HealthGateway.Common.Models;
     using HealthGateway.Immunization.Controllers;
     using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
-    using Microsoft.AspNetCore.Authentication;
-    using Microsoft.AspNetCore.Authentication.JwtBearer;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -37,8 +33,6 @@ namespace HealthGateway.Immunization.Test.Controllers
     public class ImmunizationControllerTests
     {
         private readonly string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-        private readonly string token = "Fake Access Token";
-        private readonly string userId = "1001";
 
         private readonly RequestResult<ImmunizationResult> expectedRequestResult = new ()
         {
@@ -89,28 +83,12 @@ namespace HealthGateway.Immunization.Test.Controllers
         [Fact]
         public async Task ShouldGetImmunizations()
         {
-            ClaimsPrincipal claimsPrincipal = this.GetClaimsPrincipal();
-            var httpContextAccessorMock = this.GetHttpAccessorMock(claimsPrincipal);
-            Mock<IAuthenticationService> authenticationMock = new Mock<IAuthenticationService>();
-            httpContextAccessorMock
-                .Setup(x => x.HttpContext!.RequestServices.GetService(typeof(IAuthenticationService)))
-                .Returns(authenticationMock.Object);
-            var authResult = AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, JwtBearerDefaults.AuthenticationScheme));
-            authResult.Properties.StoreTokens(new[]
-            {
-                new AuthenticationToken { Name = "access_token", Value = this.token },
-            });
-            authenticationMock
-                .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))
-                .ReturnsAsync(authResult);
-
             Mock<IImmunizationService> svcMock = new Mock<IImmunizationService>();
-            svcMock.Setup(s => s.GetImmunizations(this.token, 0)).ReturnsAsync(this.expectedRequestResult);
+            svcMock.Setup(s => s.GetImmunizations(0)).ReturnsAsync(this.expectedRequestResult);
 
             ImmunizationController controller = new ImmunizationController(
                 new Mock<ILogger<ImmunizationController>>().Object,
-                svcMock.Object,
-                httpContextAccessorMock.Object);
+                svcMock.Object);
 
             // Act
             IActionResult actual = await controller.GetImmunizations(this.hdid).ConfigureAwait(true);
@@ -130,33 +108,6 @@ namespace HealthGateway.Immunization.Test.Controllers
             }
 
             Assert.Equal(2, count);
-        }
-
-        private ClaimsPrincipal GetClaimsPrincipal()
-        {
-            List<Claim> claims = new List<Claim>()
-            {
-                new Claim(ClaimTypes.Name, "username"),
-                new Claim(ClaimTypes.NameIdentifier, this.userId),
-                new Claim("hdid", this.hdid),
-            };
-            ClaimsIdentity identity = new ClaimsIdentity(claims, "TestAuth");
-            return new ClaimsPrincipal(identity);
-        }
-
-        private Mock<IHttpContextAccessor> GetHttpAccessorMock(ClaimsPrincipal claimsPrincipal)
-        {
-            IHeaderDictionary headerDictionary = new HeaderDictionary();
-            headerDictionary.Add("Authorization", this.token);
-            Mock<HttpRequest> httpRequestMock = new Mock<HttpRequest>();
-            httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
-            Mock<HttpContext> httpContextMock = new Mock<HttpContext>();
-            httpContextMock.Setup(s => s.User).Returns(claimsPrincipal);
-            httpContextMock.Setup(s => s.Request).Returns(httpRequestMock.Object);
-
-            Mock<IHttpContextAccessor> httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(s => s.HttpContext).Returns(httpContextMock.Object);
-            return httpContextAccessorMock;
         }
     }
 }

--- a/Apps/Immunization/test/unit/ImmunizationTests.xml
+++ b/Apps/Immunization/test/unit/ImmunizationTests.xml
@@ -15,6 +15,12 @@
             </summary>
             <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the asynchronous unit test.</returns>
         </member>
+        <member name="M:HealthGateway.Immunization.Test.Controllers.ImmunizationControllerTests.ShouldGetSingleImmunization">
+            <summary>
+            GetImmunization - Happy Path.
+            </summary>
+            <returns>A <see cref="T:System.Threading.Tasks.Task"/> representing the asynchronous unit test.</returns>
+        </member>
         <member name="T:HealthGateway.Immunization.Test.Delegates.ImmsDelegateTests">
             <summary>
             RestImmunizationDelegate's Unit Tests.
@@ -25,7 +31,12 @@
             Initializes a new instance of the <see cref="T:HealthGateway.Immunization.Test.Delegates.ImmsDelegateTests"/> class.
             </summary>
         </member>
-        <member name="M:HealthGateway.Immunization.Test.Delegates.ImmsDelegateTests.Ok">
+        <member name="M:HealthGateway.Immunization.Test.Delegates.ImmsDelegateTests.GetImmunization">
+            <summary>
+            GetImmunizations - Happy Path.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Immunization.Test.Delegates.ImmsDelegateTests.GetImmunizations">
             <summary>
             GetImmunizations - Happy Path.
             </summary>
@@ -63,6 +74,11 @@
         <member name="M:HealthGateway.Immunization.Test.Services.ImmsServiceTests.ShouldGetImmunizations">
             <summary>
             GetImmunizations - Happy Path.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Immunization.Test.Services.ImmsServiceTests.ShouldGetImmunization">
+            <summary>
+            GetImmunization - Happy Path.
             </summary>
         </member>
         <member name="M:HealthGateway.Immunization.Test.Services.ImmsServiceTests.ShouldGetRecomendation">

--- a/Apps/Immunization/test/unit/Services.Test/ImmsServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmsServiceTests.cs
@@ -94,6 +94,47 @@ namespace HealthGateway.Immunization.Test.Services
         }
 
         /// <summary>
+        /// GetImmunization - Happy Path.
+        /// </summary>
+        [Fact]
+        public void ShouldGetImmunization()
+        {
+            var mockDelegate = new Mock<IImmunizationDelegate>();
+            RequestResult<PHSAResult<ImmunizationViewResponse>> delegateResult = new RequestResult<PHSAResult<ImmunizationViewResponse>>()
+            {
+                ResultStatus = Common.Constants.ResultType.Success,
+                ResourcePayload = new PHSAResult<ImmunizationViewResponse>()
+                {
+                    LoadState = new PHSALoadState() { RefreshInProgress = false, },
+                    Result = new ImmunizationViewResponse()
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "MockImmunization",
+                        OccurrenceDateTime = DateTime.Now,
+                        SourceSystemId = "MockSourceID",
+                    },
+                },
+                PageIndex = 0,
+                PageSize = 5,
+                TotalResultCount = 1,
+            };
+            RequestResult<ImmunizationEvent> expectedResult = new RequestResult<ImmunizationEvent>()
+            {
+                ResultStatus = delegateResult.ResultStatus,
+                ResourcePayload = ImmunizationEvent.FromPHSAModel(delegateResult.ResourcePayload.Result),
+                PageIndex = delegateResult.PageIndex,
+                PageSize = delegateResult.PageSize,
+                TotalResultCount = delegateResult.TotalResultCount,
+            };
+
+            mockDelegate.Setup(s => s.GetImmunization(It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            IImmunizationService service = new ImmunizationService(mockDelegate.Object);
+
+            var actualResult = service.GetImmunization("immz_id");
+            Assert.True(expectedResult.IsDeepEqual(actualResult.Result));
+        }
+
+        /// <summary>
         /// GetImmunizations - Happy Path (With Recommendations).
         /// </summary>
         [Fact]

--- a/Apps/Immunization/test/unit/Services.Test/ImmsServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmsServiceTests.cs
@@ -86,10 +86,10 @@ namespace HealthGateway.Immunization.Test.Services
                 TotalResultCount = delegateResult.TotalResultCount,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizations(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetImmunizations(It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
             IImmunizationService service = new ImmunizationService(mockDelegate.Object);
 
-            var actualResult = service.GetImmunizations(string.Empty, 0);
+            var actualResult = service.GetImmunizations(0);
             Assert.True(expectedResult.IsDeepEqual(actualResult.Result));
         }
 
@@ -114,10 +114,10 @@ namespace HealthGateway.Immunization.Test.Services
                 TotalResultCount = delegateResult.TotalResultCount,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizations(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetImmunizations(It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
             IImmunizationService service = new ImmunizationService(mockDelegate.Object);
 
-            var actualResult = service.GetImmunizations(string.Empty, 0);
+            var actualResult = service.GetImmunizations(0);
             Assert.True(expectedResult.IsDeepEqual(actualResult.Result));
             Assert.Equal(1, expectedResult.ResourcePayload.Recommendations.Count);
             var recomendationResult = expectedResult.ResourcePayload.Recommendations[0];
@@ -159,10 +159,10 @@ namespace HealthGateway.Immunization.Test.Services
                 ResultError = delegateResult.ResultError,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizations(It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetImmunizations(It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
             IImmunizationService service = new ImmunizationService(mockDelegate.Object);
 
-            var actualResult = service.GetImmunizations(string.Empty, 0);
+            var actualResult = service.GetImmunizations(0);
             Assert.True(expectedResult.IsDeepEqual(actualResult.Result));
         }
 

--- a/Apps/WebClient/src/ClientApp/src/services/restImmunizationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restImmunizationService.ts
@@ -51,7 +51,7 @@ export class RestImmunizationService implements IImmunizationService {
 
             return this.http
                 .getWithCors<RequestResult<ImmunizationResult>>(
-                    `${this.baseUri}${this.IMMS_BASE_URI}/${hdid}`
+                    `${this.baseUri}${this.IMMS_BASE_URI}?hdid=${hdid}`
                 )
                 .then((requestResult) => {
                     resolve(requestResult);


### PR DESCRIPTION
# Fixes or Implements [AB#10581](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10581)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

* Added the retrieval of a single immunization to the Immunization server
* Updated immunization controller to use the query parameter to extract the Hdid instead of it being in the path

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

