### PR TITLE
Cache Auth token AB#12058

### DIFF
--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -81,7 +81,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
             return jwtModel;
         }
 
-            /// <inheritdoc/>
+        /// <inheritdoc/>
         public (JWTModel JwtModel, bool Cached) AuthenticateUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled)
         {
             string cacheKey = $"{tokenUri}:{tokenRequest.Audience}:{tokenRequest.ClientId}:{tokenRequest.Username}";
@@ -185,11 +185,11 @@ namespace HealthGateway.Common.AccessManagement.Authentication
 
                 using (Task<HttpResponseMessage> task = client.PostAsync(tokenUri, content))
                 {
-                        HttpResponseMessage response = task.Result;
-                        string jwtTokenResponse = response.Content.ReadAsStringAsync().Result;
-                        this.logger.LogTrace($"JWT Token response: {jwtTokenResponse}");
-                        response.EnsureSuccessStatusCode();
-                        authModel = JsonSerializer.Deserialize<JWTModel>(jwtTokenResponse);
+                    HttpResponseMessage response = task.Result;
+                    string jwtTokenResponse = response.Content.ReadAsStringAsync().Result;
+                    this.logger.LogTrace($"JWT Token response: {jwtTokenResponse}");
+                    response.EnsureSuccessStatusCode();
+                    authModel = JsonSerializer.Deserialize<JWTModel>(jwtTokenResponse);
                 }
             }
             catch (HttpRequestException e)

--- a/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
@@ -39,7 +39,17 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         /// </summary>
         /// <param name="tokenUri">Uri to request the the token from.</param>
         /// <param name="tokenRequest">Token request configuration.</param>
+        /// <param name="cacheEnabled">if true caches the result.</param>
         /// <returns>An instance fo the <see cref="JWTModel"/> class.</returns>
-        JWTModel AuthenticateAsUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest);
+        JWTModel AuthenticateAsUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = false);
+
+        /// <summary>
+        /// Authenticates a resource owner user with direct grant, no user intervention.
+        /// </summary>
+        /// <param name="tokenUri">Uri to request the the token from.</param>
+        /// <param name="tokenRequest">Token request configuration.</param>
+        /// <param name="cacheEnabled">if true caches the result.</param>
+        /// <returns>An instance fo the <see cref="JWTModel"/> class and a bool representing if the objecft was cached or not.</returns>
+        (JWTModel JwtModel, bool Cached) AuthenticateUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled);
     }
 }

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Net;
     using System.Net.Http;
     using System.Text.Json;
@@ -42,6 +43,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
         /// AuthenticateAsUser - Happy Path.
         /// </summary>
         [Fact]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
         public void ShouldAuthenticateAsUser()
         {
             Uri tokenUri = new("http://testsite");

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.CommonTests.AccessManagement.Administration
 {
     using System;
+    using System.Collections.Generic;
     using System.Net;
     using System.Net.Http;
     using System.Text.Json;
@@ -25,6 +26,8 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authentication.Models;
     using HealthGateway.Common.Services;
+    using Microsoft.Extensions.Caching.Memory;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;
     using Moq.Protected;
@@ -42,6 +45,12 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
         public void ShouldAuthenticateAsUser()
         {
             Uri tokenUri = new("http://testsite");
+            Dictionary<string, string> configurationParams = new()
+            {
+                { "AuthCache:TokenCacheExpireMinutes", "20" },
+            };
+            IConfiguration configuration = CreateConfiguration(configurationParams);
+
             ClientCredentialsTokenRequest tokenRequest = new()
             {
                 ClientId = "CLIENT_ID",
@@ -49,6 +58,8 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
                 Username = "A_USERNAME",
                 Password = "SOME_PASSWORD",
             };
+
+            using IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
 
             string json = @"{ ""access_token"":""token"", ""expires_in"":500, ""refresh_expires_in"":0, ""refresh_token"":""refresh_token"", ""token_type"":""bearer"", ""not-before-policy"":25, ""session_state"":""session_state"", ""scope"":""scope"" }";
             JWTModel? expected = JsonSerializer.Deserialize<JWTModel>(json);
@@ -71,9 +82,15 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             Mock<IHttpClientService> mockHttpClientService = new();
             mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
 
-            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object);
-            JWTModel actualModel = authDelegate.AuthenticateAsUser(tokenUri, tokenRequest);
+            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, configuration, memoryCache);
+            JWTModel actualModel = authDelegate.AuthenticateAsUser(tokenUri, tokenRequest, false);
             expected.ShouldDeepEqual(actualModel);
+
+            (JWTModel cacheResult, bool cached) = authDelegate.AuthenticateUser(tokenUri, tokenRequest, true);
+            Assert.True(!cached);
+
+            (JWTModel fetchedCachedResult, cached) = authDelegate.AuthenticateUser(tokenUri, tokenRequest, true);
+            Assert.True(cached);
         }
 
         /// <summary>
