### PR TITLE
Add HDID lookup to support page AB#10756

### DIFF
--- a/Apps/AdminWebClient/src/AdminWebClient.xml
+++ b/Apps/AdminWebClient/src/AdminWebClient.xml
@@ -44,6 +44,11 @@
             Query by the SMS Phone number.
             </summary>
         </member>
+        <member name="F:HealthGateway.Admin.Constants.UserQueryType.HDID">
+            <summary>
+            Query by the users directed identifier.
+            </summary>
+        </member>
         <member name="T:HealthGateway.Admin.Controllers.AuthenticationController">
             <summary>
             The Authentication and Authorization controller.
@@ -813,6 +818,11 @@
         <member name="P:HealthGateway.Admin.Models.UserFeedbackView.Id">
             <summary>
             Gets or sets the user feedback id.
+            </summary>
+        </member>
+        <member name="P:HealthGateway.Admin.Models.UserFeedbackView.UserProfileId">
+            <summary>
+            Gets or sets the related user profile id.
             </summary>
         </member>
         <member name="P:HealthGateway.Admin.Models.UserFeedbackView.Comment">

--- a/Apps/AdminWebClient/src/ClientApp/src/models/userFeedback.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/userFeedback.ts
@@ -3,6 +3,9 @@ export default interface UserFeedback {
     // Feedback unique identifier.
     id: string;
 
+    // Associated user unique identifier.
+    userProfileId: string;
+
     // Satisfied flag.
     isSatisfied: boolean;
 

--- a/Apps/AdminWebClient/src/ClientApp/src/models/userQuery.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/userQuery.ts
@@ -2,4 +2,5 @@ export enum QueryType {
     PHN = "PHN",
     Email = "Email",
     SMS = "SMS",
+    HDID = "HDID",
 }

--- a/Apps/AdminWebClient/src/ClientApp/src/router.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/router.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import VueRouter from "vue-router";
+import VueRouter, { Route } from "vue-router";
 
 import store from "@/store/store";
 import CommunicationView from "@/views/Communication.vue";
@@ -84,6 +84,9 @@ const routes = [
         name: "Support",
         component: SupportView,
         meta: { requiresAuth: true, validRoles: [UserRoles.Admin] },
+        props: (route: Route) => ({
+            hdid: route.query.hdid,
+        }),
     },
     {
         path: "/unauthorized",

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Feedback.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Feedback.vue
@@ -1,117 +1,3 @@
-<template>
-    <v-container>
-        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
-        <BannerFeedbackComponent
-            :show-feedback.sync="showFeedback"
-            :feedback="bannerFeedback"
-            class="mt-5"
-        ></BannerFeedbackComponent>
-        <v-row justify="center">
-            <v-col>
-                <v-card>
-                    <v-card-title>Filter</v-card-title>
-                    <v-card-text>
-                        <v-row align="center">
-                            <v-col class="flex-grow-1 flex-shrink-0">
-                                <v-select
-                                    v-model="selectedAdminTagIds"
-                                    :items="adminTags"
-                                    item-text="name"
-                                    item-value="id"
-                                    label="Tags"
-                                    multiple
-                                />
-                            </v-col>
-                            <v-col class="flex-grow-0 flex-shrink-1">
-                                <v-btn
-                                    color="accent"
-                                    :disabled="!filterIsActive"
-                                    @click="clearFilter"
-                                >
-                                    Clear
-                                </v-btn>
-                            </v-col>
-                        </v-row>
-                    </v-card-text>
-                </v-card>
-            </v-col>
-        </v-row>
-        <v-row justify="center">
-            <v-col no-gutters>
-                <v-data-table
-                    :headers="tableHeaders"
-                    :items="filteredFeedbackList"
-                    :items-per-page="50"
-                    :footer-props="{
-                        'items-per-page-options': [25, 50, 100, -1],
-                    }"
-                >
-                    <template #item.createdDateTime="{ item }">
-                        <span>{{ formatDate(item.createdDateTime) }}</span>
-                    </template>
-                    <template #item.isReviewed="{ item }">
-                        <td>
-                            <v-btn
-                                class="mx-2"
-                                dark
-                                small
-                                icon
-                                @click="toggleReviewed(item)"
-                            >
-                                <v-icon
-                                    v-if="item.isReviewed"
-                                    color="green"
-                                    dark
-                                    >fa-check</v-icon
-                                >
-                                <v-icon v-if="!item.isReviewed" color="red" dark
-                                    >fa-times</v-icon
-                                >
-                            </v-btn>
-                        </td>
-                    </template>
-                    <template #item.tags="{ item: feedback }">
-                        <td>
-                            <v-combobox
-                                v-model="feedback.tags"
-                                multiple
-                                hide-selected
-                                :items="availableTags"
-                                :filter="filter"
-                                :loading="isLoadingTag"
-                                :item-text="getItemText"
-                                @input="onTagChange($event, feedback)"
-                                @focus="onTagFocus(feedback)"
-                            >
-                                <template #selection="{ item }">
-                                    <template v-if="isString(item)">
-                                        Loading...
-                                    </template>
-                                    <template v-else>
-                                        <v-chip
-                                            close
-                                            @click:close="
-                                                removeTag(feedback, item)
-                                            "
-                                        >
-                                            {{ item.tag.name }}
-                                        </v-chip>
-                                    </template>
-                                </template>
-                                <template #item="{ item }">
-                                    <v-chip>
-                                        {{ item }}
-                                    </v-chip>
-                                </template>
-                            </v-combobox>
-                        </td>
-                    </template>
-                </v-data-table>
-            </v-col>
-        </v-row>
-    </v-container>
-</template>
-
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
 
@@ -417,3 +303,117 @@ export default class FeedbackView extends Vue {
     }
 }
 </script>
