### PR TITLE
Update medication report max records AB#10553

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -53,7 +53,7 @@ export default class MedicationHistoryReportComponent extends Vue {
 
     private logger!: ILogger;
     private notFoundText = "Not Found";
-    private fileMaxRecords = 1000;
+    private fileMaxRecords = 500;
     private fileIndex = 0;
     private totalFiles = 1;
     private isPreview = true;


### PR DESCRIPTION
# Fixes or Implements [AB#10553](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10553)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Fixes blank pdf files when a profile has too many medication records by reducing the max records per file.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
