### PR TITLE
Fix IsLoading property of MudProgressLinear in Claim page AB#11848

### DIFF
--- a/Apps/Admin/Client/Pages/Claims.razor
+++ b/Apps/Admin/Client/Pages/Claims.razor
@@ -13,10 +13,11 @@
 @inject IState<State> configState;
 @inject StateFacade configFacade;
 @inject IJSRuntime jsRuntime
+@inject IDispatcher Dispatcher
 
 <PageTitle>User Info</PageTitle>
-<MudHidden IsHidden="@(!configState.Value.IsLoading)"> 
-    <MudProgressLinear Color="Color.Primary" Indeterminate="true" Class="my-7" />
+<MudHidden Invert="@(!configState.Value.IsLoading)"> 
+    <MudProgressLinear Color="Color.Primary" Indeterminate="@(configState.Value.IsLoading)" Class="my-7" />
 </MudHidden>
 <MudContainer>
     <h1>User Info</h1>
@@ -64,7 +65,7 @@
             expires = "";
         }
         string cookieValue = $"{name}={value}{expires}; path=/";
-        
+
         await jsRuntime.InvokeVoidAsync("eval", $@"document.cookie = ""{cookieValue}""");
     }
 
@@ -74,7 +75,7 @@
         ClaimsPrincipal user = authState.User;
 
         if (user.Identity!=null && user.Identity.IsAuthenticated)
-        {
+        {         
             var tokenResult = await TokenProvider.RequestAccessToken().ConfigureAwait(true);
             tokenResult.TryGetToken(out var accessToken);
             _token = accessToken.Value;

--- a/Apps/Admin/Client/Pages/Claims.razor
+++ b/Apps/Admin/Client/Pages/Claims.razor
@@ -13,7 +13,6 @@
 @inject IState<State> configState;
 @inject StateFacade configFacade;
 @inject IJSRuntime jsRuntime
-@inject IDispatcher Dispatcher
 
 <PageTitle>User Info</PageTitle>
 <MudHidden Invert="@(!configState.Value.IsLoading)"> 

--- a/Apps/Admin/Client/Pages/Claims.razor
+++ b/Apps/Admin/Client/Pages/Claims.razor
@@ -65,7 +65,6 @@
             expires = "";
         }
         string cookieValue = $"{name}={value}{expires}; path=/";
-
         await jsRuntime.InvokeVoidAsync("eval", $@"document.cookie = ""{cookieValue}""");
     }
 


### PR DESCRIPTION
# Fix IsLoading property of MudProgressLinear in Claim page [AB#11848](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11848)

## Description

Fix IsLoading property of MudProgressLinear in Claim page, if success the loading will not be visible.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
