### PR TITLE
Sort record exports by most recent AB#11675

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/covid19.vue
@@ -58,11 +58,15 @@ export default class COVID19ReportComponent extends Vue {
                 b.labResults[0].collectedDateTime
             );
 
-            return firstDate.isAfter(secondDate)
-                ? 1
-                : firstDate.isBefore(secondDate)
-                ? -1
-                : 0;
+            if (firstDate.isBefore(secondDate)) {
+                return 1;
+            }
+
+            if (firstDate.isAfter(secondDate)) {
+                return -1;
+            }
+
+            return 0;
         });
 
         return records;

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -69,11 +69,15 @@ export default class MedicationHistoryReportComponent extends Vue {
             const firstDate = new DateWrapper(a.dispensedDate);
             const secondDate = new DateWrapper(b.dispensedDate);
 
-            return firstDate.isAfter(secondDate)
-                ? 1
-                : firstDate.isBefore(secondDate)
-                ? -1
-                : 0;
+            if (firstDate.isBefore(secondDate)) {
+                return 1;
+            }
+
+            if (firstDate.isAfter(secondDate)) {
+                return -1;
+            }
+
+            return 0;
         });
 
         return records;

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationHistory.vue
@@ -151,6 +151,7 @@ export default class MedicationHistoryReportComponent extends Vue {
         {
             key: "date",
             thClass: this.headerClass,
+            tdAttr: { "data-testid": "medicationDateItem" },
         },
         {
             key: "din_pin",

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationRequest.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationRequest.vue
@@ -146,6 +146,7 @@ export default class MedicationRequestReportComponent extends Vue {
             key: "date",
             thClass: this.headerClass,
             thStyle: { width: "10%" },
+            tdAttr: { "data-testid": "medicationRequestDateItem" },
         },
         {
             key: "requested_drug_name",

--- a/Apps/WebClient/src/ClientApp/src/components/report/medicationRequest.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/medicationRequest.vue
@@ -58,11 +58,15 @@ export default class MedicationRequestReportComponent extends Vue {
             const firstDate = new DateWrapper(a.requestedDate);
             const secondDate = new DateWrapper(b.requestedDate);
 
-            return firstDate.isAfter(secondDate)
-                ? 1
-                : firstDate.isBefore(secondDate)
-                ? -1
-                : 0;
+            if (firstDate.isBefore(secondDate)) {
+                return 1;
+            }
+
+            if (firstDate.isAfter(secondDate)) {
+                return -1;
+            }
+
+            return 0;
         });
 
         return records;

--- a/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
@@ -125,6 +125,7 @@ export default class MSPVisitsReportComponent extends Vue {
         {
             key: "date",
             thClass: this.headerClass,
+            tdAttr: { "data-testid": "mspVisitDateItem" },
         },
         {
             key: "specialty_description",

--- a/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/mspVisits.vue
@@ -51,11 +51,15 @@ export default class MSPVisitsReportComponent extends Vue {
             const firstDate = new DateWrapper(a.encounterDate);
             const secondDate = new DateWrapper(b.encounterDate);
 
-            return firstDate.isAfter(secondDate)
-                ? 1
-                : firstDate.isBefore(secondDate)
-                ? -1
-                : 0;
+            if (firstDate.isBefore(secondDate)) {
+                return 1;
+            }
+
+            if (firstDate.isAfter(secondDate)) {
+                return -1;
+            }
+
+            return 0;
         });
 
         return records;

--- a/Apps/WebClient/src/ClientApp/test/healthInsights.test.ts
+++ b/Apps/WebClient/src/ClientApp/test/healthInsights.test.ts
@@ -33,6 +33,7 @@ function createWrapper(
         stubs: {
             "hg-icon": true,
             "hg-button": true,
+            "page-title": true,
         },
     });
 }

--- a/Apps/WebClient/src/ClientApp/test/timeline.test.ts
+++ b/Apps/WebClient/src/ClientApp/test/timeline.test.ts
@@ -42,6 +42,7 @@ function createWrapper(options?: GatewayStoreOptions): Wrapper<TimelineView> {
             LoadingComponent: ChildComponentStub,
             "hg-icon": true,
             "hg-button": true,
+            "page-title": true,
         },
     });
 }