@@ -110,9 +127,19 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             Mock<IHttpClientService> mockHttpClientService = new();
             mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
 
-            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object);
+            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, null, null);
             JWTModel actualModel = authDelegate.AuthenticateAsSystem(tokenUri, tokenRequest);
             expected.ShouldDeepEqual(actualModel);
+        }
+
+        private static IConfiguration CreateConfiguration(Dictionary<string, string> configParams)
+        {
+            return new ConfigurationBuilder()
+                .AddJsonFile("appsettings.json", optional: true)
+                .AddJsonFile("appsettings.Development.json", optional: true)
+                .AddJsonFile("appsettings.local.json", optional: true)
+                .AddInMemoryCollection(configParams)
+                .Build();
         }
     }
 }

--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -42,17 +42,14 @@ namespace HealthGateway.Immunization.Services
     {
         private const string PHSAConfigSectionKey = "PHSA";
         private const string AuthConfigSectionName = "ClientAuthentication";
-        private const string TokenCacheKey = "TokenCacheKey";
 
         private readonly IVaccineStatusDelegate vaccineStatusDelegate;
         private readonly IAuthenticationDelegate authDelegate;
         private readonly IHttpContextAccessor httpContextAccessor;
-        private readonly IMemoryCache memoryCache;
         private readonly ILogger<VaccineStatusService> logger;
         private readonly ClientCredentialsTokenRequest tokenRequest;
         private readonly PHSAConfig phsaConfig;
         private readonly Uri tokenUri;
-        private readonly int tokenCacheMinutes;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VaccineStatusService"/> class.
@@ -61,14 +58,12 @@ namespace HealthGateway.Immunization.Services
         /// <param name="logger">The injected logger.</param>
         /// <param name="authDelegate">The OAuth2 authentication service.</param>
         /// <param name="vaccineStatusDelegate">The injected vaccine status delegate.</param>
-        /// <param name="memoryCache">The cache to use to reduce lookups.</param>
         /// <param name="httpContextAccessor">The injected http context accessor.</param>
         public VaccineStatusService(
             IConfiguration configuration,
             ILogger<VaccineStatusService> logger,
             IAuthenticationDelegate authDelegate,
             IVaccineStatusDelegate vaccineStatusDelegate,
-            IMemoryCache memoryCache,
             IHttpContextAccessor httpContextAccessor)
         {
             this.authDelegate = authDelegate;
@@ -76,14 +71,12 @@ namespace HealthGateway.Immunization.Services
 
             IConfigurationSection? configSection = configuration?.GetSection(AuthConfigSectionName);
             this.tokenUri = configSection.GetValue<Uri>(@"TokenUri");
-            this.tokenCacheMinutes = configSection.GetValue<int>("TokenCacheExpireMinutes", 20);
             this.tokenRequest = new ClientCredentialsTokenRequest();
             configSection.Bind(this.tokenRequest); // Client ID, Client Secret, Audience, Username, Password
 
             this.phsaConfig = new();
             configuration.Bind(PHSAConfigSectionKey, this.phsaConfig);
 
-            this.memoryCache = memoryCache;
             this.httpContextAccessor = httpContextAccessor;
             this.logger = logger;
         }
@@ -238,31 +231,21 @@ namespace HealthGateway.Immunization.Services
                 IncludeFederalVaccineProof = includeVaccineProof,
             };
 
