### PR TITLE
Remove addressee when sending documents to be mailed AB#11572

### DIFF
--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -237,10 +237,8 @@ namespace HealthGateway.Admin.Services
                             SmartHealthCardQr = vaccineStatusResult.ResourcePayload.Result.QRCode.Data!,
                         };
 
-                        string addressee = $"{vaccineStatusResult.ResourcePayload.Result.FirstName} {vaccineStatusResult.ResourcePayload.Result.LastName}";
-
                         RequestResult<VaccineProofResponse> vaccineProofResponse =
-                            await this.vaccineProofDelegate.MailAsync(this.vaccineCardConfig.MailTemplate, vaccineProofRequest, request.MailAddress, addressee).ConfigureAwait(true);
+                            await this.vaccineProofDelegate.MailAsync(this.vaccineCardConfig.MailTemplate, vaccineProofRequest, request.MailAddress).ConfigureAwait(true);
 
                         if (vaccineProofResponse.ResultStatus == ResultType.Success)
                         {

--- a/Apps/Common/src/Delegates/IVaccineProofDelegate.cs
+++ b/Apps/Common/src/Delegates/IVaccineProofDelegate.cs
@@ -30,9 +30,8 @@ namespace HealthGateway.Common.Delegates
         /// <param name="vaccineProofTemplate">The template to be used for the Vaccine Proof.</param>
         /// <param name="request">The vaccination data to be sent to populate the Vaccine Proof.</param>
         /// <param name="address">The address where the Vaccine Proof should be mailed.</param>
-        /// <param name="addressee">The name of the person to which the Vaccine Proof should be addressed.</param>
         /// <returns>A response object that includes the status and identifier of the Vaccine Proof.</returns>
-        public Task<RequestResult<VaccineProofResponse>> MailAsync(VaccineProofTemplate vaccineProofTemplate, VaccineProofRequest request, Address address, string addressee);
+        public Task<RequestResult<VaccineProofResponse>> MailAsync(VaccineProofTemplate vaccineProofTemplate, VaccineProofRequest request, Address address);
 
         /// <summary>
         /// Initiates the creation of a Vaccine Proof for later retrieval.

--- a/Apps/Common/src/Delegates/VaccineProofDelegate.cs
+++ b/Apps/Common/src/Delegates/VaccineProofDelegate.cs
@@ -71,7 +71,7 @@ namespace HealthGateway.Common.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<VaccineProofResponse>> MailAsync(VaccineProofTemplate vaccineProofTemplate, VaccineProofRequest request, Address address, string addressee)
+        public async Task<RequestResult<VaccineProofResponse>> MailAsync(VaccineProofTemplate vaccineProofTemplate, VaccineProofRequest request, Address address)
         {
             RequestResult<VaccineProofResponse> retVal = new()
             {
@@ -90,8 +90,8 @@ namespace HealthGateway.Common.Delegates
                 SmartHealthCard = new BcmpSmartHealthCard() { QrCode = request.SmartHealthCardQr },
                 Address = new()
                 {
-                    AddressLine1 = addressee,
-                    AddressLine2 = string.Join(Environment.NewLine, address.StreetLines),
+                    AddressLine1 = address.StreetLines.FirstOrDefault() ?? string.Empty,
+                    AddressLine2 = string.Join(Environment.NewLine, address.StreetLines.Skip(1)),
                     City = address.City,
                     Province = address.State,
                     PostalCode = address.PostalCode,

--- a/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
@@ -55,8 +55,6 @@ namespace HealthGateway.CommonTests.Delegates
             State = "BC",
         };
 
-        private readonly string addressee = "BONNET PROTERVITY";
-
         /// <summary>
         /// Initializes a new instance of the <see cref="VaccineProofDelegateTests"/> class.
         /// </summary>
@@ -111,7 +109,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientServiceMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address, this.addressee);
+            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
             RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -146,7 +144,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientServiceMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address, this.addressee);
+            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
             RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -178,7 +176,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientServiceMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address, this.addressee);
+            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
             RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);


### PR DESCRIPTION
# Fixes [AB#11572](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11572)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Removes the addressee from the address sent to BC Mail Plus since it can be extracted from the QR code.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
