### PR TITLE
Add Mock project AB#10903

### DIFF
--- a/Apps/HealthGateway.code-workspace
+++ b/Apps/HealthGateway.code-workspace
@@ -60,6 +60,10 @@
             "path": "Encounter"
         },
         {
+            "name": "Mock",
+            "path": "Mock"
+        },
+        {
             "path": "../Testing/functional/tests"
         },
         {
@@ -100,6 +104,7 @@
             "Patient",
             "WebClient",
             "Encounter",
+            "Mock",
             "tests",
             "sampler",
             "Design"

--- a/Apps/Mock/Dockerfile
+++ b/Apps/Mock/Dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/dotnet/aspnet:5.0
+ENV ASPNETCORE_URLS=http://+:8080
+ENV ASPNETCORE_ENVIRONMENT=Production
+RUN apt-get update -y && \ 
+    apt-get install -y curl telnet
+WORKDIR /app
+COPY . .
+EXPOSE 8080
+ENTRYPOINT ["dotnet","Mock.dll"]

--- a/Apps/Mock/Mock.sln
+++ b/Apps/Mock/Mock.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31005.135
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mock", "src\Mock.csproj", "{1842E377-23AD-4A52-881E-F0B82E7893A8}"
+	ProjectSection(ProjectDependencies) = postProject
+		{8660083F-F582-47C6-BC98-6DCF0F4AC851} = {8660083F-F582-47C6-BC98-6DCF0F4AC851}
+	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "..\Common\src\Common.csproj", "{8660083F-F582-47C6-BC98-6DCF0F4AC851}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1842E377-23AD-4A52-881E-F0B82E7893A8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1842E377-23AD-4A52-881E-F0B82E7893A8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1842E377-23AD-4A52-881E-F0B82E7893A8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1842E377-23AD-4A52-881E-F0B82E7893A8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8660083F-F582-47C6-BC98-6DCF0F4AC851}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8660083F-F582-47C6-BC98-6DCF0F4AC851}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8660083F-F582-47C6-BC98-6DCF0F4AC851}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8660083F-F582-47C6-BC98-6DCF0F4AC851}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BE46271C-4B31-4344-AA2E-E94EE6936055}
+	EndGlobalSection
+EndGlobal

--- a/Apps/Mock/README.md
+++ b/Apps/Mock/README.md
@@ -1,0 +1,12 @@
+# Mock
+
+The Mock project provides mock data for testing purposes.
+
+## Run Encounter Service
+
+### Command line
+
+```bash
+cd $GATEWAYHOME/Apps/Mock
+dotnet run
+```

--- a/Apps/Mock/README.md
+++ b/Apps/Mock/README.md
@@ -2,7 +2,7 @@
 
 The Mock project provides mock data for testing purposes.
 
-## Run Encounter Service
+## Run Mock Service
 
 ### Command line
 

--- a/Apps/Mock/azure/build.yaml
+++ b/Apps/Mock/azure/build.yaml
@@ -1,0 +1,31 @@
+name: 1.0.0$(Rev:.r) #Build number
+
+pr: none
+
+resources:
+  pipelines:
+    - pipeline: Common
+      source: Common
+      trigger:
+        branches:
+          - dev
+          
+trigger:
+  batch: "true"
+  branches:
+    include:
+      - dev
+  paths:
+    include:
+      - Apps/Mock
+
+pool:
+  name: "HealthGateway"
+
+extends:
+  template: /Build/hg.yaml
+  parameters:
+    Application: Mock
+    DotNetTests: true
+    NPMInstall: false
+    NPMTests: false

--- a/Apps/Mock/azure/prbuild.yaml
+++ b/Apps/Mock/azure/prbuild.yaml
@@ -1,0 +1,22 @@
+name: PR$(Rev:.r) #Build number
+
+pr:
+  branches:
+    include:
+      - dev
+  paths:
+    include:
+      - Apps/Mock
+
+trigger: none
+
+pool:
+  name: "HealthGateway"
+
+extends:
+  template: /Build/hg.yaml
+  parameters:
+    Application: Mock
+    DotNetTests: true
+    NPMInstall: false
+    NPMTests: false

--- a/Apps/Mock/src/AssemblyInfo.cs
+++ b/Apps/Mock/src/AssemblyInfo.cs
@@ -1,0 +1,16 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+[assembly: System.CLSCompliant(false)]

--- a/Apps/Mock/src/Controllers/OdrController.cs
+++ b/Apps/Mock/src/Controllers/OdrController.cs
@@ -1,0 +1,38 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Mock.Controllers
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// The Odr Mock controller.
+    /// </summary>
+    [Route("v{version:apiVersion}/api/[controller]")]
+    [ApiController]
+    public class OdrController : ControllerBase
+    {
+        /// <summary>
+        /// Gets mock data for encounters.
+        /// </summary>
+        [HttpGet]
+        [Produces("application/json")]
+        public EmptyResult Encounter()
+        {
+            return new EmptyResult();
+        }
+    }
+}

