### PR TITLE
Separated database services configuration AB#10977

### DIFF
--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -72,6 +72,7 @@ namespace HealthGateway.AdminWebClient
             this.logger.LogDebug("Configure Services...");
 
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.ConfigureAdminAuthenticationService(services);

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -424,10 +424,19 @@ namespace HealthGateway.Common.AspNetConfiguration
             this.Logger.LogDebug("ConfigureAuditServices...");
 
             services.AddMvc(options => options.Filters.Add(typeof(AuditFilter)));
-            services.AddDbContextPool<GatewayDbContext>(options => options.UseNpgsql(
-                    this.configuration.GetConnectionString("GatewayConnection")));
             services.AddScoped<IAuditLogger, AuditLogger>();
             services.AddTransient<IWriteAuditEventDelegate, DBWriteAuditEventDelegate>();
+        }
+
+        /// <summary>
+        /// Configures the Database services.
+        /// </summary>
+        /// <param name="services">The services collection provider.</param>
+        public void ConfigureDatabaseServices(IServiceCollection services)
+        {
+            this.Logger.LogDebug("ConfigureDatabaseServices...");
+            services.AddDbContextPool<GatewayDbContext>(options => options.UseNpgsql(
+                    this.configuration.GetConnectionString("GatewayConnection")));
         }
 
         /// <summary>
