### PR TITLE
Retry PHSA requests in admin COVID support service AB#11285

### DIFF
--- a/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
+++ b/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
@@ -89,7 +89,7 @@ namespace HealthGateway.Admin.Server.Delegates
 
                 if (refreshInProgress)
                 {
-                    Thread.Sleep(this.phsaConfig.BackOffMilliseconds);
+                    Thread.Sleep(Math.Max(immsResponse.ResourcePayload!.LoadState.BackOffMilliseconds, this.phsaConfig.BackOffMilliseconds));
                 }
             }
             while (refreshInProgress && retryCount++ < this.phsaConfig.MaxRetries);

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -192,7 +192,7 @@ namespace HealthGateway.Admin.Services
                 DateOfBirth = patientResult.ResourcePayload!.Birthdate,
             };
             RequestResult<PHSAResult<VaccineStatusResult>> statusResult =
-                await this.vaccineStatusDelegate.GetVaccineStatus(statusQuery, bearerToken, false).ConfigureAwait(true);
+                await this.vaccineStatusDelegate.GetVaccineStatusWithRetries(statusQuery, bearerToken, false).ConfigureAwait(true);
 
             if (statusResult.ResultStatus != ResultType.Success)
             {
@@ -213,7 +213,7 @@ namespace HealthGateway.Admin.Services
                 ImmunizationDisease = "COVID19",
             };
             RequestResult<PHSAResult<RecordCard>> recordCardResult =
-                await this.vaccineStatusDelegate.GetRecordCard(cardQuery, bearerToken).ConfigureAwait(true);
+                await this.vaccineStatusDelegate.GetRecordCardWithRetries(cardQuery, bearerToken).ConfigureAwait(true);
 
             if (recordCardResult.ResultStatus != ResultType.Success)
             {

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -155,17 +155,17 @@ namespace HealthGateway.Admin.Services
             this.logger.LogDebug($"Retrieving covid document");
             this.logger.LogTrace($"For PHN: {phn}");
 
-            RequestResult<CovidInformation> covidInfo = await this.GetCovidInformation(phn).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(phn, PatientIdentifierType.PHN, true).ConfigureAwait(true);
 
-            if (covidInfo.ResultStatus != ResultType.Success)
+            if (patientResult.ResultStatus != ResultType.Success)
             {
-                this.logger.LogError($"Error retrieving covid information.");
+                this.logger.LogError($"Error retrieving patient information.");
                 return new RequestResult<ReportModel>()
                 {
                     PageIndex = 0,
                     PageSize = 0,
                     ResultStatus = ResultType.Error,
-                    ResultError = covidInfo.ResultError,
+                    ResultError = patientResult.ResultError,
                 };
             }
 
@@ -189,7 +189,7 @@ namespace HealthGateway.Admin.Services
             VaccineStatusQuery statusQuery = new ()
             {
                 PersonalHealthNumber = phn,
-                DateOfBirth = covidInfo.ResourcePayload!.Patient.Birthdate,
+                DateOfBirth = patientResult.ResourcePayload!.Birthdate,
             };
             RequestResult<PHSAResult<VaccineStatusResult>> statusResult =
                 await this.vaccineStatusDelegate.GetVaccineStatus(statusQuery, bearerToken, false).ConfigureAwait(true);
@@ -209,7 +209,7 @@ namespace HealthGateway.Admin.Services
             RecordCardQuery cardQuery = new ()
             {
                 PersonalHealthNumber = phn,
-                DateOfBirth = covidInfo.ResourcePayload!.Patient.Birthdate,
+                DateOfBirth = patientResult.ResourcePayload!.Birthdate,
                 ImmunizationDisease = "COVID19",
             };
             RequestResult<PHSAResult<RecordCard>> recordCardResult =

--- a/Apps/Common/src/Delegates/PHSA/IVaccineStatusDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/IVaccineStatusDelegate.cs
@@ -34,11 +34,28 @@ namespace HealthGateway.Common.Delegates.PHSA
         Task<RequestResult<PHSAResult<VaccineStatusResult>>> GetVaccineStatus(VaccineStatusQuery query, string accessToken, bool isPublicEndpoint);
 
         /// <summary>
+        /// Returns the vaccine status for the given patient, retrying multiple times if there is a refresh in progress.
+        /// </summary>
+        /// <param name="query">The vaccine status query.</param>
+        /// <param name="accessToken">The connection access token.</param>
+        /// <param name="isPublicEndpoint">Indicates whether it should use the public endpoint.</param>
+        /// <returns>The vaccine status result for the given patient.</returns>
+        Task<RequestResult<PHSAResult<VaccineStatusResult>>> GetVaccineStatusWithRetries(VaccineStatusQuery query, string accessToken, bool isPublicEndpoint);
+
+        /// <summary>
         /// Returns the record card for the given patient.
         /// </summary>
         /// <param name="query">The record card query.</param>
         /// <param name="accessToken">The connection access token.</param>
         /// <returns>The record card result for the given patient.</returns>
         Task<RequestResult<PHSAResult<RecordCard>>> GetRecordCard(RecordCardQuery query, string accessToken);
+
+        /// <summary>
+        /// Returns the record card for the given patient, retrying multiple times if there is a refresh in progress.
+        /// </summary>
+        /// <param name="query">The record card query.</param>
+        /// <param name="accessToken">The connection access token.</param>
+        /// <returns>The record card result for the given patient.</returns>
+        Task<RequestResult<PHSAResult<RecordCard>>> GetRecordCardWithRetries(RecordCardQuery query, string accessToken);
     }
 }

