### PR TITLE
Log job IDs returned from BC Mail Plus AB#11583

### DIFF
--- a/Apps/Common/src/Delegates/VaccineProofDelegate.cs
+++ b/Apps/Common/src/Delegates/VaccineProofDelegate.cs
@@ -118,6 +118,7 @@ namespace HealthGateway.Common.Delegates
                 };
                 retVal.ResultStatus = ResultType.Success;
                 retVal.TotalResultCount = 1;
+                this.logger.LogTrace($"The BC Mail Plus job {jobStatusResult.JobId} has a status of {jobStatusResult.JobStatus}");
             }
             else
             {
@@ -168,6 +169,7 @@ namespace HealthGateway.Common.Delegates
                 };
                 retVal.ResultStatus = ResultType.Success;
                 retVal.TotalResultCount = 1;
+                this.logger.LogTrace($"The BC Mail Plus job {jobStatusResult.JobId} has a status of {jobStatusResult.JobStatus}");
             }
             else
             {
@@ -209,6 +211,7 @@ namespace HealthGateway.Common.Delegates
                 };
                 retVal.ResultStatus = ResultType.Success;
                 retVal.TotalResultCount = 1;
+                this.logger.LogTrace($"The BC Mail Plus job {jobStatusResult.JobId} has a status of {jobStatusResult.JobStatus}");
             }
             else
             {


### PR DESCRIPTION
# Fixes [AB#11583](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11583)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Adds log statements to capture the job IDs and statuses returned from BC Mail Plus.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