-            this.memoryCache.TryGetValue(TokenCacheKey, out string? accessToken);
-            if (accessToken == null)
+            try
             {
-                this.logger.LogInformation("Access token not found in cache");
-                accessToken = this.authDelegate.AuthenticateAsUser(this.tokenUri, this.tokenRequest).AccessToken;
-                if (!string.IsNullOrEmpty(accessToken))
-                {
-                    this.logger.LogInformation("Attempting to store Access token in cache");
-                    MemoryCacheEntryOptions cacheEntryOptions = new();
-                    cacheEntryOptions.AbsoluteExpiration = new DateTimeOffset(DateTime.Now.AddMinutes(this.tokenCacheMinutes));
-                    this.memoryCache.Set(TokenCacheKey, accessToken, cacheEntryOptions);
-                }
-                else
-                {
-                    this.logger.LogCritical("The auth token is null or empty - unable to cache or proceed");
-                    retVal.ResultError = new()
-                    {
-                        ResultMessage = "Error authenticating with KeyCloak",
-                        ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState),
-                    };
-                    return retVal;
-                }
+                string? accessToken = this.authDelegate.AuthenticateAsUser(this.tokenUri, this.tokenRequest, true).AccessToken;
+                retVal = await this.GetVaccineStatusFromDelegate(query, accessToken, phn).ConfigureAwait(true);
             }
-
-            retVal = await this.GetVaccineStatusFromDelegate(query, accessToken, phn).ConfigureAwait(true);
+            catch (InvalidOperationException e)
+            {
+                this.logger.LogCritical($"Error during authentication {e}");
+                retVal.ResultError = new()
+                {
+                    ResultMessage = "Error authenticating with KeyCloak",
+                    ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState),
+                };
+                return retVal;
+            }
 
             return retVal;
         }

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -66,7 +66,6 @@
         "ClientSecret": "****",
         "Username": "****",
         "Password": "****",
-        "TokenCacheExpireMinutes": 30
     },
     "AvailabilityFilter": {
         "VaccineStatus": true
@@ -79,10 +78,13 @@
         "Token": "****",
         "SchemaVersion": "HG1",
         "BackOffMilliseconds": 4000,
-        "MaxRetries": 7,
+        "MaxRetries": 7
     },
     "TimeZone": {
         "UnixTimeZoneId": "America/Vancouver",
         "WindowsTimeZoneId": "Pacific Standard Time"
+    },
+    "AuthCache": {
+        "TokenCacheExpireMinutes": "20"
     }
 }

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -33,7 +33,6 @@ namespace HealthGateway.Immunization.Test.Services
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -109,14 +108,13 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             if (isPublicEndpoint)
@@ -187,14 +185,13 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             if (isPublicEndpoint)
@@ -272,14 +269,13 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             if (isPublicEndpoint)
@@ -359,14 +355,13 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             if (isPublicEndpoint)
@@ -448,14 +443,13 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             if (isPublicEndpoint)
@@ -490,7 +484,6 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
@@ -512,7 +505,6 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
@@ -533,7 +525,6 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                GetMemoryCache(),
                 this.GetHttpContextAccessor().Object);
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
@@ -541,15 +532,6 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<VaccineStatus> actualResult = Task.Run(async () => await service.GetPublicVaccineStatus(this.phn, dobString, "yyyyMMddx").ConfigureAwait(true)).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-        }
-
-        private static IMemoryCache? GetMemoryCache()
-        {
-            ServiceCollection services = new();
-            services.AddMemoryCache();
-            ServiceProvider serviceProvider = services.BuildServiceProvider();
-
-            return serviceProvider.GetService<IMemoryCache>();
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -109,7 +109,7 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>())).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -187,7 +187,7 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>())).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -272,7 +272,7 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>())).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -359,7 +359,7 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>())).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -448,7 +448,7 @@ namespace HealthGateway.Immunization.Test.Services
             mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, isPublicEndpoint)).Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>())).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
 
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -448,7 +448,7 @@ namespace HealthGateway.LaboratoryTests
             mockLaboratoryDelegateFactory.Setup(s => s.CreateInstance()).Returns(mockLaboratoryDelegate.Object);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>())).Returns(jwtModel);
