### PR TITLE
 Update service endpoints to relative paths AB#12053

### DIFF
--- a/Apps/Admin/Client/wwwroot/appsettings.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.json
@@ -10,9 +10,9 @@
         "ClientId": "hg-admin-blazor"
     },
     "Services": {
-        "Configuration": "https://dev.healthgateway.gov.bc.ca",
-        "CsvExport": "https://dev.healthgateway.gov.bc.ca/admin/v1/api/CsvExport",
-        "Support": "https://dev.healthgateway.gov.bc.ca/admin/v1/api/Support"
+        "Configuration": "v1/api/Configuration",
+        "CsvExport": "v1/api/CsvExport",
+        "Support": "v1/api/Support"
     },
     "PrototypeFeaturesEnabled": false
 }


### PR DESCRIPTION
# Fixes [AB#12053](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12053)

## Description

Replaces the service endpoint URLs in Admin.Client's appsettings.json with relative paths and forms the URLs by combining the paths with the base URL from the application.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
