### PR TITLE
Swagger Issue AB#12099

### DIFF
--- a/Apps/Immunization/src/Controllers/AuthenticatedVaccineStatusController.cs
+++ b/Apps/Immunization/src/Controllers/AuthenticatedVaccineStatusController.cs
@@ -65,13 +65,13 @@ namespace HealthGateway.Immunization.Controllers
         [HttpGet]
         [Produces("application/json")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<IActionResult> GetVaccineStatus([FromQuery] string hdid)
+        public async Task<RequestResult<VaccineStatus>> GetVaccineStatus([FromQuery] string hdid)
         {
             this.logger.LogDebug($"Getting vaccine status for HDID {hdid}");
             RequestResult<VaccineStatus> result = await this.vaccineStatusService.GetAuthenticatedVaccineStatus(hdid).ConfigureAwait(true);
             this.logger.LogDebug($"Finished getting vaccine status for HDID {hdid}");
 
-            return new JsonResult(result);
+            return result;
         }
 
         /// <summary>
@@ -87,13 +87,13 @@ namespace HealthGateway.Immunization.Controllers
         [Produces("application/json")]
         [Route("pdf")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<IActionResult> GetVaccineProof([FromQuery] string hdid)
+        public async Task<RequestResult<VaccineProofDocument>> GetVaccineProof([FromQuery] string hdid)
         {
             this.logger.LogDebug($"Getting  Vaccine Proof for HDID {hdid}");
             RequestResult<VaccineProofDocument> result = await this.vaccineStatusService.GetAuthenticatedVaccineProof(hdid).ConfigureAwait(true);
             this.logger.LogDebug($"Finished getting Vaccine Proof for HDID {hdid}");
 
-            return new JsonResult(result);
+            return result;
         }
     }
 }

--- a/Apps/Immunization/src/Controllers/ImmunizationController.cs
+++ b/Apps/Immunization/src/Controllers/ImmunizationController.cs
@@ -70,13 +70,13 @@ namespace HealthGateway.Immunization.Controllers
         [Produces("application/json")]
         [Route("{immunizationId}")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<IActionResult> GetImmunization([FromQuery] string hdid, string immunizationId)
+        public async Task<RequestResult<ImmunizationEvent>> GetImmunization([FromQuery] string hdid, string immunizationId)
         {
             this.logger.LogDebug($"Getting immunization {immunizationId} for user {hdid}");
             RequestResult<ImmunizationEvent> result = await this.service.GetImmunization(immunizationId).ConfigureAwait(true);
 
             this.logger.LogDebug($"Finished getting immunization {immunizationId} for user {hdid}");
-            return new JsonResult(result);
+            return result;
         }
 
         /// <summary>
@@ -91,13 +91,13 @@ namespace HealthGateway.Immunization.Controllers
         [HttpGet]
         [Produces("application/json")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<IActionResult> GetImmunizations([FromQuery] string hdid)
+        public async Task<RequestResult<ImmunizationResult>> GetImmunizations([FromQuery] string hdid)
         {
             this.logger.LogDebug($"Getting immunizations for user {hdid}");
             RequestResult<ImmunizationResult> result = await this.service.GetImmunizations().ConfigureAwait(true);
 
             this.logger.LogDebug($"Finished getting immunizations for user {hdid}");
-            return new JsonResult(result);
+            return result;
         }
     }
 }

--- a/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
@@ -91,18 +91,14 @@ namespace HealthGateway.Immunization.Test.Controllers
             ImmunizationController controller = new(new Mock<ILogger<ImmunizationController>>().Object, svcMock.Object);
 
             // Act
-            IActionResult actual = await controller.GetImmunizations(this.hdid).ConfigureAwait(true);
+            RequestResult<ImmunizationResult> actual = await controller.GetImmunizations(this.hdid).ConfigureAwait(true);
 
             // Verify
-            Assert.IsType<JsonResult>(actual);
-
-            JsonResult? jsonResult = actual as JsonResult;
-            RequestResult<ImmunizationResult>? result = jsonResult?.Value as RequestResult<ImmunizationResult>;
-            Assert.True(result != null && result.ResultStatus == ResultType.Success);
+            Assert.True(actual != null && actual.ResultStatus == ResultType.Success);
             int count = 0;
-            if (result != null && result.ResultStatus == ResultType.Success)
+            if (actual != null && actual.ResultStatus == ResultType.Success)
             {
-                foreach (ImmunizationEvent? immz in result.ResourcePayload!.Immunizations)
+                foreach (ImmunizationEvent? immz in actual.ResourcePayload!.Immunizations)
                 {
                     count++;
                 }
@@ -150,13 +146,10 @@ namespace HealthGateway.Immunization.Test.Controllers
             ImmunizationController controller = new(new Mock<ILogger<ImmunizationController>>().Object, svcMock.Object);
 
             // Act
-            IActionResult actual = await controller.GetImmunization(this.hdid, immunizationId).ConfigureAwait(true);
+            RequestResult<ImmunizationEvent> actual = await controller.GetImmunization(this.hdid, immunizationId).ConfigureAwait(true);
 
             // Verify
-            Assert.IsType<JsonResult>(actual);
-            JsonResult? jsonResult = actual as JsonResult;
-            RequestResult<ImmunizationEvent>? result = jsonResult?.Value as RequestResult<ImmunizationEvent>;
-            Assert.True(result != null && result.ResultStatus == ResultType.Success);
+            Assert.True(actual != null && actual.ResultStatus == ResultType.Success);
         }
     }
 }