+
+<template>
+    <v-container>
+        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
+        <BannerFeedbackComponent
+            :show-feedback.sync="showFeedback"
+            :feedback="bannerFeedback"
+            class="mt-5"
+        ></BannerFeedbackComponent>
+        <v-row justify="center">
+            <v-col>
+                <v-card>
+                    <v-card-title>Filter</v-card-title>
+                    <v-card-text>
+                        <v-row align="center">
+                            <v-col class="flex-grow-1 flex-shrink-0">
+                                <v-select
+                                    v-model="selectedAdminTagIds"
+                                    :items="adminTags"
+                                    item-text="name"
+                                    item-value="id"
+                                    label="Tags"
+                                    multiple
+                                />
+                            </v-col>
+                            <v-col class="flex-grow-0 flex-shrink-1">
+                                <v-btn
+                                    color="accent"
+                                    :disabled="!filterIsActive"
+                                    @click="clearFilter"
+                                >
+                                    Clear
+                                </v-btn>
+                            </v-col>
+                        </v-row>
+                    </v-card-text>
+                </v-card>
+            </v-col>
+        </v-row>
+        <v-row justify="center">
+            <v-col no-gutters>
+                <v-data-table
+                    :headers="tableHeaders"
+                    :items="filteredFeedbackList"
+                    :items-per-page="50"
+                    :footer-props="{
+                        'items-per-page-options': [25, 50, 100, -1],
+                    }"
+                >
+                    <template #item.createdDateTime="{ item }">
+                        <span>{{ formatDate(item.createdDateTime) }}</span>
+                    </template>
+                    <template #item.isReviewed="{ item }">
+                        <td>
+                            <v-btn
+                                class="mx-2"
+                                dark
+                                small
+                                icon
+                                @click="toggleReviewed(item)"
+                            >
+                                <v-icon
+                                    v-if="item.isReviewed"
+                                    color="green"
+                                    dark
+                                    >fa-check</v-icon
+                                >
+                                <v-icon v-if="!item.isReviewed" color="red" dark
+                                    >fa-times</v-icon
+                                >
+                            </v-btn>
+                        </td>
+                    </template>
+                    <template #item.tags="{ item: feedback }">
+                        <td>
+                            <v-combobox
+                                v-model="feedback.tags"
+                                multiple
+                                hide-selected
+                                :items="availableTags"
+                                :filter="filter"
+                                :loading="isLoadingTag"
+                                :item-text="getItemText"
+                                @input="onTagChange($event, feedback)"
+                                @focus="onTagFocus(feedback)"
+                            >
+                                <template #selection="{ item }">
+                                    <template v-if="isString(item)">
+                                        Loading...
+                                    </template>
+                                    <template v-else>
+                                        <v-chip
+                                            close
+                                            @click:close="
+                                                removeTag(feedback, item)
+                                            "
+                                        >
+                                            {{ item.tag.name }}
+                                        </v-chip>
+                                    </template>
+                                </template>
+                                <template #item="{ item }">
+                                    <v-chip>
+                                        {{ item }}
+                                    </v-chip>
+                                </template>
+                            </v-combobox>
+                        </td>
+                    </template>
+                </v-data-table>
+            </v-col>
+        </v-row>
+    </v-container>
+</template>

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Feedback.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Feedback.vue
@@ -4,11 +4,13 @@ import { Component, Vue } from "vue-property-decorator";
 import BannerFeedbackComponent from "@/components/core/BannerFeedback.vue";
 import LoadingComponent from "@/components/core/Loading.vue";
 import { ResultType } from "@/constants/resulttype";
