### PR TITLE
Fixes revoke issue on disconnect for AB#10689

### DIFF
--- a/Apps/Database/src/Delegates/DBWalletDelegate.cs
+++ b/Apps/Database/src/Delegates/DBWalletDelegate.cs
@@ -64,6 +64,9 @@ namespace HealthGateway.Database.Delegates
                 connection = this.dbContext.WalletConnection
                                            .Where(p => p.Id == id &&
                                                        p.UserProfileId == userProfileId)
+                                           .Include(c => c.Credentials
+                                                  .Where(q => q.Status != WalletCredentialStatus.Revoked)
+                                                  .OrderByDescending(q => q.CreatedDateTime))
                                            .FirstOrDefault();
             }
             else


### PR DESCRIPTION
# Fixes or Implements [AB#10689](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10689)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

When revoking credentials based on connection, the list of credential was not being returned.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
