### PR TITLE
Fix Unit Tests for VaccineStatusService AB#11648

### DIFF
--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -184,10 +184,10 @@ namespace HealthGateway.Immunization.Test.Services
         }
 
         /// <summary>
-        /// GetVaccineStatus - when the status when there is data mismatch.
+        /// GetPublicVaccineStatus - get the error result when the status indicator is "DataMismatch".
         /// </summary>
         [Fact]
-        public void ShouldGetErrorDismatchVaccineStatus()
+        public void ShouldGetErrorDataMismatchVaccineStatus()
         {
             RequestResult<PHSAResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -246,14 +246,14 @@ namespace HealthGateway.Immunization.Test.Services
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             var actualResult = Task.Run(async () => await service.GetPublicVaccineStatus(this.phn, dobString, dovString).ConfigureAwait(true)).Result;
             Assert.Equal(Common.Constants.ResultType.ActionRequired, actualResult.ResultStatus);
-            Assert.Equal(expectedResult.ResultError.ActionCode, actual: actualResult.ResultError?.ActionCode);
+            Assert.Equal(expectedResult.ResultError.ActionCode, actualResult.ResultError?.ActionCode);
         }
 
         /// <summary>
         /// GetPublicVaccineProof - Happy path.
         /// </summary>
         [Fact]
-        public void ShouldPublicGetVaccineProof()
+        public void ShouldGetPublicVaccineProof()
         {
             RequestResult<PHSAResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -319,7 +319,7 @@ namespace HealthGateway.Immunization.Test.Services
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             var actualResult = Task.Run(async () => await service.GetPublicVaccineProof(this.phn, dobString, dovString).ConfigureAwait(true)).Result;
-            Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actual: actualResult.ResourcePayload?.Document.Data);
+            Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResult.ResourcePayload?.Document.Data);
             Assert.NotNull(actualResult.ResourcePayload?.Document.Data);
             Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
         }
@@ -393,7 +393,7 @@ namespace HealthGateway.Immunization.Test.Services
                 this.GetHttpContextAccessor().Object);
 
             var actualResult = Task.Run(async () => await service.GetAuthenticatedVaccineProof(this.hdid).ConfigureAwait(true)).Result;
-            Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actual: actualResult.ResourcePayload?.Document.Data);
+            Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResult.ResourcePayload?.Document.Data);
             Assert.NotNull(actualResult.ResourcePayload?.Document.Data);
             Assert.Equal(Common.Constants.ResultType.Success, actualResult.ResultStatus);
         }

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -42,7 +42,6 @@ namespace HealthGateway.Immunization.Test.Services
     /// <summary>
     /// VaccineStatusService's Unit Tests.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out", Justification = "Ignore broken tests")]
     public class VaccineStatusServiceTests
     {
         private readonly string phn = "9735353315";

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -125,6 +125,8 @@ namespace HealthGateway.Immunization.Test.Services
         /// <param name="statusIndicator"> status indicator from delegate.</param>
         /// <param name="state">final state.</param>
         [Theory]
+        [InlineData("Exempt", VaccineState.Exempt)]
+        [InlineData("PartialDosesReceived", VaccineState.PartialDosesReceived)]
         [InlineData("AllDosesReceived", VaccineState.AllDosesReceived)]
         public void ShouldGetAuthenticatedVaccineStatus(string statusIndicator, VaccineState state)
         {
@@ -155,7 +157,7 @@ namespace HealthGateway.Immunization.Test.Services
                 ResourcePayload = new VaccineStatus()
                 {
                     Loaded = true,
-                    RetryIn = 0,                   
+                    RetryIn = 0,
                     FirstName = "Bob",
                     LastName = "Test",
                     Birthdate = this.dob,


### PR DESCRIPTION
# Fix Unit Tests for VaccineStatusService [AB#11648](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11648)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Fix Unit Test for Vaccine Status Service based on the new implemented way to get the PDF for both public and authenticated.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
