### PR TITLE
Fix the Cypress Test failing on recent change on publicSave.js AB#11699

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/vaccineCard/publicSave.js
+++ b/Testing/functional/tests/cypress/integration/e2e/vaccineCard/publicSave.js
@@ -24,7 +24,7 @@ function enterVaccineCardPHN(phn) {
 
 function interceptVaccineStatus() {
     cy.intercept("GET", "**/v1/api/PublicVaccineStatus/pdf", {
-        fixture: "ImmunizationService/vaccineProof.json",
+        fixture: "ImmunizationService/vaccineProofLoaded.json",
     });
 }
 


### PR DESCRIPTION
# Fix the Cypress Test failing on recent change on publicSave.js AB#11699

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

Fix the Cypress Test failing on recent change on publicSave.js

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

Run the functional test for publicsave.js

### UI Changes

**NO**

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
