### PR TITLE
Fix dark mode setting being ignored when first logging in AB#12114

### DIFF
--- a/Apps/Admin/Client/Layouts/LoginLayout.razor
+++ b/Apps/Admin/Client/Layouts/LoginLayout.razor
@@ -1,6 +1,5 @@
 @using HealthGateway.Admin.Client.Theme
 @inherits LayoutComponentBase
-@inject Blazored.LocalStorage.ILocalStorageService LocalStorage
 
 <MudThemeProvider Theme="@CurrentTheme" />
 <MudSnackbarProvider />
@@ -11,29 +10,3 @@
         </MudPaper>
     </div>
 </MudContainer>
-
-@code
-{
-    private const string DarkThemeKey = "DarkMode";
-
-    private bool DarkMode { get; set; } = true;
-
-    private static MudTheme LightTheme { get; } = new LightTheme();
-
-    private static MudTheme DarkTheme { get; } = new DarkTheme();
-
-    private MudTheme? CurrentTheme => this.DarkMode ? DarkTheme : LightTheme;
-
-    /// <inheritdoc/>
-    protected async override void OnInitialized()
-    {
-        if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey).ConfigureAwait(true))
-        {
-            this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey).ConfigureAwait(true);
-        }
-        else
-        {
-            await this.LocalStorage.SetItemAsync<bool>(DarkThemeKey, this.DarkMode).ConfigureAwait(true);
-        }
-    }
-}

--- a/Apps/Admin/Client/Layouts/LoginLayout.razor.cs
+++ b/Apps/Admin/Client/Layouts/LoginLayout.razor.cs
@@ -44,6 +44,7 @@ namespace HealthGateway.Admin.Client.Layouts
             if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey).ConfigureAwait(true))
             {
                 this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey).ConfigureAwait(true);
+                this.StateHasChanged();
             }
             else
             {

--- a/Apps/Admin/Client/Layouts/LoginLayout.razor.cs
+++ b/Apps/Admin/Client/Layouts/LoginLayout.razor.cs
@@ -1,0 +1,54 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Layouts
+{
+    using Blazored.LocalStorage;
+    using HealthGateway.Admin.Client.Theme;
+    using Microsoft.AspNetCore.Components;
+    using MudBlazor;
+
+    /// <summary>
+    /// Login Layout theming and logic.
+    /// </summary>
+    public partial class LoginLayout
+    {
+        private const string DarkThemeKey = "DarkMode";
+
+        [Inject]
+        private ILocalStorageService LocalStorage { get; set; } = default!;
+
+        private bool DarkMode { get; set; } = true;
+
+        private MudTheme LightTheme { get; } = new LightTheme();
+
+        private MudTheme DarkTheme { get; } = new DarkTheme();
+
+        private MudTheme? CurrentTheme => this.DarkMode ? this.DarkTheme : this.LightTheme;
+
+        /// <inheritdoc />
+        protected async override void OnInitialized()
+        {
+            if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey).ConfigureAwait(true))
+            {
+                this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey).ConfigureAwait(true);
+            }
+            else
+            {
+                await this.LocalStorage.SetItemAsync<bool>(DarkThemeKey, this.DarkMode).ConfigureAwait(true);
+            }
+        }
+    }
+}

--- a/Apps/Admin/Client/Layouts/MainLayout.razor.cs
+++ b/Apps/Admin/Client/Layouts/MainLayout.razor.cs
@@ -54,6 +54,7 @@ namespace HealthGateway.Admin.Client.Layouts
             if (await this.LocalStorage.ContainKeyAsync(DarkThemeKey).ConfigureAwait(true))
             {
                 this.DarkMode = await this.LocalStorage.GetItemAsync<bool>(DarkThemeKey).ConfigureAwait(true);
+                this.StateHasChanged();
             }
             else
             {


### PR DESCRIPTION
# Fixes [AB#12114](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12114)

## Description

- Moves LoginLayout code to code-behind file
- Adds StateHasChanged() call to ensure layouts re-render after initializing the DarkMode value

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
