### PR TITLE
Fix ordering of rating modal and loading overlay AB#9162

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/assets/scss/_variables.scss
+++ b/Apps/WebClient/src/ClientApp/src/assets/scss/_variables.scss
@@ -14,12 +14,14 @@ $danger: #d93e45;
 
 $heading_color: #313132;
 
-$z_top_layer: 9999;
-$z_datepicker: 1036;
-$z_header: 1035;
-$z_popover: 1030; // Less than modal backdrop (1040)
-$z_sidebar: 1020; // Less than modal backdrop (1040)
 $z_overlay: 998;
+$z_sidebar: 1020; // Less than modal backdrop (1040)
+$z_popover: 1030; // Less than modal backdrop (1040)
+$z_header: 1035;
+$z_datepicker: 1036; // more than header
+$z_loading_overlay: 1090;
+$z_application_rating: 1100;
+$z_top_layer: 9999;
 
 $header-height: 65px;
 $timeline-filter-height: 54px;

--- a/Apps/WebClient/src/ClientApp/src/components/loading.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/loading.vue
@@ -107,7 +107,7 @@ export default class LoadingComponent extends Vue {
 @import "@/assets/scss/_variables.scss";
 .fullScreen {
     position: fixed;
-    z-index: 9998;
+    z-index: $z_loading_overlay;
     top: 0;
     left: 0;
     width: 100%;
@@ -118,7 +118,7 @@ export default class LoadingComponent extends Vue {
 }
 .block {
     position: absolute;
-    z-index: 9998;
+    z-index: $z_loading_overlay;
     top: 0;
     left: 0;
     width: 100%;

--- a/Apps/WebClient/src/ClientApp/src/components/modal/rating.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/rating.vue
@@ -70,6 +70,7 @@ export default class RatingComponent extends Vue {
             id="rating-modal"
             ref="rating-modal"
             v-model="isVisible"
+            data-modal="rating"
             data-testid="ratingModal"
             title="Rating"
             size="md"
@@ -115,3 +116,9 @@ export default class RatingComponent extends Vue {
         </b-modal>
     </div>
 </template>
+<style lang="scss">
+@import "@/assets/scss/_variables.scss";
+[data-modal="rating"] {
+    z-index: $z_application_rating !important;
+}
+</style>


### PR DESCRIPTION
# Fixes [AB#9162](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/9162)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Makes the rating modal appear on top of the loading overlay and other elements, like the timeline filter popover.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

![image](https://user-images.githubusercontent.com/16570293/123862100-c71e7980-d8dc-11eb-9baf-368540ea745b.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
