### PR TITLE
Fix date parsing on COVID support page AB#11056

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -12,7 +12,7 @@ import { StateList } from "@/constants/stateList";
 import Address from "@/models/address";
 import BannerFeedback from "@/models/bannerFeedback";
 import CovidCardPatientResult from "@/models/covidCardPatientResult";
-import { DateWrapper, StringISODateTime } from "@/models/dateWrapper";
+import { DateWrapper, StringISODate } from "@/models/dateWrapper";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
 import { ICovidSupportService } from "@/services/interfaces";
@@ -300,13 +300,11 @@ export default class CovidCardView extends Vue {
         }
     }
 
-    private formatDate(date: StringISODateTime): string {
+    private formatDate(date: StringISODate): string {
         if (!date) {
             return "";
         }
-        return new DateWrapper(date, { isUtc: true }).format(
-            DateWrapper.defaultFormat
-        );
+        return new DateWrapper(date).format(DateWrapper.defaultFormat);
     }
 }
 </script>


### PR DESCRIPTION
# Fixes [AB#11056](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11056)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Changes birth date parsing in front-end to presume local time rather than UTC.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
