### PR TITLE
Add input masks to COVID Support page AB#11038

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/package.json
+++ b/Apps/AdminWebClient/src/ClientApp/package.json
@@ -20,6 +20,7 @@
         "reflect-metadata": "^0.1.13",
         "register-service-worker": "^1.7.2",
         "tiptap-vuetify": "^2.24.0",
+        "v-mask": "^2.2.4",
         "vee-validate": "^3.4.5",
         "vue": "^2.6.12",
         "vue-class-component": "^7.2.6",

--- a/Apps/AdminWebClient/src/ClientApp/src/@types/v-mask.d.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/@types/v-mask.d.ts
@@ -1,0 +1,10 @@
+declare module "v-mask" {
+    import { DirectiveFunction } from "vue";
+
+    interface VueMaskDirectiveType {
+        bind: DirectiveFunction;
+        componentUpdated: DirectiveFunction;
+        unbind: DirectiveFunction;
+    }
+    export const VueMaskDirective: VueMaskDirectiveType;
+}

--- a/Apps/AdminWebClient/src/ClientApp/src/main.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/main.ts
@@ -3,6 +3,7 @@ import "tiptap-vuetify/dist/main.css";
 
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import { TiptapVuetifyPlugin } from "tiptap-vuetify";
+import { VueMaskDirective } from "v-mask";
 import Vue from "vue";
 import DatetimePicker from "vuetify-datetime-picker";
 
@@ -33,6 +34,7 @@ Vue.use(TiptapVuetifyPlugin, {
     vuetify,
     iconsGroup: "md",
 });
+Vue.directive("mask", VueMaskDirective);
 Vue.filter("date", dateFilter);
 Vue.component("FontAwesomeIcon", FontAwesomeIcon);
 

--- a/Apps/AdminWebClient/src/ClientApp/src/utility/masks.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/utility/masks.ts
@@ -1,0 +1,14 @@
+export type MaskCharacter = string | RegExp;
+export type Mask = string | ((value: string) => MaskCharacter[]);
+
+export function zipCodeMask(value: string): MaskCharacter[] {
+    const numbers = value.replace(/[^0-9-]/g, "");
+    const zipFormat: MaskCharacter[] = [/\d/, /\d/, /\d/, /\d/, /\d/];
+    const extendedFormat = zipFormat.concat("-", /\d/, /\d/, /\d/, /\d/);
+    return numbers.length > 5 ? extendedFormat : zipFormat;
+}
+
+const phnMask = "#### ### ###";
+const postalCodeMask = "A#A #A#";
+
+export { phnMask, postalCodeMask };


### PR DESCRIPTION
# Implements [AB#11038](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11038)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Adds input mask to nicely format the PHN and Postal Code fields.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
