### PR TITLE
Fix 'Admin not showing logged in users on dashboard' for AB#11351

### DIFF
--- a/Apps/AdminWebClient/src/appsettings.json
+++ b/Apps/AdminWebClient/src/appsettings.json
@@ -4,6 +4,9 @@
             "Default": "Information",
             "System": "Warning",
             "Microsoft": "Warning"
+        },
+        "SensitiveDataLogging": {
+            "Enabled": false
         }
     },
     "OpenIdConnect": {

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -438,7 +438,8 @@ namespace HealthGateway.Common.AspNetConfiguration
             bool isSensitiveDataLoggingEnabled = section.GetValue<bool>("Enabled", false);
             this.Logger.LogDebug($"Sensitive Data Logging is enabled: {isSensitiveDataLoggingEnabled}");
 
-            services.AddDbContextPool<GatewayDbContext>(options => {
+            services.AddDbContextPool<GatewayDbContext>(options =>
+            {
                 options.UseNpgsql(this.configuration.GetConnectionString("GatewayConnection"));
                 if (isSensitiveDataLoggingEnabled)
                 {

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -434,8 +434,26 @@ namespace HealthGateway.Common.AspNetConfiguration
         public void ConfigureDatabaseServices(IServiceCollection services)
         {
             this.Logger.LogDebug("ConfigureDatabaseServices...");
-            services.AddDbContextPool<GatewayDbContext>(options => options.UseNpgsql(
-                    this.configuration.GetConnectionString("GatewayConnection")));
+            IConfigurationSection section = this.configuration.GetSection("Logging:SensitiveDataLogging");
+            bool isSensitiveDataLoggingEnabled = section.GetValue<bool>("Enabled", false);
+            this.Logger.LogDebug($"Sensitive Data Logging is enabled: {isSensitiveDataLoggingEnabled}");
+
+            services.AddDbContextPool<GatewayDbContext>(options => {
+                options.UseNpgsql(this.configuration.GetConnectionString("GatewayConnection"));
+                if (isSensitiveDataLoggingEnabled)
+                {
+                    options.EnableSensitiveDataLogging();
+                }
+            });
+
+            if (isSensitiveDataLoggingEnabled)
+            {
+                services.AddLogging(loggingBuilder =>
+                {
+                    loggingBuilder.AddConsole()
+                        .AddFilter(DbLoggerCategory.Database.Command.Name, LogLevel.Information);
+                });
+            }
         }
 
         /// <summary>

--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -170,7 +170,7 @@ namespace HealthGateway.Database.Delegates
         {
             Dictionary<DateTime, int> dateCount = this.dbContext.UserProfile
                 .Select(x => new { x.HdId, x.LastLoginDateTime })
-                .Union(
+                .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime }))
                 .Select(x => new { x.HdId, lastLoginDate = x.LastLoginDateTime.AddMinutes(offset.TotalMinutes).Date })
                 .Distinct()
@@ -199,7 +199,7 @@ namespace HealthGateway.Database.Delegates
 
             int recurrentCount = this.dbContext.UserProfile
                 .Select(x => new { x.HdId, x.LastLoginDateTime })
-                .Union(
+                .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime }))
                 .Select(x => new { x.HdId, lastLoginDate = x.LastLoginDateTime.AddMinutes(offset.TotalMinutes).Date })
                 .Where(x => x.lastLoginDate >= startDate && x.lastLoginDate <= endDate)


### PR DESCRIPTION
# Fixes or Implements [AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)

-   [ ] Enhancement
-   [x] Bug
-   [ ] Documentation

## Description

1. Changed Union to Union All for GetLoggedinUsersCount.  Improved by roughly 22 seconds.
2. Changed Union to Union All for GetRecurringUsersCount. Improved by roughly 2.5 seconds.
3. Added 'Sensitive Data Logging' option in appsettings.json. By default sensitive logging is disabled via ConfigureDatabaseServices in StartupConfiguration.cs.

**Execution Plan for GetLoggedinUserCount:**

Before:

<img width="1744" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetLoggedInUserCount-1" src="https://user-images.githubusercontent.com/58790456/141017188-590196af-faf4-4ace-b348-9bafa427ecbd.png">

<img width="1747" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetLoggedInUserCount-2" src="https://user-images.githubusercontent.com/58790456/141017206-8eb0a73b-0021-4c0a-8bf8-6db1688e0a88.png">

After:

<img width="879" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetLoggedInUserCount-3" src="https://user-images.githubusercontent.com/58790456/141017347-57b70d54-9e2d-484f-90ac-4e7c28eb9dd0.png">

<img width="875" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetLoggedInUserCount-4" src="https://user-images.githubusercontent.com/58790456/141017372-2afaf443-a814-475d-8cfa-c8b31f3db910.png">

**Execution Plan for GetRecurringUsersCount:**

Before:

<img width="1737" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetRecurringUsersCount-1" src="https://user-images.githubusercontent.com/58790456/141017487-7901dfda-0c72-4422-8293-8afa4910662d.png">

<img width="876" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetRecurringUsersCount-2" src="https://user-images.githubusercontent.com/58790456/141017494-99621549-16e7-4e64-bfaa-b7674f244acc.png">

After:

<img width="873" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetRecurringUsersCount-3" src="https://user-images.githubusercontent.com/58790456/141017517-84254bab-76d2-41f8-9167-73e4223ba4d8.png">

<img width="876" alt="[AB#11351](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11351)-GetRecurringUsersCount-4" src="https://user-images.githubusercontent.com/58790456/141017525-99b3b8aa-5dc4-4ad0-92d9-991b5f4123ac.png">

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