@@ -437,7 +446,7 @@ namespace HealthGateway.Common.AspNetConfiguration
         public void ConfigureSwaggerServices(IServiceCollection services)
         {
             services.Configure<SwaggerSettings>(this.configuration.GetSection(nameof(SwaggerSettings)));
-            var xmlFile = $"{Assembly.GetCallingAssembly() !.GetName().Name}.xml";
+            var xmlFile = $"{Assembly.GetCallingAssembly()!.GetName().Name}.xml";
             var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
             services
                 .AddApiVersionWithExplorer()
@@ -497,9 +506,9 @@ namespace HealthGateway.Common.AspNetConfiguration
             services.AddTransient<QUPA_AR101102_PortType>(s =>
             {
                 IConfigurationSection clientConfiguration = this.configuration.GetSection("PatientService:ClientRegistry");
-                EndpointAddress clientRegistriesEndpoint = new (new Uri(clientConfiguration.GetValue<string>("ServiceUrl")));
+                EndpointAddress clientRegistriesEndpoint = new(new Uri(clientConfiguration.GetValue<string>("ServiceUrl")));
 
-                QUPA_AR101102_PortTypeClient client = new (
+                QUPA_AR101102_PortTypeClient client = new(
                                         QUPA_AR101102_PortTypeClient.EndpointConfiguration.QUPA_AR101102_Port,
                                         clientRegistriesEndpoint);
                 if (clientConfiguration.GetValue<bool>("IsSecure", true))
@@ -508,7 +517,7 @@ namespace HealthGateway.Common.AspNetConfiguration
                     // Note: As per reading we do not have to dispose of the certificate.
                     string clientCertificatePath = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Path");
                     string certificatePassword = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Password");
-                    X509Certificate2 clientRegistriesCertificate = new (System.IO.File.ReadAllBytes(clientCertificatePath), certificatePassword);
+                    X509Certificate2 clientRegistriesCertificate = new(System.IO.File.ReadAllBytes(clientCertificatePath), certificatePassword);
                     client.ClientCredentials.ClientCertificate.Certificate = clientRegistriesCertificate;
                     client.Endpoint.EndpointBehaviors.Add(s.GetService<IEndpointBehavior>());
                     client.ClientCredentials.ServiceCertificate.SslCertificateAuthentication =
@@ -534,7 +543,7 @@ namespace HealthGateway.Common.AspNetConfiguration
         public void ConfigureTracing(IServiceCollection services)
         {
             this.Logger.LogDebug("Setting up OpenTelemetry");
-            OpenTelemetryConfig config = new ();
+            OpenTelemetryConfig config = new();
             this.configuration.GetSection("OpenTelemetry").Bind(config);
             if (config.Enabled)
             {
@@ -761,7 +770,7 @@ namespace HealthGateway.Common.AspNetConfiguration
         {
             this.Logger.LogDebug("OnAuthenticationFailed...");
 
-            AuditEvent auditEvent = new ()
+            AuditEvent auditEvent = new()
             {
                 AuditEventDateTime = DateTime.UtcNow,
                 TransactionDuration = 0, // There's not a way to calculate the duration here.

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -446,7 +446,7 @@ namespace HealthGateway.Common.AspNetConfiguration
         public void ConfigureSwaggerServices(IServiceCollection services)
         {
             services.Configure<SwaggerSettings>(this.configuration.GetSection(nameof(SwaggerSettings)));
-            var xmlFile = $"{Assembly.GetCallingAssembly()!.GetName().Name}.xml";
+            var xmlFile = $"{Assembly.GetCallingAssembly() !.GetName().Name}.xml";
             var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
             services
                 .AddApiVersionWithExplorer()
@@ -506,9 +506,9 @@ namespace HealthGateway.Common.AspNetConfiguration
             services.AddTransient<QUPA_AR101102_PortType>(s =>
             {
                 IConfigurationSection clientConfiguration = this.configuration.GetSection("PatientService:ClientRegistry");
-                EndpointAddress clientRegistriesEndpoint = new(new Uri(clientConfiguration.GetValue<string>("ServiceUrl")));
+                EndpointAddress clientRegistriesEndpoint = new (new Uri(clientConfiguration.GetValue<string>("ServiceUrl")));
 
-                QUPA_AR101102_PortTypeClient client = new(
+                QUPA_AR101102_PortTypeClient client = new (
                                         QUPA_AR101102_PortTypeClient.EndpointConfiguration.QUPA_AR101102_Port,
                                         clientRegistriesEndpoint);
                 if (clientConfiguration.GetValue<bool>("IsSecure", true))
@@ -517,7 +517,7 @@ namespace HealthGateway.Common.AspNetConfiguration
                     // Note: As per reading we do not have to dispose of the certificate.
                     string clientCertificatePath = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Path");
                     string certificatePassword = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Password");
-                    X509Certificate2 clientRegistriesCertificate = new(System.IO.File.ReadAllBytes(clientCertificatePath), certificatePassword);
+                    X509Certificate2 clientRegistriesCertificate = new (System.IO.File.ReadAllBytes(clientCertificatePath), certificatePassword);
                     client.ClientCredentials.ClientCertificate.Certificate = clientRegistriesCertificate;
                     client.Endpoint.EndpointBehaviors.Add(s.GetService<IEndpointBehavior>());
                     client.ClientCredentials.ServiceCertificate.SslCertificateAuthentication =
@@ -543,7 +543,7 @@ namespace HealthGateway.Common.AspNetConfiguration
         public void ConfigureTracing(IServiceCollection services)
         {
             this.Logger.LogDebug("Setting up OpenTelemetry");
-            OpenTelemetryConfig config = new();
+            OpenTelemetryConfig config = new ();
             this.configuration.GetSection("OpenTelemetry").Bind(config);
             if (config.Enabled)
             {
@@ -770,7 +770,7 @@ namespace HealthGateway.Common.AspNetConfiguration
         {
             this.Logger.LogDebug("OnAuthenticationFailed...");
 
-            AuditEvent auditEvent = new()
+            AuditEvent auditEvent = new ()
             {
                 AuditEventDateTime = DateTime.UtcNow,
                 TransactionDuration = 0, // There's not a way to calculate the duration here.

--- a/Apps/Common/src/Common.xml
+++ b/Apps/Common/src/Common.xml
@@ -770,6 +770,12 @@
             </summary>
             <param name="services">The services collection provider.</param>
         </member>
+        <member name="M:HealthGateway.Common.AspNetConfiguration.StartupConfiguration.ConfigureDatabaseServices(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+            <summary>
+            Configures the Database services.
+            </summary>
+            <param name="services">The services collection provider.</param>
+        </member>
         <member name="M:HealthGateway.Common.AspNetConfiguration.StartupConfiguration.ConfigureSwaggerServices(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
             <summary>
             Configures the swagger services.

--- a/Apps/Encounter/src/Startup.cs
+++ b/Apps/Encounter/src/Startup.cs
@@ -50,6 +50,7 @@ namespace HealthGateway.Encounter
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.startupConfig.ConfigureAuthServicesForJwtBearer(services);

--- a/Apps/Immunization/src/Startup.cs
+++ b/Apps/Immunization/src/Startup.cs
@@ -49,6 +49,7 @@ namespace HealthGateway.Immunization
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.startupConfig.ConfigureAuthServicesForJwtBearer(services);

--- a/Apps/Laboratory/src/Startup.cs
+++ b/Apps/Laboratory/src/Startup.cs
@@ -50,6 +50,7 @@ namespace HealthGateway.Laboratory
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.startupConfig.ConfigureAuthServicesForJwtBearer(services);

--- a/Apps/Medication/src/Startup.cs
+++ b/Apps/Medication/src/Startup.cs
@@ -53,6 +53,7 @@ namespace HealthGateway.Medication
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.startupConfig.ConfigureAuthServicesForJwtBearer(services);

--- a/Apps/Mock/src/Mock.xml
+++ b/Apps/Mock/src/Mock.xml
@@ -18,17 +18,17 @@
         </member>
         <member name="M:HealthGateway.Mock.Controllers.OdrController.Medication(HealthGateway.Mock.Models.OdrRequest)">
             <summary>
-            Gets mock data for encounters.
+            Gets mock data for medications.
             </summary>
             <param name="request">The query request.</param>
-            <returns>The mocked encounter json.</returns>
+            <returns>The mocked medication json.</returns>
         </member>
         <member name="M:HealthGateway.Mock.Controllers.OdrController.MaintainProtectiveWord(HealthGateway.Mock.Models.OdrRequest)">
             <summary>
-            Gets mock data for encounters.
+            Mocks the endpoint for retrieving the protective word.
             </summary>
             <param name="request">The query request.</param>
-            <returns>The mocked encounter json.</returns>
+            <returns>The mocked protective word json.</returns>
         </member>
         <member name="T:HealthGateway.Mock.Controllers.PhsaController">
             <summary>

--- a/Apps/Mock/src/Startup.cs
+++ b/Apps/Mock/src/Startup.cs
@@ -56,6 +56,7 @@ namespace HealthGateway.Mock
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureSwaggerServices(services);
             this.startupConfig.ConfigureAccessControl(services);

--- a/Apps/Patient/src/Startup.cs
+++ b/Apps/Patient/src/Startup.cs
@@ -47,6 +47,7 @@ namespace HealthGateway.Patient
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.startupConfig.ConfigureAuthServicesForJwtBearer(services);

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -66,6 +66,7 @@ namespace HealthGateway.WebClient
         public void ConfigureServices(IServiceCollection services)
         {
             this.startupConfig.ConfigureForwardHeaders(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
             this.startupConfig.ConfigureAuditServices(services);
             this.startupConfig.ConfigureAuthServicesForJwtBearer(services);


### PR DESCRIPTION
# Fixes or Implements [AB#10977](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10977)
-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Added DB config.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
