### PR TITLE
Verify and Update unit test for new GetAsset Call AB#11594

### DIFF
--- a/Apps/Immunization/test/unit/Services.Test/VaccineProofServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineProofServiceTests.cs
@@ -1,0 +1,314 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Immunization.Test.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Delegates;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Immunization.Services;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// VaccineProofService Unit Tests.
+    /// </summary>
+    public class VaccineProofServiceTests
+    {
+        private readonly string assetPdfUri = "https://bcmaildirect.gov.bc.ca/HLTSHC/TEST/HLTSHC.Oct.28.2021_114555_b97efeaa0b19bb094e6369f39a8abf28.pdf";
+
+        /// <summary>
+        /// Get a Vaccine Record Proof - Happy Path.
+        /// </summary>
+        [Fact]
+        public void GetProofOk()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+                { "BCMailPlus:Endpoint", "https://${HOST}/${ENV}/auth=${TOKEN}/JSON/" },
+                { "BCMailPlus:Host", "Host" },
+                { "BCMailPlus:JobEnvironment", "JobEnvironment" },
+                { "BCMailPlus:JobClass", "JobClass" },
+                { "BCMailPlus:SchemaVersion", "SchemaVersion" },
+                { "BCMailPlus:BackOffMilliseconds", "10" },
+                { "BCMailPlus:MaxRetries", "2" },
+                { "BCMailPlus:CacheTtl", "0" },
+            };
+
+            VaccineProofRequest request = new()
+            {
+                SmartHealthCardQr = "SHC QR Image",
+                Status = VaccinationStatus.Fully,
+            };
+
+            string hdid = "mock hdid";
+
+            var mockVaccineProofDelegate = new Mock<IVaccineProofDelegate>();
+
+            string id = "id";
+            Uri assetUri = new(this.assetPdfUri);
+
+            RequestResult<VaccineProofResponse> generateResult = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Id = id,
+                    Status = VaccineProofRequestStatus.Started,
+                    AssetUri = assetUri,
+                },
+            };
+            mockVaccineProofDelegate.Setup(s => s.GenerateAsync(It.IsAny<VaccineProofTemplate>(), request)).Returns(Task.FromResult(generateResult));
+
+            RequestResult<VaccineProofResponse> statusResultStarted = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Id = id,
+                    Status = VaccineProofRequestStatus.Started,
+                },
+            };
+            RequestResult<VaccineProofResponse> statusResultCompleted = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Id = id,
+                    Status = VaccineProofRequestStatus.Completed,
+                },
+            };
+            mockVaccineProofDelegate.SetupSequence(s => s.GetStatusAsync(id))
+                    .Returns(Task.FromResult(statusResultStarted))
+                    .Returns(Task.FromResult(statusResultCompleted));
+
+            RequestResult<ReportModel> assetResult = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Data = "Base64 Encoded PDF",
+                    FileName = "Filename.pdf",
+                },
+            };
+
+            mockVaccineProofDelegate.Setup(s => s.GetAssetAsync(assetUri)).Returns(Task.FromResult(assetResult));
+
+            IVaccineProofService service = new VaccineProofService(
+                GetConfiguration(myConfiguration),
+                new Mock<ILogger<VaccineProofService>>().Object,
+                mockVaccineProofDelegate.Object,
+                new Mock<IVaccineProofRequestCacheDelegate>().Object);
+
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, request, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            Assert.True(actualResult.ResultStatus == ResultType.Success);
+            Assert.True(actualResult.ResourcePayload != null &&
+                        actualResult.ResourcePayload.Data == assetResult.ResourcePayload.Data);
+        }
+
+        /// <summary>
+        /// The generate request on the Vaccine Proof delegate failed.
+        /// </summary>
+        [Fact]
+        public void GetProofGenerateFailed()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+                { "BCMailPlus:Endpoint", "https://${HOST}/${ENV}/auth=${TOKEN}/JSON/" },
+                { "BCMailPlus:Host", "Host" },
+                { "BCMailPlus:JobEnvironment", "JobEnvironment" },
+                { "BCMailPlus:JobClass", "JobClass" },
+                { "BCMailPlus:SchemaVersion", "SchemaVersion" },
+                { "BCMailPlus:BackOffMilliseconds", "10" },
+                { "BCMailPlus:MaxRetries", "2" },
+                { "BCMailPlus:CacheTtl", "0" },
+            };
+
+            VaccineProofRequest request = new()
+            {
+                SmartHealthCardQr = "SHC QR Image",
+                Status = VaccinationStatus.Fully,
+            };
+
+            string hdid = "mock hdid";
+
+            var mockVaccineProofDelegate = new Mock<IVaccineProofDelegate>();
+
+            RequestResult<VaccineProofResponse> generateResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+            mockVaccineProofDelegate.Setup(s => s.GenerateAsync(It.IsAny<VaccineProofTemplate>(), request)).Returns(Task.FromResult(generateResult));
+
+            IVaccineProofService service = new VaccineProofService(
+                GetConfiguration(myConfiguration),
+                new Mock<ILogger<VaccineProofService>>().Object,
+                mockVaccineProofDelegate.Object,
+                new Mock<IVaccineProofRequestCacheDelegate>().Object);
+
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, request, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            Assert.True(actualResult.ResultStatus == Common.Constants.ResultType.Error);
+        }
+
+        /// <summary>
+        /// The status request on the Vaccine Proof delegate failed.
+        /// </summary>
+        [Fact]
+        public void GetProofStatusFailed()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+                { "BCMailPlus:Endpoint", "https://${HOST}/${ENV}/auth=${TOKEN}/JSON/" },
+                { "BCMailPlus:Host", "Host" },
+                { "BCMailPlus:JobEnvironment", "JobEnvironment" },
+                { "BCMailPlus:JobClass", "JobClass" },
+                { "BCMailPlus:SchemaVersion", "SchemaVersion" },
+                { "BCMailPlus:BackOffMilliseconds", "10" },
+                { "BCMailPlus:MaxRetries", "2" },
+                { "BCMailPlus:CacheTtl", "0" },
+            };
+
+            VaccineProofRequest request = new()
+            {
+                SmartHealthCardQr = "SHC QR Image",
+                Status = VaccinationStatus.Fully,
+            };
+
+            string hdid = "mock hdid";
+
+            var mockVaccineProofDelegate = new Mock<IVaccineProofDelegate>();
+
+            string id = "id";
+            Uri assetUri = new(this.assetPdfUri);
+            RequestResult<VaccineProofResponse> generateResult = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Id = id,
+                    Status = VaccineProofRequestStatus.Started,
+                    AssetUri = assetUri,
+                },
+            };
+            mockVaccineProofDelegate.Setup(s => s.GenerateAsync(It.IsAny<VaccineProofTemplate>(), request)).Returns(Task.FromResult(generateResult));
+
+            RequestResult<VaccineProofResponse> statusResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+            mockVaccineProofDelegate.Setup(s => s.GetStatusAsync(id)).Returns(Task.FromResult(statusResult));
+
+            RequestResult<ReportModel> assetResult = new()
+            {
+                ResultStatus = ResultType.Error,              
+            };
+            mockVaccineProofDelegate.Setup(s => s.GetAssetAsync(assetUri)).Returns(Task.FromResult(assetResult));
+
+            IVaccineProofService service = new VaccineProofService(
+                GetConfiguration(myConfiguration),
+                new Mock<ILogger<VaccineProofService>>().Object,
+                mockVaccineProofDelegate.Object,
+                new Mock<IVaccineProofRequestCacheDelegate>().Object);
+
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, request, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            Assert.True(actualResult.ResultStatus == ResultType.Error);
+        }
+
+        /// <summary>
+        /// The get asset request on the Vaccine Proof delegate failed.
+        /// </summary>
+        [Fact]
+        public void GetProofAssetFailed()
+        {
+            var myConfiguration = new Dictionary<string, string>
+            {
+                { "BCMailPlus:Endpoint", "https://${HOST}/${ENV}/auth=${TOKEN}/JSON/" },
+                { "BCMailPlus:Host", "Host" },
+                { "BCMailPlus:JobEnvironment", "JobEnvironment" },
+                { "BCMailPlus:JobClass", "JobClass" },
+                { "BCMailPlus:SchemaVersion", "SchemaVersion" },
+                { "BCMailPlus:BackOffMilliseconds", "10" },
+                { "BCMailPlus:MaxRetries", "2" },
+                { "BCMailPlus:CacheTtl", "0" },
+            };
+
+            VaccineProofRequest request = new()
+            {
+                SmartHealthCardQr = "SHC QR Image",
+                Status = VaccinationStatus.Fully,
+            };
+
+            string hdid = "mock hdid";
+
+            var mockVaccineProofDelegate = new Mock<IVaccineProofDelegate>();
+
+            string id = "id";
+            Uri assetUri = new(this.assetPdfUri);
+            RequestResult<VaccineProofResponse> generateResult = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Id = id,
+                    Status = VaccineProofRequestStatus.Started,
+                    AssetUri = assetUri,
+                },
+            };
+            mockVaccineProofDelegate.Setup(s => s.GenerateAsync(It.IsAny<VaccineProofTemplate>(), request)).Returns(Task.FromResult(generateResult));
+
+            RequestResult<VaccineProofResponse> statusResult = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = new()
+                {
+                    Id = id,
+                    Status = VaccineProofRequestStatus.Completed,
+                },
+            };
+            mockVaccineProofDelegate.Setup(s => s.GetStatusAsync(id)).Returns(Task.FromResult(statusResult));
+
+            RequestResult<ReportModel> assetResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+            mockVaccineProofDelegate.Setup(s => s.GetAssetAsync(assetUri)).Returns(Task.FromResult(assetResult));
+
+            IVaccineProofService service = new VaccineProofService(
+                GetConfiguration(myConfiguration),
+                new Mock<ILogger<VaccineProofService>>().Object,
+                mockVaccineProofDelegate.Object,
+                new Mock<IVaccineProofRequestCacheDelegate>().Object);
+
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, request, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            Assert.True(actualResult.ResultStatus == ResultType.Error);
+        }
+
+        private static IConfiguration GetConfiguration(Dictionary<string, string>? keyValuePairs = null)
+        {
+            keyValuePairs ??= new();
+            IConfiguration configuration = new ConfigurationBuilder()
+                        .AddInMemoryCollection(keyValuePairs)
+                        .Build();
+            return configuration;
+        }
+    }
+}


### PR DESCRIPTION
# Verify and Update unit test for new GetAsset Call [AB#11594](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11594)

-   [ ] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

A sentences or two describing the overall goals of the pull request's commits.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
