### PR TITLE
Show success indication after mailing COVID Card AB#11035

### DIFF
--- a/Apps/AdminWebClient/src/Server/Delegates/SFTPMailDelegate.cs
+++ b/Apps/AdminWebClient/src/Server/Delegates/SFTPMailDelegate.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Admin.Server.Delegates
     using System.Diagnostics;
     using System.IO;
     using HealthGateway.Admin.Server.Models;
+    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
@@ -85,6 +86,7 @@ namespace HealthGateway.Admin.Server.Delegates
             if (!this.connectionInitialized)
             {
                 retVal.ResourcePayload = false;
+                retVal.ResultStatus = ResultType.Error;
                 retVal.ResultError = new RequestResultError() { ResultMessage = $"Connection is not initialized", ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState) };
                 this.logger.LogError($"Document could not be mailed because connection is not initialized");
             }
@@ -103,10 +105,12 @@ namespace HealthGateway.Admin.Server.Delegates
                     sftpClient.Disconnect();
 
                     retVal.ResourcePayload = true;
+                    retVal.ResultStatus = ResultType.Success;
                 }
                 catch (Exception e)
                 {
                     retVal.ResourcePayload = false;
+                    retVal.ResultStatus = ResultType.Error;
                     retVal.ResultError = new RequestResultError() { ResultMessage = $"Exception mailing document: {e}", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.SFTP) };
                     this.logger.LogError($"Unexpected exception in QueueDocument {e}");
                 }


### PR DESCRIPTION
# Fixes [AB#11035](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11035)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Sets the result status to success when successfully mailing a document.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