--- a/Apps/Mock/src/Mock.csproj
+++ b/Apps/Mock/src/Mock.csproj
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <RootNamespace>HealthGateway.Mock</RootNamespace>
+    <DocumentationFile>.\Mock.xml</DocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <SonarQubeSetting Include="sonar.stylecop.projectFilePath">
+      <Value>$(MSBuildProjectFullPath)/src</Value>
+    </SonarQubeSetting>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Remove="wwwroot\dist\vendor-manifest.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Common\src\Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/Apps/Mock/src/Mock.xml
+++ b/Apps/Mock/src/Mock.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<doc>
+    <assembly>
+        <name>Mock</name>
+    </assembly>
+    <members>
+        <member name="T:HealthGateway.Mock.Controllers.OdrController">
+            <summary>
+            The Odr Mock controller.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Mock.Controllers.OdrController.Encounter">
+            <summary>
+            Gets mock data for encounters.
+            </summary>
+        </member>
+        <member name="T:HealthGateway.Mock.Program">
+            <summary>
+            The entry point for the project.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Mock.Program.Main(System.String[])">
+            <summary>.
+            The entry point for the class.
+            </summary>
+            <param name="args">The command line arguments to be passed in.</param>
+        </member>
+        <member name="M:HealthGateway.Mock.Program.CreateHostBuilder(System.String[])">
+            <summary>.
+            Creates the IWebHostBuilder.
+            </summary>
+            <param name="args">The command line arguments to be passed in.</param>
+            <returns>Returns the configured webhost.</returns>
+        </member>
+        <member name="T:HealthGateway.Mock.Startup">
+            <summary>
+            Configures the application during startup.
+            </summary>
+        </member>
+        <member name="M:HealthGateway.Mock.Startup.#ctor(Microsoft.AspNetCore.Hosting.IWebHostEnvironment,Microsoft.Extensions.Configuration.IConfiguration)">
+            <summary>
+            Initializes a new instance of the <see cref="T:HealthGateway.Mock.Startup"/> class.
+            </summary>
+            <param name="env">The injected Environment provider.</param>
+            <param name="configuration">The injected configuration provider.</param>
+        </member>
+        <member name="M:HealthGateway.Mock.Startup.ConfigureServices(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            This method gets called by the runtime. Use this method to add services to the container.
+            </summary>
+            <param name="services">The injected services provider.</param>
+        </member>
+        <member name="M:HealthGateway.Mock.Startup.Configure(Microsoft.AspNetCore.Builder.IApplicationBuilder)">
+            <summary>
+            This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+            </summary>
+            <param name="app">The application builder.</param>
+        </member>
+    </members>
+</doc>

