### PR TITLE
Add e2e tests for public COVID-19 test results AB#12038

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/covid19/publicCovidTest.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/publicCovidTest.js
@@ -1,0 +1,171 @@
+const dobYearSelector =
+    "[data-testid=dateOfBirthInput] [data-testid=formSelectYear]";
+const dobMonthSelector =
+    "[data-testid=dateOfBirthInput] [data-testid=formSelectMonth]";
+const dobDaySelector =
+    "[data-testid=dateOfBirthInput] [data-testid=formSelectDay]";
+const collectionDateYearSelector =
+    "[data-testid=dateOfCollectionInput] [data-testid=formSelectYear]";
+const collectionDateMonthSelector =
+    "[data-testid=dateOfCollectionInput] [data-testid=formSelectMonth]";
+const collectionDateDaySelector =
+    "[data-testid=dateOfCollectionInput] [data-testid=formSelectDay]";
+
+const publicLaboratoryResultModule = "PublicLaboratoryResult";
+const laboratoryModule = "Laboratory";
+const covidTestUrl = "/covidtest";
+
+const phn = "9875813462";
+const dobYear = "1950";
+const dobMonth = "March";
+const dobDay = "15";
+
+const indeterminateCollectionDateYear = "2021";
+const indeterminateCollectionDateMonth = "October";
+const indeterminateCollectionDateDay = "7";
+
+const pendingCollectionDateYear = "2021";
+const pendingCollectionDateMonth = "November";
+const pendingCollectionDateDay = "27";
+
+const positiveCollectionDateYear = "2020";
+const positiveCollectionDateMonth = "September";
+const positiveCollectionDateDay = "29";
+
+const negativeCollectionDateYear = "2021";
+const negativeCollectionDateMonth = "November";
+const negativeCollectionDateDay = "5";
+
+const cancelledCollectionDateYear = "2020";
+const cancelledCollectionDateMonth = "September";
+const cancelledCollectionDateDay = "27";
+
+const multipleCollectionDateYear = "2021";
+const multipleCollectionDateMonth = "November";
+const multipleCollectionDateDay = "24";
+
+function selectOption(selector, option) {
+    return cy.get(selector).should("be.visible", "be.enabled").select(option);
+}
+
+function enterCovidTestPHN(phn) {
+    cy.get("[data-testid=phnInput]")
+        .should("be.visible", "be.enabled")
+        .clear()
+        .type(phn);
+}
+
+function clickCovidTestEnterButton() {
+    cy.get("[data-testid=btnEnter]").should("be.enabled", "be.visible").click();
+}
+
+function enterFormInputs(
+    collectionDateYear,
+    collectionDateMonth,
+    collectionDateDay
+) {
+    enterCovidTestPHN(phn);
+    selectOption(dobYearSelector, dobYear);
+    selectOption(dobMonthSelector, dobMonth);
+    selectOption(dobDaySelector, dobDay);
+    selectOption(collectionDateYearSelector, collectionDateYear);
+    selectOption(collectionDateMonthSelector, collectionDateMonth);
+    selectOption(collectionDateDaySelector, collectionDateDay);
+
+    clickCovidTestEnterButton();
+}
+
+function checkResult(
+    expectedResult,
+    expectedTestStatus,
+    expectedResultClass = null
+) {
+    cy.get("[data-testid=public-covid-test-result-form-title]").should(
+        "be.visible"
+    );
+
+    cy.get("[data-testid=public-display-name]").should("be.visible");
+
+    cy.get("[data-testid=test-type-1]").should("be.visible");
+
+    const result = cy.get("[data-testid=test-outcome-span-1]");
+
+    if (expectedResultClass != null) {
+        result.should("have.class", expectedResultClass);
+    }
+
+    result.should("be.visible").contains(expectedResult);
+
+    cy.get("[data-testid=collection-date-1]").should("be.visible");
+
+    cy.get("[data-testid=test-status]")
+        .should("be.visible")
+        .contains(expectedTestStatus);
+
+    cy.get("[data-testid=result-date-1]").should("be.visible");
+
+    cy.get("[data-testid=reporting-lab]").should("be.visible");
+
+    cy.get("[data-testid=result-description]").should("be.visible");
+}
+
+describe("Public COVID-19 Test Results", () => {
+    beforeEach(() => {
+        cy.enableModules([laboratoryModule, publicLaboratoryResultModule]);
+        cy.visit(covidTestUrl);
+    });
+
+    it("Successful Response: Negative Result", () => {
+        enterFormInputs(
+            negativeCollectionDateYear,
+            negativeCollectionDateMonth,
+            negativeCollectionDateDay
+        );
+        checkResult("Negative", "Final", "text-success");
+    });
+
+    it("Successful Response: Positive Result", () => {
+        enterFormInputs(
+            positiveCollectionDateYear,
+            positiveCollectionDateMonth,
+            positiveCollectionDateDay
+        );
+        checkResult("Positive", "Final", "text-danger");
+    });
+
+    it("Successful Response: Indeterminate Result", () => {
+        enterFormInputs(
+            indeterminateCollectionDateYear,
+            indeterminateCollectionDateMonth,
+            indeterminateCollectionDateDay
+        );
+        checkResult("Indeterminate", "Final");
+    });
+
+    it("Successful Response: Pending Result", () => {
+        enterFormInputs(
+            pendingCollectionDateYear,
+            pendingCollectionDateMonth,
+            pendingCollectionDateDay
+        );
+        checkResult("NotSet", "Pending");
+    });
+
+    it("Successful Response: Cancelled Result", () => {
+        enterFormInputs(
+            cancelledCollectionDateYear,
+            cancelledCollectionDateMonth,
+            cancelledCollectionDateDay
+        );
+        checkResult("Cancelled", "StatusChange");
+    });
+
+    it("Successful Response: Multiple Results", () => {
+        enterFormInputs(
+            multipleCollectionDateYear,
+            multipleCollectionDateMonth,
+            multipleCollectionDateDay
+        );
+        cy.get(".covid-test-result").should("have.length.at.least", 2);
+    });
+});

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/publicVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/publicVaccineCard.js
@@ -30,8 +30,8 @@ function enterVaccineCardPHN(phn) {
         .type(phn);
 }
 
