### PR TITLE
Display in-app messages when logged in and banners when not AB#10754

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/communication.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/communication.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component, Watch } from "vue-property-decorator";
+import { Getter } from "vuex-class";
 
 import Communication, { CommunicationType } from "@/models/communication";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
@@ -13,21 +14,42 @@ export default class CommunicationComponent extends Vue {
     private bannerCommunication: Communication | null = null;
     private inAppCommunication: Communication | null = null;
 
+    @Getter("oidcIsAuthenticated", { namespace: "auth" })
+    oidcIsAuthenticated!: boolean;
+
+    @Getter("userIsRegistered", { namespace: "user" })
+    userIsRegistered!: boolean;
+
+    @Getter("isValidIdentityProvider", { namespace: "auth" })
+    isValidIdentityProvider!: boolean;
+
+    @Getter("isOffline", { namespace: "config" })
+    isOffline!: boolean;
+
+    private get isInApp(): boolean {
+        return (
+            this.oidcIsAuthenticated &&
+            this.userIsRegistered &&
+            this.isValidIdentityProvider &&
+            !this.isOffline
+        );
+    }
+
     private get hasCommunication(): boolean {
-        if (this.$route.path === "/") {
-            return this.bannerCommunication != null;
-        } else {
+        if (this.isInApp) {
             return this.inAppCommunication != null;
+        } else {
+            return this.bannerCommunication != null;
         }
     }
 
     private get text(): string {
-        if (this.$route.path === "/") {
+        if (this.isInApp) {
+            return this.inAppCommunication ? this.inAppCommunication.text : "";
+        } else {
             return this.bannerCommunication
                 ? this.bannerCommunication.text
                 : "";
-        } else {
-            return this.inAppCommunication ? this.inAppCommunication.text : "";
         }
     }
 


### PR DESCRIPTION
# Fixes [AB#10754](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10754)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Displays the regular banner on pages when the user is not authenticated and the in-app message on pages when the user is authenticated.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
