### PR TITLE
Moved cdogs delegate and models to common

### DIFF
--- a/Apps/Common/src/Delegates/CDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/CDogsDelegate.cs
@@ -13,29 +13,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Delegates
+namespace HealthGateway.Common.Delegates
 {
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Globalization;
-    using System.Linq;
     using System.Net.Http;
     using System.Net.Http.Headers;
     using System.Net.Mime;
-    using System.ServiceModel;
     using System.Text;
     using System.Text.Json;
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.Common.Services;
     using HealthGateway.Common.Utils;
-    using HealthGateway.WebClient.Models;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
-    using ServiceReference;
 
     /// <summary>
     /// The CDogs report generator delegate.

--- a/Apps/Common/src/Delegates/ICDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/ICDogsDelegate.cs
@@ -13,31 +13,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Models
+namespace HealthGateway.Common.Delegates
 {
-    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.CDogs;
 
     /// <summary>
-    /// Model that defines the cdogs template.
+    /// The CDogs report service.
     /// </summary>
-    public class CDogsTemplateModel
+    public interface ICDogsDelegate
     {
         /// <summary>
-        /// Gets or sets the template content.
+        /// Generates a report based on the request model provided.
         /// </summary>
-        [JsonPropertyName("content")]
-        public string Content { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets the content encoding type.
-        /// </summary>
-        [JsonPropertyName("encodingType")]
-        public string EncodingType { get; set; } = "base64";
-
-        /// <summary>
-        /// Gets or sets the file type.
-        /// </summary>
-        [JsonPropertyName("fileType")]
-        public string FileType { get; set; } = "docx";
+        /// <param name="request">The cdogs request model.</param>
+        /// <returns>The report data.</returns>
+        Task<RequestResult<ReportModel>> GenerateReportAsync(CDogsRequestModel request);
     }
 }

--- a/Apps/Common/src/Models/CDogs/CDogsConfig.cs
+++ b/Apps/Common/src/Models/CDogs/CDogsConfig.cs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Models
+namespace HealthGateway.Common.Models.CDogs
 {
     /// <summary>
     /// The configuration for the ODR portion of the ResetMedStatement delegate.

--- a/Apps/Common/src/Models/CDogs/CDogsOptionsModel.cs
+++ b/Apps/Common/src/Models/CDogs/CDogsOptionsModel.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Models
+namespace HealthGateway.Common.Models.CDogs
 {
     using System.Text.Json.Serialization;
 

--- a/Apps/Common/src/Models/CDogs/CDogsRequestModel.cs
+++ b/Apps/Common/src/Models/CDogs/CDogsRequestModel.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Models
+namespace HealthGateway.Common.Models.CDogs
 {
     using System.Text.Json;
     using System.Text.Json.Serialization;

--- a/Apps/Common/src/Models/CDogs/CDogsTemplateModel.cs
+++ b/Apps/Common/src/Models/CDogs/CDogsTemplateModel.cs
@@ -13,22 +13,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Delegates
+namespace HealthGateway.Common.Models.CDogs
 {
-    using System.Threading.Tasks;
-    using HealthGateway.Common.Models;
-    using HealthGateway.WebClient.Models;
+    using System.Text.Json.Serialization;
 
     /// <summary>
-    /// The CDogs report service.
+    /// Model that defines the cdogs template.
     /// </summary>
-    public interface ICDogsDelegate
+    public class CDogsTemplateModel
     {
         /// <summary>
-        /// Generates a report based on the request model provided.
+        /// Gets or sets the template content.
         /// </summary>
-        /// <param name="request">The cdogs request model.</param>
-        /// <returns>The report data.</returns>
-        Task<RequestResult<ReportModel>> GenerateReportAsync(CDogsRequestModel request);
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the content encoding type.
+        /// </summary>
+        [JsonPropertyName("encodingType")]
+        public string EncodingType { get; set; } = "base64";
+
+        /// <summary>
+        /// Gets or sets the file type.
+        /// </summary>
+        [JsonPropertyName("fileType")]
+        public string FileType { get; set; } = "docx";
     }
 }

--- a/Apps/Common/src/Models/CDogs/ReportModel.cs
+++ b/Apps/Common/src/Models/CDogs/ReportModel.cs
@@ -13,9 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Models
+namespace HealthGateway.Common.Models.CDogs
 {
-     /// <summary>
+    /// <summary>
     /// Object that defines a report.
     /// </summary>
     public class ReportModel

--- a/Apps/WebClient/src/Server/Controllers/ReportController.cs
+++ b/Apps/WebClient/src/Server/Controllers/ReportController.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.WebClient.Controllers
 {
     using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.WebClient.Models;
     using HealthGateway.WebClient.Services;
     using Microsoft.AspNetCore.Authorization;

--- a/Apps/WebClient/src/Server/Services/IReportService.cs
+++ b/Apps/WebClient/src/Server/Services/IReportService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.WebClient.Services
 {
     using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.WebClient.Models;
 
     /// <summary>

--- a/Apps/WebClient/src/Server/Services/ReportService.cs
+++ b/Apps/WebClient/src/Server/Services/ReportService.cs
@@ -19,11 +19,11 @@ namespace HealthGateway.WebClient.Services
     using System.Globalization;
     using System.IO;
     using System.Reflection;
-    using System.Text;
     using System.Text.Json;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Models;
-    using HealthGateway.WebClient.Delegates;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.WebClient.Models;
     using Microsoft.Extensions.Logging;
 

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -24,7 +24,6 @@ namespace HealthGateway.WebClient
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
-    using HealthGateway.WebClient.Delegates;
     using HealthGateway.WebClient.Listeners;
     using HealthGateway.WebClient.Services;
     using Microsoft.AspNetCore.Builder;
@@ -36,7 +35,6 @@ namespace HealthGateway.WebClient
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Logging;
     using VueCliMiddleware;
 
     /// <summary>

--- a/Apps/WebClient/src/WebClient.xml
+++ b/Apps/WebClient/src/WebClient.xml
@@ -513,34 +513,6 @@
             <returns>An empty response.</returns>
             <response code="204">Webhook request received.</response>
         </member>
-        <member name="T:HealthGateway.WebClient.Delegates.CDogsDelegate">
-            <summary>
-            The CDogs report generator delegate.
-            </summary>
-        </member>
-        <member name="M:HealthGateway.WebClient.Delegates.CDogsDelegate.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.WebClient.Delegates.CDogsDelegate},HealthGateway.Common.Services.IHttpClientService,Microsoft.Extensions.Configuration.IConfiguration)">
-            <summary>
-            Initializes a new instance of the <see cref="T:HealthGateway.WebClient.Delegates.CDogsDelegate"/> class.
-            </summary>
-            <param name="logger">Injected Logger Provider.</param>
-            <param name="httpClientService">The injected http client service.</param>
-            <param name="configuration">The injected configuration provider.</param>
-        </member>
-        <member name="M:HealthGateway.WebClient.Delegates.CDogsDelegate.GenerateReportAsync(HealthGateway.WebClient.Models.CDogsRequestModel)">
-            <inheritdoc/>
-        </member>
-        <member name="T:HealthGateway.WebClient.Delegates.ICDogsDelegate">
-            <summary>
-            The CDogs report service.
-            </summary>
-        </member>
-        <member name="M:HealthGateway.WebClient.Delegates.ICDogsDelegate.GenerateReportAsync(HealthGateway.WebClient.Models.CDogsRequestModel)">
-            <summary>
-            Generates a report based on the request model provided.
-            </summary>
-            <param name="request">The cdogs request model.</param>
-            <returns>The report data.</returns>
-        </member>
         <member name="T:HealthGateway.WebClient.Listeners.BannerListener">
             <summary>
             Implements the abstract DB Listener and listens on the BannerChange channel.
@@ -714,98 +686,6 @@
         <member name="P:HealthGateway.WebClient.Models.BannerChangeEvent.Data">
             <summary>
             Gets or sets the Communication object.
-            </summary>
-        </member>
-        <member name="T:HealthGateway.WebClient.Models.CDogsConfig">
-            <summary>
-            The configuration for the ODR portion of the ResetMedStatement delegate.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsConfig.ServiceName">
-            <summary>
-            Gets or sets the OpenShift service name.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsConfig.ServiceHostSuffix">
-            <summary>
-            Gets or sets the host suffix used to lookup the service host.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsConfig.ServicePortSuffix">
-            <summary>
-            Gets or sets the port suffix used to lookup the service port.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsConfig.BaseEndpoint">
-            <summary>
-            Gets or sets the base Url used to connect to the ODR Proxy.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsConfig.DynamicServiceLookup">
-            <summary>
-            Gets or sets a value indicating whether dynamic service lookup should occur.
-            if enabled, the Url will be created using environment variables.
-            If not enabled, the configured Url will be used.
-            </summary>
-        </member>
-        <member name="T:HealthGateway.WebClient.Models.CDogsOptionsModel">
-            <summary>
-            Model that defines the cdogs options.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsOptionsModel.ConvertTo">
-            <summary>
-            Gets or sets the file type to convert to.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsOptionsModel.Overwrite">
-            <summary>
-            Gets or sets a value indicating whether to overwrite the file type.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsOptionsModel.ReportName">
-            <summary>
-            Gets or sets the report name.
-            </summary>
-        </member>
-        <member name="T:HealthGateway.WebClient.Models.CDogsRequestModel">
-            <summary>
-            Object that defines the cdogs request for creating a report.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsRequestModel.Data">
-            <summary>
-            Gets or sets the Json data.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsRequestModel.Options">
-            <summary>
-            Gets or sets the options.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsRequestModel.Template">
-            <summary>
-            Gets or sets the template.
-            </summary>
-        </member>
-        <member name="T:HealthGateway.WebClient.Models.CDogsTemplateModel">
-            <summary>
-            Model that defines the cdogs template.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsTemplateModel.Content">
-            <summary>
-            Gets or sets the template content.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsTemplateModel.EncodingType">
-            <summary>
-            Gets or sets the content encoding type.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.CDogsTemplateModel.FileType">
-            <summary>
-            Gets or sets the file type.
             </summary>
         </member>
         <member name="T:HealthGateway.WebClient.Models.CreateNoteRequest">
@@ -1068,21 +948,6 @@
         <member name="P:HealthGateway.WebClient.Models.OpenIdConnectConfiguration.Callbacks">
             <summary>
             Gets or sets the Callback URIs.
-            </summary>
-        </member>
-        <member name="T:HealthGateway.WebClient.Models.ReportModel">
-            <summary>
-            Object that defines a report.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.ReportModel.FileName">
-            <summary>
-            Gets or sets the report type.
-            </summary>
-        </member>
-        <member name="P:HealthGateway.WebClient.Models.ReportModel.Data">
-            <summary>
-            Gets or sets the report data.
             </summary>
         </member>
         <member name="T:HealthGateway.WebClient.Models.ReportFormatType">
@@ -2239,7 +2104,7 @@
         <member name="T:HealthGateway.WebClient.Services.ReportService">
             <inheritdoc />
         </member>
-        <member name="M:HealthGateway.WebClient.Services.ReportService.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.WebClient.Services.ReportService},HealthGateway.WebClient.Delegates.ICDogsDelegate)">
+        <member name="M:HealthGateway.WebClient.Services.ReportService.#ctor(Microsoft.Extensions.Logging.ILogger{HealthGateway.WebClient.Services.ReportService},HealthGateway.Common.Delegates.ICDogsDelegate)">
             <summary>
             Initializes a new instance of the <see cref="T:HealthGateway.WebClient.Services.ReportService"/> class.
             </summary>

--- a/Apps/WebClient/test/unit/Controllers.Test/ReportControllerTests.cs
+++ b/Apps/WebClient/test/unit/Controllers.Test/ReportControllerTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.WebClient.Test.Controllers
 {
     using DeepEqual.Syntax;
     using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.WebClient.Controllers;
     using HealthGateway.WebClient.Models;
     using HealthGateway.WebClient.Services;

--- a/Apps/WebClient/test/unit/Delegates.Test/CDogsDelegateTest.cs
+++ b/Apps/WebClient/test/unit/Delegates.Test/CDogsDelegateTest.cs
@@ -23,10 +23,10 @@ namespace HealthGateway.WebClient.Test.Delegates
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.Common.Services;
-    using HealthGateway.WebClient.Delegates;
-    using HealthGateway.WebClient.Models;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;

--- a/Apps/WebClient/test/unit/Services.Test/ReportServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services.Test/ReportServiceTests.cs
@@ -15,15 +15,13 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.WebClient.Test.Services
 {
-    using System;
     using System.Text.Json;
     using DeepEqual.Syntax;
+    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Models;
-    using HealthGateway.WebClient.Delegates;
+    using HealthGateway.Common.Models.CDogs;
     using HealthGateway.WebClient.Models;
     using HealthGateway.WebClient.Services;
-    using Microsoft.Extensions.Caching.Memory;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;


### PR DESCRIPTION
# Fixes or Implements [AB#11022](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11022)

-   [X] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Moved CDOGS functionality to Common to make it reusable.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