--- a/Testing/functional/tests/cypress/fixtures/Report/covid19UnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/covid19UnSorted.json
@@ -1,0 +1,93 @@
+{
+    "resourcePayload": [
+        {
+            "id": "8a0f0405-ca77-4216-a743-059adf432804",
+            "phn": "973535****",
+            "orderingProviderIds": "383410821",
+            "orderingProviders": "EZSGWZEQ Monica",
+            "reportingLab": "Excelleris",
+            "location": "Excelleris",
+            "ormOrOru": "ORU",
+            "messageDateTime": "2020-09-04T16:53:57+00:00",
+            "messageId": "13921638391",
+            "additionalData": "This test was performed at Cam Coady Building - 7455-130th Street, Surrey, British Columbia, V3W 1H8\u003Cbr\u003E",
+            "reportAvailable": true,
+            "labResults": [
+                {
+                    "id": "e7ad8590-cd03-41fd-95b9-45e6f60d3060",
+                    "testType": null,
+                    "outOfRange": false,
+                    "collectedDateTime": "2020-09-03T10:00:00+00:00",
+                    "testStatus": "Final",
+                    "labResultOutcome": "Negative",
+                    "resultDescription": "NEGATIVE for COVID-19 virus (SARS-CoV-2)\nby NAAT.\n\nThis is a validated laboratory developed\nassay.\n",
+                    "receivedDateTime": "2020-09-03T23:40:00+00:00",
+                    "resultDateTime": "2020-09-04T16:45:09+00:00",
+                    "loinc": "94309-2",
+                    "loincName": "COVID-19 Coronavirus RNA (PCR/NAAT)"
+                }
+            ]
+        },
+        {
+            "id": "cfd2d90a-a8f8-4080-8301-078fbb780115",
+            "phn": "973535****",
+            "orderingProviderIds": "249381347",
+            "orderingProviders": "WIW Sue",
+            "reportingLab": "Iha",
+            "location": "Iha",
+            "ormOrOru": "ORU",
+            "messageDateTime": "2020-09-16T09:43:00+00:00",
+            "messageId": "169161987",
+            "additionalData": null,
+            "reportAvailable": true,
+            "labResults": [
+                {
+                    "id": "576655fe-658e-44ac-9972-ad08b43c4ce0",
+                    "testType": "Nasopharynx Swab",
+                    "outOfRange": true,
+                    "collectedDateTime": "2020-07-14T16:48:00+00:00",
+                    "testStatus": "Amended",
+                    "labResultOutcome": "Positive",
+                    "resultDescription": "ORGANISM 1                     COVID-19 VIRUS (2019-NCOV)*\u003Cbr\u003EDETECTED BY NAT",
+                    "receivedDateTime": "2020-07-15T05:35:00+00:00",
+                    "resultDateTime": "2020-07-15T05:35:00+00:00",
+                    "loinc": "XXX-1927",
+                    "loincName": "Microbiology Report"
+                }
+            ]
+        },
+        {
+            "id": "edae73ba-671c-4463-a0c1-10926ed0c387",
+            "phn": "973535****",
+            "orderingProviderIds": "51001",
+            "orderingProviders": "PLISVIHA ROCCO",
+            "reportingLab": "Viha",
+            "location": "Viha",
+            "ormOrOru": "ORU",
+            "messageDateTime": "2020-12-21T18:22:00+00:00",
+            "messageId": "Q961215152T113790716",
+            "additionalData": "COVID-19 virus (2019 n-CoV) detected by NAT. This is a validated laboratory developed test. Communicable Disease and Infection Prevention and Control programs notified.",
+            "reportAvailable": true,
+            "labResults": [
+                {
+                    "id": "ec6c0df8-4fc4-4fc8-85dc-947120cf49c3",
+                    "testType": "BAL",
+                    "outOfRange": true,
+                    "collectedDateTime": "2020-12-21T15:30:00+00:00",
+                    "testStatus": "Final",
+                    "labResultOutcome": "Positive",
+                    "resultDescription": "Positive",
+                    "receivedDateTime": "2020-12-21T18:06:00+00:00",
+                    "resultDateTime": "2020-12-21T18:21:59+00:00",
+                    "loinc": "94309-2",
+                    "loincName": "COVID-19"
+                }
+            ]
+        }
+    ],
+    "totalResultCount": 3,
+    "pageIndex": 0,
+    "pageSize": 25,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/fixtures/Report/immunizationUnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/immunizationUnSorted.json
@@ -1,0 +1,75 @@
+{
+    "resourcePayload": {
+        "loadState": {
+            "refreshInProgress": false
+        },
+        "immunizations": [
+            {
+                "id": "8bae0359-4eb6-4504-a313-08d992a432e4",
+                "dateOfImmunization": "2019-01-01T00:00:00",
+                "status": "Completed",
+                "valid": false,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Measles, Mumps, Rubella",
+                    "immunizationAgents": [
+                        {
+                            "code": "61153008",
+                            "name": "MMR",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "3a530cd1-c185-4a90-a314-08d992a432e4",
+                "dateOfImmunization": "2001-02-14T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Tetanus",
+                    "immunizationAgents": [
+                        {
+                            "code": "58098008",
+                            "name": "Tetanus",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "705f0200-7e6e-4935-a315-08d992a432e4",
+                "dateOfImmunization": "2021-01-07T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Chickenpox (Varicella)",
+                    "immunizationAgents": [
+                        {
+                            "code": "412530002",
+                            "name": "Varicella",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            }
+        ],
+        "recommendations": []
+    },
+    "totalResultCount": 3,
+    "pageIndex": 0,
+    "pageSize": 25,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/fixtures/Report/medicationRequestUnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/medicationRequestUnSorted.json
@@ -1,0 +1,39 @@
+{
+    "resourcePayload": [
+        {
+            "drugName": "TEST",
+            "requestStatus": "Complete",
+            "requestedDate": "2019-01-01",
+            "prescriberFirstName": "Health",
+            "prescriberLastName": "Gateway",
+            "effectiveDate": "2019-01-05",
+            "expiryDate": "2019-02-05",
+            "referenceNumber": "1234567890"
+        },
+        {
+            "drugName": "OverDoseTest",
+            "requestStatus": "Complete",
+            "requestedDate": "2014-01-01",
+            "prescriberFirstName": "Health",
+            "prescriberLastName": "Gateway",
+            "effectiveDate": "2014-01-05",
+            "expiryDate": "2014-02-05",
+            "referenceNumber": "1234567890"
+        },
+        {
+            "drugName": "PartialDoseTest",
+            "requestStatus": "Complete",
+            "requestedDate": "2020-01-01",
+            "prescriberFirstName": "Health",
+            "prescriberLastName": "Gateway",
+            "effectiveDate": "2020-01-05",
+            "expiryDate": "2020-02-05",
+            "referenceNumber": "1234567890"
+        }
+    ],
+    "totalResultCount": 3,
+    "pageIndex": 0,
+    "pageSize": 25,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/fixtures/Report/medicationStatementUnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/medicationStatementUnSorted.json
@@ -3,7 +3,7 @@
         {
             "prescriptionIdentifier": "9529523",
             "prescriptionStatus": "\u0000",
-            "dispensedDate": "2019-01-30T00:00:00",
+            "dispensedDate": "2019-12-29T00:00:00",
             "practitionerSurname": "PZVVPS",
             "directions": ".. SHAKE WELL .. DRINK 50MLS CARRY 80MLS DAILY DAILY  MAY BE POISONOUS TO OTHERS",
             "dateEntered": null,
@@ -37,7 +37,7 @@
         {
             "prescriptionIdentifier": "133920",
             "prescriptionStatus": "\u0000",
-            "dispensedDate": "2021-02-29T00:00:00",
+            "dispensedDate": "2019-12-30T00:00:00",
             "practitionerSurname": "PLJDDRV",
             "directions": "TAKE 2 TABLETS AT BEDTIME",
             "dateEntered": null,
@@ -71,7 +71,7 @@
         {
             "prescriptionIdentifier": "6787902",
             "prescriptionStatus": "\u0000",
-            "dispensedDate": "2019-12-25T00:00:00",
+            "dispensedDate": "2020-12-28T00:00:00",
             "practitionerSurname": "PZVVPS",
             "directions": "TAKE 2 TABLETS AT BEDTIME (DISPENSE WITH METHADONE MON/THURS)",
             "dateEntered": null,
@@ -101,65 +101,9 @@
                 "phoneNumber": "250-5095824",
                 "faxNumber": "250-5073852"
             }
-        },
-        {
-            "prescriptionIdentifier": "9528727",
-            "prescriptionStatus": "\u0000",
-            "dispensedDate": "2018-02-25T00:00:00",
-            "practitionerSurname": "PZVVPS",
-            "directions": ".. SHAKE WELL .. DRINK 50MLS CARRY 80MLS DAILY DAILY  MAY BE POISONOUS TO OTHERS",
-            "dateEntered": null,
-            "pharmacyId": "",
-            "medicationSummary": {
-                "din": "66999990",
-                "brandName": "Methadone (Maintenance) 1mg/Ml",
-                "genericName": "",
-                "quantity": 520,
-                "maxDailyDosage": 0,
-                "drugDiscontinuedDate": null,
-                "form": "",
-                "manufacturer": "",
-                "strength": "",
-                "strengthUnit": "",
-                "isPin": true
-            },
-            "dispensingPharmacy": {
-                "pharmacyId": "BC00007912",
-                "name": "DJOPXNCCHKDTAPPALZCDV",
-                "addressLine1": "GRRJJQOBCUUUHZW",
-                "addressLine2": "",
-                "city": "KAMLOOPS",
-                "province": "BC",
-                "postalCode": "JTAEKA",
-                "countryCode": "CAN",
-                "phoneNumber": "250-5095824",
-                "faxNumber": "250-5073852"
-            }
-        },
-        {
-            "prescriptionIdentifier": "6784060",
-            "prescriptionStatus": "\u0000",
-            "dispensedDate": "2021-01-22T00:00:00",
-            "practitionerSurname": "PZVVPS",
-            "directions": "TAKE 2 TABLETS AT BEDTIME (DISPENSE WITH METHADONE MON/THURS)",
-            "dateEntered": null,
-            "pharmacyId": "",
-            "medicationSummary": {
-                "din": "2391724",
-                "brandName": "MINT-ZOPICLONE",
-                "genericName": "ZOPICLONE",
-                "quantity": 6,
-                "maxDailyDosage": 0,
-                "drugDiscontinuedDate": null,
-                "form": "TABLET",
-                "manufacturer": "MINT PHARMACEUTICALS INC",
-                "strength": "7.5",
-                "strengthUnit": "MG",
-                "isPin": false
-            }
         }
     ],
-    "totalResultCount": 5,
+    "totalResultCount": 3,
     "pageIndex": 1,
     "pageSize": 20000,
     "resultStatus": 1,

--- a/Testing/functional/tests/cypress/fixtures/Report/mspVisitUnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/mspVisitUnSorted.json
@@ -1,0 +1,36 @@
+{
+    "resourcePayload": [
+        {
+            "id": "f57bcb39-64ca-0a17-5477-92ea7f084fbf",
+            "encounterDate": "2020-07-15T00:00:00",
+            "specialtyDescription": "FAMILY MEDICINE",
+            "practitionerName": "ILCVAPPOJ CLPXWG",
+            "clinic": {
+                "name": "FRANCIS N WER WERASDF"
+            }
+        },
+        {
+            "id": "72c2d6c0-b370-24e6-0b5c-04e42b6511c8",
+            "encounterDate": "2021-01-14T00:00:00",
+            "specialtyDescription": "LABORATORY MEDICINE",
+            "practitionerName": "TFWBLV GBXIK LRNSOII",
+            "clinic": {
+                "name": "DAVID WRN WER WERASDF"
+            }
+        },
+        {
+            "id": "5ba67647-1463-8efb-7da7-62a5cb984f71",
+            "encounterDate": "2021-03-14T00:00:00",
+            "specialtyDescription": "FAMILY MEDICINE",
+            "practitionerName": "SHERRI LYNN DSFGHRIO",
+            "clinic": {
+                "name": "ERIC SDFN WER WERASDF"
+            }
+        }
+    ],
+    "totalResultCount": 3,
+    "pageIndex": 1,
+    "pageSize": 20000,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/integration/e2e/report/reportFiltering.js
+++ b/Testing/functional/tests/cypress/integration/e2e/report/reportFiltering.js
@@ -116,10 +116,9 @@ describe("Report Filtering", () => {
                         expect(filteredBrandText).to.not.equal(brandText);
                     });
 
-                cy.get("[data-testid=advancedBtn]").click();
-
+                cy.get("[data-testid=advancedBtn]").click();         
                 cy.get(
-                    `[data-testid=medicationExclusionFilter] [title=${brandText}] button`
+                    `[data-testid=medicationExclusionFilter] [title="${brandText}"] button`
                 )
                     .should("be.enabled", "be.visible")
                     .click();

--- a/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
@@ -1,0 +1,263 @@
+const { AuthMethod } = require("../../../support/constants");
+const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
+
+describe("Reports - Medication", () => {
+    beforeEach(() => {
+        cy.enableModules([
+            "Encounter",
+            "Medication",
+            "Laboratory",
+            "Immunization",
+            "MedicationRequest",
+        ]);
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/reports"
+        );
+    });
+
+    it("Validate Medication Statement Report with Unsorted Data", () => {
+        cy.intercept("GET", `**/v1/api/MedicationStatement/${HDID}`, (req) => {
+            req.reply({
+                fixture: "Report/medicationStatementUnSorted.json",
+            });
+        });
+        cy.get("[data-testid=reportType]")
+            .should("be.enabled", "be.visible")
+            .select("Medications");
+        cy.get("[data-testid=reportSample]").should("be.visible");
+
+        cy.get("[data-testid=medicationDateItem]")
+            .first()
+            .then(($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = new Date($dateItem.text().trim());
+                cy.get("[data-testid=medicationDateItem]")
+                    .eq(1)
+                    .then(($dateItem) => {
+                        // Column date in the 2nd row in the table
+                        const secondDate = new Date($dateItem.text().trim());
+                        expect(firstDate).to.be.gte(secondDate);
+                        // Column date in the last row in the table
+                        cy.get("[data-testid=medicationDateItem]")
+                            .eq(2)
+                            .then(($dateItem) => {
+                                // Column date in the last row in the table
+                                const lastDate = new Date(
+                                    $dateItem.text().trim()
+                                );
+                                expect(firstDate).to.be.gte(lastDate);
+                                expect(secondDate).to.be.gte(lastDate);
+                            });
+                    });
+            });
+    });
+
+    it("Validate Medication Request Report with Unsorted Data", () => {
+        cy.intercept("GET", `**/v1/api/MedicationRequest/${HDID}`, (req) => {
+            req.reply({
+                fixture: "Report/medicationRequestUnSorted.json",
+            });
+        });
+        cy.get("[data-testid=reportType]")
+            .should("be.enabled", "be.visible")
+            .select("Special Authority Requests");
+
+        cy.get("[data-testid=reportSample]").should("be.visible");
+
+        cy.get("[data-testid=medicationRequestDateItem]")
+            .first()
+            .then(($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = new Date($dateItem.text().trim());
+                cy.get("[data-testid=medicationRequestDateItem]")
+                    .eq(1)
+                    .then(($dateItem) => {
+                        // Column date in the 2nd row in the table
+                        const secondDate = new Date($dateItem.text().trim());
+                        expect(firstDate).to.be.gte(secondDate);
+                        // Column date in the last row in the table
+                        cy.get("[data-testid=medicationRequestDateItem]")
+                            .eq(2)
+                            .then(($dateItem) => {
+                                // Column date in the last row in the table
+                                const lastDate = new Date(
+                                    $dateItem.text().trim()
+                                );
+                                expect(firstDate).to.be.gte(lastDate);
+                                expect(secondDate).to.be.gte(lastDate);
+                            });
+                    });
+            });
+    });
+});
+
+describe("Reports - Covid19", () => {
+    beforeEach(() => {
+        cy.enableModules([
+            "Encounter",
+            "Medication",
+            "Laboratory",
+            "Immunization",
+            "MedicationRequest",
+        ]);
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/reports"
+        );
+    });
+
+    it("Validate Covid19 Report with Unsorted Data", () => {
+        cy.intercept("GET", `**/v1/api/Laboratory?hdid=${HDID}`, (req) => {
+            req.reply({
+                fixture: "Report/covid19UnSorted.json",
+            });
+        });
+        cy.get("[data-testid=reportType]")
+            .should("be.enabled", "be.visible")
+            .select("COVID-19 Test Results");
+
+        cy.get("[data-testid=reportSample]").should("be.visible");
+
+        cy.get("[data-testid=covid19DateItem]")
+            .first()
+            .then(($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = new Date($dateItem.text().trim());
+                cy.get("[data-testid=covid19DateItem]")
+                    .eq(1)
+                    .then(($dateItem) => {
+                        // Column date in the 2nd row in the table
+                        const secondDate = new Date($dateItem.text().trim());
+                        expect(firstDate).to.be.gte(secondDate);
+                        // Column date in the last row in the table
+                        cy.get("[data-testid=covid19DateItem]")
+                            .eq(2)
+                            .then(($dateItem) => {
+                                // Column date in the last row in the table
+                                const lastDate = new Date(
+                                    $dateItem.text().trim()
+                                );
+                                expect(firstDate).to.be.gte(lastDate);
+                                expect(secondDate).to.be.gte(lastDate);
+                            });
+                    });
+            });
+    });
+});
+
+describe("Reports - Immunization", () => {
+    beforeEach(() => {
+        cy.enableModules([
+            "Encounter",
+            "Medication",
+            "Laboratory",
+            "Immunization",
+            "MedicationRequest",
+        ]);
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/reports"
+        );
+    });
+
+    it("Validate Immunization Report with Unsorted Data", () => {
+        cy.intercept("GET", `**/v1/api/Immunization?hdid=${HDID}`, (req) => {
+            req.reply({
+                fixture: "Report/immunizationUnSorted.json",
+            });
+        });
+        cy.get("[data-testid=reportType]")
+            .should("be.enabled", "be.visible")
+            .select("Immunizations");
+
+        cy.get("[data-testid=reportSample]").should("be.visible");
+
+        cy.get("[data-testid=immunizationDateItem]")
+            .first()
+            .then(($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = new Date($dateItem.text().trim());
+                cy.get("[data-testid=immunizationDateItem]")
+                    .eq(1)
+                    .then(($dateItem) => {
+                        // Column date in the 2nd row in the table
+                        const secondDate = new Date($dateItem.text().trim());
+                        expect(firstDate).to.be.gte(secondDate);
+                        // Column date in the last row in the table
+                        cy.get("[data-testid=immunizationDateItem]")
+                            .eq(2)
+                            .then(($dateItem) => {
+                                // Column date in the last row in the table
+                                const lastDate = new Date(
+                                    $dateItem.text().trim()
+                                );
+                                expect(firstDate).to.be.gte(lastDate);
+                                expect(secondDate).to.be.gte(lastDate);
+                            });
+                    });
+            });
+    });
+});
+
+describe("Reports - MSP Visit", () => {
+    beforeEach(() => {
+        cy.enableModules([
+            "Encounter",
+            "Medication",
+            "Laboratory",
+            "Immunization",
+            "MedicationRequest",
+        ]);
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/reports"
+        );
+    });
+
+    it("Validate MSP Visit Report with Unsorted Data", () => {
+        cy.intercept("GET", `**/v1/api/Encounter/${HDID}`, (req) => {
+            req.reply({
+                fixture: "Report/mspVisitUnSorted.json",
+            });
+        });
+        cy.get("[data-testid=reportType]")
+            .should("be.enabled", "be.visible")
+            .select("Health Visits");
+
+        cy.get("[data-testid=reportSample]").should("be.visible");
+
+        cy.get("[data-testid=mspVisitDateItem]")
+            .first()
+            .then(($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = new Date($dateItem.text().trim());
+                cy.get("[data-testid=mspVisitDateItem]")
+                    .eq(1)
+                    .then(($dateItem) => {
+                        // Column date in the 2nd row in the table
+                        const secondDate = new Date($dateItem.text().trim());
+                        expect(firstDate).to.be.gte(secondDate);
+                        // Column date in the last row in the table
+                        cy.get("[data-testid=mspVisitDateItem]")
+                            .eq(2)
+                            .then(($dateItem) => {
+                                // Column date in the last row in the table
+                                const lastDate = new Date(
+                                    $dateItem.text().trim()
+                                );
+                                expect(firstDate).to.be.gte(lastDate);
+                                expect(secondDate).to.be.gte(lastDate);
+                            });
+                    });
+            });
+    });
+});


### PR DESCRIPTION
# Implements [AB#11675](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11675)

## Description

Reverses the sorting for exports so that the most recent records are displayed first.  Also includes functional tests and a fix for an error reported when running unit tests.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
