### PR TITLE
Add validation to Support page form AB#12012

### DIFF
--- a/Apps/Admin/Client/Pages/Support.razor
+++ b/Apps/Admin/Client/Pages/Support.razor
@@ -11,10 +11,10 @@
     @MessageVerificationState.Value.RequestError?.Message
 </HgBannerFeedback>
 
-<MudForm>
+<MudForm @ref="Form">
     <MudGrid Spacing="0">
         <MudItem xs="12" sm="3">
-            <HgSelect T="UserQueryType" Label="Query Type" @bind-Value="SelectedQueryType">
+            <HgSelect T="UserQueryType" Label="Query Type" Required="@true" @bind-Value="SelectedQueryType">
                 @foreach (UserQueryType queryType in QueryTypes)
                 {
                     <MudSelectItem Value="@queryType" />
@@ -22,10 +22,10 @@
             </HgSelect>
         </MudItem>
         <MudItem xs="12" sm="9">
-            <HgTextField LeftMargin="Breakpoint.Sm" T="string" Label="@SelectedQueryType.ToString()" @bind-Value="QueryParameter" />
+            <HgTextField LeftMargin="Breakpoint.Sm" T="string" Label="@SelectedQueryType.ToString()" Required="@true" Validation="@ValidateQueryParameter" @bind-Value="QueryParameter" />
         </MudItem>
         <MudItem Class="d-flex justify-end" xs="12">
-            <HgButton TopMargin="Breakpoint.Always" EndIcon="@Icons.Material.Filled.Search" Variant="Variant.Filled" Color="Color.Primary" @onclick="Search">Search</HgButton>
+            <HgButton TopMargin="Breakpoint.Always" EndIcon="@Icons.Material.Filled.Search" Variant="Variant.Filled" Color="Color.Primary" @onclick="SearchAsync">Search</HgButton>
         </MudItem>
     </MudGrid>
 </MudForm>

--- a/Apps/Common/src/Delegates/CDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/CDogsDelegate.cs
@@ -25,12 +25,12 @@ namespace HealthGateway.Common.Delegates
     using System.Text.Json;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.CDogs;
     using HealthGateway.Common.Services;
-    using HealthGateway.Common.Utils;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -105,9 +105,11 @@ namespace HealthGateway.Common.Delegates
                     if (response.IsSuccessStatusCode)
                     {
                         retVal.ResultStatus = ResultType.Success;
-                        retVal.ResourcePayload = new ReportModel();
-                        retVal.ResourcePayload.Data = Convert.ToBase64String(payload);
-                        retVal.ResourcePayload.FileName = $"{request.Options.ReportName}.{request.Options.ConvertTo}";
+                        retVal.ResourcePayload = new ReportModel
+                        {
+                            Data = Convert.ToBase64String(payload),
+                            FileName = $"{request.Options.ReportName}.{request.Options.ConvertTo}",
+                        };
                         retVal.TotalResultCount = 1;
                     }
                     else

--- a/Apps/Common/src/Models/BCMailPlusConfig.cs
+++ b/Apps/Common/src/Models/BCMailPlusConfig.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.Common.Models
 {
     using System.Collections.Generic;
-    using HealthGateway.Common.Utils;
+    using HealthGateway.Common.Data.Utils;
 
     /// <summary>
     /// Defines the BC Mail Plus Configuration model.

--- a/Apps/Common/src/Services/EmailQueueService.cs
+++ b/Apps/Common/src/Services/EmailQueueService.cs
@@ -20,8 +20,8 @@ namespace HealthGateway.Common.Services
     using Hangfire;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Jobs;
-    using HealthGateway.Common.Utils;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using Microsoft.AspNetCore.Hosting;

--- a/Apps/CommonData/src/Utils/StringManipulator.cs
+++ b/Apps/CommonData/src/Utils/StringManipulator.cs
@@ -1,4 +1,4 @@
-﻿//-------------------------------------------------------------------------
+//-------------------------------------------------------------------------
 // Copyright © 2019 Province of British Columbia
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.Common.Utils
+namespace HealthGateway.Common.Data.Utils
 {
     using System.Collections.Generic;
     using System.Text.RegularExpressions;

--- a/Apps/CommonData/src/Utils/StringManipulator.cs
+++ b/Apps/CommonData/src/Utils/StringManipulator.cs
@@ -23,6 +23,9 @@ namespace HealthGateway.Common.Data.Utils
     /// </summary>
     public static class StringManipulator
     {
+        private static readonly Regex PlaceholderRegex = new("\\$\\{(.*?)\\}");
+        private static readonly Regex WhitespaceRegex = new(@"\s");
+
         /// <summary>
         /// Replaces any occurences of ${key} in the string with the value.
         /// </summary>
@@ -54,12 +57,27 @@ namespace HealthGateway.Common.Data.Utils
                 // The regex will find all instances of ${ANYTHING} and will evaluate if the keys between
                 // the mustaches match one of those in the dictionary.  If so it then replaces the match
                 // with the value in the dictionary.
-                retVal = Regex.Replace(inStr, "\\$\\{(.*?)\\}", m =>
+                retVal = PlaceholderRegex.Replace(inStr, m =>
                    (m.Groups.Count > 1 && data.ContainsKey(m.Groups[1].Value)) ?
                    data[m.Groups[1].Value] : m.Value);
             }
 
             return retVal;
+        }
+
+        /// <summary>
+        /// Removes any whitespace from the provided string.
+        /// </summary>
+        /// <param name="target">A string that may contain whitespace.</param>
+        /// <returns>The string with whitespace removed.</returns>
+        public static string? StripWhitespace(string? target)
+        {
+            if (target is null)
+            {
+                return target;
+            }
+
+            return WhitespaceRegex.Replace(target, string.Empty);
         }
     }
 }


### PR DESCRIPTION
# Implements [AB#12012](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12012)

## Description

- Move StringManipulator utility from Common project to Common.Data
- Add StripWhitespace() method to StringManipulator utility
- Add validation to Support page form

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