+            mockAuthDelegate.Setup(s => s.AuthenticateAsUser(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), false)).Returns(jwtModel);
 
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,

--- a/Apps/Medication/src/Delegates/SalesforceDelegate.cs
+++ b/Apps/Medication/src/Delegates/SalesforceDelegate.cs
@@ -36,7 +36,7 @@ namespace HealthGateway.Medication.Delegates
     /// <summary>
     /// Salesforce Implementation that retrieves Medication Requests.
     /// </summary>
-    public class SalesforeceDelegate : IMedicationRequestDelegate
+    public class SalesforceDelegate : IMedicationRequestDelegate
     {
         private const string SalesforceConfigSectionKey = "Salesforce";
 
@@ -46,14 +46,14 @@ namespace HealthGateway.Medication.Delegates
         private readonly IAuthenticationDelegate authDelegate;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="SalesforeceDelegate"/> class.
+        /// Initializes a new instance of the <see cref="SalesforceDelegate"/> class.
         /// </summary>
         /// <param name="logger">Injected Logger Provider.</param>
         /// <param name="httpClientService">The injected http client service.</param>
         /// <param name="configuration">The injected configuration provider.</param>
         /// <param name="authDelegate">The delegate responsible authentication.</param>
-        public SalesforeceDelegate(
-            ILogger<SalesforeceDelegate> logger,
+        public SalesforceDelegate(
+            ILogger<SalesforceDelegate> logger,
             IHttpClientService httpClientService,
             IConfiguration configuration,
             IAuthenticationDelegate authDelegate)
@@ -78,7 +78,7 @@ namespace HealthGateway.Medication.Delegates
                     ResultStatus = Common.Constants.ResultType.Error,
                 };
 
-                string? accessToken = this.authDelegate.AuthenticateAsUser(this.salesforceConfig.TokenUri, this.salesforceConfig.ClientAuthentication).AccessToken;
+                string? accessToken = this.authDelegate.AuthenticateAsUser(this.salesforceConfig.TokenUri, this.salesforceConfig.ClientAuthentication, true).AccessToken;
                 if (string.IsNullOrEmpty(accessToken))
                 {
                     this.logger.LogError($"Authenticated as User System access token is null or emtpy, Error:\n{accessToken}");

--- a/Apps/Medication/src/Startup.cs
+++ b/Apps/Medication/src/Startup.cs
@@ -74,6 +74,7 @@ namespace HealthGateway.Medication
             });
 
             // Add services
+            services.AddMemoryCache();
             services.AddTransient<IMedicationService, RestMedicationService>();
             services.AddTransient<IMedicationStatementService, RestMedicationStatementService>();
             services.AddTransient<IMedicationRequestService, MedicationRequestService>();
@@ -84,7 +85,7 @@ namespace HealthGateway.Medication
             services.AddTransient<IMedStatementDelegate, RestMedStatementDelegate>();
             services.AddTransient<IGenericCacheDelegate, DBGenericCacheDelegate>();
             services.AddTransient<IHashDelegate, HMACHashDelegate>();
-            services.AddTransient<IMedicationRequestDelegate, SalesforeceDelegate>();
+            services.AddTransient<IMedicationRequestDelegate, SalesforceDelegate>();
             services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
         }
 

--- a/Apps/Medication/src/appsettings.json
+++ b/Apps/Medication/src/appsettings.json
@@ -69,6 +69,9 @@
         "ConsoleEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",
-        "IgnorePathPrefixes": ["/health"]
+        "IgnorePathPrefixes": [ "/health" ]
+    },
+    "AuthCache": {
+        "TokenCacheExpireMinutes": "20"
     }
 }

--- a/Apps/Medication/test/unit/Delegates/SalesforceDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/SalesforceDelegateTests.cs
@@ -80,7 +80,8 @@ namespace HealthGateway.Medication.Delegates.Test
             mockAuthenticationDelegate
                 .Setup(s => s.AuthenticateAsUser(
                     It.Is<Uri>(x => x.ToString() == tokenUri.ToString()),
-                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId)))
+                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId),
+                    true))
                 .Returns(() => authorizationJWT);
 
             // Setup Http response
