### PR TITLE
Resolves Hangfire jobid issue and new warnings for AB#11812

### DIFF
--- a/Apps/Common/src/Models/ODR/ODRHistoryResponse.cs
+++ b/Apps/Common/src/Models/ODR/ODRHistoryResponse.cs
@@ -27,7 +27,7 @@ namespace HealthGateway.Common.Models.ODR
         /// Gets or sets the Id of the request.
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid Id { get; set; } = default;
+        public Guid Id { get; set; } = Guid.Empty;
 
         /// <summary>
         /// Gets or sets the total records available from the server for the query excluding page limits.

--- a/Apps/Common/src/Models/ODR/ODRHistoryWrapper.cs
+++ b/Apps/Common/src/Models/ODR/ODRHistoryWrapper.cs
@@ -27,7 +27,7 @@ namespace HealthGateway.Common.Models.ODR
         /// Gets or sets the Id of the request.
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid Id { get; set; } = default;
+        public Guid Id { get; set; } = Guid.Empty;
 
         /// <summary>
         /// Gets or sets the HDID of the requestor.

--- a/Apps/Directory.Build.props
+++ b/Apps/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis" Version="4.0.1" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.31.0.39249">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.32.0.39516">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -69,6 +69,7 @@ namespace HealthGateway.JobScheduler
         /// <param name="services">The passed in Service Collection.</param>
         public void ConfigureServices(IServiceCollection services)
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyCaseInsensitiveDbParameters", true);
             this.startupConfig.ConfigureForwardHeaders(services);
             this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);

--- a/Apps/Medication/src/Models/ODR/ProtectiveWord.cs
+++ b/Apps/Medication/src/Models/ODR/ProtectiveWord.cs
@@ -27,7 +27,7 @@ namespace HealthGateway.Medication.Models.ODR
         /// Gets or sets the Id of the request.
         /// </summary>
         [JsonPropertyName("uuid")]
-        public Guid Id { get; set; } = default;
+        public Guid Id { get; set; } = Guid.Empty;
 
         /// <summary>
         /// Gets or sets the HDID of the requestor.


### PR DESCRIPTION
# Fixes or Implements [AB#11812](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11812)

-   [ ] Enhancement
-   [X] Bug
-   [ ] Documentation

## Description

Resolves a Hangfire issue which is related to the Ngpsql 5 upgrade.
Updated Sonar Analyzer and resolved new warnings.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### Steps to Reproduce

If this is a bug, please provide details on how to reproduce the code.

### UI Changes

No

### Browsers Tested

-   [X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