-function select(selector, value) {
-    cy.get(selector).should("be.visible", "be.enabled").select(value);
+function selectOption(selector, option) {
+    return cy.get(selector).should("be.visible", "be.enabled").select(option);
 }
 
 function clickVaccineCardEnterButton() {
@@ -57,12 +57,12 @@ describe("Public Vaccine Card Result", () => {
 
         enterVaccineCardPHN(phn);
 
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
-        select(dovYearSelector, dovYear);
-        select(dovMonthSelector, dovMonth);
-        select(dovDaySelector, dovDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
+        selectOption(dovYearSelector, dovYear);
+        selectOption(dovMonthSelector, dovMonth);
+        selectOption(dovDaySelector, dovDay);
 
         clickVaccineCardEnterButton();
 
@@ -79,12 +79,12 @@ describe("Public Vaccine Card Result", () => {
         cy.visit(vaccineCardUrl);
 
         enterVaccineCardPHN(fullyVaccinatedPhn);
-        select(dobYearSelector, fullyVaccinatedDobYear);
-        select(dobMonthSelector, fullyVaccinatedDobMonth);
-        select(dobDaySelector, fullyVaccinatedDobDay);
-        select(dovYearSelector, fullyVaccinatedDovYear);
-        select(dovMonthSelector, fullyVaccinatedDovMonth);
-        select(dovDaySelector, fullyVaccinatedDovDay);
+        selectOption(dobYearSelector, fullyVaccinatedDobYear);
+        selectOption(dobMonthSelector, fullyVaccinatedDobMonth);
+        selectOption(dobDaySelector, fullyVaccinatedDobDay);
+        selectOption(dovYearSelector, fullyVaccinatedDovYear);
+        selectOption(dovMonthSelector, fullyVaccinatedDovMonth);
+        selectOption(dovDaySelector, fullyVaccinatedDovDay);
 
         clickVaccineCardEnterButton();
 
@@ -106,12 +106,12 @@ describe("Public Vaccine Card Downloads", () => {
         cy.visit(vaccineCardUrl);
 
         enterVaccineCardPHN(fullyVaccinatedPhn);
-        select(dobYearSelector, fullyVaccinatedDobYear);
-        select(dobMonthSelector, fullyVaccinatedDobMonth);
-        select(dobDaySelector, fullyVaccinatedDobDay);
-        select(dovYearSelector, fullyVaccinatedDovYear);
-        select(dovMonthSelector, fullyVaccinatedDovMonth);
-        select(dovDaySelector, fullyVaccinatedDovDay);
+        selectOption(dobYearSelector, fullyVaccinatedDobYear);
+        selectOption(dobMonthSelector, fullyVaccinatedDobMonth);
+        selectOption(dobDaySelector, fullyVaccinatedDobDay);
+        selectOption(dovYearSelector, fullyVaccinatedDovYear);
+        selectOption(dovMonthSelector, fullyVaccinatedDovMonth);
+        selectOption(dovDaySelector, fullyVaccinatedDovDay);
 
         clickVaccineCardEnterButton();
     });

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicCovidTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicCovidTest.js
@@ -23,6 +23,10 @@ const publicLaboratoryResultModule = "PublicLaboratoryResult";
 const laboratoryModule = "Laboratory";
 const covidTestUrl = "/covidtest";
 
+const dummyYear = "2021";
+const dummyMonth = "June";
+const dummyDay = "15";
+
 function selectOption(selector, option) {
     return cy.get(selector).should("be.visible", "be.enabled").select(option);
 }
@@ -42,6 +46,7 @@ function selectShouldNotContain(selector, value) {
 function enterCovidTestPHN(phn) {
     cy.get("[data-testid=phnInput]")
         .should("be.visible", "be.enabled")
+        .clear()
         .type(phn);
 }
 
@@ -49,18 +54,18 @@ function clickCovidTestEnterButton() {
     cy.get("[data-testid=btnEnter]").should("be.enabled", "be.visible").click();
 }
 
-describe("Public User - Covid19 Test Result Page", () => {
+describe("Public COVID-19 Test Form", () => {
     beforeEach(() => {
         cy.enableModules([laboratoryModule, publicLaboratoryResultModule]);
         cy.visit(covidTestUrl);
     });
 
-    it("Public Covid19 Test - Cancel", () => {
+    it("Cancel Button Should Go to Landing Page", () => {
         cy.get("[data-testid=btnCancel]").should("be.visible").click();
         cy.get("[data-testid=covid-test-button]").should("exist");
     });
 
-    it("Public Covid19 Test - Login BC Services Card App", () => {
+    it("Log In Button Should Go to Login Page", () => {
         cy.get("[data-testid=btnLogin]")
             .should("be.visible", "be.enabled")
             .click();
@@ -68,43 +73,33 @@ describe("Public User - Covid19 Test Result Page", () => {
         cy.get("[data-testid=vaccineCardFormTitle]").should("not.exist");
     });
 
-    it("Public Covid19 Test - Valid PHN via Select Year", () => {
-        enterCovidTestPHN(Cypress.env("phn"));
-        selectOption(dobYearSelector, "Year");
-        cy.get("[data-testid=phnInput]")
-            .should("be.visible", "be.enabled")
-            .and("have.class", "form-control is-valid");
-    });
-
-    it("Public Covid19 Test - Invalid PHN via Select Year", () => {
-        enterCovidTestPHN(Cypress.env("phn").replace(/.$/, ""));
-        selectOption(dobYearSelector, "Year");
-        cy.get(feedbackPhnMustBeValidSelector).should("be.visible");
-    });
-
-    it("Public Covid19 Test - PHN, DOB and Collection Date not entered via Click Enter", () => {
+    it("Validate PHN, DOB, and Collection Date Required", () => {
         clickCovidTestEnterButton();
+
         cy.get(feedbackPhnIsRequiredSelector).should("be.visible");
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
     });
 
-    it("Public Covid19 Test - DOB and Collection Date not entered with Invalid PHN via Click Enter", () => {
-        enterCovidTestPHN(Cypress.env("phn").replace(/.$/, ""));
-        clickCovidTestEnterButton();
-        cy.get(feedbackPhnMustBeValidSelector).should("be.visible");
-        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
-        cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
-    });
-
-    it("Public Covid19 Test - DOB and Collection Date not entered via Click Enter", () => {
+    it("Validate PHN Format", () => {
+        cy.log("Validate valid PHN passes validation.");
         enterCovidTestPHN(Cypress.env("phn"));
+
+        selectOption(dobYearSelector, "Year");
+
+        cy.get("[data-testid=phnInput]")
+            .should("be.visible", "be.enabled")
+            .and("have.class", "form-control is-valid");
+
+        cy.log("Validate invalid PHN fails validation.");
+        enterCovidTestPHN(Cypress.env("phn").replace(/.$/, ""));
+
         clickCovidTestEnterButton();
-        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
-        cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
+
+        cy.get(feedbackPhnMustBeValidSelector).should("be.visible");
     });
 
-    it("Public Covid19 Test - DOB and Collection Date cannot be future dated", () => {
+    it("Validate Date Range for DOB and Collection Date", () => {
         const d = new Date();
         const year = d.getFullYear();
         const monthNumber = d.getMonth(); //Maps to monthNames constant array. Index starts at 0
@@ -125,8 +120,6 @@ describe("Public User - Covid19 Test Result Page", () => {
                 " - Day: " +
                 day
         );
-
-        enterCovidTestPHN(Cypress.env("phn"));
 
         d.setDate(d.getDate() + 1);
         const nextYear = d.getFullYear() === year ? year + 1 : d.getFullYear();
@@ -172,67 +165,68 @@ describe("Public User - Covid19 Test Result Page", () => {
         selectShouldContain(collectionDateDaySelector, day);
     });
 
-    it("Public Covid19 Test - DOB Year and Collection Date not entered via Click Enter", () => {
-        const dobMonth = "June";
-        const dobDay = "15";
+    it("Validate DOB Year Required", () => {
+        selectOption(dobMonthSelector, dummyMonth);
+        selectOption(dobDaySelector, dummyDay);
 
-        enterCovidTestPHN(Cypress.env("phn"));
-        selectOption(dobMonthSelector, dobMonth);
-        selectOption(dobDaySelector, dobDay);
         clickCovidTestEnterButton();
+
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
+    });
+
+    it("Validate DOB Month Required", () => {
+        selectOption(dobYearSelector, dummyYear);
+        selectOption(dobDaySelector, dummyDay);
+
+        clickCovidTestEnterButton();
+
+        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
+    });
+
+    it("Validate DOB Day Required", () => {
+        selectOption(dobYearSelector, dummyYear);
+        selectOption(dobMonthSelector, dummyMonth);
+
+        clickCovidTestEnterButton();
+
+        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
+    });
+
+    it("Validate Collection Date Year Required", () => {
+        selectOption(collectionDateMonthSelector, dummyMonth);
+        selectOption(collectionDateDaySelector, dummyDay);
+
+        clickCovidTestEnterButton();
+
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
     });
 
-    it("Public Covid19 Test - DOB Month and Collection Date not entered via Click Enter", () => {
-        const dobYear = "2021";
-        const dobDay = "15";
+    it("Validate Collection Date Month Required", () => {
+        selectOption(collectionDateYearSelector, dummyYear);
+        selectOption(collectionDateDaySelector, dummyDay);
 
-        enterCovidTestPHN(Cypress.env("phn"));
-        selectOption(dobYearSelector, dobYear);
-        selectOption(dobDaySelector, dobDay);
         clickCovidTestEnterButton();
-        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
+
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
     });
 
-    it("Public Covid19 Test - DOB Day and Collection Date not entered via Click Enter", () => {
-        const dobYear = "2021";
-        const dobMonth = "June";
+    it("Validate Collection Date Day Required", () => {
+        selectOption(collectionDateYearSelector, dummyYear);
+        selectOption(collectionDateMonthSelector, dummyMonth);
 
-        enterCovidTestPHN(Cypress.env("phn"));
-        selectOption(dobYearSelector, dobYear);
-        selectOption(dobMonthSelector, dobMonth);
         clickCovidTestEnterButton();
-        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
+
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
     });
+});
 
-    it("Public Covid19 Test - Collection Date Month and DOB not entered via Click Enter", () => {
-        const collectionDateYear = "2021";
-        const collectionDateDay = "15";
-
-        enterCovidTestPHN(Cypress.env("phn"));
-        selectOption(collectionDateYearSelector, collectionDateYear);
-        selectOption(collectionDateDaySelector, collectionDateDay);
-        clickCovidTestEnterButton();
-        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
-        cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
+describe("Public COVID-19 Test Results", () => {
+    beforeEach(() => {
+        cy.enableModules([laboratoryModule, publicLaboratoryResultModule]);
+        cy.visit(covidTestUrl);
     });
 
-    it("Public Covid19 Test - Collection Date Day and DOB not entered via Click Enter", () => {
-        const collectionDateYear = "2021";
-        const collectionDateMonth = "June";
-
-        enterCovidTestPHN(Cypress.env("phn"));
-        selectOption(collectionDateYearSelector, collectionDateYear);
-        selectOption(collectionDateMonthSelector, collectionDateMonth);
-        clickCovidTestEnterButton();
-        cy.get(feedbackDobIsRequiredSelector).should("be.visible");
-        cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
-    });
-
-    it("Public Covid19 Test Results - Click another test", () => {
+    it("Successful Response: 1 Result", () => {
         const phn = "9735361219 ";
         const dobYear = "1994";
         const dobMonth = "June";
@@ -241,8 +235,6 @@ describe("Public User - Covid19 Test Result Page", () => {
         const collectionDateMonth = "January";
         const collectionDateDay = "20";
 
-        cy.enableModules(["Laboratory", "PublicLaboratoryResult"]);
-        cy.visit("/covidTest");
         cy.intercept("GET", "**/v1/api/PublicLaboratory/CovidTests", (req) => {
             req.reply({
                 fixture: "LaboratoryService/covidTest.json",
@@ -283,12 +275,9 @@ describe("Public User - Covid19 Test Result Page", () => {
 
         cy.get("[data-testid=btnCheckAnotherTest]").should("be.visible");
         cy.get("[data-testid=btnLogin]").should("be.visible");
-
-        cy.get("[data-testid=btnCheckAnotherTest]").click();
-        cy.get("[data-testid=phnInput]").should("be.visible");
     });
 
-    it("Public Covid19 Test - Empty Results", () => {
+    it("Successful Response: No Results", () => {
         const phn = "9735361219 ";
         const dobYear = "1994";
         const dobMonth = "June";
@@ -319,7 +308,7 @@ describe("Public User - Covid19 Test Result Page", () => {
         cy.get("[data-testid=btnLogin]").should("be.visible");
     });
 
-    it("Public Covid19 Test - Data Mismatch", () => {
+    it("Unsuccessful Response: Data Mismatch", () => {
         const phn = "9735361219 ";
         const dobYear = "1994";
         const dobMonth = "June";
@@ -345,7 +334,7 @@ describe("Public User - Covid19 Test Result Page", () => {
         cy.get("[data-testid=error-text-description]").should("be.visible");
     });
 
-    it("Public Covid19 Test - Invalid", () => {
+    it("Unsuccessful Response: Invalid", () => {
         const phn = "9735361219 ";
         const dobYear = "1994";
         const dobMonth = "June";
@@ -371,7 +360,7 @@ describe("Public User - Covid19 Test Result Page", () => {
         cy.get("[data-testid=error-text-description]").should("be.visible");
     });
 
-    it("Public Covid19 Test - Empty Results and Check another test", () => {
+    it("Check Another Test Button Should Go to Form", () => {
         const phn = "9735361219 ";
         const dobYear = "1994";
         const dobMonth = "June";

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicCovidTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicCovidTest.js
@@ -23,26 +23,26 @@ const publicLaboratoryResultModule = "PublicLaboratoryResult";
 const laboratoryModule = "Laboratory";
 const covidTestUrl = "/covidtest";
 
-function enterCovidTestPHN(phn) {
-    cy.get("[data-testid=phnInput]")
-        .should("be.visible", "be.enabled")
-        .type(phn);
+function selectOption(selector, option) {
+    return cy.get(selector).should("be.visible", "be.enabled").select(option);
 }
 
-function select(selector, value) {
-    cy.get(selector).should("be.visible", "be.enabled").select(value);
-}
-
-function selectExist(selector, value) {
+function selectShouldContain(selector, value) {
     cy.get(selector)
         .children("[value=" + value + "]")
         .should("exist");
 }
 
-function selectNotExist(selector, value) {
+function selectShouldNotContain(selector, value) {
     cy.get(selector)
         .children("[value=" + value + "]")
         .should("not.exist");
+}
+
+function enterCovidTestPHN(phn) {
+    cy.get("[data-testid=phnInput]")
+        .should("be.visible", "be.enabled")
+        .type(phn);
 }
 
 function clickCovidTestEnterButton() {
@@ -70,7 +70,7 @@ describe("Public User - Covid19 Test Result Page", () => {
 
     it("Public Covid19 Test - Valid PHN via Select Year", () => {
         enterCovidTestPHN(Cypress.env("phn"));
-        select(dobYearSelector, "Year");
+        selectOption(dobYearSelector, "Year");
         cy.get("[data-testid=phnInput]")
             .should("be.visible", "be.enabled")
             .and("have.class", "form-control is-valid");
@@ -78,7 +78,7 @@ describe("Public User - Covid19 Test Result Page", () => {
 
     it("Public Covid19 Test - Invalid PHN via Select Year", () => {
         enterCovidTestPHN(Cypress.env("phn").replace(/.$/, ""));
-        select(dobYearSelector, "Year");
+        selectOption(dobYearSelector, "Year");
         cy.get(feedbackPhnMustBeValidSelector).should("be.visible");
     });
 
@@ -137,12 +137,12 @@ describe("Public User - Covid19 Test Result Page", () => {
 
         // Test Future Year does not exist
         cy.log("Testing Future Year does not exist.");
-        selectNotExist(dobYearSelector, nextYear.toString());
-        selectNotExist(collectionDateYearSelector, nextYear.toString());
+        selectShouldNotContain(dobYearSelector, nextYear.toString());
+        selectShouldNotContain(collectionDateYearSelector, nextYear.toString());
 
         // Test Current Year
-        select(dobYearSelector, year.toString());
-        select(collectionDateYearSelector, year.toString());
+        selectOption(dobYearSelector, year.toString());
+        selectOption(collectionDateYearSelector, year.toString());
         cy.log("Testing Current Year.");
 
         if (nextMonth > 1) {
@@ -150,26 +150,26 @@ describe("Public User - Covid19 Test Result Page", () => {
             cy.log(
                 "Current year has been set in dropdown, so if next month is 1 - January, it means current month is December. Test Future Month does not exist. Month can only be current or past month for current year."
             );
-            selectNotExist(dobMonthSelector, nextMonth);
-            selectNotExist(collectionDateMonthSelector, nextMonth);
+            selectShouldNotContain(dobMonthSelector, nextMonth);
+            selectShouldNotContain(collectionDateMonthSelector, nextMonth);
         }
 
         cy.log("Test and set Current Month");
-        select(dobMonthSelector, monthNames[monthNumber]);
-        select(collectionDateMonthSelector, monthNames[monthNumber]);
+        selectOption(dobMonthSelector, monthNames[monthNumber]);
+        selectOption(collectionDateMonthSelector, monthNames[monthNumber]);
 
         if (nextDay > 1) {
             cy.log("Next Day: " + nextDay);
             cy.log(
                 "Current Year and Month have been set. If next day is 1, it means previous day was last day of current month. Next Day is associated with the current month. Test Future Day in current month does not exist."
             );
-            selectNotExist(dobDaySelector, nextDay);
-            selectNotExist(collectionDateDaySelector, nextDay);
+            selectShouldNotContain(dobDaySelector, nextDay);
+            selectShouldNotContain(collectionDateDaySelector, nextDay);
         }
         //Test Current Day exists
         cy.log("Test Current Day exists.");
-        selectExist(dobDaySelector, day);
-        selectExist(collectionDateDaySelector, day);
+        selectShouldContain(dobDaySelector, day);
+        selectShouldContain(collectionDateDaySelector, day);
     });
 
     it("Public Covid19 Test - DOB Year and Collection Date not entered via Click Enter", () => {
@@ -177,8 +177,8 @@ describe("Public User - Covid19 Test Result Page", () => {
         const dobDay = "15";
 
         enterCovidTestPHN(Cypress.env("phn"));
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
         clickCovidTestEnterButton();
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
@@ -189,8 +189,8 @@ describe("Public User - Covid19 Test Result Page", () => {
         const dobDay = "15";
 
         enterCovidTestPHN(Cypress.env("phn"));
-        select(dobYearSelector, dobYear);
-        select(dobDaySelector, dobDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobDaySelector, dobDay);
         clickCovidTestEnterButton();
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
@@ -201,8 +201,8 @@ describe("Public User - Covid19 Test Result Page", () => {
         const dobMonth = "June";
 
         enterCovidTestPHN(Cypress.env("phn"));
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
         clickCovidTestEnterButton();
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
@@ -213,8 +213,8 @@ describe("Public User - Covid19 Test Result Page", () => {
         const collectionDateDay = "15";
 
         enterCovidTestPHN(Cypress.env("phn"));
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateDaySelector, collectionDateDay);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateDaySelector, collectionDateDay);
         clickCovidTestEnterButton();
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
@@ -225,8 +225,8 @@ describe("Public User - Covid19 Test Result Page", () => {
         const collectionDateMonth = "June";
 
         enterCovidTestPHN(Cypress.env("phn"));
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateMonthSelector, collectionDateMonth);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateMonthSelector, collectionDateMonth);
         clickCovidTestEnterButton();
         cy.get(feedbackDobIsRequiredSelector).should("be.visible");
         cy.get(feedbackCollectionDateIsRequiredSelector).should("be.visible");
@@ -250,12 +250,12 @@ describe("Public User - Covid19 Test Result Page", () => {
         });
 
         enterCovidTestPHN(phn);
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateMonthSelector, collectionDateMonth);
-        select(collectionDateDaySelector, collectionDateDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateMonthSelector, collectionDateMonth);
+        selectOption(collectionDateDaySelector, collectionDateDay);
 
         clickCovidTestEnterButton();
         cy.get("[data-testid=public-covid-test-result-form-title]").should(
@@ -305,12 +305,12 @@ describe("Public User - Covid19 Test Result Page", () => {
 
         enterCovidTestPHN(phn);
 
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateMonthSelector, collectionDateMonth);
-        select(collectionDateDaySelector, collectionDateDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateMonthSelector, collectionDateMonth);
+        selectOption(collectionDateDaySelector, collectionDateDay);
         clickCovidTestEnterButton();
         cy.get("[data-testid=public-covid-test-result-form-title]").should(
             "be.visible"
@@ -335,12 +335,12 @@ describe("Public User - Covid19 Test Result Page", () => {
         });
 
         enterCovidTestPHN(phn);
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateMonthSelector, collectionDateMonth);
-        select(collectionDateDaySelector, collectionDateDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateMonthSelector, collectionDateMonth);
+        selectOption(collectionDateDaySelector, collectionDateDay);
         clickCovidTestEnterButton();
         cy.get("[data-testid=error-text-description]").should("be.visible");
     });
@@ -361,12 +361,12 @@ describe("Public User - Covid19 Test Result Page", () => {
         });
 
         enterCovidTestPHN(phn);
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateMonthSelector, collectionDateMonth);
-        select(collectionDateDaySelector, collectionDateDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateMonthSelector, collectionDateMonth);
+        selectOption(collectionDateDaySelector, collectionDateDay);
         clickCovidTestEnterButton();
         cy.get("[data-testid=error-text-description]").should("be.visible");
     });
@@ -388,12 +388,12 @@ describe("Public User - Covid19 Test Result Page", () => {
 
         enterCovidTestPHN(phn);
 
-        select(dobYearSelector, dobYear);
-        select(dobMonthSelector, dobMonth);
-        select(dobDaySelector, dobDay);
-        select(collectionDateYearSelector, collectionDateYear);
-        select(collectionDateMonthSelector, collectionDateMonth);
-        select(collectionDateDaySelector, collectionDateDay);
+        selectOption(dobYearSelector, dobYear);
+        selectOption(dobMonthSelector, dobMonth);
+        selectOption(dobDaySelector, dobDay);
+        selectOption(collectionDateYearSelector, collectionDateYear);
+        selectOption(collectionDateMonthSelector, collectionDateMonth);
+        selectOption(collectionDateDaySelector, collectionDateDay);
 
         clickCovidTestEnterButton();
         cy.get("[data-testid=public-covid-test-result-form-title]").should(

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicVaccineCard.js
@@ -35,27 +35,27 @@ const fullyVaccinatedDovYear = "2021";
 const fullyVaccinatedDovMonth = "January";
 const fullyVaccinatedDovDay = "20";
 
-function enterVaccineCardPHN(phn) {
-    cy.get("[data-testid=phnInput]")
-        .should("be.visible", "be.enabled")
-        .clear()
-        .type(phn);
+function selectOption(selector, option) {
+    return cy.get(selector).should("be.visible", "be.enabled").select(option);
 }
 
-function select(selector, value) {
-    cy.get(selector).should("be.visible", "be.enabled").select(value);
-}
-
-function selectExist(selector, value) {
+function selectShouldContain(selector, value) {
     cy.get(selector)
         .children("[value=" + value + "]")
         .should("exist");
 }
 
-function selectNotExist(selector, value) {
+function selectShouldNotContain(selector, value) {
     cy.get(selector)
         .children("[value=" + value + "]")
         .should("not.exist");
+}
+
+function enterVaccineCardPHN(phn) {
+    cy.get("[data-testid=phnInput]")
+        .should("be.visible", "be.enabled")
+        .clear()
+        .type(phn);
 }
 
 function clickVaccineCardEnterButton() {
@@ -94,7 +94,7 @@ describe("Public Vaccine Card Form", () => {
         cy.log("Validate valid PHN passes validation.");
         enterVaccineCardPHN(Cypress.env("phn"));
 
-        select(dobYearSelector, "Year");
+        selectOption(dobYearSelector, "Year");
 
         cy.get("[data-testid=phnInput]")
             .should("be.visible", "be.enabled")
@@ -139,12 +139,12 @@ describe("Public Vaccine Card Form", () => {
 
         // Test Future Year does not exist
         cy.log("Testing Future Year does not exist.");
-        selectNotExist(dobYearSelector, nextYear.toString());
-        selectNotExist(dovYearSelector, nextYear.toString());
+        selectShouldNotContain(dobYearSelector, nextYear.toString());
+        selectShouldNotContain(dovYearSelector, nextYear.toString());
 
         // Test Current Year
-        select(dobYearSelector, year.toString());
-        select(dovYearSelector, year.toString());
+        selectOption(dobYearSelector, year.toString());
+        selectOption(dovYearSelector, year.toString());
         cy.log("Testing Current Year.");
 
         if (nextMonth > 1) {
@@ -152,31 +152,31 @@ describe("Public Vaccine Card Form", () => {
             cy.log(
                 "Current year has been set in dropdown, so if next month is 1 - January, it means current month is December. Test Future Month does not exist. Month can only be current or past month for current year."
             );
-            selectNotExist(dobMonthSelector, nextMonth);
-            selectNotExist(dovMonthSelector, nextMonth);
+            selectShouldNotContain(dobMonthSelector, nextMonth);
+            selectShouldNotContain(dovMonthSelector, nextMonth);
         }
 
         cy.log("Test and set Current Month");
-        select(dobMonthSelector, monthNames[monthNumber]);
-        select(dovMonthSelector, monthNames[monthNumber]);
+        selectOption(dobMonthSelector, monthNames[monthNumber]);
+        selectOption(dovMonthSelector, monthNames[monthNumber]);
 
         if (nextDay > 1) {
             cy.log("Next Day: " + nextDay);
             cy.log(
                 "Current Year and Month have been set. If next day is 1, it means previous day was last day of current month. Next Day is associated with the current month. Test Future Day in current month does not exist."
             );
-            selectNotExist(dobDaySelector, nextDay);
-            selectNotExist(dovDaySelector, nextDay);
+            selectShouldNotContain(dobDaySelector, nextDay);
+            selectShouldNotContain(dovDaySelector, nextDay);
         }
         //Test Current Day exists
         cy.log("Test Current Day exists.");
-        selectExist(dobDaySelector, day);
-        selectExist(dovDaySelector, day);
+        selectShouldContain(dobDaySelector, day);
+        selectShouldContain(dovDaySelector, day);
     });
 
     it("Validate DOB Year Required", () => {
-        select(dobMonthSelector, dummyMonth);
-        select(dobDaySelector, dummyDay);
+        selectOption(dobMonthSelector, dummyMonth);
+        selectOption(dobDaySelector, dummyDay);
 
         clickVaccineCardEnterButton();
 
@@ -184,8 +184,8 @@ describe("Public Vaccine Card Form", () => {
     });
 
     it("Validate DOB Month Required", () => {
-        select(dobYearSelector, dummyYear);
-        select(dobDaySelector, dummyDay);
+        selectOption(dobYearSelector, dummyYear);
+        selectOption(dobDaySelector, dummyDay);
 
         clickVaccineCardEnterButton();
 
@@ -193,8 +193,8 @@ describe("Public Vaccine Card Form", () => {
     });
 
     it("Validate DOB Day Required", () => {
-        select(dobYearSelector, dummyYear);
-        select(dobMonthSelector, dummyMonth);
+        selectOption(dobYearSelector, dummyYear);
+        selectOption(dobMonthSelector, dummyMonth);
 
         clickVaccineCardEnterButton();
 
@@ -202,8 +202,8 @@ describe("Public Vaccine Card Form", () => {
     });
 
     it("Validate DOV Year Required", () => {
-        select(dovMonthSelector, dummyMonth);
-        select(dovDaySelector, dummyDay);
+        selectOption(dovMonthSelector, dummyMonth);
+        selectOption(dovDaySelector, dummyDay);
 
         clickVaccineCardEnterButton();
 
@@ -211,8 +211,8 @@ describe("Public Vaccine Card Form", () => {
     });
 
     it("Validate DOV Month Required", () => {
-        select(dovYearSelector, dummyYear);
-        select(dovDaySelector, dummyDay);
+        selectOption(dovYearSelector, dummyYear);
+        selectOption(dovDaySelector, dummyDay);
 
         clickVaccineCardEnterButton();
 
@@ -220,8 +220,8 @@ describe("Public Vaccine Card Form", () => {
     });
 
     it("Validate DOV Day Required", () => {
-        select(dovYearSelector, dummyYear);
-        select(dovMonthSelector, dummyMonth);
+        selectOption(dovYearSelector, dummyYear);
+        selectOption(dovMonthSelector, dummyMonth);
 
         clickVaccineCardEnterButton();
 
@@ -244,12 +244,12 @@ describe("Public Vaccine Card Downloads", () => {
         cy.visit(vaccineCardUrl);
 
         enterVaccineCardPHN(fullyVaccinatedPhn);
-        select(dobYearSelector, fullyVaccinatedDobYear);
-        select(dobMonthSelector, fullyVaccinatedDobMonth);
-        select(dobDaySelector, fullyVaccinatedDobDay);
-        select(dovYearSelector, fullyVaccinatedDovYear);
-        select(dovMonthSelector, fullyVaccinatedDovMonth);
-        select(dovDaySelector, fullyVaccinatedDovDay);
+        selectOption(dobYearSelector, fullyVaccinatedDobYear);
+        selectOption(dobMonthSelector, fullyVaccinatedDobMonth);
+        selectOption(dobDaySelector, fullyVaccinatedDobDay);
+        selectOption(dovYearSelector, fullyVaccinatedDovYear);
+        selectOption(dovMonthSelector, fullyVaccinatedDovMonth);
+        selectOption(dovDaySelector, fullyVaccinatedDovDay);
 
         clickVaccineCardEnterButton();
     });
@@ -334,12 +334,12 @@ describe("Public Vaccine Card Downloads When PublicVaccineDownloadPdf Disabled",
         cy.visit(vaccineCardUrl);
 
         enterVaccineCardPHN(fullyVaccinatedPhn);
-        select(dobYearSelector, fullyVaccinatedDobYear);
-        select(dobMonthSelector, fullyVaccinatedDobMonth);
-        select(dobDaySelector, fullyVaccinatedDobDay);
-        select(dovYearSelector, fullyVaccinatedDovYear);
-        select(dovMonthSelector, fullyVaccinatedDovMonth);
-        select(dovDaySelector, fullyVaccinatedDovDay);
+        selectOption(dobYearSelector, fullyVaccinatedDobYear);
+        selectOption(dobMonthSelector, fullyVaccinatedDobMonth);
+        selectOption(dobDaySelector, fullyVaccinatedDobDay);
+        selectOption(dovYearSelector, fullyVaccinatedDovYear);
+        selectOption(dovMonthSelector, fullyVaccinatedDovMonth);
+        selectOption(dovDaySelector, fullyVaccinatedDovDay);
 
         clickVaccineCardEnterButton();
 


### PR DESCRIPTION
# Implements AB#12038

## Description

- Refactors shared functions used by functional tests for public COVID-19 pages
- Refactors functional tests for the public COVID-19 test page to match the changes to the tests for the public vaccine card page
- Adds new e2e tests for retrieving COVID-19 test results

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
