### PR TITLE
Format dates for current locale on admin support page AB#10758

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/models/messageVerification.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/messageVerification.ts
@@ -13,10 +13,10 @@ export default interface MessageVerification {
     verificationType: VerificationType;
     smsNumber: string | null;
     smsValidationCode: string;
-    expireDate: string;
+    expireDate: Date;
     verificationAttempts: number;
     deleted: boolean;
-    updatedDateTime: string;
+    updatedDateTime: Date;
 }
 
 export interface Email {
@@ -25,7 +25,7 @@ export interface Email {
     to: string;
     subject: string;
     body: string;
-    sentDateTime: string;
+    sentDateTime: Date;
     lastRetryDateTime?: string;
     attempts: number;
     smtpStatusCode: number;

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import moment from "moment";
 import { Component, Vue } from "vue-property-decorator";
 
 import BannerFeedbackComponent from "@/components/core/BannerFeedback.vue";
@@ -121,8 +120,11 @@ export default class SupportView extends Vue {
         this.supportService = container.get(SERVICE_IDENTIFIER.SupportService);
     }
 
-    private formatDate(date: string): string {
-        return moment(date).format("l LT");
+    private formatDate(date: Date): string {
+        if (!date) {
+            return "";
+        }
+        return new Date(Date.parse(date + "Z")).toLocaleString();
     }
 
     private handleSearch() {


### PR DESCRIPTION
# Implements [AB#10758](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10758)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Changes date display to local time instead of UTC on the Support page in the Admin application.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
