### PR TITLE
Add test for PHN on Profile for AB#10875

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/profile.js
@@ -16,6 +16,10 @@ describe("User Profile", () => {
         );
     });
 
+    it("PHN Visible and Correct", () => {
+        cy.get("[data-testid=PHN]").should("be.visible").contains("9735353315");
+    });
+
     it("Edit email address", () => {
         cy.intercept(
             "PUT",


### PR DESCRIPTION
# Fixes or Implements [AB#10875](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10875)

-   [X] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Added functional test to verify PHN is on Profile page.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [X] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
