### PR TITLE
Add Swagger auth mechanism for Api Key on AB#10682

### DIFF
--- a/Apps/Common/src/Swagger/ConfigureSwaggerGenOptions.cs
+++ b/Apps/Common/src/Swagger/ConfigureSwaggerGenOptions.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Common.Swagger
     using System;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.AccessManagement.Authorization.Requirements;
     using Microsoft.AspNetCore.Mvc.ApiExplorer;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Options;
@@ -65,6 +66,15 @@ namespace HealthGateway.Common.Swagger
                 BearerFormat = "JWT",
                 In = ParameterLocation.Header,
                 Scheme = "bearer",
+            });
+
+            options.AddSecurityDefinition("apikey", new OpenApiSecurityScheme
+            {
+                Name = ApiKeyRequirement.ApiKeyHeaderNameDefault,
+                Description = $"Authorization using the {ApiKeyRequirement.ApiKeyHeaderNameDefault} header. Example: \"{ApiKeyRequirement.ApiKeyHeaderNameDefault} {{apiKey}}\"",
+                Type = SecuritySchemeType.ApiKey,
+                In = ParameterLocation.Header,
+                Scheme = "apikey",
             });
 
             // Add auth header filter


### PR DESCRIPTION
# Fixes or Implements [AB#10682](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10682)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

Adds authorization for x-api-key into Swagger

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
