### PR TITLE
Fixes hdid on admin web client vax status request AB#11233

### DIFF
--- a/Apps/Common/src/Delegates/PHSA/RestVaccineStatusDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestVaccineStatusDelegate.cs
@@ -104,7 +104,7 @@ namespace HealthGateway.Common.Delegates.PHSA
                     endpoint = new Uri(endpointString);
                     content = new StringContent(json, null, MediaTypeNames.Application.Json);
                 }
-                else
+                else if (!string.IsNullOrEmpty(query.HdId))
                 {
                     Dictionary<string, string?> queryDict = new ()
                     {
@@ -112,6 +112,12 @@ namespace HealthGateway.Common.Delegates.PHSA
                     };
                     endpointString += this.phsaConfig.VaccineStatusEndpoint;
                     endpoint = new Uri(QueryHelpers.AddQueryString(endpointString, queryDict));
+                }
+                else
+                {
+                    endpointString += this.phsaConfig.VaccineStatusEndpoint;
+                    endpoint = new Uri(endpointString);
+                    content = new StringContent(json, null, MediaTypeNames.Application.Json);
                 }
 
                 client.DefaultRequestHeaders.Accept.Clear();


### PR DESCRIPTION
# Fixes or Implements [AB#11233](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11233)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Fixes vaccine status card in admin.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
