### PR TITLE
Fixes padding/margin issue on profile ab#10729

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/profile.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/profile.vue
@@ -439,9 +439,9 @@ export default class ProfileView extends Vue {
 </script>
 
 <template>
-    <div class="m-3">
+    <div class="flex-grow-1 d-flex flex-column">
         <LoadingComponent :is-loading="isLoading"></LoadingComponent>
-        <b-row class="py-1 my-3 py-md-5 fluid">
+        <b-row class="my-2 fluid">
             <div class="col-12 col-lg-9 column-wrapper">
                 <b-alert
                     :show="showCheckEmailAlert"
@@ -457,9 +457,9 @@ export default class ProfileView extends Vue {
                         If you didn't receive one, please check your junk mail.
                     </span>
                 </b-alert>
-                <page-title title="Profile" />
+                <page-title title="Profile" class="px-2" />
                 <div v-if="!isLoading">
-                    <div v-if="isActiveProfile">
+                    <div v-if="isActiveProfile" class="px-2">
                         <b-row class="mb-3">
                             <b-col>
                                 <label for="profileNames" class="hg-label"
@@ -835,7 +835,7 @@ export default class ProfileView extends Vue {
                             </b-col>
                         </b-row>
                     </div>
-                    <b-row v-if="isActiveProfile" class="mb-3">
+                    <b-row v-if="isActiveProfile" class="mb-3 px-2">
                         <b-col>
                             <label class="hg-label">Manage Account</label>
                             <div>


### PR DESCRIPTION
# Fixes or Implements [AB#10729](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10729)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

Fixes the padding issue before the title on the profile page and makes it the same as timeline
Adjusts the left margin for content to be the same as timeline

<img width="858" alt="image" src="https://user-images.githubusercontent.com/51342761/122884518-1835d880-d2f3-11eb-95da-c215233b5dc0.png">


If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

Yes

### Browsers Tested

-   [X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
