### PR TITLE
Show message when record has invalid COVID-19 doses AB#11359

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/models/selectItem.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/selectItem.ts
@@ -1,0 +1,8 @@
+// Interface for an item in a select component
+export default interface SelectItem {
+    text: string | number;
+    value: string | number;
+    disabled?: boolean;
+    divider?: boolean;
+    header?: string;
+}

--- a/Apps/AdminWebClient/src/ClientApp/src/models/vaccineDetails.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/vaccineDetails.ts
@@ -3,6 +3,7 @@ import { StringISODate } from "@/models/dateWrapper";
 export interface VaccineDetails {
     doses: VaccineDose[];
     vaccineStatus: string;
+    containsInvalidDoses: boolean;
 }
 
 export interface VaccineDose {

--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -13,6 +13,7 @@ import Address from "@/models/address";
 import BannerFeedback from "@/models/bannerFeedback";
 import CovidCardPatientResult from "@/models/covidCardPatientResult";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
+import SelectItem from "@/models/selectItem";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
 import { ICovidSupportService } from "@/services/interfaces";
@@ -79,7 +80,7 @@ export default class CovidCardView extends Vue {
         },
     ];
 
-    private get internationalDestinations() {
+    private get internationalDestinations(): SelectItem[] {
         // sort destinations alphabetically except place Canada and US at the top
         const destinations = Object.keys(InternationalDestinations)
             .filter(
@@ -105,7 +106,7 @@ export default class CovidCardView extends Vue {
             : countryName.toLocaleUpperCase();
     }
 
-    private get patientName() {
+    private get patientName(): string {
         return `${this.searchResult?.patient?.firstname} ${this.searchResult?.patient?.lastname}`;
     }
 
@@ -113,7 +114,7 @@ export default class CovidCardView extends Vue {
         return this.searchResult?.vaccineDetails?.containsInvalidDoses === true;
     }
 
-    private get provinceStateList() {
+    private get provinceStateList(): SelectItem[] {
         if (this.isCanadaSelected) {
             return Object.keys(Provinces).map((provinceCode) => {
                 return {
@@ -133,11 +134,11 @@ export default class CovidCardView extends Vue {
         }
     }
 
-    private get isCanadaSelected() {
+    private get isCanadaSelected(): boolean {
         return this.selectedDestination === Countries.CA[0];
     }
 
-    private get isUnitedStatesSelected() {
+    private get isUnitedStatesSelected(): boolean {
         return this.selectedDestination === Countries.US[0];
     }
 

--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -109,6 +109,10 @@ export default class CovidCardView extends Vue {
         return `${this.searchResult?.patient?.firstname} ${this.searchResult?.patient?.lastname}`;
     }
 
+    private get containsInvalidDoses(): boolean {
+        return this.searchResult?.vaccineDetails?.containsInvalidDoses === true;
+    }
+
     private get provinceStateList() {
         if (this.isCanadaSelected) {
             return Object.keys(Provinces).map((provinceCode) => {
@@ -481,6 +485,15 @@ export default class CovidCardView extends Vue {
                                     <span>{{ formatDate(item.date) }}</span>
                                 </template>
                             </v-data-table>
+                            <v-alert
+                                v-if="containsInvalidDoses"
+                                dense
+                                color="orange"
+                                type="warning"
+                                class="mt-4"
+                            >
+                                This record has invalid doses.
+                            </v-alert>
                         </v-col>
                     </v-row>
                     <v-row justify="end">

--- a/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
+++ b/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
@@ -100,6 +100,7 @@ namespace HealthGateway.Admin.Server.Delegates
                     response.ResourcePayload.Result?.VaccineStatusResult)
                 {
                     Blocked = response.ResourcePayload.Result?.Blocked ?? false,
+                    ContainsInvalidDoses = response.ResourcePayload.Result?.ContainsInvalidDoses ?? false,
                 };
 
                 retVal = new ()

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/VaccineDetails.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/VaccineDetails.cs
@@ -53,6 +53,11 @@ namespace HealthGateway.Admin.Models.CovidSupport
         public bool Blocked { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the requested record contains any invalid doses.
+        /// </summary>
+        public bool ContainsInvalidDoses { get; set; }
+
+        /// <summary>
         /// Gets the retrieved doses. Empty if no valid COVID-19 doses were found.
         /// </summary>
         public IList<VaccineDose> Doses { get; }

--- a/Apps/AdminWebClient/src/Server/Models/Immunization/VaccineDetailsResponse.cs
+++ b/Apps/AdminWebClient/src/Server/Models/Immunization/VaccineDetailsResponse.cs
@@ -62,6 +62,12 @@ namespace HealthGateway.Admin.Models.CovidSupport.PHSA
         public bool Blocked { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the requested record contains any invalid doses.
+        /// </summary>
+        [JsonPropertyName("containsInvalidDoses")]
+        public bool ContainsInvalidDoses { get; set; }
+
+        /// <summary>
         /// Gets the patient's dose dates from the Provincial Immunization Registry (Panorama).
         /// </summary>
         [JsonPropertyName("pirLookupDoseDates")]


### PR DESCRIPTION
# Implements [AB#11359](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11359)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Displays a warning message on the COVID-19 support page underneath the list of immunizations if the record contains any invalid doses.

Also adds some missing return types to the getters on the page.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
