### PR TITLE
Fix vertical padding on banner messages AB#10751

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/communication.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/communication.vue
@@ -70,9 +70,7 @@ export default class CommunicationComponent extends Vue {
 <template>
     <b-row v-if="hasCommunication">
         <b-col class="p-0 m-0">
-            <div class="text-center communication p-2">
-                <span v-html="text"></span>
-            </div>
+            <div class="text-center communication p-2" v-html="text" />
         </b-col>
     </b-row>
 </template>
@@ -83,5 +81,9 @@ export default class CommunicationComponent extends Vue {
 .communication {
     background-color: $bcgold;
     color: black;
+
+    :last-child {
+        margin-bottom: 0;
+    }
 }
 </style>


### PR DESCRIPTION
# Fixes [AB#10751](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10751)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Removes the extra margin added by the final paragraph in banner messages.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

![image](https://user-images.githubusercontent.com/16570293/122980237-46e09d00-d34d-11eb-8877-58e701326209.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
