### PR TITLE
Fix add after revoke and revoke without add for AB#10679

### DIFF
--- a/Apps/WebClient/src/Server/Services/IWalletService.cs
+++ b/Apps/WebClient/src/Server/Services/IWalletService.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.WebClient.Services
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Common.Models;
+    using HealthGateway.Database.Models;
     using HealthGateway.WebClient.Models;
 
     /// <summary>
@@ -72,11 +73,18 @@ namespace HealthGateway.WebClient.Services
         Task<RequestResult<WalletConnectionModel>> DisconnectConnection(Guid connectionId, string hdId);
 
         /// <summary>
-        /// Revokes the wallet identified wallet credentials.
+        /// Revokes the identified wallet credential if in created or added state.
         /// </summary>
         /// <param name="credentialId">The wallet credential id.</param>
         /// <param name="hdId">The user hdid.</param>
         /// <returns>A wallet credential model wrapped in a RequestResult.</returns>
         Task<RequestResult<WalletCredentialModel>> RevokeCredential(Guid credentialId, string hdId);
+
+        /// <summary>
+        /// Revokes the identified wallet credential if in created or added state.
+        /// </summary>
+        /// <param name="credential">The wallet credential id.</param>
+        /// <returns>A wallet credential model wrapped in a RequestResult.</returns>
+        Task<RequestResult<WalletCredentialModel>> RevokeCredential(WalletCredential credential);
     }
 }

--- a/Apps/WebClient/src/Server/Services/IWalletStatusService.cs
+++ b/Apps/WebClient/src/Server/Services/IWalletStatusService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.WebClient.Services
 {
     using System;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Models;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Models;
@@ -39,6 +40,6 @@ namespace HealthGateway.WebClient.Services
         /// </summary>
         /// <param name="agentData">The data received from the agent to update.</param>
         /// <returns>The updated WalletCredential wrapped in a RequestResult.</returns>
-        RequestResult<WalletCredential> UpdateIssuedCredential(WebhookData agentData);
+        Task<RequestResult<WalletCredential>> UpdateIssuedCredential(WebhookData agentData);
     }
 }

--- a/Apps/WebClient/src/Server/Services/WalletStatusService.cs
+++ b/Apps/WebClient/src/Server/Services/WalletStatusService.cs
@@ -108,9 +108,10 @@ namespace HealthGateway.WebClient.Services
                 credential.RevocationRegistryId = agentData.RevocationRegistryId;
                 if (credential.Status == WalletCredentialStatus.Revoked)
                 {
-                   var result = await this.walletAgentService.RevokeCredential(credential).ConfigureAwait(true);
-                   retVal.ResultStatus = result.ResultStatus;
-                   retVal.ResultError = result.ResultError;
+                    var result = await this.walletAgentService.RevokeCredential(credential).ConfigureAwait(true);
+                    retVal.ResourcePayload = credential;
+                    retVal.ResultStatus = result.ResultStatus;
+                    retVal.ResultError = result.ResultError;
                 }
                 else
                 {

--- a/Apps/WebClient/src/WebClient.xml
+++ b/Apps/WebClient/src/WebClient.xml
@@ -1917,10 +1917,17 @@
         </member>
         <member name="M:HealthGateway.WebClient.Services.IWalletService.RevokeCredential(System.Guid,System.String)">
             <summary>
-            Revokes the wallet identified wallet credentials.
+            Revokes the identified wallet credential if in created or added state.
             </summary>
             <param name="credentialId">The wallet credential id.</param>
             <param name="hdId">The user hdid.</param>
+            <returns>A wallet credential model wrapped in a RequestResult.</returns>
+        </member>
+        <member name="M:HealthGateway.WebClient.Services.IWalletService.RevokeCredential(HealthGateway.Database.Models.WalletCredential)">
+            <summary>
+            Revokes the identified wallet credential if in created or added state.
+            </summary>
+            <param name="credential">The wallet credential id.</param>
             <returns>A wallet credential model wrapped in a RequestResult.</returns>
         </member>
         <member name="T:HealthGateway.WebClient.Services.IWalletStatusService">
@@ -2122,15 +2129,19 @@
         <member name="M:HealthGateway.WebClient.Services.WalletService.RevokeCredential(System.Guid,System.String)">
             <inheritdoc/>
         </member>
+        <member name="M:HealthGateway.WebClient.Services.WalletService.RevokeCredential(HealthGateway.Database.Models.WalletCredential)">
+            <inheritdoc/>
+        </member>
         <member name="T:HealthGateway.WebClient.Services.WalletStatusService">
             <inheritdoc />
         </member>
-        <member name="M:HealthGateway.WebClient.Services.WalletStatusService.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.WebClient.Services.WalletStatusService},HealthGateway.Database.Delegates.IWalletDelegate)">
+        <member name="M:HealthGateway.WebClient.Services.WalletStatusService.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.WebClient.Services.WalletStatusService},HealthGateway.Database.Delegates.IWalletDelegate,HealthGateway.WebClient.Services.IWalletService)">
             <summary>
             Initializes a new instance of the <see cref="T:HealthGateway.WebClient.Services.WalletStatusService"/> class.
             </summary>
             <param name="logger">Injected Logger Provider.</param>
             <param name="walletDelegate">Injected Wallet delegate.</param>
+            <param name="walletAgentService">The Wallet Agent Service for revocation purposes.</param>
         </member>
         <member name="M:HealthGateway.WebClient.Services.WalletStatusService.UpdateWalletConnectionStatus(System.Guid,HealthGateway.Database.Constants.WalletConnectionStatus)">
             <inheritdoc />


### PR DESCRIPTION
# Fixes or Implements [AB#10679](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10679)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

Disables the agent revoke call if a user revokes before adding to wallet.
Adds revoke after credential added if credential was previously revoked.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
