### PR TITLE
Allow empty passphrase and update config for new provider for AB#11148

### DIFF
--- a/Apps/AdminWebClient/src/Server/Delegates/SFTPMailDelegate.cs
+++ b/Apps/AdminWebClient/src/Server/Delegates/SFTPMailDelegate.cs
@@ -51,18 +51,27 @@ namespace HealthGateway.Admin.Server.Delegates
             this.logger = logger;
             this.documentStorageConfiguration = new DocumentStorageConfiguration();
             configuration.Bind(DocumentStorageConfigurationSectionKey, this.documentStorageConfiguration);
-
             try
             {
+                PrivateKeyFile privateKey;
+                if (!string.IsNullOrEmpty(this.documentStorageConfiguration.PrivateKeyPassphrase))
+                {
+                    privateKey = new PrivateKeyFile(
+                        this.documentStorageConfiguration.PrivateKeyPath,
+                        this.documentStorageConfiguration.PrivateKeyPassphrase);
+                }
+                else
+                {
+                    privateKey = new PrivateKeyFile(this.documentStorageConfiguration.PrivateKeyPath);
+                }
+
                 this.connectionInfo = new (
-                    this.documentStorageConfiguration.SftpHostname,
-                    this.documentStorageConfiguration.SftpPort,
+                this.documentStorageConfiguration.SftpHostname,
+                this.documentStorageConfiguration.SftpPort,
+                this.documentStorageConfiguration.SftpUsername,
+                new PrivateKeyAuthenticationMethod(
                     this.documentStorageConfiguration.SftpUsername,
-                    new PrivateKeyAuthenticationMethod(
-                        this.documentStorageConfiguration.SftpUsername,
-                        new PrivateKeyFile(
-                            this.documentStorageConfiguration.PrivateKeyPath,
-                            this.documentStorageConfiguration.PrivateKeyPassphrase)));
+                    privateKey));
                 this.connectionInitialized = true;
             }
             catch (Exception e)

--- a/Apps/AdminWebClient/src/appsettings.Development.json
+++ b/Apps/AdminWebClient/src/appsettings.Development.json
@@ -46,7 +46,7 @@
         }
     },
     "DocumentStorage": {
-        "PrivateKeyPath": "/usr/local/sftp/HG_SFTP_2021-Dev.pem"
+        "SftpFolderPath": "Test"
     },
     "Immunization": {
         "EndPoint": "https://phsahealthgatewayapi-dev.azurewebsites.net/api/v1/Support/Immunizations"

--- a/Apps/AdminWebClient/src/appsettings.hgdev.json
+++ b/Apps/AdminWebClient/src/appsettings.hgdev.json
@@ -19,7 +19,7 @@
         }
     },
     "DocumentStorage": {
-        "PrivateKeyPath": "/usr/local/sftp/HG_SFTP_2021-Dev.pem"
+        "SftpFolderPath": "Test"
     },
     "Immunization": {
         "EndPoint": "https://phsahealthgatewayapi-dev.azurewebsites.net/api/v1/Support/Immunizations"

--- a/Apps/AdminWebClient/src/appsettings.hgmock.json
+++ b/Apps/AdminWebClient/src/appsettings.hgmock.json
@@ -19,7 +19,7 @@
         }
     },
     "DocumentStorage": {
-        "PrivateKeyPath": "/usr/local/sftp/HG_SFTP_2021-Dev.pem"
+        "SftpFolderPath": "Test"
     },
     "Immunization": {
         "EndPoint": "https://mock.healthgateway.gov.bc.ca/api/mockservice/v1/api/phsa/Support/Immunizations"

--- a/Apps/AdminWebClient/src/appsettings.hgpoc.json
+++ b/Apps/AdminWebClient/src/appsettings.hgpoc.json
@@ -19,7 +19,7 @@
         }
     },
     "DocumentStorage": {
-        "PrivateKeyPath": "/usr/local/sftp/HG_SFTP_2021-Dev.pem"
+        "SftpFolderPath": "Test"
     },
     "Immunization": {
         "EndPoint": "https://phsahealthgatewayapi-dev.azurewebsites.net/api/v1/Support/Immunizations"

--- a/Apps/AdminWebClient/src/appsettings.hgtest.json
+++ b/Apps/AdminWebClient/src/appsettings.hgtest.json
@@ -19,7 +19,7 @@
         }
     },
     "DocumentStorage": {
-        "PrivateKeyPath": "/usr/local/sftp/HG_SFTP_2021-Test.pem"
+        "SftpFolderPath": "Test"
     },
     "Immunization": {
         "EndPoint": "https://phsahealthgatewayapi-test.azurewebsites.net/api/v1/Support/Immunizations"

--- a/Apps/AdminWebClient/src/appsettings.json
+++ b/Apps/AdminWebClient/src/appsettings.json
@@ -66,12 +66,12 @@
         "CacheTTL": 90
     },
     "DocumentStorage": {
-        "SftpHostname": "ftpsvcs.hlth.gov.bc.ca",
+        "SftpHostname": "SOLIMAR1.qp.gov.bc.ca",
         "SftpPort": 22,
         "SftpUsername": "***",
-        "SftpFolderPath": "ToMaximus",
-        "PrivateKeyPath": "/usr/local/sftp/HG_SFTP_2021-Prod.pem",
-        "PrivateKeyPassphrase": "***"
+        "SftpFolderPath": "Prod",
+        "PrivateKeyPath": "/usr/local/sftp/hlth_dhsi_PRIVATE_KEY.pem",
+        "PrivateKeyPassphrase": ""
     },
     "Immunization": {
         "EndPoint": "https://phsahealthgatewayapi-prod.azurewebsites.net/api/v1/Support/Immunizations",


### PR DESCRIPTION
# Fixes or Implements [AB#11148](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11148)

-   [X] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Allow for empty passwords in SFTP Delegate and update config.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
