### PR TITLE
Remove data that is no longer used in PDF template AB#11229

### DIFF
--- a/Apps/Common/src/Delegates/ReportDelegate.cs
+++ b/Apps/Common/src/Delegates/ReportDelegate.cs
@@ -58,10 +58,6 @@ namespace HealthGateway.Common.Delegates
             pdfRequest.Data.Add("currentDateTime", currentPacificTime.ToString("MMMM-dd-yyyy, HH:mm", CultureInfo.InvariantCulture));
             pdfRequest.HtmlTemplate = AssetReader.Read("HealthGateway.Common.Assets.Templates.VaccineStatusCard.html") !;
 
-            string birthdate = vaccineStatus.Birthdate.HasValue
-                ? vaccineStatus.Birthdate.Value.ToString("yyyy-MMM-dd", CultureInfo.InvariantCulture).ToUpper(CultureInfo.InvariantCulture)
-                : string.Empty;
-            pdfRequest.Data.Add("birthdate", birthdate);
             pdfRequest.Data.Add("name", $"{vaccineStatus.FirstName} {vaccineStatus.LastName}");
             pdfRequest.Data.Add("qrCodeImageSrc", vaccineStatus.QRCode.Data);
 
@@ -76,26 +72,22 @@ namespace HealthGateway.Common.Delegates
             {
                 case VaccineState.AllDosesReceived:
                     pdfRequest.Data.Add("resultText", "Vaccinated");
-                    pdfRequest.Data.Add("resultBorder", BorderSolid);
                     string? checkMarkBase64 = AssetReader.Read("HealthGateway.Common.Assets.Images.checkmark-black.svg", true);
                     pdfRequest.Data.Add("resultImageSrc", $"data:image/svg+xml;base64, {checkMarkBase64}");
                     pdfRequest.Data.Add("resultImageDisplay", "block");
                     break;
                 case VaccineState.PartialDosesReceived:
                     pdfRequest.Data.Add("resultText", "Partially Vaccinated");
-                    pdfRequest.Data.Add("resultBorder", BorderDashed);
                     pdfRequest.Data.Add("resultImageSrc", string.Empty);
                     pdfRequest.Data.Add("resultImageDisplay", "none");
                     break;
                 case VaccineState.Exempt:
                     pdfRequest.Data.Add("resultText", "Exempt");
-                    pdfRequest.Data.Add("resultBorder", BorderDashed);
                     pdfRequest.Data.Add("resultImageSrc", string.Empty);
                     pdfRequest.Data.Add("resultImageDisplay", "none");
                     break;
                 default:
                     pdfRequest.Data.Add("resultText", "No Records Found");
-                    pdfRequest.Data.Add("resultBorder", BorderDashed);
                     pdfRequest.Data.Add("resultImageSrc", string.Empty);
                     pdfRequest.Data.Add("resultImageDisplay", "none");
                     break;

--- a/Apps/Common/src/Delegates/ReportDelegate.cs
+++ b/Apps/Common/src/Delegates/ReportDelegate.cs
@@ -58,7 +58,10 @@ namespace HealthGateway.Common.Delegates
             pdfRequest.Data.Add("currentDateTime", currentPacificTime.ToString("MMMM-dd-yyyy, HH:mm", CultureInfo.InvariantCulture));
             pdfRequest.HtmlTemplate = AssetReader.Read("HealthGateway.Common.Assets.Templates.VaccineStatusCard.html") !;
 
-            pdfRequest.Data.Add("birthdate", vaccineStatus.Birthdate!.Value.ToString("yyyy-MMM-dd", CultureInfo.InvariantCulture).ToUpper(CultureInfo.InvariantCulture));
+            string birthdate = vaccineStatus.Birthdate.HasValue
+                ? vaccineStatus.Birthdate.Value.ToString("yyyy-MMM-dd", CultureInfo.InvariantCulture).ToUpper(CultureInfo.InvariantCulture)
+                : string.Empty;
+            pdfRequest.Data.Add("birthdate", birthdate);
             pdfRequest.Data.Add("name", $"{vaccineStatus.FirstName} {vaccineStatus.LastName}");
             pdfRequest.Data.Add("qrCodeImageSrc", vaccineStatus.QRCode.Data);
 

--- a/Apps/Common/src/Delegates/ReportDelegate.cs
+++ b/Apps/Common/src/Delegates/ReportDelegate.cs
@@ -27,8 +27,6 @@ namespace HealthGateway.Common.Delegates
     /// <inheritdoc/>
     public class ReportDelegate : IReportDelegate
     {
-        private const string BorderDashed = "dashed";
-        private const string BorderSolid = "solid";
         private const string UnixTzKey = "TimeZone:UnixTimeZoneId";
         private const string WindowsTzKey = "TimeZone:WindowsTimeZoneId";
         private readonly IIronPDFDelegate ironPdfDelegate;


### PR DESCRIPTION
# Fixes [AB#11229](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11229)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Fixes an exception caused by a null birthdate by removing it, since it is no longer used when generating the PDF.  Removes the resultBorder field which is also no longer used as well.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
