### PR TITLE
Register added Keycloak user for invalid dose functonal tests  to seed data for AB#11418.

### DIFF
--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -65,6 +65,35 @@ VALUES (
 	null
 );
 
+/* Invaliddoses - Keycloak User */
+INSERT INTO gateway."UserProfile"(
+	"UserProfileId", 
+	"CreatedBy", 
+	"CreatedDateTime", 
+	"UpdatedBy", 
+	"UpdatedDateTime", 
+	"AcceptedTermsOfService", 
+	"Email", 
+	"ClosedDateTime", 
+	"IdentityManagementId", 
+	"LastLoginDateTime", 
+	"EncryptionKey", 
+	"SMSNumber")
+VALUES (
+	'DEV4FPEGCXG2NB5K2USBL52S66SC3GOUHWRP3GTXR2BTY5HEC4YA',	
+	'System', 
+	current_timestamp, 
+	'System', 
+	current_timestamp, 
+	true, 
+	null,
+	null,
+	null,
+	current_timestamp, 
+	'SnSf90IS+9I75+wXNuInLdod7s9bpiSjWW4vs94g7BY=',
+	null
+);
+
 /* Communication Banner */
 INSERT INTO gateway."Communication"(
 	"CommunicationId", 


### PR DESCRIPTION
# Fixes or Implements [AB#11418](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11418)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Need to register Keycloak user for invalid dose functional tests to seed data.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
