### PR TITLE
Display data mismatch error instead of not found AB#11301

### DIFF
--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -182,12 +182,15 @@ namespace HealthGateway.Immunization.Services
                 retVal.ResourcePayload = VaccineStatus.FromModel(payload, phn);
                 retVal.ResourcePayload.State = retVal.ResourcePayload.State switch
                 {
-                    var state when
-                        state == VaccineState.DataMismatch ||
-                        state == VaccineState.Threshold ||
-                        state == VaccineState.Blocked => VaccineState.NotFound,
+                    var state when state == VaccineState.Threshold || state == VaccineState.Blocked => VaccineState.NotFound,
                     _ => retVal.ResourcePayload.State
                 };
+
+                if (retVal.ResourcePayload.State == VaccineState.DataMismatch)
+                {
+                    retVal.ResultStatus = ResultType.ActionRequired;
+                    retVal.ResultError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
+                }
             }
 
             if (result.ResourcePayload != null)

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
@@ -1,4 +1,6 @@
+import { ActionType } from "@/constants/actionType";
 import { ResultType } from "@/constants/resulttype";
+import BannerError from "@/models/bannerError";
 import CovidVaccineRecord from "@/models/covidVaccineRecord";
 import { StringISODate } from "@/models/dateWrapper";
 import Report from "@/models/report";
@@ -111,25 +113,34 @@ export const actions: VaccinationStatusActions = {
         const logger: ILogger = container.get(SERVICE_IDENTIFIER.Logger);
 
         logger.error(`ERROR: ${JSON.stringify(error)}`);
-        context.commit(
-            "vaccinationStatusError",
-            ErrorTranslator.toBannerError(
-                "Error Retrieving Vaccine Card",
-                error
-            )
-        );
+        const bannerError: BannerError = {
+            title: "Our Apologies",
+            description:
+                "We've found an issue and the Health Gateway team is working hard to fix it.",
+            detail: "",
+            errorCode: "",
+        };
+
+        if (error.actionCode === ActionType.DataMismatch) {
+            bannerError.title = "Data Mismatch";
+            bannerError.description = error.resultMessage;
+        }
+
+        context.commit("vaccinationStatusError", bannerError);
     },
     handlePdfError(context, error: ResultError) {
         const logger: ILogger = container.get(SERVICE_IDENTIFIER.Logger);
 
         logger.error(`ERROR: ${JSON.stringify(error)}`);
-        context.commit(
-            "pdfError",
-            ErrorTranslator.toBannerError(
-                "Error Retrieving Vaccine Card PDF",
-                error
-            )
-        );
+        const bannerError: BannerError = {
+            title: "Our Apologies",
+            description:
+                "We've found an issue and the Health Gateway team is working hard to fix it.",
+            detail: "",
+            errorCode: "",
+        };
+
+        context.commit("pdfError", bannerError);
     },
     retrieveAuthenticatedVaccineStatus(
         context,

--- a/Apps/WebClient/src/ClientApp/src/views/publicVaccineCard.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/publicVaccineCard.vue
@@ -295,16 +295,15 @@ export default class PublicVaccineCardView extends Vue {
                         <b-alert
                             variant="danger"
                             class="mb-3 p-3"
-                            :show="error !== undefined"
+                            show
                             dismissible
                         >
-                            <h2 class="h4">Our Apologies</h2>
+                            <h2 class="h4">{{ error.title }}</h2>
                             <div
                                 data-testid="errorTextDescription"
                                 class="pl-4"
                             >
-                                We've found an issue and the Health Gateway team
-                                is working hard to fix it.
+                                {{ error.description }}
                             </div>
                         </b-alert>
                     </div>


### PR DESCRIPTION
# Implements [AB#11354](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11354)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Displays an error message on the vaccine card form when a data mismatch occurs instead of directing to the "Not Found" result.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
