### PR TITLE
Display message when loading vaccination result is delayed AB#11082

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/loading.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/loading.vue
@@ -23,6 +23,7 @@ export default class LoadingComponent extends Vue {
     @Prop() isLoading!: boolean;
     @Prop() isCustom!: boolean;
     @Prop({ default: true }) fullScreen!: boolean;
+    @Prop() text!: string | undefined;
     private step = 0;
     private intervalId = 0;
 
@@ -77,7 +78,11 @@ export default class LoadingComponent extends Vue {
             :active.sync="isLoading"
             data-testid="loadingSpinner"
             :is-full-page="true"
-        ></loading>
+        >
+            <template v-if="text" #after>
+                <div class="m-3">{{ text }}</div>
+            </template>
+        </loading>
         <div v-else>
             <div class="spinner" data-testid="timelineLoading">
                 <div id="first" class="double-bounce">

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
@@ -30,6 +30,10 @@ export const actions: VaccinationStatusActions = {
                         const payload = result.resourcePayload;
                         if (!payload.loaded && payload.retryin > 0) {
                             logger.info("VaccinationStatus not loaded");
+                            context.commit(
+                                "setStatusMessage",
+                                "We're busy but will continue to try to fetch your record...."
+                            );
                             setTimeout(() => {
                                 logger.info(
                                     "Re-querying for vaccination status"
@@ -39,10 +43,11 @@ export const actions: VaccinationStatusActions = {
                                     dateOfBirth: params.dateOfBirth,
                                 });
                             }, payload.retryin);
+                            resolve();
+                        } else {
+                            context.commit("setVaccinationStatus", payload);
+                            resolve();
                         }
-
-                        context.commit("setVaccinationStatus", payload);
-                        resolve();
                     } else {
                         context.dispatch("handleError", result.resultError);
                         reject(result.resultError);

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/getters.ts
@@ -16,4 +16,7 @@ export const getters: VaccinationStatusGetters = {
     error(state: VaccinationStatusState): BannerError | undefined {
         return state.error;
     },
+    statusMessage(state: VaccinationStatusState): string {
+        return state.statusMessage;
+    },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/mutations.ts
@@ -11,6 +11,7 @@ export const mutations: VaccinationStatusMutations = {
             state.status === LoadStatus.DEFERRED
                 ? LoadStatus.ASYNC_REQUESTED
                 : LoadStatus.REQUESTED;
+        state.statusMessage = "";
     },
     setVaccinationStatus(
         state: VaccinationStatusState,
@@ -18,10 +19,15 @@ export const mutations: VaccinationStatusMutations = {
     ) {
         state.vaccinationStatus = vaccinationStatus;
         state.status = LoadStatus.LOADED;
+        state.statusMessage = "";
     },
     vaccinationStatusError(state: VaccinationStatusState, error: BannerError) {
         state.vaccinationStatus = undefined;
         state.error = error;
         state.status = LoadStatus.ERROR;
+        state.statusMessage = "";
+    },
+    setStatusMessage(state: VaccinationStatusState, statusMessage: string) {
+        state.statusMessage = statusMessage;
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/types.ts
@@ -18,6 +18,7 @@ export interface VaccinationStatusState {
     vaccinationStatus?: VaccinationStatus;
     error?: BannerError;
     status: LoadStatus;
+    statusMessage: string;
 }
 
 export interface VaccinationStatusGetters
@@ -27,6 +28,7 @@ export interface VaccinationStatusGetters
     ): VaccinationStatus | undefined;
     isLoading(state: VaccinationStatusState): boolean;
     error(state: VaccinationStatusState): BannerError | undefined;
+    statusMessage(state: VaccinationStatusState): string;
 }
 
 type StoreContext = ActionContext<VaccinationStatusState, RootState>;
@@ -53,6 +55,10 @@ export interface VaccinationStatusMutations
     vaccinationStatusError(
         state: VaccinationStatusState,
         error: BannerError
+    ): void;
+    setStatusMessage(
+        state: VaccinationStatusState,
+        statusMessage: string
     ): void;
 }
 

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/vaccinationStatus.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/vaccinationStatus.ts
@@ -9,6 +9,7 @@ const state: VaccinationStatusState = {
     vaccinationStatus: undefined,
     error: undefined,
     status: LoadStatus.NONE,
+    statusMessage: "",
 };
 
 const namespaced = true;

--- a/Apps/WebClient/src/ClientApp/src/views/vaccinationStatus.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/vaccinationStatus.vue
@@ -46,6 +46,9 @@ export default class VaccinationStatusView extends Vue {
     @Getter("error", { namespace: "vaccinationStatus" })
     error!: BannerError | undefined;
 
+    @Getter("statusMessage", { namespace: "vaccinationStatus" })
+    statusMessage!: string;
+
     private logger!: ILogger;
     private displayResult = false;
     private errorDisplaySeconds = 5;
@@ -104,7 +107,7 @@ export default class VaccinationStatusView extends Vue {
 
 <template>
     <div class="fill-height d-flex flex-column">
-        <LoadingComponent :is-loading="isLoading" />
+        <LoadingComponent :is-loading="isLoading" :text="statusMessage" />
         <div class="header">
             <img
                 class="img-fluid m-3"
@@ -225,5 +228,19 @@ export default class VaccinationStatusView extends Vue {
 
 .header {
     background-color: $hg-brand-primary;
+}
+</style>
+
+<style lang="scss">
+@import "@/assets/scss/_variables.scss";
+
+.vld-overlay {
+    .vld-background {
+        opacity: 0.75;
+    }
+
+    .vld-icon {
+        text-align: center;
+    }
 }
 </style>


### PR DESCRIPTION
# Implements [AB#11082](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11082)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Displays a message underneath the loading spinner on the vaccination status form if a requery is needed.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
