### PR TITLE
Fix issues with times on public COVID-19 test page AB#12037

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/models/dateWrapper.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/dateWrapper.ts
@@ -1,6 +1,7 @@
 import { DateTime, Duration, DurationObject, DurationUnit } from "luxon";
 
 const timezone = "America/Vancouver";
+const locale = "en-US"; // times display as 4:07 PM in en-US locale and 4:07 p.m. in en-CA locale
 
 /**
  * Typed representation of a ISO Date, time is not relevant.
@@ -148,7 +149,10 @@ export class DateWrapper {
      */
     public format(formatString?: string): string {
         return this.internalDate.toFormat(
-            formatString || DateWrapper.defaultFormat
+            formatString || DateWrapper.defaultFormat,
+            {
+                locale: locale,
+            }
         );
     }
 

--- a/Apps/WebClient/src/ClientApp/src/views/publicCovidTest.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/publicCovidTest.vue
@@ -138,7 +138,7 @@ export default class PublicCovidTestView extends Vue {
 
     private formatDate(date: StringISODateTime): string {
         if (date) {
-            const dateWrapper = new DateWrapper(date);
+            const dateWrapper = new DateWrapper(date, { hasTime: true });
             const dateString = dateWrapper.format("yyyy-MMM-dd");
             const timeString = dateWrapper.format("t").replace(" ", "\u00A0");
             return `${dateString}, ${timeString}`;


### PR DESCRIPTION
# Fixes [AB#12037](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12037)

## Description

- Fixes result and collection datetimes on the public COVID-19 test page results being 3 hours off
- Fixes functional tests failing locally because the browser launched by Cypress was formatting dates in 24-hour time due to running with en-GB locale

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