--- a/Apps/Common/src/Delegates/PHSA/RestVaccineStatusDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestVaccineStatusDelegate.cs
@@ -220,7 +220,7 @@ namespace HealthGateway.Common.Delegates.PHSA
                 if (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries)
                 {
                     this.logger.LogDebug($"Refresh in progress, trying again....");
-                    Thread.Sleep(this.phsaConfig.BackOffMilliseconds);
+                    Thread.Sleep(Math.Max(response.ResourcePayload!.LoadState.BackOffMilliseconds, this.phsaConfig.BackOffMilliseconds));
                 }
             }
             while (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries);
@@ -363,7 +363,7 @@ namespace HealthGateway.Common.Delegates.PHSA
                 if (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries)
                 {
                     this.logger.LogDebug($"Refresh in progress, trying again....");
-                    Thread.Sleep(this.phsaConfig.BackOffMilliseconds);
+                    Thread.Sleep(Math.Max(response.ResourcePayload!.LoadState.BackOffMilliseconds, this.phsaConfig.BackOffMilliseconds));
                 }
             }
             while (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries);

--- a/Apps/Common/src/Delegates/PHSA/RestVaccineStatusDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestVaccineStatusDelegate.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Common.Delegates.PHSA
     using System.Net.Http.Headers;
     using System.Net.Mime;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Constants.PHSA;
@@ -195,6 +196,53 @@ namespace HealthGateway.Common.Delegates.PHSA
         }
 
         /// <inheritdoc/>
+        public async Task<RequestResult<PHSAResult<VaccineStatusResult>>> GetVaccineStatusWithRetries(VaccineStatusQuery query, string accessToken, bool isPublicEndpoint)
+        {
+            using Activity? activity = Source.StartActivity("RetryGetVaccineStatus");
+            RequestResult<PHSAResult<VaccineStatusResult>> retVal = new ()
+            {
+                ResultStatus = ResultType.Error,
+                PageIndex = 0,
+            };
+
+            RequestResult<PHSAResult<VaccineStatusResult>> response;
+            int attemptCount = 0;
+            bool refreshInProgress;
+            do
+            {
+                response = await this.GetVaccineStatus(query, accessToken, isPublicEndpoint).ConfigureAwait(true);
+
+                refreshInProgress = response.ResultStatus == ResultType.Success &&
+                                    response.ResourcePayload != null &&
+                                    response.ResourcePayload.LoadState.RefreshInProgress;
+
+                attemptCount++;
+                if (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries)
+                {
+                    this.logger.LogDebug($"Refresh in progress, trying again....");
+                    Thread.Sleep(this.phsaConfig.BackOffMilliseconds);
+                }
+            }
+            while (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries);
+
+            if (refreshInProgress)
+            {
+                this.logger.LogDebug($"Maximum retry attempts reached.");
+                retVal.ResultError = new RequestResultError() { ResultMessage = "Refresh in progress", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+            }
+            else if (response.ResultStatus == ResultType.Success)
+            {
+                retVal = response;
+            }
+            else
+            {
+                retVal.ResultError = response.ResultError;
+            }
+
+            return retVal;
+        }
+
+        /// <inheritdoc/>
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
         public async Task<RequestResult<PHSAResult<RecordCard>>> GetRecordCard(RecordCardQuery query, string accessToken)
         {
@@ -287,6 +335,53 @@ namespace HealthGateway.Common.Delegates.PHSA
             }
 
             this.logger.LogDebug($"Finished getting record card {query.PersonalHealthNumber.Substring(0, 5)} {query.DateOfBirth}");
+            return retVal;
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<PHSAResult<RecordCard>>> GetRecordCardWithRetries(RecordCardQuery query, string accessToken)
+        {
+            using Activity? activity = Source.StartActivity("RetryGetRecordCard");
+            RequestResult<PHSAResult<RecordCard>> retVal = new ()
+            {
+                ResultStatus = ResultType.Error,
+                PageIndex = 0,
+            };
+
+            RequestResult<PHSAResult<RecordCard>> response;
+            int attemptCount = 0;
+            bool refreshInProgress;
+            do
+            {
+                response = await this.GetRecordCard(query, accessToken).ConfigureAwait(true);
+
+                refreshInProgress = response.ResultStatus == ResultType.Success &&
+                                    response.ResourcePayload != null &&
+                                    response.ResourcePayload.LoadState.RefreshInProgress;
+
+                attemptCount++;
+                if (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries)
+                {
+                    this.logger.LogDebug($"Refresh in progress, trying again....");
+                    Thread.Sleep(this.phsaConfig.BackOffMilliseconds);
+                }
+            }
+            while (refreshInProgress && attemptCount <= this.phsaConfig.MaxRetries);
+
+            if (refreshInProgress)
+            {
+                this.logger.LogDebug($"Maximum retry attempts reached.");
+                retVal.ResultError = new RequestResultError() { ResultMessage = "Refresh in progress", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+            }
+            else if (response.ResultStatus == ResultType.Success)
+            {
+                retVal = response;
+            }
+            else
+            {
+                retVal.ResultError = response.ResultError;
+            }
+
             return retVal;
         }
     }


### PR DESCRIPTION
# Implements [AB#11285](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11285)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Adds support for retrying PHSA calls in the backend for the admin COVID support service.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
