### PR TITLE
Fix link name for AB#12015.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/publicCovidTest.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/publicCovidTest.vue
@@ -370,8 +370,8 @@ export default class PublicCovidTestView extends Vue {
                                             (resultDescriptionIndex + 1)
                                         "
                                         target="blank_"
-                                        >here.</a
-                                    >
+                                        >page</a
+                                    >.
                                 </b-col>
                             </b-row>
                         </div>


### PR DESCRIPTION
# Fixes or Implements [AB#12015](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12015)

## Description

1. Change "here" to "page". 
2. Keep period, but do not hyperlink.

<img width="2531" alt="Screen Shot 2021-12-24 at 11 11 51 AM" src="https://user-images.githubusercontent.com/58790456/147369831-422d67f4-53fc-4496-8748-c31a151171ae.png">

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
