### PR TITLE
Fix test failure for AB#10873

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/profile.js
@@ -1,4 +1,5 @@
 const { AuthMethod } = require("../../../support/constants");
+const fakeSMSNumber = "7781234567";
 
 describe("User Profile", () => {
     const emailAddress =
@@ -97,7 +98,7 @@ describe("User Profile", () => {
         );
         cy.get("[data-testid=editSMSBtn]").click();
         cy.get("[data-testid=smsInvalidNewEqualsOld]").should("be.visible");
-        cy.get("[data-testid=smsNumberInput]").clear().type("7781234567");
+        cy.get("[data-testid=smsNumberInput]").clear().type(fakeSMSNumber);
         cy.get("[data-testid=saveSMSEditBtn]").click();
         cy.get('[data-testid="countdownText"]').contains(/\d{1,2}s$/); // has 1 or 2 digits before the last 's' character
 
@@ -117,9 +118,7 @@ describe("User Profile", () => {
             .should("be.disabled")
             .invoke("val")
             .then((value) =>
-                expect(value.replace(/\D+/g, "")).to.eq(
-                    Cypress.env("phoneNumber").toString()
-                )
+                expect(value.replace(/\D+/g, "")).to.eq(fakeSMSNumber)
             );
     });
 


### PR DESCRIPTION
# Fixes or Implements [AB#10873](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10873)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

Invalid SMS Number test was failing as I removed Mandad's number and replaced with a stubbed fake number.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [X] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