--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -147,8 +147,9 @@ namespace HealthGateway.Laboratory.Controllers
         [HttpPost]
         [Route("{hdid}/rapidTest")]
         [Authorize(Policy = LaboratoryPolicy.Write)]
-        public async Task<IActionResult> CreateRapidTestAsync(string hdid, [FromBody] AuthenticatedRapidTestRequest rapidTestRequest)
+        public async Task<RequestResult<AuthenticatedRapidTestResponse>> CreateRapidTestAsync(string hdid, [FromBody] AuthenticatedRapidTestRequest rapidTestRequest)
         {
+            RequestResult<AuthenticatedRapidTestResponse> result = new();
             this.logger.LogDebug($"Post rapid test for hdid {hdid}");
             HttpContext? httpContext = this.httpContextAccessor.HttpContext;
             if (httpContext != null)
@@ -156,13 +157,13 @@ namespace HealthGateway.Laboratory.Controllers
                 string? accessToken = await httpContext.GetTokenAsync("access_token").ConfigureAwait(true);
                 if (accessToken != null)
                 {
-                    RequestResult<AuthenticatedRapidTestResponse> result = await this.service.CreateRapidTestAsync(hdid, accessToken, rapidTestRequest).ConfigureAwait(true);
+                    result = await this.service.CreateRapidTestAsync(hdid, accessToken, rapidTestRequest).ConfigureAwait(true);
                     this.logger.LogDebug($"Finished submitting a rapid test from controller... {hdid}");
-                    return new JsonResult(result);
+                    return result;
                 }
             }
 
-            return this.Unauthorized();
+            return result;
         }
     }
 }

--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -145,6 +145,7 @@ namespace HealthGateway.Laboratory.Controllers
         /// <response code="403">DID Claim is missing or can not resolve PHN.</response>
         /// <response code="409">Combination of Phn and Serial number already exists.</response>
         [HttpPost]
+        [Produces("application/json")]
         [Route("{hdid}/rapidTest")]
         [Authorize(Policy = LaboratoryPolicy.Write)]
         public async Task<RequestResult<AuthenticatedRapidTestResponse>> CreateRapidTestAsync(string hdid, [FromBody] AuthenticatedRapidTestRequest rapidTestRequest)

--- a/Apps/Patient/src/Controllers/PatientController.cs
+++ b/Apps/Patient/src/Controllers/PatientController.cs
@@ -1,4 +1,4 @@
-﻿//-------------------------------------------------------------------------
+//-------------------------------------------------------------------------
 // Copyright © 2019 Province of British Columbia
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,7 +58,7 @@ namespace HealthGateway.Patient.Controllers
         [Produces("application/json")]
         [Route("{hdid}")]
         [Authorize(Policy = PatientPolicy.Read)]
-        public async Task<IActionResult> GetPatient(string hdid)
+        public async Task<RequestResult<Models.PatientModel>> GetPatient(string hdid)
         {
             RequestResult<Common.Models.PatientModel> patientResult = await this.service.GetPatient(hdid).ConfigureAwait(true);
             RequestResult<Models.PatientModel> result = new()
@@ -71,7 +71,7 @@ namespace HealthGateway.Patient.Controllers
                 TotalResultCount = patientResult.TotalResultCount,
             };
 
-            return new JsonResult(result);
+            return result;
         }
     }
 }

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -79,10 +79,9 @@ namespace HealthGateway.Patient.Test.Controllers
             patientService.Setup(x => x.GetPatient(It.IsAny<string>(), PatientIdentifierType.HDID, false)).ReturnsAsync(mockResult);
 
             PatientController patientController = new(patientService.Object);
-            Task<IActionResult> actualResult = patientController.GetPatient("123");
+            RequestResult<Models.PatientModel> actualResult = patientController.GetPatient("123").Result;
 
-            Assert.IsType<JsonResult>(actualResult.Result);
-            expectedResult.ShouldDeepEqual(((JsonResult)actualResult.Result).Value);
+            expectedResult.ShouldDeepEqual(actualResult);
         }
     }
 }


### PR DESCRIPTION
# Swagger Issue [AB#12099](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12099)

## Description
**This PR includes the following changes:**
1. Fixed missing swagger schema for the following endpoints:
    - AuthenticatedVaccineStatus 
    - Immunization
    - Patient
    - SubmitRapidTest
2. Fixed the failing unit tests.
3. Restrict the response to Json format for SubmitRapidTest.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

**NO**

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
