### PR TITLE
Clean up logic in VaccineStatusService AB#11607

### DIFF
--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -106,6 +106,7 @@ namespace HealthGateway.Immunization.Services
         {
             bool includeVaccineProof = true;
             RequestResult<VaccineStatus> vaccineStatusResult = await this.GetPublicVaccineStatusWithOptionalProof(phn, dateOfBirth, dateOfVaccine, includeVaccineProof).ConfigureAwait(true);
+            VaccineStatus payload = vaccineStatusResult.ResourcePayload!;
 
             RequestResult<VaccineProofDocument> retVal = new()
             {
@@ -113,24 +114,26 @@ namespace HealthGateway.Immunization.Services
                 ResultError = vaccineStatusResult.ResultError,
                 TotalResultCount = vaccineStatusResult.TotalResultCount,
                 PageIndex = vaccineStatusResult.PageIndex,
+                ResourcePayload = new()
+                {
+                    Loaded = payload.Loaded,
+                    RetryIn = payload.RetryIn,
+                    Document = payload.FederalVaccineProof ?? new(),
+                    QRCode = payload.QRCode,
+                },
             };
 
-            if (vaccineStatusResult.ResourcePayload != null)
+            if (vaccineStatusResult.ResultStatus == ResultType.Success)
             {
-                retVal.ResourcePayload = new()
+                if (payload.State == VaccineState.NotFound)
                 {
-                    Loaded = vaccineStatusResult.ResourcePayload.Loaded,
-                    RetryIn = vaccineStatusResult.ResourcePayload.RetryIn,
-                    Document = vaccineStatusResult.ResourcePayload.FederalVaccineProof ?? new(),
-                    QRCode = vaccineStatusResult.ResourcePayload.QRCode,
-                };
-            }
-            else
-            {
-                retVal.ResultStatus = ResultType.Error;
-                if (retVal.ResultError == null)
+                    retVal.ResultStatus = ResultType.ActionRequired;
+                    retVal.ResultError = ErrorTranslator.ActionRequired("Vaccine Proof document is not available.", ActionType.Invalid);
+                }
+                else if (payload.Loaded && payload.FederalVaccineProof?.Data == null)
                 {
-                    retVal.ResultError = new RequestResultError() { ResultMessage = "Vaccine Proof document is not available.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+                    retVal.ResultStatus = ResultType.Error;
+                    retVal.ResultError = new RequestResultError() { ResultMessage = "Vaccine Proof document is not available.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.PHSA) };
                 }
             }
 
@@ -142,6 +145,7 @@ namespace HealthGateway.Immunization.Services
         {
             bool includeVaccineProof = true;
             RequestResult<VaccineStatus> vaccineStatusResult = await this.GetAuthenticatedVaccineStatusWithOptionalProof(hdid, includeVaccineProof).ConfigureAwait(true);
+            VaccineStatus payload = vaccineStatusResult.ResourcePayload!;
 
             RequestResult<VaccineProofDocument> retVal = new()
             {
@@ -149,32 +153,26 @@ namespace HealthGateway.Immunization.Services
                 ResultError = vaccineStatusResult.ResultError,
                 TotalResultCount = vaccineStatusResult.TotalResultCount,
                 PageIndex = vaccineStatusResult.PageIndex,
+                ResourcePayload = new()
+                {
+                    Loaded = payload.Loaded,
+                    RetryIn = payload.RetryIn,
+                    Document = payload.FederalVaccineProof ?? new(),
+                    QRCode = payload.QRCode,
+                },
             };
 
-            if (vaccineStatusResult.ResourcePayload != null)
+            if (vaccineStatusResult.ResultStatus == ResultType.Success)
             {
-                if (vaccineStatusResult.ResourcePayload.State == VaccineState.NotFound)
+                if (payload.State == VaccineState.NotFound)
                 {
                     retVal.ResultStatus = ResultType.ActionRequired;
-                    retVal.ResultError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.Invalid);
+                    retVal.ResultError = ErrorTranslator.ActionRequired("Vaccine Proof document is not available.", ActionType.Invalid);
                 }
-                else
+                else if (payload.Loaded && payload.FederalVaccineProof?.Data == null)
                 {
-                    retVal.ResourcePayload = new()
-                    {
-                        Loaded = vaccineStatusResult.ResourcePayload.Loaded,
-                        RetryIn = vaccineStatusResult.ResourcePayload.RetryIn,
-                        Document = vaccineStatusResult.ResourcePayload.FederalVaccineProof ?? new(),
-                        QRCode = vaccineStatusResult.ResourcePayload.QRCode,
-                    };
-                }
-            }
-            else
-            {
-                retVal.ResultStatus = ResultType.Error;
-                if (retVal.ResultError == null)
-                {
-                    retVal.ResultError = new RequestResultError() { ResultMessage = "Vaccine Proof document is not available.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA) };
+                    retVal.ResultStatus = ResultType.Error;
+                    retVal.ResultError = new RequestResultError() { ResultMessage = "Vaccine Proof document is not available.", ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.PHSA) };
                 }
             }
 
@@ -289,24 +287,20 @@ namespace HealthGateway.Immunization.Services
             RequestResult<VaccineStatus> retVal = new()
             {
                 ResultStatus = ResultType.Error,
+                ResourcePayload = new() { State = VaccineState.NotFound },
             };
 
             bool isPublicEndpoint = string.IsNullOrEmpty(query.HdId);
             RequestResult<PHSAResult<VaccineStatusResult>> result = await this.vaccineStatusDelegate.GetVaccineStatus(query, accessToken, isPublicEndpoint).ConfigureAwait(true);
             VaccineStatusResult? payload = result.ResourcePayload?.Result;
+            PHSALoadState? loadState = result.ResourcePayload?.LoadState;
 
             retVal.ResultStatus = result.ResultStatus;
             retVal.ResultError = result.ResultError;
 
-            if (payload == null)
-            {
-                retVal.ResourcePayload = new();
-                retVal.ResourcePayload.State = VaccineState.NotFound;
-            }
-            else
+            if (payload != null)
             {
                 retVal.ResourcePayload = VaccineStatus.FromModel(payload, phn);
-                retVal.ResourcePayload.Loaded = true;
                 retVal.ResourcePayload.State = retVal.ResourcePayload.State switch
                 {
                     var state when state == VaccineState.Threshold || state == VaccineState.Blocked => VaccineState.NotFound,
@@ -320,12 +314,15 @@ namespace HealthGateway.Immunization.Services
                 }
             }
 
-            if (result.ResourcePayload != null && result.ResourcePayload.LoadState.RefreshInProgress)
+            if (loadState != null)
             {
-                retVal.ResultStatus = ResultType.ActionRequired;
-                retVal.ResultError = ErrorTranslator.ActionRequired("Vaccine status refresh in progress", ActionType.Refresh);
-                retVal.ResourcePayload.Loaded = !result.ResourcePayload.LoadState.RefreshInProgress;
-                retVal.ResourcePayload.RetryIn = Math.Max(result.ResourcePayload.LoadState.BackOffMilliseconds, this.phsaConfig.BackOffMilliseconds);
+                retVal.ResourcePayload.Loaded = !loadState.RefreshInProgress;
+                if (loadState.RefreshInProgress)
+                {
+                    retVal.ResultStatus = ResultType.ActionRequired;
+                    retVal.ResultError = ErrorTranslator.ActionRequired("Vaccine status refresh in progress", ActionType.Refresh);
+                    retVal.ResourcePayload.RetryIn = Math.Max(loadState.BackOffMilliseconds, this.phsaConfig.BackOffMilliseconds);
+                }
             }
 
             return retVal;


### PR DESCRIPTION
# Implements [AB#11607](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11607)

-   [ ] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Cleans up the vaccine proof download logic relating to successes, retries, not found results, and empty payloads.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
