### PR TITLE
Remove vaccine proof request cache items for AB#11591

### DIFF
--- a/Apps/JobScheduler/src/Jobs/CleanCacheJob.cs
+++ b/Apps/JobScheduler/src/Jobs/CleanCacheJob.cs
@@ -62,13 +62,26 @@ namespace Healthgateway.JobScheduler.Jobs
             this.logger.LogInformation("CleanCacheJob Starting");
             List<GenericCache> oldIds = this.dbContext.GenericCache
                     .Where(cache => cache.ExpiryDateTime < DateTime.UtcNow)
-                    .Select(cache => new GenericCache { Id = cache.Id, Version = cache.Version })
+                    .Select(cache => new GenericCache { Id = cache.Id, Version = cache.Version, ExpiryDateTime = cache.ExpiryDateTime })
+                    .OrderBy(o => o.ExpiryDateTime)
                     .Take(this.deleteMaxRows)
                     .ToList();
             if (oldIds.Count > 0)
             {
-                this.logger.LogInformation($"Deleting {oldIds.Count} Cache entries out of a maximum of {this.deleteMaxRows}");
+                this.logger.LogInformation($"Deleting {oldIds.Count} Generic cache entries out of a maximum of {this.deleteMaxRows}");
                 this.dbContext.RemoveRange(oldIds);
+                this.dbContext.SaveChanges();
+            }
+
+            List<VaccineProofRequestCache> oldVaccineRequests = this.dbContext.VaccineProofRequestCache
+                    .Where(cache => cache.ExpiryDateTime < DateTime.UtcNow)
+                    .Take(this.deleteMaxRows)
+                    .OrderBy(o => o.ExpiryDateTime)
+                    .ToList();
+            if (oldVaccineRequests.Count > 0)
+            {
+                this.logger.LogInformation($"Deleting {oldVaccineRequests.Count} Vaccine Proof Request cache entries out of a maximum of {this.deleteMaxRows}");
+                this.dbContext.RemoveRange(oldVaccineRequests);
                 this.dbContext.SaveChanges();
             }
 


### PR DESCRIPTION
# Fixes or Implements [AB#11591](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11591)

-   [X] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Remove old Vaccine Proof Request cache items.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.
Manually tested the query and delete.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
