### PR TITLE
Refactor User Profile unit tests  AB#10077

### DIFF
--- a/Apps/WebClient/test/unit/Services.Test/Constants/TestConstants.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Constants/TestConstants.cs
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Constants
+{
+    /// <summary>
+    /// Class that have all constants.
+    /// </summary>
+   public static class TestConstants
+    {
+        /// <summary>
+        /// Constants to use when action is update.
+        /// </summary>
+        public const string UpdateAction = "Update";
+
+        /// <summary>
+        /// Constants to use when action is create.
+        /// </summary>
+        public const string CreateAction = "Create";
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/ConfigServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/ConfigServiceMock.cs
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using HealthGateway.WebClient.Models;
+    using HealthGateway.WebClient.Services;
+    using Moq;
+
+    /// <summary>
+    /// ConfigServiceMock.
+    /// </summary>
+    public class ConfigServiceMock : Mock<IConfigurationService>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigServiceMock"/> class.
+        /// </summary>
+        /// <param name="minPatientAge">minPatientAge.</param>
+        public ConfigServiceMock(int minPatientAge)
+        {
+            this.Setup(s => s.GetConfiguration()).Returns(new ExternalConfiguration() { WebClient = new WebClientConfiguration() { MinPatientAge = minPatientAge } });
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/ConfigServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/ConfigServiceMock.cs
@@ -27,7 +27,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="ConfigServiceMock"/> class.
         /// </summary>
-        /// <param name="minPatientAge">minPatientAge.</param>
+        /// <param name="minPatientAge">minimum patient age.</param>
         public ConfigServiceMock(int minPatientAge)
         {
             this.Setup(s => s.GetConfiguration()).Returns(new ExternalConfiguration() { WebClient = new WebClientConfiguration() { MinPatientAge = minPatientAge } });

--- a/Apps/WebClient/test/unit/Services.Test/Mock/CryptoDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/CryptoDelegateMock.cs
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using HealthGateway.Common.Delegates;
+    using Moq;
+
+    /// <summary>
+    /// CryptoDelegateMock.
+    /// </summary>
+    public class CryptoDelegateMock : Mock<ICryptoDelegate>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CryptoDelegateMock"/> class.
+        /// </summary>
+        /// <param name="message">message.</param>
+        public CryptoDelegateMock(string message)
+        {
+            this.Setup(s => s.GenerateKey()).Returns(message);
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/CryptoDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/CryptoDelegateMock.cs
@@ -26,7 +26,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="CryptoDelegateMock"/> class.
         /// </summary>
-        /// <param name="message">message.</param>
+        /// <param name="message">message sent to delegate.</param>
         public CryptoDelegateMock(string message)
         {
             this.Setup(s => s.GenerateKey()).Returns(message);

--- a/Apps/WebClient/test/unit/Services.Test/Mock/EmailQueueServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/EmailQueueServiceMock.cs
@@ -27,7 +27,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="EmailQueueServiceMock"/> class.
         /// </summary>
-        /// <param name="shouldCommit">shouldCommit.</param>
+        /// <param name="shouldCommit">check if allowing to commit.</param>
         public EmailQueueServiceMock(bool shouldCommit)
         {
             this.Setup(s => s.QueueNewEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), shouldCommit));

--- a/Apps/WebClient/test/unit/Services.Test/Mock/EmailQueueServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/EmailQueueServiceMock.cs
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using System.Collections.Generic;
+    using HealthGateway.Common.Services;
+    using Moq;
+
+    /// <summary>
+    /// EmailQueueServiceMock.
+    /// </summary>
+    public class EmailQueueServiceMock : Mock<IEmailQueueService>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="EmailQueueServiceMock"/> class.
+        /// </summary>
+        /// <param name="shouldCommit">shouldCommit.</param>
+        public EmailQueueServiceMock(bool shouldCommit)
+        {
+            this.Setup(s => s.QueueNewEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), shouldCommit));
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/HttpContextAccessorMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/HttpContextAccessorMock.cs
@@ -26,7 +26,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="HttpContextAccessorMock"/> class.
         /// </summary>
-        /// <param name="headerDictionary">headerDictionary.</param>
+        /// <param name="headerDictionary">header dictionary.</param>
         public HttpContextAccessorMock(IHeaderDictionary headerDictionary)
         {
             Mock<HttpRequest> httpRequestMock = new();

--- a/Apps/WebClient/test/unit/Services.Test/Mock/HttpContextAccessorMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/HttpContextAccessorMock.cs
@@ -1,0 +1,40 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using Microsoft.AspNetCore.Http;
+    using Moq;
+
+    /// <summary>
+    /// HttpContextAccessorMock.
+    /// </summary>
+    public class HttpContextAccessorMock : Mock<IHttpContextAccessor>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HttpContextAccessorMock"/> class.
+        /// </summary>
+        /// <param name="headerDictionary">headerDictionary.</param>
+        public HttpContextAccessorMock(IHeaderDictionary headerDictionary)
+        {
+            Mock<HttpRequest> httpRequestMock = new();
+            httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
+
+            Mock<HttpContext> httpContextMock = new();
+            httpContextMock.Setup(s => s.Request).Returns(httpRequestMock.Object);
+            this.Setup(s => s.HttpContext).Returns(httpContextMock.Object);
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/LegalAgreementDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/LegalAgreementDelegateMock.cs
@@ -30,7 +30,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="LegalAgreementDelegateMock"/> class.
         /// </summary>
-        /// <param name="termsOfService">termsOfService.</param>
+        /// <param name="termsOfService">terms of service.</param>
         public LegalAgreementDelegateMock(LegalAgreement termsOfService)
         {
             this.Setup(s => s.GetActiveByAgreementType(LegalAgreementType.TermsofService))

--- a/Apps/WebClient/test/unit/Services.Test/Mock/LegalAgreementDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/LegalAgreementDelegateMock.cs
@@ -1,0 +1,40 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using System;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using Moq;
+
+    /// <summary>
+    /// LegalAgreementDelegateMock.
+    /// </summary>
+    public class LegalAgreementDelegateMock : Mock<ILegalAgreementDelegate>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LegalAgreementDelegateMock"/> class.
+        /// </summary>
+        /// <param name="termsOfService">termsOfService.</param>
+        public LegalAgreementDelegateMock(LegalAgreement termsOfService)
+        {
+            this.Setup(s => s.GetActiveByAgreementType(LegalAgreementType.TermsofService))
+                .Returns(new DBResult<LegalAgreement>() { Payload = termsOfService });
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/MessagingVerificationDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/MessagingVerificationDelegateMock.cs
@@ -36,7 +36,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="MessagingVerificationDelegateMock"/> class.
         /// </summary>
-        /// <param name="messagingVerification">messagingVerification.</param>
+        /// <param name="messagingVerification">messaging verification.</param>
         public MessagingVerificationDelegateMock(MessagingVerification messagingVerification)
         {
             this.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(messagingVerification);

--- a/Apps/WebClient/test/unit/Services.Test/Mock/MessagingVerificationDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/MessagingVerificationDelegateMock.cs
@@ -1,0 +1,45 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using System;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using Moq;
+
+    /// <summary>
+    /// MessagingVerificationDelegateMock.
+    /// </summary>
+    public class MessagingVerificationDelegateMock : Mock<IMessagingVerificationDelegate>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagingVerificationDelegateMock"/> class.
+        /// </summary>
+        public MessagingVerificationDelegateMock()
+        {
+           this.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(new MessagingVerification());
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MessagingVerificationDelegateMock"/> class.
+        /// </summary>
+        /// <param name="messagingVerification">messagingVerification.</param>
+        public MessagingVerificationDelegateMock(MessagingVerification messagingVerification)
+        {
+            this.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(messagingVerification);
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/NotificationSettingsServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/NotificationSettingsServiceMock.cs
@@ -1,0 +1,35 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using Moq;
+
+    /// <summary>
+    /// NotificationSettingsServiceMock.
+    /// </summary>
+    public class NotificationSettingsServiceMock : Mock<INotificationSettingsService>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationSettingsServiceMock"/> class.
+        /// </summary>
+        public NotificationSettingsServiceMock()
+        {
+            this.Setup(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()));
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/PatientServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/PatientServiceMock.cs
@@ -29,7 +29,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="PatientServiceMock"/> class.
         /// </summary>
         /// <param name="hdid">hdid.</param>
-        /// <param name="patientModel">patientModel.</param>
+        /// <param name="patientModel">patient model.</param>
         public PatientServiceMock(string hdid, PatientModel patientModel)
         {
             this.Setup(s => s.GetPatient(hdid, PatientIdentifierType.HDID, false))

--- a/Apps/WebClient/test/unit/Services.Test/Mock/PatientServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/PatientServiceMock.cs
@@ -1,0 +1,43 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using Moq;
+
+    /// <summary>
+    /// PatientServiceMock.
+    /// </summary>
+    public class PatientServiceMock : Mock<IPatientService>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatientServiceMock"/> class.
+        /// </summary>
+        /// <param name="hdid">hdid.</param>
+        /// <param name="patientModel">patientModel.</param>
+        public PatientServiceMock(string hdid, PatientModel patientModel)
+        {
+            this.Setup(s => s.GetPatient(hdid, PatientIdentifierType.HDID, false))
+                .ReturnsAsync(new RequestResult<PatientModel>
+                {
+                    ResultStatus = ResultType.Success,
+                    ResourcePayload = patientModel,
+                });
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
@@ -41,7 +41,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="UserPreferenceDelegateMock"/> class.
         /// </summary>
-        /// <param name="readResult">readResult.</param>
+        /// <param name="readResult">read result.</param>
         /// <param name="action">action.</param>
         public UserPreferenceDelegateMock(DBResult<UserPreference> readResult, string action)
         {

--- a/Apps/WebClient/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
+    using HealthGateway.WebClientTests.Services.Test.Constants;
     using Moq;
 
     /// <summary>
@@ -45,12 +46,12 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <param name="action">action.</param>
         public UserPreferenceDelegateMock(DBResult<UserPreference> readResult, string action)
         {
-            if (action == "update")
+            if (action == TestConstants.UpdateAction)
             {
                 this.Setup(s => s.UpdateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
             }
 
-            if (action == "create")
+            if (action == TestConstants.CreateAction)
             {
                 this.Setup(s => s.CreateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
             }

--- a/Apps/WebClient/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
@@ -1,0 +1,59 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using System;
+    using System.Collections.Generic;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using Moq;
+
+    /// <summary>
+    /// UserPreferenceDelegateMock.
+    /// </summary>
+    public class UserPreferenceDelegateMock : Mock<IUserPreferenceDelegate>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserPreferenceDelegateMock"/> class.
+        /// </summary>
+        /// <param name="readResult">readResult.</param>
+        /// <param name="hdid">hdid.</param>
+        public UserPreferenceDelegateMock(DBResult<IEnumerable<UserPreference>> readResult, string hdid)
+        {
+            this.Setup(s => s.GetUserPreferences(hdid)).Returns(readResult);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserPreferenceDelegateMock"/> class.
+        /// </summary>
+        /// <param name="readResult">readResult.</param>
+        /// <param name="action">action.</param>
+        public UserPreferenceDelegateMock(DBResult<UserPreference> readResult, string action)
+        {
+            if (action == "update")
+            {
+                this.Setup(s => s.UpdateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
+            }
+
+            if (action == "create")
+            {
+                this.Setup(s => s.CreateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
+            }
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
@@ -1,0 +1,65 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.WebClientTests.Services.Test.Mock
+{
+    using System;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using Moq;
+
+    /// <summary>
+    /// UserProfileDelegateMock.
+    /// </summary>
+    public class UserProfileDelegateMock : Mock<IUserProfileDelegate>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProfileDelegateMock"/> class.
+        /// </summary>
+        /// <param name="userProfile">userProfile.</param>
+        /// <param name="userProfileData">userProfileData.</param>
+        /// <param name="hdid">hdid.</param>
+        public UserProfileDelegateMock(UserProfile userProfile, DBResult<UserProfile> userProfileData, string hdid)
+        {
+            this.Setup(s => s.GetUserProfile(hdid)).Returns(userProfileData);
+            this.Setup(s => s.Update(userProfile, true)).Returns(userProfileData);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProfileDelegateMock"/> class.
+        /// </summary>
+        /// <param name="userProfile">userProfile.</param>
+        /// <param name="insertResult">insertResult.</param>
+        public UserProfileDelegateMock(UserProfile userProfile, DBResult<UserProfile> insertResult)
+        {
+            this.Setup(s => s.InsertUserProfile(It.Is<UserProfile>(x => x.HdId == userProfile.HdId))).Returns(insertResult);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProfileDelegateMock"/> class.
+        /// </summary>
+        /// <param name="hdid">hdid.</param>
+        /// <param name="userProfile">userProfile.</param>
+        /// <param name="userProfileDBResult">userProfileDBResult.</param>
+        /// <param name="commit">commit.</param>
+        public UserProfileDelegateMock(string hdid, UserProfile userProfile, DBResult<UserProfile> userProfileDBResult, bool commit = true)
+        {
+            this.Setup(s => s.GetUserProfile(hdid)).Returns(userProfileDBResult);
+            this.Setup(s => s.Update(userProfile, commit)).Returns(userProfileDBResult);
+        }
+    }
+}

--- a/Apps/WebClient/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
@@ -30,8 +30,8 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileDelegateMock"/> class.
         /// </summary>
-        /// <param name="userProfile">userProfile.</param>
-        /// <param name="userProfileData">userProfileData.</param>
+        /// <param name="userProfile">user profile.</param>
+        /// <param name="userProfileData">user profile data.</param>
         /// <param name="hdid">hdid.</param>
         public UserProfileDelegateMock(UserProfile userProfile, DBResult<UserProfile> userProfileData, string hdid)
         {
@@ -42,8 +42,8 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileDelegateMock"/> class.
         /// </summary>
-        /// <param name="userProfile">userProfile.</param>
-        /// <param name="insertResult">insertResult.</param>
+        /// <param name="userProfile">user profile.</param>
+        /// <param name="insertResult">insert result.</param>
         public UserProfileDelegateMock(UserProfile userProfile, DBResult<UserProfile> insertResult)
         {
             this.Setup(s => s.InsertUserProfile(It.Is<UserProfile>(x => x.HdId == userProfile.HdId))).Returns(insertResult);
@@ -53,8 +53,8 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="UserProfileDelegateMock"/> class.
         /// </summary>
         /// <param name="hdid">hdid.</param>
-        /// <param name="userProfile">userProfile.</param>
-        /// <param name="userProfileDBResult">userProfileDBResult.</param>
+        /// <param name="userProfile">user profile.</param>
+        /// <param name="userProfileDBResult">user profile from DBResult.</param>
         /// <param name="commit">commit.</param>
         public UserProfileDelegateMock(string hdid, UserProfile userProfile, DBResult<UserProfile> userProfileDBResult, bool commit = true)
         {

--- a/Apps/WebClient/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/WebClient/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -42,11 +42,11 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
         /// </summary>
         /// <param name="hdId">hdId.</param>
-        /// <param name="dbResultStatus">dbResultStatus.</param>
-        /// <param name="userProfileData">userProfileData.</param>
-        /// <param name="userProfileDbResult">userProfileDbResult.</param>
-        /// <param name="readResult">readResult.</param>
-        /// <param name="termsOfService">termsOfService.</param>
+        /// <param name="dbResultStatus">db result status.</param>
+        /// <param name="userProfileData">user profile data.</param>
+        /// <param name="userProfileDbResult">user profile from DbResult.</param>
+        /// <param name="readResult">read result.</param>
+        /// <param name="termsOfService">terms of service.</param>
         public UserProfileServiceMock(string hdId, DBStatusCode dbResultStatus, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, DBResult<IEnumerable<UserPreference>> readResult, LegalAgreement termsOfService)
         {
             this.userProfileService = new UserProfileService(
@@ -69,9 +69,9 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
         /// </summary>
         /// <param name="message">message.</param>
-        /// <param name="userProfileData">userProfileData.</param>
-        /// <param name="userProfileDbResult">userProfileDbResult.</param>
-        /// <param name="registrationStatus">registrationStatus.</param>
+        /// <param name="userProfileData">user profile data.</param>
+        /// <param name="userProfileDbResult">user profile from DbResult.</param>
+        /// <param name="registrationStatus">registration status.</param>
         public UserProfileServiceMock(string message,  UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, string registrationStatus)
         {
             var externalConfiguration = new ExternalConfiguration()
@@ -103,8 +103,8 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
         /// </summary>
         /// <param name="hdid">hdid.</param>
-        /// <param name="patientModel">patientModel.</param>
-        /// <param name="minPatientAge">minPatientAge.</param>
+        /// <param name="patientModel">patient model.</param>
+        /// <param name="minPatientAge">minimum patient age.</param>
         public UserProfileServiceMock(string hdid, PatientModel patientModel, int minPatientAge)
         {
             this.userProfileService = new UserProfileService(
@@ -127,11 +127,11 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
         /// </summary>
         /// <param name="hdId">hdId.</param>
-        /// <param name="userProfileData">userProfileData.</param>
-        /// <param name="userProfileDbResult">userProfileDbResult.</param>
-        /// <param name="readResult">readResult.</param>
-        /// <param name="messagingVerification">messagingVerification.</param>
-        /// <param name="termsOfService">termsOfService.</param>
+        /// <param name="userProfileData">user profile data.</param>
+        /// <param name="userProfileDbResult">user profile from DbResult.</param>
+        /// <param name="readResult">read result.</param>
+        /// <param name="messagingVerification">messaging verification.</param>
+        /// <param name="termsOfService">terms of service.</param>
         /// <param name="commit">commit.</param>
         public UserProfileServiceMock(string hdId, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, DBResult<IEnumerable<UserPreference>> readResult, MessagingVerification messagingVerification, LegalAgreement termsOfService, bool commit = true)
         {
@@ -154,7 +154,7 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
         /// </summary>
-        /// <param name="readResult">readResult.</param>
+        /// <param name="readResult">read result.</param>
         /// <param name="action">action.</param>
         public UserProfileServiceMock(DBResult<UserPreference> readResult, string action)
         {
@@ -178,11 +178,11 @@ namespace HealthGateway.WebClientTests.Services.Test.Mock
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
         /// </summary>
         /// <param name="hdId">hdId.</param>
-        /// <param name="userProfileData">userProfileData.</param>
-        /// <param name="userProfileDbResult">userProfileDbResult.</param>
-        /// <param name="headerDictionary">headerDictionary.</param>
-        /// <param name="shouldEmailCommit">shouldEmailCommit.</param>
-        /// <param name="shouldProfileCommit">shouldProfileCommit.</param>
+        /// <param name="userProfileData">user profile data.</param>
+        /// <param name="userProfileDbResult">user profile from DbResult.</param>
+        /// <param name="headerDictionary">header dictionary.</param>
+        /// <param name="shouldEmailCommit">should email commit.</param>
+        /// <param name="shouldProfileCommit">should profile commit.</param>
         public UserProfileServiceMock(string hdId, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, IHeaderDictionary headerDictionary, bool shouldEmailCommit, bool shouldProfileCommit = true)
         {
             this.userProfileService = new UserProfileService(

--- a/Apps/WebClient/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -27,6 +27,7 @@ namespace HealthGateway.WebClient.Test.Services
     using HealthGateway.WebClient.Constants;
     using HealthGateway.WebClient.Models;
     using HealthGateway.WebClient.Services;
+    using HealthGateway.WebClientTests.Services.Test.Constants;
     using HealthGateway.WebClientTests.Services.Test.Mock;
     using Microsoft.AspNetCore.Http;
     using Moq;
@@ -38,7 +39,7 @@ namespace HealthGateway.WebClient.Test.Services
     public class UserProfileServiceTests
     {
         private readonly string hdid = "1234567890123456789012345678901234567890123456789012";
-        private readonly Mock<IConfigurationService> emptyConfigServiceMock = new Mock<IConfigurationService>();
+        private readonly Mock<IConfigurationService> emptyConfigServiceMock = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileServiceTests"/> class.
@@ -56,10 +57,10 @@ namespace HealthGateway.WebClient.Test.Services
         }
 
         /// <summary>
-        /// GetUserProfile call - Happy Path.
+        /// GetUserProfile call - test for status Read, Error and NotFound.
         /// </summary>
         /// <param name="dBStatus">Db Status code.</param>
-        [Theory(DisplayName = "ShouldGetUserProfile by status - {0}")]
+        [Theory]
         [InlineData(DBStatusCode.Read)]
         [InlineData(DBStatusCode.Error)]
         [InlineData(DBStatusCode.NotFound)]
@@ -132,12 +133,12 @@ namespace HealthGateway.WebClient.Test.Services
         }
 
         /// <summary>
-        ///  CreateUserProfile call.
+        /// CreateUserProfile call.
         /// </summary>
         /// <param name="dbStatus">Db status code.</param>
         /// <param name="registration">Registration status code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Theory(DisplayName = "ShouldInsertUserProfile when status is {0} registration status is {1}")]
+        [Theory]
         [InlineData(DBStatusCode.Created, RegistrationStatus.Open)]
         [InlineData(DBStatusCode.Error, RegistrationStatus.Closed)]
         public async Task ShouldInsertUserProfile(DBStatusCode dbStatus, string registration)
@@ -237,7 +238,7 @@ namespace HealthGateway.WebClient.Test.Services
         /// GetUserPreferences call.
         /// </summary>
         /// <param name="dBStatusCode">Db status code.</param>
-        [Theory(DisplayName = "ShouldGetUserPreference by status - {0}")]
+        [Theory]
         [InlineData(DBStatusCode.Read)]
         [InlineData(DBStatusCode.Error)]
         public void ShouldGetUserPreference(DBStatusCode dBStatusCode)
@@ -305,7 +306,7 @@ namespace HealthGateway.WebClient.Test.Services
         ///  CreateUserPreference call.
         /// </summary>
         /// <param name="dBStatusCode">dBStatusCode.</param>
-        [Theory(DisplayName = "ShouldCreateUserPreference by status - {0}")]
+        [Theory]
         [InlineData(DBStatusCode.Created)]
         [InlineData(DBStatusCode.Error)]
         public void ShouldCreateUserPreference(DBStatusCode dBStatusCode)
@@ -323,7 +324,7 @@ namespace HealthGateway.WebClient.Test.Services
                 Status = dBStatusCode,
             };
 
-            IUserProfileService service = new UserProfileServiceMock(readResult, "create").UserProfileServiceMockInstance();
+            IUserProfileService service = new UserProfileServiceMock(readResult, TestConstants.CreateAction).UserProfileServiceMockInstance();
 
             // Act
             var actualResult = service.CreateUserPreference(userPreferenceModel);
@@ -345,7 +346,7 @@ namespace HealthGateway.WebClient.Test.Services
         ///  UpdateUserPreference call.
         /// </summary>
         /// <param name="dBStatusCode">dBStatusCode.</param>
-        [Theory(DisplayName = "ShouldUpdateUserPreference by status - {0}")]
+        [Theory]
         [InlineData(DBStatusCode.Updated)]
         [InlineData(DBStatusCode.Error)]
         public void ShouldUpdateUserPreference(DBStatusCode dBStatusCode)
@@ -363,7 +364,7 @@ namespace HealthGateway.WebClient.Test.Services
                 Status = dBStatusCode,
             };
 
-            IUserProfileService service = new UserProfileServiceMock(readResult, "update").UserProfileServiceMockInstance();
+            IUserProfileService service = new UserProfileServiceMock(readResult, TestConstants.UpdateAction).UserProfileServiceMockInstance();
 
             // Act
             var actualResult = service.UpdateUserPreference(userPreferenceModel);
@@ -521,7 +522,7 @@ namespace HealthGateway.WebClient.Test.Services
         }
 
         /// <summary>
-        /// RecoverUserProfile - Alraedy active happy Path.
+        /// RecoverUserProfile - Active happy Path.
         /// </summary>
         [Fact]
         public void ShouldRecoverUserProfileAlreadyActive()

--- a/Apps/WebClient/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -18,21 +18,17 @@ namespace HealthGateway.WebClient.Test.Services
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using DeepEqual.Syntax;
     using HealthGateway.Common.Constants;
-    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
-    using HealthGateway.Common.Services;
     using HealthGateway.Database.Constants;
-    using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
     using HealthGateway.WebClient.Constants;
     using HealthGateway.WebClient.Models;
     using HealthGateway.WebClient.Services;
+    using HealthGateway.WebClientTests.Services.Test.Mock;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
 
@@ -60,84 +56,123 @@ namespace HealthGateway.WebClient.Test.Services
         }
 
         /// <summary>
-        /// GetUserProfile - Happy Path.
+        /// GetUserProfile call - Happy Path.
         /// </summary>
-        [Fact]
-        public void ShouldGetUserProfile()
+        /// <param name="dBStatus">Db Status code.</param>
+        [Theory(DisplayName = "ShouldGetUserProfile by status - {0}")]
+        [InlineData(DBStatusCode.Read)]
+        [InlineData(DBStatusCode.Error)]
+        [InlineData(DBStatusCode.NotFound)]
+        public void ShouldGetUserProfile(DBStatusCode dBStatus)
         {
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteGetUserProfile(DBStatusCode.Read, DateTime.Today);
-            var actualResult = result.Item1;
-            var expectedRecord = result.Item2;
+            // Arrange
+            UserProfile userProfile = new()
+            {
+                HdId = this.hdid,
+                AcceptedTermsOfService = true,
+                LastLoginDateTime = DateTime.Today,
+            };
 
-            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Equal(this.hdid, expectedRecord.HdId);
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = dBStatus,
+            };
+
+            LegalAgreement termsOfService = new()
+            {
+                Id = Guid.NewGuid(),
+                LegalText = string.Empty,
+                EffectiveDate = DateTime.Now,
+            };
+
+            UserPreference dbUserPreference = new()
+            {
+                HdId = this.hdid,
+                Preference = "TutorialPopover",
+                Value = true.ToString(),
+            };
+
+            List<UserPreference> userPreferences = new();
+            userPreferences.Add(dbUserPreference);
+
+            DBResult<IEnumerable<UserPreference>> readResult = new()
+            {
+                Payload = userPreferences,
+                Status = DBStatusCode.Read,
+            };
+
+            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
+            expected.HasTermsOfServiceUpdated = true;
+
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, dBStatus, userProfile, userProfileDBResult, readResult, termsOfService).UserProfileServiceMockInstance();
+
+            // Act
+            RequestResult<UserProfileModel> actualResult = service.GetUserProfile(this.hdid, DateTime.Now);
+
+            // Assert
+            if (dBStatus == DBStatusCode.Read)
+            {
+                Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+                Assert.Equal(this.hdid, expected.HdId);
+                Assert.True(actualResult.ResourcePayload?.HasTermsOfServiceUpdated);
+            }
+
+            if (dBStatus == DBStatusCode.Error)
+            {
+                Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+                Assert.Equal("testhostServer-CI-DB", actualResult.ResultError?.ErrorCode);
+            }
+
+            if (dBStatus == DBStatusCode.NotFound)
+            {
+                Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+                Assert.Null(actualResult.ResourcePayload?.HdId);
+            }
         }
 
         /// <summary>
-        /// GetUserProfile - Happy Path With Terms of Service Updated.
+        ///  CreateUserProfile call.
         /// </summary>
-        [Fact]
-        public void ShouldGetUserProfileWithTermsOfServiceUpdated()
-        {
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteGetUserProfile(DBStatusCode.Read, DateTime.Today);
-            var actualResult = result.Item1;
-
-            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.True(actualResult.ResourcePayload?.HasTermsOfServiceUpdated);
-        }
-
-        /// <summary>
-        /// GetUserProfile - Database Error.
-        /// </summary>
-        [Fact]
-        public void ShouldGetUserProfileWithDBError()
-        {
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteGetUserProfile(DBStatusCode.Error, DateTime.Today);
-            var actualResult = result.Item1;
-
-            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            Assert.Equal("testhostServer-CI-DB", actualResult.ResultError?.ErrorCode);
-        }
-
-        /// <summary>
-        /// GetUserProfile - Not Found Error.
-        /// </summary>
-        [Fact]
-        public void ShouldGetUserProfileWithProfileNotFoundError()
-        {
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteGetUserProfile(DBStatusCode.NotFound, DateTime.Today);
-            var actualResult = result.Item1;
-
-            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Null(actualResult.ResourcePayload?.HdId);
-        }
-
-        /// <summary>
-        /// InsertUserProfile - Happy Path.
-        /// </summary>
+        /// <param name="dbStatus">Db status code.</param>
+        /// <param name="registration">Registration status code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldInsertUserProfile()
+        [Theory(DisplayName = "ShouldInsertUserProfile when status is {0} registration status is {1}")]
+        [InlineData(DBStatusCode.Created, RegistrationStatus.Open)]
+        [InlineData(DBStatusCode.Error, RegistrationStatus.Closed)]
+        public async Task ShouldInsertUserProfile(DBStatusCode dbStatus, string registration)
         {
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = await this.ExecuteInsertUserProfile(DBStatusCode.Created, RegistrationStatus.Open).ConfigureAwait(true);
-            var actualResult = result.Item1;
+            // Arrange
+            UserProfile userProfile = new()
+            {
+                HdId = this.hdid,
+                AcceptedTermsOfService = true,
+                Email = "unit.test@hgw.ca",
+            };
 
-            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-        }
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = dbStatus,
+            };
 
-        /// <summary>
-        /// InsertUserProfile - Closed Registration Error.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldInsertUserProfileWithClosedRegistration()
-        {
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = await this.ExecuteInsertUserProfile(DBStatusCode.Error, RegistrationStatus.Closed).ConfigureAwait(true);
-            var actualResult = result.Item1;
+            var service = new UserProfileServiceMock("abc", userProfile, userProfileDBResult, registration).UserProfileServiceMockInstance();
 
-            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            Assert.Equal(ErrorTranslator.InternalError(ErrorType.InvalidState), actualResult.ResultError?.ErrorCode);
-            Assert.Equal("Registration is closed", actualResult.ResultError!.ResultMessage);
+            // Act
+            RequestResult<UserProfileModel> actualResult = await service.CreateUserProfile(new CreateUserRequest() { Profile = userProfile }, DateTime.Today, It.IsAny<string>()).ConfigureAwait(true);
+
+            // Assert
+            if (dbStatus == DBStatusCode.Created && registration == RegistrationStatus.Open)
+            {
+                Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            }
+
+            if (dbStatus == DBStatusCode.Error && registration == RegistrationStatus.Closed)
+            {
+                Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+                Assert.Equal(ErrorTranslator.InternalError(ErrorType.InvalidState), actualResult.ResultError?.ErrorCode);
+                Assert.Equal("Registration is closed", actualResult.ResultError!.ResultMessage);
+            }
         }
 
         /// <summary>
@@ -147,14 +182,15 @@ namespace HealthGateway.WebClient.Test.Services
         [Fact]
         public async Task ShouldQueueNotificationUpdate()
         {
-            UserProfile userProfile = new UserProfile
+            // Arrange
+            UserProfile userProfile = new()
             {
-                HdId = "1234567890123456789012345678901234567890123456789012",
+                HdId = this.hdid,
                 AcceptedTermsOfService = true,
                 Email = string.Empty,
             };
 
-            DBResult<UserProfile> insertResult = new DBResult<UserProfile>
+            DBResult<UserProfile> insertResult = new()
             {
                 Payload = userProfile,
                 Status = DBStatusCode.Created,
@@ -162,38 +198,12 @@ namespace HealthGateway.WebClient.Test.Services
 
             UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
 
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            profileDelegateMock.Setup(s => s.InsertUserProfile(It.Is<UserProfile>(x => x.HdId == userProfile.HdId))).Returns(insertResult);
+            var service = new UserProfileServiceMock("abc", userProfile, insertResult, RegistrationStatus.Open).UserProfileServiceMockInstance();
 
-            Mock<IMessagingVerificationDelegate> emailInviteDelegateMock = new Mock<IMessagingVerificationDelegate>();
-            emailInviteDelegateMock.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(new MessagingVerification());
-
-            Mock<ICryptoDelegate> cryptoDelegateMock = new Mock<ICryptoDelegate>();
-            cryptoDelegateMock.Setup(s => s.GenerateKey()).Returns("abc");
-
-            Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
-            notificationServiceMock.Setup(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()));
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                this.emptyConfigServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                notificationServiceMock.Object,
-                profileDelegateMock.Object,
-                new Mock<IUserPreferenceDelegate>().Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                new Mock<IMessagingVerificationDelegate>().Object,
-                cryptoDelegateMock.Object,
-                new Mock<IHttpContextAccessor>().Object);
-
-            // Execute
+            // Act
             RequestResult<UserProfileModel> actualResult = await service.CreateUserProfile(new CreateUserRequest() { Profile = userProfile }, DateTime.Today, It.IsAny<string>()).ConfigureAwait(true);
 
-            // Verify
-            notificationServiceMock.Verify(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()), Times.Once());
+            // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Equal(expected.HdId, actualResult.ResourcePayload?.HdId);
             Assert.Equal(expected.Email, actualResult.ResourcePayload?.Email);
@@ -206,130 +216,201 @@ namespace HealthGateway.WebClient.Test.Services
         [Fact]
         public async Task ShouldValidateAgeAsync()
         {
-            PatientModel patientModel = new PatientModel()
+            // Arrange
+            PatientModel patientModel = new()
             {
                 Birthdate = DateTime.Now.AddYears(-15),
             };
-            Mock<IPatientService> patientServiceMock = new Mock<IPatientService>();
-            patientServiceMock
-                .Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.HDID, false))
-                .ReturnsAsync(new RequestResult<PatientModel>
-                {
-                    ResultStatus = ResultType.Success,
-                    ResourcePayload = patientModel,
-                });
-            Mock<IConfigurationService> configServiceMock = new Mock<IConfigurationService>();
-            configServiceMock.Setup(s => s.GetConfiguration()).Returns(new ExternalConfiguration() { WebClient = new WebClientConfiguration() { MinPatientAge = 19 } });
 
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                patientServiceMock.Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                configServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                new Mock<INotificationSettingsService>().Object,
-                new Mock<IUserProfileDelegate>().Object,
-                new Mock<IUserPreferenceDelegate>().Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                new Mock<IMessagingVerificationDelegate>().Object,
-                new Mock<ICryptoDelegate>().Object,
-                new Mock<IHttpContextAccessor>().Object);
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, patientModel, 19).UserProfileServiceMockInstance();
+            PrimitiveRequestResult<bool> expected = new() { ResultStatus = ResultType.Success, ResourcePayload = false };
 
-            PrimitiveRequestResult<bool> expected = new PrimitiveRequestResult<bool>() { ResultStatus = ResultType.Success, ResourcePayload = false };
+            // Act
             PrimitiveRequestResult<bool> actualResult = await service.ValidateMinimumAge(this.hdid).ConfigureAwait(true);
+
+            // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Equal(expected.ResourcePayload, actualResult.ResourcePayload);
         }
 
         /// <summary>
-        /// GetUserPreference - Happy Path.
+        /// GetUserPreferences call.
         /// </summary>
-        [Fact]
-        public void ShouldGetUserPreference()
+        /// <param name="dBStatusCode">Db status code.</param>
+        [Theory(DisplayName = "ShouldGetUserPreference by status - {0}")]
+        [InlineData(DBStatusCode.Read)]
+        [InlineData(DBStatusCode.Error)]
+        public void ShouldGetUserPreference(DBStatusCode dBStatusCode)
         {
-            Tuple<RequestResult<Dictionary<string, UserPreferenceModel>>, List<UserPreferenceModel>> result = this.ExecuteGetUserPreference(DBStatusCode.Read);
-            var actualResult = result.Item1;
-            var expectedRecord = result.Item2;
-
-            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Equal(actualResult.ResourcePayload?.Count, expectedRecord.Count);
-            Assert.Equal(actualResult.ResourcePayload?["TutorialPopover"].Value, expectedRecord[0].Value);
-        }
-
-        /// <summary>
-        /// GetUserPreference - Database Error.
-        /// </summary>
-        [Fact]
-        public void ShouldGetUserPreferenceWithDBError()
-        {
-            Tuple<RequestResult<Dictionary<string, UserPreferenceModel>>, List<UserPreferenceModel>> result = this.ExecuteGetUserPreference(DBStatusCode.Error);
-            var actualResult = result.Item1;
-
-            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
-        }
-
-        /// <summary>
-        /// CreateUserPreference - Happy Path.
-        /// </summary>
-        [Fact]
-        public void ShouldCreateUserPreference()
-        {
-            RequestResult<UserPreferenceModel> result = this.ExecuteCreateUserPreference(DBStatusCode.Created);
-
-            Assert.Equal(ResultType.Success, result.ResultStatus);
-        }
-
-        /// <summary>
-        /// CreateUserPreference - Database Error.
-        /// </summary>
-        [Fact]
-        public void ShouldCreateUserPreferenceWithDBError()
-        {
-            RequestResult<UserPreferenceModel> actualResult = this.ExecuteCreateUserPreference(DBStatusCode.Error);
-
-            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
-        }
-
-        /// <summary>
-        /// UpdateUserPreference - Happy Path.
-        /// </summary>
-        [Fact]
-        public void ShouldUpdateUserPreference()
-        {
-            RequestResult<UserPreferenceModel> result = this.ExecuteUpdateUserPreference(DBStatusCode.Updated);
-
-            Assert.Equal(ResultType.Success, result.ResultStatus);
-        }
-
-        /// <summary>
-        /// UpdateUserPreference - Database Error.
-        /// </summary>
-        [Fact]
-        public void ShouldUpdateUserPreferenceWithDBError()
-        {
-            RequestResult<UserPreferenceModel> actualResult = this.ExecuteUpdateUserPreference(DBStatusCode.Error);
-
-            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
-        }
-
-        /// <summary>
-        /// CloseUserProfile - Happy Path.
-        /// </summary>
-        [Fact]
-        public void ShouldCloseUserProfile()
-        {
-            UserProfile userProfile = new UserProfile
+            // Arrange
+            UserProfile userProfile = new()
             {
                 HdId = this.hdid,
                 AcceptedTermsOfService = true,
             };
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteCloseUserProfile(userProfile, DBStatusCode.Read);
-            var actualResult = result.Item1;
 
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = dBStatusCode,
+            };
+
+            LegalAgreement termsOfService = new()
+            {
+                Id = Guid.NewGuid(),
+                LegalText = string.Empty,
+                EffectiveDate = DateTime.Now,
+            };
+
+            UserPreferenceModel userPreferenceModel = new()
+            {
+                HdId = this.hdid,
+                Preference = "TutorialPopover",
+                Value = true.ToString(),
+            };
+
+            List<UserPreferenceModel> userPreferences = new();
+            userPreferences.Add(userPreferenceModel);
+
+            List<UserPreference> dbUserPreferences = new();
+            dbUserPreferences.Add(userPreferenceModel.ToDbModel());
+
+            DBResult<IEnumerable<UserPreference>> readResult = new()
+            {
+                Payload = dbUserPreferences,
+                Status = dBStatusCode,
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, userProfile, userProfileDBResult, readResult, new MessagingVerification(), termsOfService).UserProfileServiceMockInstance();
+
+            // Act
+            RequestResult<Dictionary<string, UserPreferenceModel>> actualResult = service.GetUserPreferences(this.hdid);
+
+            // Assert
+            if (dBStatusCode == DBStatusCode.Read)
+            {
+                Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+                Assert.Equal(actualResult.ResourcePayload?.Count, userPreferences.Count);
+                Assert.Equal(actualResult.ResourcePayload?["TutorialPopover"].Value, userPreferences[0].Value);
+            }
+
+            if (dBStatusCode == DBStatusCode.Error)
+            {
+                Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+                Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
+            }
+        }
+
+        /// <summary>
+        ///  CreateUserPreference call.
+        /// </summary>
+        /// <param name="dBStatusCode">dBStatusCode.</param>
+        [Theory(DisplayName = "ShouldCreateUserPreference by status - {0}")]
+        [InlineData(DBStatusCode.Created)]
+        [InlineData(DBStatusCode.Error)]
+        public void ShouldCreateUserPreference(DBStatusCode dBStatusCode)
+        {
+            // Arrange
+            UserPreferenceModel userPreferenceModel = new()
+            {
+                HdId = this.hdid,
+                Preference = "TutorialPopover",
+                Value = "mocked value",
+            };
+            DBResult<UserPreference> readResult = new()
+            {
+                Payload = userPreferenceModel.ToDbModel(),
+                Status = dBStatusCode,
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(readResult, "create").UserProfileServiceMockInstance();
+
+            // Act
+            var actualResult = service.CreateUserPreference(userPreferenceModel);
+
+            // Assert
+            if (dBStatusCode == DBStatusCode.Created)
+            {
+                Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            }
+
+            if (dBStatusCode == DBStatusCode.Error)
+            {
+                Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+                Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
+            }
+        }
+
+        /// <summary>
+        ///  UpdateUserPreference call.
+        /// </summary>
+        /// <param name="dBStatusCode">dBStatusCode.</param>
+        [Theory(DisplayName = "ShouldUpdateUserPreference by status - {0}")]
+        [InlineData(DBStatusCode.Updated)]
+        [InlineData(DBStatusCode.Error)]
+        public void ShouldUpdateUserPreference(DBStatusCode dBStatusCode)
+        {
+            // Arrange
+            UserPreferenceModel userPreferenceModel = new()
+            {
+                HdId = this.hdid,
+                Preference = "TutorialPopover",
+                Value = "mocked value",
+            };
+            DBResult<UserPreference> readResult = new()
+            {
+                Payload = userPreferenceModel.ToDbModel(),
+                Status = dBStatusCode,
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(readResult, "update").UserProfileServiceMockInstance();
+
+            // Act
+            var actualResult = service.UpdateUserPreference(userPreferenceModel);
+
+            // Assert
+            if (dBStatusCode == DBStatusCode.Updated)
+            {
+                Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            }
+
+            if (dBStatusCode == DBStatusCode.Error)
+            {
+                Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+                Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
+            }
+        }
+
+        /// <summary>
+        /// ShouldCloseUserProfile.
+        /// </summary>
+        [Fact]
+        public void ShouldCloseUserProfile()
+        {
+            // Arrange
+            UserProfile userProfile = new()
+            {
+                HdId = this.hdid,
+                AcceptedTermsOfService = true,
+            };
+
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = DBStatusCode.Read,
+            };
+
+            IHeaderDictionary headerDictionary = new HeaderDictionary
+            {
+                { "referer", "http://localhost/" },
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, userProfile, userProfileDBResult, headerDictionary, false, true).UserProfileServiceMockInstance();
+
+            // Act
+            var actualResult = service.CloseUserProfile(this.hdid, Guid.NewGuid());
+
+            // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResourcePayload?.ClosedDateTime);
         }
@@ -340,15 +421,30 @@ namespace HealthGateway.WebClient.Test.Services
         [Fact]
         public void PreviouslyClosedUserProfile()
         {
-            UserProfile userProfile = new UserProfile
+            // Arrange
+            UserProfile userProfile = new()
             {
                 HdId = this.hdid,
                 AcceptedTermsOfService = true,
                 ClosedDateTime = DateTime.Today,
             };
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteCloseUserProfile(userProfile, DBStatusCode.Read);
-            var actualResult = result.Item1;
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = DBStatusCode.Read,
+            };
 
+            IHeaderDictionary headerDictionary = new HeaderDictionary
+            {
+                { "referer", "http://localhost/" },
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, userProfile, userProfileDBResult, headerDictionary, false, true).UserProfileServiceMockInstance();
+
+            // Act
+            var actualResult = service.CloseUserProfile(this.hdid, Guid.NewGuid());
+
+            // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Equal(userProfile.ClosedDateTime, actualResult.ResourcePayload?.ClosedDateTime);
         }
@@ -359,15 +455,31 @@ namespace HealthGateway.WebClient.Test.Services
         [Fact]
         public void ShouldCloseUserProfileAndQueueNewEmail()
         {
-            UserProfile userProfile = new UserProfile
+            // Arrange
+            UserProfile userProfile = new()
             {
                 HdId = this.hdid,
                 AcceptedTermsOfService = true,
                 Email = "unit.test@hgw.ca",
             };
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteCloseUserProfile(userProfile, DBStatusCode.Read);
-            var actualResult = result.Item1;
 
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = DBStatusCode.Read,
+            };
+
+            IHeaderDictionary headerDictionary = new HeaderDictionary
+            {
+                { "referer", "http://localhost/" },
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, userProfile, userProfileDBResult, headerDictionary, false, true).UserProfileServiceMockInstance();
+
+            // Act
+            var actualResult = service.CloseUserProfile(this.hdid, Guid.NewGuid());
+
+            // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResourcePayload?.ClosedDateTime);
         }
@@ -378,16 +490,32 @@ namespace HealthGateway.WebClient.Test.Services
         [Fact]
         public void ShouldRecoverUserProfile()
         {
-            UserProfile userProfile = new UserProfile
+            // Arrange
+            UserProfile userProfile = new()
             {
                 HdId = this.hdid,
                 AcceptedTermsOfService = true,
                 ClosedDateTime = DateTime.Today,
                 Email = "unit.test@hgw.ca",
             };
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteRecoverUserProfile(userProfile, DBStatusCode.Read);
-            var actualResult = result.Item1;
 
+            DBResult<UserProfile> userProfileDBResult = new()
+            {
+                Payload = userProfile,
+                Status = DBStatusCode.Read,
+            };
+
+            IHeaderDictionary headerDictionary = new HeaderDictionary
+            {
+                { "referer", "http://localhost/" },
+            };
+
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, userProfile, userProfileDBResult, headerDictionary, false, true).UserProfileServiceMockInstance();
+
+            // Act
+            var actualResult = service.RecoverUserProfile(this.hdid);
+
+            // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Null(actualResult.ResourcePayload?.ClosedDateTime);
         }
@@ -398,403 +526,33 @@ namespace HealthGateway.WebClient.Test.Services
         [Fact]
         public void ShouldRecoverUserProfileAlreadyActive()
         {
+            // Arrange
             UserProfile userProfile = new UserProfile
             {
                 HdId = this.hdid,
                 AcceptedTermsOfService = true,
                 ClosedDateTime = null,
             };
-            Tuple<RequestResult<UserProfileModel>, UserProfileModel> result = this.ExecuteRecoverUserProfile(userProfile, DBStatusCode.Read);
-            var actualResult = result.Item1;
 
-            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Null(actualResult.ResourcePayload?.ClosedDateTime);
-        }
-
-        private async Task<Tuple<RequestResult<UserProfileModel>, UserProfileModel>> ExecuteInsertUserProfile(
-            DBStatusCode dbResultStatus,
-            string registrationStatus)
-        {
-            UserProfile userProfile = new UserProfile
-            {
-                HdId = this.hdid,
-                AcceptedTermsOfService = true,
-                Email = "unit.test@hgw.ca",
-            };
-
-            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            profileDelegateMock.Setup(s => s.InsertUserProfile(It.Is<UserProfile>(x => x.HdId == userProfile.HdId))).Returns(new DBResult<UserProfile>
+            DBResult<UserProfile> userProfileDBResult = new()
             {
                 Payload = userProfile,
-                Status = dbResultStatus,
-            });
-
-            Mock<IConfigurationService> configServiceMock = new Mock<IConfigurationService>();
-            configServiceMock.Setup(s => s.GetConfiguration()).Returns(new ExternalConfiguration() { WebClient = new WebClientConfiguration() { RegistrationStatus = registrationStatus } });
-
-            Mock<ICryptoDelegate> cryptoDelegateMock = new Mock<ICryptoDelegate>();
-            cryptoDelegateMock.Setup(s => s.GenerateKey()).Returns("abc");
-
-            Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
-            notificationServiceMock.Setup(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()));
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                configServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                notificationServiceMock.Object,
-                profileDelegateMock.Object,
-                new Mock<IUserPreferenceDelegate>().Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                new Mock<IMessagingVerificationDelegate>().Object,
-                cryptoDelegateMock.Object,
-                new Mock<IHttpContextAccessor>().Object);
-
-            RequestResult<UserProfileModel> actualResult = await service.CreateUserProfile(new CreateUserRequest() { Profile = userProfile }, DateTime.Today, It.IsAny<string>()).ConfigureAwait(true);
-
-            return new Tuple<RequestResult<UserProfileModel>, UserProfileModel>(actualResult, expected);
-        }
-
-        private Tuple<RequestResult<UserProfileModel>, UserProfileModel> ExecuteRecoverUserProfile(
-            UserProfile userProfile,
-            DBStatusCode dbResultStatus = DBStatusCode.Read)
-        {
-            DBResult<UserProfile> userProfileDBResult = new DBResult<UserProfile>
-            {
-                Payload = userProfile,
-                Status = dbResultStatus,
-            };
-
-            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(userProfileDBResult);
-            profileDelegateMock.Setup(s => s.Update(userProfile, true)).Returns(userProfileDBResult);
-
-            Mock<IEmailQueueService> emailQueueServiceMock = new Mock<IEmailQueueService>();
-            emailQueueServiceMock
-                .Setup(s => s.QueueNewEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), false));
-
-            IHeaderDictionary headerDictionary = new HeaderDictionary();
-            headerDictionary.Add("referer", "http://localhost/");
-            Mock<HttpRequest> httpRequestMock = new Mock<HttpRequest>();
-            httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
-            Mock<HttpContext> httpContextMock = new Mock<HttpContext>();
-            httpContextMock.Setup(s => s.Request).Returns(httpRequestMock.Object);
-            Mock<IHttpContextAccessor> httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(s => s.HttpContext).Returns(httpContextMock.Object);
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                new Mock<IConfigurationService>().Object,
-                emailQueueServiceMock.Object,
-                new Mock<INotificationSettingsService>().Object,
-                profileDelegateMock.Object,
-                new Mock<IUserPreferenceDelegate>().Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                new Mock<IMessagingVerificationDelegate>().Object,
-                new Mock<ICryptoDelegate>().Object,
-                httpContextAccessorMock.Object);
-
-            RequestResult<UserProfileModel> actualResult = service.RecoverUserProfile(this.hdid);
-
-            return new Tuple<RequestResult<UserProfileModel>, UserProfileModel>(actualResult, expected);
-        }
-
-        private RequestResult<UserPreferenceModel> ExecuteCreateUserPreference(DBStatusCode dbResultStatus = DBStatusCode.Created)
-        {
-            UserPreferenceModel userPreferenceModel = new UserPreferenceModel
-            {
-                HdId = this.hdid,
-                Preference = "TutorialPopover",
-                Value = "mocked value",
-            };
-            DBResult<UserPreference> readResult = new DBResult<UserPreference>
-            {
-                Payload = userPreferenceModel.ToDbModel(),
-                Status = dbResultStatus,
-            };
-            Mock<IUserPreferenceDelegate> preferenceDelegateMock = new Mock<IUserPreferenceDelegate>();
-
-            preferenceDelegateMock.Setup(s => s.CreateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            Mock<IConfigurationService> configServiceMock = new Mock<IConfigurationService>();
-            Mock<ICryptoDelegate> cryptoDelegateMock = new Mock<ICryptoDelegate>();
-            Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
-            Mock<IMessagingVerificationDelegate> messageVerificationDelegateMock = new Mock<IMessagingVerificationDelegate>();
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                configServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                notificationServiceMock.Object,
-                profileDelegateMock.Object,
-                preferenceDelegateMock.Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                messageVerificationDelegateMock.Object,
-                cryptoDelegateMock.Object,
-                new Mock<IHttpContextAccessor>().Object);
-
-            return service.CreateUserPreference(userPreferenceModel);
-        }
-
-        private Tuple<RequestResult<Dictionary<string, UserPreferenceModel>>, List<UserPreferenceModel>> ExecuteGetUserPreference(
-    DBStatusCode dbResultStatus = DBStatusCode.Read)
-        {
-            UserProfile userProfile = new UserProfile
-            {
-                HdId = this.hdid,
-                AcceptedTermsOfService = true,
-            };
-
-            DBResult<UserProfile> userProfileDBResult = new DBResult<UserProfile>
-            {
-                Payload = userProfile,
-                Status = dbResultStatus,
-            };
-
-            LegalAgreement termsOfService = new LegalAgreement()
-            {
-                Id = Guid.NewGuid(),
-                LegalText = string.Empty,
-                EffectiveDate = DateTime.Now,
-            };
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(userProfileDBResult);
-            profileDelegateMock.Setup(s => s.Update(userProfile, true)).Returns(userProfileDBResult);
-
-            UserPreferenceModel userPreferenceModel = new UserPreferenceModel
-            {
-                HdId = this.hdid,
-                Preference = "TutorialPopover",
-                Value = true.ToString(),
-            };
-
-            List<UserPreferenceModel> userPreferences = new List<UserPreferenceModel>();
-            userPreferences.Add(userPreferenceModel);
-
-            List<UserPreference> dbUserPreferences = new List<UserPreference>();
-            dbUserPreferences.Add(userPreferenceModel.ToDbModel());
-
-            DBResult<IEnumerable<UserPreference>> readResult = new DBResult<IEnumerable<UserPreference>>
-            {
-                Payload = dbUserPreferences,
-                Status = dbResultStatus,
-            };
-            Mock<IUserPreferenceDelegate> preferenceDelegateMock = new Mock<IUserPreferenceDelegate>();
-            preferenceDelegateMock.Setup(s => s.GetUserPreferences(this.hdid)).Returns(readResult);
-
-            Mock<IMessagingVerificationDelegate> emailInviteDelegateMock = new Mock<IMessagingVerificationDelegate>();
-            emailInviteDelegateMock.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(new MessagingVerification());
-
-            Mock<ILegalAgreementDelegate> legalAgreementDelegateMock = new Mock<ILegalAgreementDelegate>();
-            legalAgreementDelegateMock
-                .Setup(s => s.GetActiveByAgreementType(LegalAgreementType.TermsofService))
-                .Returns(new DBResult<LegalAgreement>() { Payload = termsOfService });
-
-            Mock<ICryptoDelegate> cryptoDelegateMock = new Mock<ICryptoDelegate>();
-            Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
-            Mock<IMessagingVerificationDelegate> messageVerificationDelegateMock = new Mock<IMessagingVerificationDelegate>();
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                this.emptyConfigServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                notificationServiceMock.Object,
-                profileDelegateMock.Object,
-                preferenceDelegateMock.Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                messageVerificationDelegateMock.Object,
-                cryptoDelegateMock.Object,
-                new Mock<IHttpContextAccessor>().Object);
-
-            RequestResult<Dictionary<string, UserPreferenceModel>> actualResult = service.GetUserPreferences(this.hdid);
-
-            return new Tuple<RequestResult<Dictionary<string, UserPreferenceModel>>, List<UserPreferenceModel>>(actualResult, userPreferences);
-        }
-
-        private RequestResult<UserPreferenceModel> ExecuteUpdateUserPreference(DBStatusCode dbResultStatus = DBStatusCode.Updated)
-        {
-            UserPreferenceModel userPreferenceModel = new UserPreferenceModel
-            {
-                HdId = this.hdid,
-                Preference = "TutorialPopover",
-                Value = "mocked value",
-            };
-            DBResult<UserPreference> readResult = new DBResult<UserPreference>
-            {
-                Payload = userPreferenceModel.ToDbModel(),
-                Status = dbResultStatus,
-            };
-            Mock<IUserPreferenceDelegate> preferenceDelegateMock = new Mock<IUserPreferenceDelegate>();
-
-            preferenceDelegateMock.Setup(s => s.UpdateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            Mock<IConfigurationService> configServiceMock = new Mock<IConfigurationService>();
-
-            Mock<ICryptoDelegate> cryptoDelegateMock = new Mock<ICryptoDelegate>();
-            Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
-            Mock<IMessagingVerificationDelegate> messageVerificationDelegateMock = new Mock<IMessagingVerificationDelegate>();
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                configServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                notificationServiceMock.Object,
-                profileDelegateMock.Object,
-                preferenceDelegateMock.Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                messageVerificationDelegateMock.Object,
-                cryptoDelegateMock.Object,
-                new Mock<IHttpContextAccessor>().Object);
-
-            return service.UpdateUserPreference(userPreferenceModel);
-        }
-
-        private Tuple<RequestResult<UserProfileModel>, UserProfileModel> ExecuteCloseUserProfile(
-            UserProfile userProfile,
-            DBStatusCode dbResultStatus = DBStatusCode.Read)
-        {
-            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
-
-            DBResult<UserProfile> userProfileDBResult = new DBResult<UserProfile>
-            {
-                Payload = userProfile,
-                Status = dbResultStatus,
-            };
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(userProfileDBResult);
-            profileDelegateMock.Setup(s => s.Update(userProfile, true)).Returns(userProfileDBResult);
-
-            Mock<IEmailQueueService> emailQueueServiceMock = new Mock<IEmailQueueService>();
-            emailQueueServiceMock
-                .Setup(s => s.QueueNewEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), false));
-
-            IHeaderDictionary headerDictionary = new HeaderDictionary();
-            headerDictionary.Add("referer", "http://localhost/");
-            Mock<HttpRequest> httpRequestMock = new Mock<HttpRequest>();
-            httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
-            Mock<HttpContext> httpContextMock = new Mock<HttpContext>();
-            httpContextMock.Setup(s => s.Request).Returns(httpRequestMock.Object);
-            Mock<IHttpContextAccessor> httpContextAccessorMock = new Mock<IHttpContextAccessor>();
-            httpContextAccessorMock.Setup(s => s.HttpContext).Returns(httpContextMock.Object);
-
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                new Mock<IConfigurationService>().Object,
-                emailQueueServiceMock.Object,
-                new Mock<INotificationSettingsService>().Object,
-                profileDelegateMock.Object,
-                new Mock<IUserPreferenceDelegate>().Object,
-                new Mock<ILegalAgreementDelegate>().Object,
-                new Mock<IMessagingVerificationDelegate>().Object,
-                new Mock<ICryptoDelegate>().Object,
-                httpContextAccessorMock.Object);
-
-            RequestResult<UserProfileModel> actualResult = service.CloseUserProfile(this.hdid, Guid.NewGuid());
-
-            return new Tuple<RequestResult<UserProfileModel>, UserProfileModel>(actualResult, expected);
-        }
-
-        private Tuple<RequestResult<UserProfileModel>, UserProfileModel> ExecuteGetUserProfile(DBStatusCode dbResultStatus, DateTime lastLoginDateTime)
-        {
-            UserProfile userProfile = new UserProfile
-            {
-                HdId = this.hdid,
-                AcceptedTermsOfService = true,
-                LastLoginDateTime = lastLoginDateTime,
-            };
-
-            DBResult<UserProfile> userProfileDBResult = new DBResult<UserProfile>
-            {
-                Payload = userProfile,
-                Status = dbResultStatus,
-            };
-
-            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
-            expected.HasTermsOfServiceUpdated = true;
-
-            LegalAgreement termsOfService = new LegalAgreement()
-            {
-                Id = Guid.NewGuid(),
-                LegalText = string.Empty,
-                EffectiveDate = DateTime.Now,
-            };
-
-            Mock<IUserProfileDelegate> profileDelegateMock = new Mock<IUserProfileDelegate>();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(userProfileDBResult);
-            profileDelegateMock.Setup(s => s.Update(userProfile, true)).Returns(userProfileDBResult);
-
-            UserPreference dbUserPreference = new UserPreference
-            {
-                HdId = this.hdid,
-                Preference = "TutorialPopover",
-                Value = true.ToString(),
-            };
-            List<UserPreference> userPreferences = new List<UserPreference>();
-            userPreferences.Add(dbUserPreference);
-            DBResult<IEnumerable<UserPreference>> readResult = new DBResult<IEnumerable<UserPreference>>
-            {
-                Payload = userPreferences,
                 Status = DBStatusCode.Read,
             };
-            Mock<IUserPreferenceDelegate> preferenceDelegateMock = new Mock<IUserPreferenceDelegate>();
-            preferenceDelegateMock.Setup(s => s.GetUserPreferences(this.hdid)).Returns(readResult);
 
-            Mock<IMessagingVerificationDelegate> emailInviteDelegateMock = new Mock<IMessagingVerificationDelegate>();
-            emailInviteDelegateMock.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(new MessagingVerification());
+            IHeaderDictionary headerDictionary = new HeaderDictionary
+            {
+                { "referer", "http://localhost/" },
+            };
 
-            Mock<ILegalAgreementDelegate> legalAgreementDelegateMock = new Mock<ILegalAgreementDelegate>();
-            legalAgreementDelegateMock
-                .Setup(s => s.GetActiveByAgreementType(LegalAgreementType.TermsofService))
-                .Returns(new DBResult<LegalAgreement>() { Payload = termsOfService });
+            IUserProfileService service = new UserProfileServiceMock(this.hdid, userProfile, userProfileDBResult, headerDictionary, false, true).UserProfileServiceMockInstance();
 
-            Mock<ICryptoDelegate> cryptoDelegateMock = new Mock<ICryptoDelegate>();
-            Mock<INotificationSettingsService> notificationServiceMock = new Mock<INotificationSettingsService>();
-            Mock<IMessagingVerificationDelegate> messageVerificationDelegateMock = new Mock<IMessagingVerificationDelegate>();
+            // Act
+            var actualResult = service.RecoverUserProfile(this.hdid);
 
-            IUserProfileService service = new UserProfileService(
-                new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
-                new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object,
-                this.emptyConfigServiceMock.Object,
-                new Mock<IEmailQueueService>().Object,
-                notificationServiceMock.Object,
-                profileDelegateMock.Object,
-                preferenceDelegateMock.Object,
-                legalAgreementDelegateMock.Object,
-                messageVerificationDelegateMock.Object,
-                cryptoDelegateMock.Object,
-                new Mock<IHttpContextAccessor>().Object);
-
-            RequestResult<UserProfileModel> actualResult = service.GetUserProfile(this.hdid, DateTime.Now);
-
-            return new Tuple<RequestResult<UserProfileModel>, UserProfileModel>(actualResult, expected);
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload?.ClosedDateTime);
         }
     }
 }

--- a/Apps/WebClient/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -527,7 +527,7 @@ namespace HealthGateway.WebClient.Test.Services
         public void ShouldRecoverUserProfileAlreadyActive()
         {
             // Arrange
-            UserProfile userProfile = new UserProfile
+            UserProfile userProfile = new()
             {
                 HdId = this.hdid,
                 AcceptedTermsOfService = true,


### PR DESCRIPTION
# Refactor User Profile unit tests  [AB#10077](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/10077)

-   [x] Enhancement
-   [ ] Bug
-   [ ] Documentation

## Description

Refactor the userprofileservice unit tests. Introduce new classes to have a reusable tests. 

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