+import { UserRoles } from "@/constants/userRoles";
 import BannerFeedback from "@/models/bannerFeedback";
 import UserFeedback, { AdminTag, UserFeedbackTag } from "@/models/userFeedback";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
 import { IUserFeedbackService } from "@/services/interfaces";
+import store from "@/store/store";
 
 @Component({
     components: {
@@ -84,6 +86,11 @@ export default class FeedbackView extends Vue {
                     this.selectedAdminTagIds.includes(feedbackTag.tag.id)
                 ).length > 0
         );
+    }
+
+    private get canAccessSupport() {
+        const userRoles: string[] = store.getters["auth/roles"];
+        return userRoles.some((userRole) => userRole === UserRoles.Admin);
     }
 
     private mounted() {
@@ -306,12 +313,12 @@ export default class FeedbackView extends Vue {
 
 <template>
     <v-container>
-        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
+        <LoadingComponent :is-loading="isLoading" />
         <BannerFeedbackComponent
             :show-feedback.sync="showFeedback"
             :feedback="bannerFeedback"
             class="mt-5"
-        ></BannerFeedbackComponent>
+        />
         <v-row justify="center">
             <v-col>
                 <v-card>
@@ -354,6 +361,23 @@ export default class FeedbackView extends Vue {
                 >
                     <template #item.createdDateTime="{ item }">
                         <span>{{ formatDate(item.createdDateTime) }}</span>
+                    </template>
+                    <template #item.email="{ item }">
+                        <td>
+                            <button
+                                v-if="canAccessSupport"
+                                class="mr-1"
+                                @click="
+                                    $router.push({
+                                        path: '/support',
+                                        query: { hdid: item.userProfileId },
+                                    })
+                                "
+                            >
+                                <v-icon>mdi-account-search</v-icon>
+                            </button>
+                            <span>{{ item.email }}</span>
+                        </td>
                     </template>
                     <template #item.isReviewed="{ item }">
                         <td>

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -126,7 +126,8 @@ export default class SupportView extends Vue {
     }
 
     private handleSearch() {
-        if (this.selectedQueryType === null) {
+        if (this.selectedQueryType === null || this.searchText.length === 0) {
+            this.emailList = [];
             return;
         }
 
@@ -164,32 +165,33 @@ export default class SupportView extends Vue {
 
 <template>
     <v-container>
-        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
+        <LoadingComponent :is-loading="isLoading" />
         <BannerFeedbackComponent
             :show-feedback.sync="showFeedback"
             :feedback="bannerFeedback"
             class="mt-5"
-        ></BannerFeedbackComponent>
-        <v-row justify="center">
-            <v-col cols="2">
-                <v-combobox
-                    v-model="selectedQueryType"
-                    :items="queryTypes"
-                    label="Query Type"
-                    outlined
-                ></v-combobox
-            ></v-col>
-            <v-col>
-                <v-text-field v-model="searchText" label="Search Query">
-                </v-text-field>
-            </v-col>
-            <v-col>
-                <v-btn class="mt-2" @click="handleSearch()">
-                    Search
-                    <v-icon class="ml-2" size="sm">fas fa-search</v-icon>
-                </v-btn>
-            </v-col>
-        </v-row>
+        />
+        <form @submit.prevent="handleSearch()">
+            <v-row align="center">
+                <v-col cols="4" sm="3" lg="2">
+                    <v-combobox
+                        v-model="selectedQueryType"
+                        :items="queryTypes"
+                        label="Query Type"
+                        outlined
+                    />
+                </v-col>
+                <v-col>
+                    <v-text-field v-model="searchText" label="Search Query" />
+                </v-col>
+                <v-col cols="auto">
+                    <v-btn type="submit" class="mt-2">
+                        Search
+                        <v-icon class="ml-2" size="sm">fas fa-search</v-icon>
+                    </v-btn>
+                </v-col>
+            </v-row>
+        </form>
         <v-row justify="center">
             <v-col>
                 <v-row>

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import moment from "moment";
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Prop, Vue } from "vue-property-decorator";
 
 import BannerFeedbackComponent from "@/components/core/BannerFeedback.vue";
 import CommunicationTable from "@/components/core/CommunicationTable.vue";
@@ -35,6 +35,8 @@ interface UserSearchRow {
     },
 })
 export default class SupportView extends Vue {
+    @Prop({ default: null, required: false }) hdid!: string;
+
     private isLoading = false;
     private showFeedback = false;
     private bannerFeedback: BannerFeedback = {
@@ -119,6 +121,12 @@ export default class SupportView extends Vue {
 
     private mounted() {
         this.supportService = container.get(SERVICE_IDENTIFIER.SupportService);
+        if (this.hdid) {
+            this.selectedQueryType = QueryType.HDID;
+            this.searchText = this.hdid;
+            this.handleSearch();
+            this.$router.replace({ path: "/support" });
+        }
     }
 
     private formatDate(date: string): string {

--- a/Apps/AdminWebClient/src/Server/Constants/UserQueryType.cs
+++ b/Apps/AdminWebClient/src/Server/Constants/UserQueryType.cs
@@ -34,5 +34,10 @@ namespace HealthGateway.Admin.Constants
         /// Query by the SMS Phone number.
         /// </summary>
         SMS,
+
+        /// <summary>
+        /// Query by the users directed identifier.
+        /// </summary>
+        HDID,
     }
 }

--- a/Apps/AdminWebClient/src/Server/Models/UserFeedbackView.cs
+++ b/Apps/AdminWebClient/src/Server/Models/UserFeedbackView.cs
@@ -49,6 +49,11 @@ namespace HealthGateway.Admin.Models
         public Guid Id { get; set; }
 
         /// <summary>
+        /// Gets or sets the related user profile id.
+        /// </summary>
+        public string? UserProfileId { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets or sets the feedback comments.
         /// </summary>
         public string? Comment { get; set; }
@@ -93,6 +98,7 @@ namespace HealthGateway.Admin.Models
             UserFeedbackView userFeedbackView = new ()
             {
                 Id = model.Id,
+                UserProfileId = model.UserProfileId,
                 Comment = model.Comment,
                 CreatedDateTime = model.CreatedDateTime,
                 IsReviewed = model.IsReviewed,

--- a/Apps/AdminWebClient/src/Server/Services/DashboardService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/DashboardService.cs
@@ -123,6 +123,9 @@ namespace HealthGateway.Admin.Services
                 case UserQueryType.SMS:
                     dbResult = this.messagingVerificationDelegate.GetUserMessageVerifications(Database.Constants.UserQueryType.SMS, queryString);
                     break;
+                case UserQueryType.HDID:
+                    dbResult = this.messagingVerificationDelegate.GetUserMessageVerifications(Database.Constants.UserQueryType.HDID, queryString);
+                    break;
             }
 
             if (dbResult != null && dbResult.Status == Database.Constants.DBStatusCode.Read)


### PR DESCRIPTION
# Implements [AB#10756](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10756)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

- Adds the ability to look up verifications by HDID on the support page in the admin site
- Adds buttons to the table on the feedback page to jump to the support page with the verifications for that user loaded
- Improves the experience of the search on the support page by allowing you to hit the Enter key in the text box to perform the search

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

![image](https://user-images.githubusercontent.com/16570293/124840504-fc137780-df3f-11eb-9e52-e79fe9a4426c.png)

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
