### PR TITLE
Fix tz issue and appsettings  wrong key for AB#11278

### DIFF
--- a/Apps/AdminWebClient/src/appsettings.json
+++ b/Apps/AdminWebClient/src/appsettings.json
@@ -15,7 +15,7 @@
         "ResponseType": "code",
         "Scope": "openid profile email offline_access"
     },
-    "EnabledRoles": ["AdminUser", "AdminReviewer", "SupportUser"],
+    "EnabledRoles": [ "AdminUser", "AdminReviewer", "SupportUser" ],
     "SwaggerSettings": {
         "RoutePrefix": "swagger",
         "Info": {
@@ -91,5 +91,9 @@
         "Subject": "BC Vaccine Card",
         "Title": "BC Vaccine Card",
         "LicenseKey": "****"
+    },
+    "TimeZone": {
+        "UnixTimeZoneId": "America/Vancouver",
+        "WindowsTimeZoneId": "Pacific Standard Time"
     }
 }

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -44,7 +44,7 @@
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "ClientId": "healthgateway-admin-local",
-        "TokenCacheMinutes": 4
+        "TokenCacheExpireMinutes": 4
     },
     "AvailabilityFilter": {
         "VaccineStatus": false

--- a/Apps/Immunization/src/appsettings.hgdev.json
+++ b/Apps/Immunization/src/appsettings.hgdev.json
@@ -25,6 +25,6 @@
     },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheMinutes": 4
+        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.hgmock.json
+++ b/Apps/Immunization/src/appsettings.hgmock.json
@@ -28,6 +28,6 @@
     },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheMinutes": 4
+        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.hgpoc.json
+++ b/Apps/Immunization/src/appsettings.hgpoc.json
@@ -25,6 +25,6 @@
     },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheMinutes": 4
+        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.hgtest.json
+++ b/Apps/Immunization/src/appsettings.hgtest.json
@@ -25,6 +25,6 @@
     },
     "ClientAuthentication": {
         "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheMinutes": 4
+        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -78,5 +78,9 @@
         "Subject": "BC Vaccine Card",
         "Title": "BC Vaccine Card",
         "LicenseKey": "****"
+    },
+    "TimeZone": {
+        "UnixTimeZoneId": "America/Vancouver",
+        "WindowsTimeZoneId": "Pacific Standard Time"
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#11278](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11278)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

Fix timezone issue when deploying into OpenShift and fix wrong keys in non-prod environment appsettings.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