--- a/Apps/Mock/src/Program.cs
+++ b/Apps/Mock/src/Program.cs
@@ -1,0 +1,45 @@
+﻿//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Mock
+{
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.AspNetConfiguration;
+    using Microsoft.Extensions.Hosting;
+
+    /// <summary>
+    /// The entry point for the project.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class Program
+    {
+        /// <summary>.
+        /// The entry point for the class.
+        /// </summary>
+        /// <param name="args">The command line arguments to be passed in.</param>
+        public static void Main(string[] args)
+        {
+            CreateHostBuilder(args).Build().Run();
+        }
+
+        /// <summary>.
+        /// Creates the IWebHostBuilder.
+        /// </summary>
+        /// <param name="args">The command line arguments to be passed in.</param>
+        /// <returns>Returns the configured webhost.</returns>
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            ProgramConfiguration.CreateHostBuilder<Startup>(args);
+    }
+}

--- a/Apps/Mock/src/Properties/launchSettings.json
+++ b/Apps/Mock/src/Properties/launchSettings.json
@@ -1,0 +1,20 @@
+{
+    "iisSettings": {
+        "windowsAuthentication": false,
+        "anonymousAuthentication": true,
+        "iisExpress": {
+            "applicationUrl": "http://0.0.0.0:7000",
+            "sslPort": 0
+        }
+    },
+    "$schema": "http://json.schemastore.org/launchsettings.json",
+    "profiles": {
+        "HealthGateway.Mock": {
+            "commandName": "Project",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "applicationUrl": "http://0.0.0.0:7000;"
+        }
+    }
+}

--- a/Apps/Mock/src/Startup.cs
+++ b/Apps/Mock/src/Startup.cs
@@ -1,0 +1,67 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Mock
+{
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.AspNetConfiguration;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Configures the application during startup.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public class Startup
+    {
+        private readonly StartupConfiguration startupConfig;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Startup"/> class.
+        /// </summary>
+        /// <param name="env">The injected Environment provider.</param>
+        /// <param name="configuration">The injected configuration provider.</param>
+        public Startup(IWebHostEnvironment env, IConfiguration configuration)
+        {
+            this.startupConfig = new StartupConfiguration(configuration, env);
+        }
+
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to add services to the container.
+        /// </summary>
+        /// <param name="services">The injected services provider.</param>
+        public void ConfigureServices(IServiceCollection services)
+        {
+            this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureHttpServices(services);
+            this.startupConfig.ConfigureSwaggerServices(services);
+            this.startupConfig.ConfigureAccessControl(services);
+        }
+
+        /// <summary>
+        /// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+        /// </summary>
+        /// <param name="app">The application builder.</param>
+        public void Configure(IApplicationBuilder app)
+        {
+            this.startupConfig.UseForwardHeaders(app);
+            this.startupConfig.UseSwagger(app);
+            this.startupConfig.UseHttp(app);
+            this.startupConfig.UseRest(app);
+        }
+    }
+}

--- a/Apps/Mock/src/appsettings.json
+++ b/Apps/Mock/src/appsettings.json
@@ -1,0 +1,22 @@
+{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Information",
+            "Microsoft": "Warning"
+        }
+    },
+    "ForwardProxies": {
+        "Enabled": "false"
+    },
+    "SwaggerSettings": {
+        "RoutePrefix": "swagger",
+        "Info": {
+            "Title": "Health Gateway Mock Services documentation",
+            "Description": "Provides API documentation for Health Gateway Mock Service.",
+            "License": {
+                "Name": "Apache 2.0",
+                "Url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+            }
+        }
+    }
+}

--- a/Apps/Mock/src/omnisharp.json
+++ b/Apps/Mock/src/omnisharp.json
@@ -1,0 +1,5 @@
+{
+    "RoslynExtensionsOptions": {
+        "enableAnalyzersSupport": true
+    }
+}


### PR DESCRIPTION
# Fixes or Implements [AB#10903](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10903)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Adds mock project.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
