### PR TITLE
Move banner below header on vaccine card pages AB#11106

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/vaccinationStatusResult.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/vaccinationStatusResult.vue
@@ -13,6 +13,7 @@ import { Action, Getter } from "vuex-class";
 import LoadingComponent from "@/components/loading.vue";
 import MessageModalComponent from "@/components/modal/genericMessage.vue";
 import { VaccinationState } from "@/constants/vaccinationState";
+import BannerError from "@/models/bannerError";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
 import Report from "@/models/report";
 import VaccinationStatus from "@/models/vaccinationStatus";
@@ -34,6 +35,9 @@ export default class VaccinationStatusResultView extends Vue {
     @Getter("vaccinationStatus", { namespace: "vaccinationStatus" }) status!:
         | VaccinationStatus
         | undefined;
+
+    @Getter("error", { namespace: "vaccinationStatus" })
+    error!: BannerError | undefined;
 
     @Action("getReport", { namespace: "vaccinationStatus" })
     getReport!: (params: {
@@ -195,6 +199,30 @@ export default class VaccinationStatusResultView extends Vue {
                     </b-col>
                 </b-row>
             </div>
+        </div>
+        <div v-if="error !== undefined" class="container">
+            <b-alert
+                variant="danger"
+                class="no-print my-3"
+                :show="error !== undefined"
+                dismissible
+            >
+                <h4>{{ error.title }}</h4>
+                <h6>{{ error.errorCode }}</h6>
+                <div class="pl-4">
+                    <p data-testid="errorTextDescription">
+                        {{ error.description }}
+                    </p>
+                    <p data-testid="errorTextDetails">
+                        {{ error.detail }}
+                    </p>
+                    <p v-if="error.traceId" data-testid="errorSupportDetails">
+                        If this issue persists, contact HealthGateway@gov.bc.ca
+                        and provide
+                        <span class="trace-id">{{ error.traceId }}</span>
+                    </p>
+                </div>
+            </b-alert>
         </div>
         <div
             class="

--- a/Apps/WebClient/src/ClientApp/src/views/vaccinationStatus.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/vaccinationStatus.vue
@@ -51,7 +51,6 @@ export default class VaccinationStatusView extends Vue {
 
     private logger!: ILogger;
     private displayResult = false;
-    private errorDisplaySeconds = 5;
 
     private phn = "";
     private dateOfBirth = "";
@@ -116,34 +115,37 @@ export default class VaccinationStatusView extends Vue {
                 alt="BC Mark"
             />
         </div>
-        <div v-if="error !== undefined" class="container">
-            <b-alert
-                variant="danger"
-                class="no-print my-3"
-                :show="error !== undefined"
-                dismissible
-            >
-                <h4>{{ error.title }}</h4>
-                <h6>{{ error.errorCode }}</h6>
-                <div class="pl-4">
-                    <p data-testid="errorTextDescription">
-                        {{ error.description }}
-                    </p>
-                    <p data-testid="errorTextDetails">
-                        {{ error.detail }}
-                    </p>
-                    <p v-if="error.traceId" data-testid="errorSupportDetails">
-                        If this issue persists, contact HealthGateway@gov.bc.ca
-                        and provide
-                        <span class="trace-id">{{ error.traceId }}</span>
-                    </p>
-                </div>
-            </b-alert>
-        </div>
         <vaccination-status-result v-if="displayResult" />
         <div v-else>
             <div class="p-3 bg-success text-white" no-gutters>
                 <h3 class="text-center m-0">COVID‑19 Vaccination Check</h3>
+            </div>
+            <div v-if="error !== undefined" class="container">
+                <b-alert
+                    variant="danger"
+                    class="no-print my-3"
+                    :show="error !== undefined"
+                    dismissible
+                >
+                    <h4>{{ error.title }}</h4>
+                    <h6>{{ error.errorCode }}</h6>
+                    <div class="pl-4">
+                        <p data-testid="errorTextDescription">
+                            {{ error.description }}
+                        </p>
+                        <p data-testid="errorTextDetails">
+                            {{ error.detail }}
+                        </p>
+                        <p
+                            v-if="error.traceId"
+                            data-testid="errorSupportDetails"
+                        >
+                            If this issue persists, contact
+                            HealthGateway@gov.bc.ca and provide
+                            <span class="trace-id">{{ error.traceId }}</span>
+                        </p>
+                    </div>
+                </b-alert>
             </div>
             <form class="container my-3" @submit.prevent="handleSubmit">
                 <p>Please provide the following.</p>


### PR DESCRIPTION
# Fixes [AB#11106](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11106)

-   [ ] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Fixes the odd positioning of error messages on the public vaccine card pages.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
