### PR TITLE
Trace notification setting responses from PHSA AB#10909

### DIFF
--- a/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/RestNotificationSettingsDelegate.cs
@@ -79,6 +79,8 @@ namespace HealthGateway.Common.Delegates
                 Uri endpoint = new Uri(this.nsConfig.Endpoint);
                 HttpResponseMessage response = await client.GetAsync(endpoint).ConfigureAwait(true);
                 string payload = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+                this.logger.LogTrace($"Response: {response}");
+                this.logger.LogTrace($"Payload: {payload}");
                 switch (response.StatusCode)
                 {
                     case HttpStatusCode.OK:
@@ -160,6 +162,8 @@ namespace HealthGateway.Common.Delegates
                 this.logger.LogTrace($"Http content: {json}");
                 HttpResponseMessage response = await client.PutAsync(endpoint, content).ConfigureAwait(true);
                 string payload = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+                this.logger.LogTrace($"Response: {response}");
+                this.logger.LogTrace($"Payload: {payload}");
                 switch (response.StatusCode)
                 {
                     case HttpStatusCode.Created:


### PR DESCRIPTION
# Supports [AB#10909](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10909)

-   [ ] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Enables tracing for notification settings so mock data can be captured.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
