### PR TITLE
Fixes broken layout on responsive screen AB#10871

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
@@ -154,7 +154,8 @@ export default class COVID19ReportComponent extends Vue {
             </b-row>
             <b-table
                 v-if="!isEmpty || isLaboratoryLoading"
-                striped
+                :striped="true"
+                :fixed="true"
                 :busy="isLaboratoryLoading"
                 :items="items"
                 :fields="fields"

--- a/Apps/WebClient/src/ClientApp/src/components/report/immunizationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/immunizationHistory.vue
@@ -282,8 +282,9 @@ export default class ImmunizationHistoryReportComponent extends Vue {
                     </b-row>
                     <b-table
                         v-if="!isRecommendationEmpty || isLoading"
+                        :striped="true"
+                        :fixed="true"
                         :busy="isLoading"
-                        striped
                         :items="recomendationItems"
                         :fields="recomendationFields"
                         class="mt-2 table-style"

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -184,7 +184,8 @@ export default class MedicationHistoryReportComponent extends Vue {
             </b-row>
             <b-table
                 v-if="!isEmpty || isLoading"
-                striped
+                :striped="true"
+                :fixed="true"
                 :busy="isLoading"
                 :items="items"
                 :fields="fields"

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationRequest.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationRequest.vue
@@ -175,7 +175,8 @@ export default class MedicationRequestReportComponent extends Vue {
             </b-row>
             <b-table
                 v-if="!isEmpty || isLoading"
-                striped
+                :striped="true"
+                :fixed="true"
                 :busy="isLoading"
                 :items="items"
                 :fields="fields"

--- a/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
@@ -139,7 +139,8 @@ export default class MSPVisitsReportComponent extends Vue {
 
                 <b-table
                     v-if="!isEmpty || isLoading"
-                    striped
+                    :striped="true"
+                    :fixed="true"
                     :busy="isLoading"
                     :items="items"
                     :fields="fields"

--- a/Apps/WebClient/src/ClientApp/src/views/reports.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/reports.vue
@@ -240,7 +240,7 @@ export default class ReportsView extends Vue {
 <template>
     <div class="m-3 flex-grow-1 d-flex flex-column">
         <b-row>
-            <b-col class="col-12 col-lg-9 column-wrapper">
+            <b-col class="col-12 column-wrapper">
                 <page-title title="Export Records" />
                 <div class="my-3 px-3 py-4 form">
                     <b-row>
@@ -249,7 +249,7 @@ export default class ReportsView extends Vue {
                         </b-col>
                     </b-row>
                     <b-row align-h="between" class="py-2">
-                        <b-col class="mb-2" md="12" lg="">
+                        <b-col class="mb-2" sm="">
                             <b-form-select
                                 id="reportType"
                                 v-model="reportComponent"
@@ -491,7 +491,7 @@ export default class ReportsView extends Vue {
     width: 100%;
     height: 600px;
     overflow-y: scroll;
-    overflow-x: hidden;
+    overflow-x: scroll;
 }
 .form {
     background-color: $soft_background;


### PR DESCRIPTION
# Fixes or Implements [AB#10871](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10871)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Removes right aligned padding of reports view (now is full screen).
Sets the table to fixed size.
![image](https://user-images.githubusercontent.com/60719756/125506141-421c91be-d15f-4cbe-b4f6-c0fc04b73131.png)
![image](https://user-images.githubusercontent.com/60719756/125506184-a1f51462-92d1-49bd-bf6f-9bb897e77035.png)

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