@@ -92,7 +93,7 @@ namespace HealthGateway.Medication.Delegates.Test
             Mock<IHttpClientService> mockHttpClient = CreateHttpClient(httpResponseMessage, phn, authorizationJWT?.AccessToken);
 
             // Setup class to be tested
-            IMedicationRequestDelegate medDelegate = new SalesforeceDelegate(
+            IMedicationRequestDelegate medDelegate = new SalesforceDelegate(
                 CreateLogger(),
                 mockHttpClient.Object,
                 configuration,
@@ -144,11 +145,12 @@ namespace HealthGateway.Medication.Delegates.Test
             mockAuthenticationDelegate
                 .Setup(s => s.AuthenticateAsUser(
                     It.Is<Uri>(x => x.ToString() == tokenUri.ToString()),
-                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId)))
+                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId),
+                    true))
                 .Returns(() => new JWTModel());
 
             // Setup class to be tested
-            IMedicationRequestDelegate medDelegate = new SalesforeceDelegate(
+            IMedicationRequestDelegate medDelegate = new SalesforceDelegate(
                 CreateLogger(),
                 new Mock<IHttpClientService>().Object,
                 configuration,
@@ -203,7 +205,8 @@ namespace HealthGateway.Medication.Delegates.Test
             mockAuthenticationDelegate
                 .Setup(s => s.AuthenticateAsUser(
                     It.Is<Uri>(x => x.ToString() == tokenUri.ToString()),
-                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId)))
+                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId),
+                    true))
                 .Returns(() => authorizationJWT);
 
             // Setup Http response
@@ -214,7 +217,7 @@ namespace HealthGateway.Medication.Delegates.Test
             Mock<IHttpClientService> mockHttpClient = CreateHttpClient(httpResponseMessage, phn, authorizationJWT?.AccessToken);
 
             // Setup class to be tested
-            IMedicationRequestDelegate medDelegate = new SalesforeceDelegate(
+            IMedicationRequestDelegate medDelegate = new SalesforceDelegate(
                 CreateLogger(),
                 mockHttpClient.Object,
                 configuration,
@@ -269,7 +272,8 @@ namespace HealthGateway.Medication.Delegates.Test
             mockAuthenticationDelegate
                 .Setup(s => s.AuthenticateAsUser(
                     It.Is<Uri>(x => x.ToString() == tokenUri.ToString()),
-                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId)))
+                    It.Is<ClientCredentialsTokenRequest>(x => x.ClientId == tokenRequest.ClientId),
+                    true))
                 .Returns(() => authorizationJWT);
 
             // Setup Http response
@@ -280,7 +284,7 @@ namespace HealthGateway.Medication.Delegates.Test
             Mock<IHttpClientService> mockHttpClient = CreateHttpClient(httpResponseMessage, phn, authorizationJWT?.AccessToken);
 
             // Setup class to be tested
-            IMedicationRequestDelegate medDelegate = new SalesforeceDelegate(
+            IMedicationRequestDelegate medDelegate = new SalesforceDelegate(
                 CreateLogger(),
                 mockHttpClient.Object,
                 configuration,
@@ -306,10 +310,10 @@ namespace HealthGateway.Medication.Delegates.Test
                 .Build();
         }
 
-        private static ILogger<SalesforeceDelegate> CreateLogger()
+        private static ILogger<SalesforceDelegate> CreateLogger()
         {
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            return loggerFactory.CreateLogger<SalesforeceDelegate>();
+            return loggerFactory.CreateLogger<SalesforceDelegate>();
         }
 
         private static JWTModel CreateJWTModel(string json)


### PR DESCRIPTION
# Fixes or Implements [AB#12058](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12058), [AB#12067](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12067)

## Description

Adds the ability  to cache the auth token when using AuthenticateAsUser in the common AuthenticationDelegate.
Immunization was updated to make use of the cache and remove the local service cache.
Medication was updated to make use of the new cache (Salesforce).

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

No

### Browsers Tested

-   [X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
