### PR TITLE
Cache access token to reduce KeyCloak traffic for AB#11278

### DIFF
--- a/Apps/Immunization/src/Startup.cs
+++ b/Apps/Immunization/src/Startup.cs
@@ -63,6 +63,7 @@ namespace HealthGateway.Immunization
             this.startupConfig.ConfigurePatientAccess(services);
 
             // Add Services
+            services.AddMemoryCache();
             services.AddTransient<IImmunizationService, ImmunizationService>();
             services.AddTransient<IVaccineStatusService, VaccineStatusService>();
 

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -43,7 +43,8 @@
     },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "ClientId": "healthgateway-admin-local"
+        "ClientId": "healthgateway-admin-local",
+        "TokenCacheMinutes": 4
     },
     "AvailabilityFilter": {
         "VaccineStatus": false

--- a/Apps/Immunization/src/appsettings.hgdev.json
+++ b/Apps/Immunization/src/appsettings.hgdev.json
@@ -24,6 +24,7 @@
         "CacheTTL": 90
     },
     "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token"
+        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
+        "TokenCacheMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.hgmock.json
+++ b/Apps/Immunization/src/appsettings.hgmock.json
@@ -27,6 +27,7 @@
         "CacheTTL": 90
     },
     "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token"
+        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
+        "TokenCacheMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.hgpoc.json
+++ b/Apps/Immunization/src/appsettings.hgpoc.json
@@ -24,6 +24,7 @@
         "CacheTTL": 90
     },
     "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token"
+        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
+        "TokenCacheMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.hgtest.json
+++ b/Apps/Immunization/src/appsettings.hgtest.json
@@ -24,6 +24,7 @@
         "CacheTTL": 90
     },
     "ClientAuthentication": {
-        "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token"
+        "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
+        "TokenCacheMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -33,7 +33,8 @@
         "PublicVaccineStatusEndPoint": "/api/v1/Public/Immunizations/VaccineStatusIndicator",
         "VaccineStatusEndPoint": "/api/v1/Immunizations/VaccineStatusIndicator",
         "FetchSize": "25",
-        "BackOffMilliseconds": "10000"
+        "BackOffMilliseconds": "10000",
+        "TokenCacheMinutes":  30
     },
     "OpenTelemetry": {
         "Enabled": false,
@@ -64,7 +65,8 @@
         "ClientId": "healthgateway-admin",
         "ClientSecret": "****",
         "Username": "****",
-        "Password": "****"
+        "Password": "****",
+        "TokenCacheExpireMinutes": 30
     },
     "AvailabilityFilter": {
         "VaccineStatus": true

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -33,8 +33,7 @@
         "PublicVaccineStatusEndPoint": "/api/v1/Public/Immunizations/VaccineStatusIndicator",
         "VaccineStatusEndPoint": "/api/v1/Immunizations/VaccineStatusIndicator",
         "FetchSize": "25",
-        "BackOffMilliseconds": "10000",
-        "TokenCacheMinutes":  30
+        "BackOffMilliseconds": "10000"
     },
     "OpenTelemetry": {
         "Enabled": false,

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -29,7 +29,10 @@ namespace HealthGateway.Immunization.Test.Services
     using HealthGateway.Immunization.Delegates;
     using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
+    using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
 
@@ -93,9 +96,11 @@ namespace HealthGateway.Immunization.Test.Services
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
+                new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                new Mock<IReportDelegate>().Object);
+                new Mock<IReportDelegate>().Object,
+                GetMemoryCache());
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
@@ -111,9 +116,11 @@ namespace HealthGateway.Immunization.Test.Services
         {
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
+                new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                new Mock<IReportDelegate>().Object);
+                new Mock<IReportDelegate>().Object,
+                GetMemoryCache());
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
@@ -129,9 +136,11 @@ namespace HealthGateway.Immunization.Test.Services
         {
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
+                new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                new Mock<IReportDelegate>().Object);
+                new Mock<IReportDelegate>().Object,
+                GetMemoryCache());
 
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             var actualResult = Task.Run(async () => await service.GetVaccineStatus(this.phn, "yyyyMMddx", dovString).ConfigureAwait(true)).Result;
@@ -146,13 +155,24 @@ namespace HealthGateway.Immunization.Test.Services
         {
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
+                new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                new Mock<IReportDelegate>().Object);
+                new Mock<IReportDelegate>().Object,
+                GetMemoryCache());
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             var actualResult = Task.Run(async () => await service.GetVaccineStatus(this.phn, dobString, "yyyyMMddx").ConfigureAwait(true)).Result;
             Assert.Equal(Common.Constants.ResultType.Error, actualResult.ResultStatus);
+        }
+
+        private static IMemoryCache? GetMemoryCache()
+        {
+            ServiceCollection services = new ServiceCollection();
+            services.AddMemoryCache();
+            ServiceProvider serviceProvider = services.BuildServiceProvider();
+
+            return serviceProvider.GetService<IMemoryCache>();
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()


### PR DESCRIPTION
# Fixes or Implements [AB#11278](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11278)

-   [X] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Caches the Access Token in memory to reduce traffic to the authentication server.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.
Manual testing of cache completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
