### PR TITLE
Stop retrieving vaccination history for mailed documents AB#11317

### DIFF
--- a/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.Admin.Controllers
         }
 
         /// <summary>
-        /// Provides an api to send immunization information though mail to a given land address.
+        /// Triggers the process to physically mail the Vaccine Card document.
         /// </summary>
         /// <returns>A wrapped result indicating the mail status.</returns>
         /// <param name="request">The mail document request.</param>
@@ -67,13 +67,13 @@ namespace HealthGateway.Admin.Controllers
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpPost]
         [Route("Patient/Document")]
-        public async Task<IActionResult> MailDocument([FromBody] MailDocumentRequest request)
+        public async Task<IActionResult> MailVaccineCard([FromBody] MailDocumentRequest request)
         {
-            return new JsonResult(await this.covidSupportService.MailDocumentAsync(request).ConfigureAwait(true));
+            return new JsonResult(await this.covidSupportService.MailVaccineCardAsync(request).ConfigureAwait(true));
         }
 
         /// <summary>
-        /// Gets the covid immunization document.
+        /// Gets the COVID-19 Vaccine Record document that includes the Vaccine Card and Vaccination History.
         /// </summary>
         /// <returns>The encoded immunization document.</returns>
         /// <param name="phn">The personal health number that matches the document to retrieve.</param>
@@ -82,9 +82,9 @@ namespace HealthGateway.Admin.Controllers
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpGet]
         [Route("Patient/Document")]
-        public async Task<IActionResult> RetrieveDocument([FromHeader] string phn)
+        public async Task<IActionResult> RetrieveVaccineRecord([FromHeader] string phn)
         {
-            return new JsonResult(await this.covidSupportService.RetrieveDocumentAsync(phn, null).ConfigureAwait(true));
+            return new JsonResult(await this.covidSupportService.RetrieveVaccineRecordAsync(phn).ConfigureAwait(true));
         }
     }
 }

--- a/Apps/AdminWebClient/src/Server/Services/ICovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/ICovidSupportService.cs
@@ -20,7 +20,7 @@ namespace HealthGateway.Admin.Services
     using HealthGateway.Common.Models;
 
     /// <summary>
-    /// Service that provides Covid Support functionality.
+    /// Service that provides COVID-19 Support functionality.
     /// </summary>
     public interface ICovidSupportService
     {
@@ -32,18 +32,17 @@ namespace HealthGateway.Admin.Services
         Task<RequestResult<CovidInformation>> GetCovidInformation(string phn);
 
         /// <summary>
-        /// Gets all the emails in the system up to the pageSize.
+        /// Mails a document that represents a patient's vaccine card.
         /// </summary>
         /// <param name="request">The request information to retrieve patient information.</param>
         /// <returns>A RequestResult with True if the request was sucessfull.</returns>
-        Task<PrimitiveRequestResult<bool>> MailDocumentAsync(MailDocumentRequest request);
+        Task<PrimitiveRequestResult<bool>> MailVaccineCardAsync(MailDocumentRequest request);
 
         /// <summary>
-        /// Gets all the emails in the system up to the pageSize.
+        /// Gets a document that represents a patient's vaccine card and vaccine history.
         /// </summary>
         /// <param name="phn">The personal health number that matches the person to retrieve.</param>
-        /// <param name="address">The optional patient address information.</param>
         /// <returns>The encoded document.</returns>
-        Task<RequestResult<ReportModel>> RetrieveDocumentAsync(string phn, Address? address);
+        Task<RequestResult<ReportModel>> RetrieveVaccineRecordAsync(string phn);
     }
 }

--- a/Apps/Common/src/Delegates/IReportDelegate.cs
+++ b/Apps/Common/src/Delegates/IReportDelegate.cs
@@ -40,5 +40,14 @@ namespace HealthGateway.Common.Delegates
         /// <param name="base64RecordCard">The base64 of the record card PDF.</param>
         /// <returns>Returns the report model containing the pdf document.</returns>
         RequestResult<ReportModel> GetVaccineStatusAndRecordPDF(VaccineStatus vaccineStatus, Address? address, string base64RecordCard);
+
+        /// <summary>
+        /// Merges two PDFs.
+        /// </summary>
+        /// <param name="base64Document1">The first document, encoded in base64.</param>
+        /// <param name="base64Document2">The second document, encoded in base64.</param>
+        /// <param name="fileName">The file name to assign to the merged document.</param>
+        /// <returns>Returns the report model containing the merged pdf document.</returns>
+        RequestResult<ReportModel> MergePDFs(string base64Document1, string base64Document2, string fileName);
     }
 }

--- a/Apps/Common/src/Delegates/ReportDelegate.cs
+++ b/Apps/Common/src/Delegates/ReportDelegate.cs
@@ -108,6 +108,12 @@ namespace HealthGateway.Common.Delegates
             return this.ironPdfDelegate.Merge(vaccineStatusResult.ResourcePayload!.Data, base64RecordCard, vaccineStatusResult.ResourcePayload.FileName);
         }
 
+        /// <inheritdoc/>
+        public RequestResult<ReportModel> MergePDFs(string base64Document1, string base64Document2, string fileName)
+        {
+            return this.ironPdfDelegate.Merge(base64Document1, base64Document2, fileName);
+        }
+
         private TimeZoneInfo GetLocalTimeZone()
         {
             return TimeZoneInfo.FindSystemTimeZoneById(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?


### PR DESCRIPTION
# Implements [AB#11317](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11317)

-   [ ] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Removes the retrieval of vaccination history from PHSA for documents mailed from the admin COVID-19 support page.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
