### PR TITLE
Fixed Timeline page caught in infinite loop when navigated from Terms of Service  AB#11989

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/termsOfService.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/termsOfService.vue
@@ -18,8 +18,7 @@ import { ILogger, IUserProfileService } from "@/services/interfaces";
     },
 })
 export default class TermsOfServiceView extends Vue {
-    private logger: ILogger = container.get(SERVICE_IDENTIFIER.Logger);
-
+    private logger!: ILogger;
     private userProfileService!: IUserProfileService;
     private isLoading = true;
     private hasErrors = false;
@@ -37,6 +36,7 @@ export default class TermsOfServiceView extends Vue {
     ];
 
     private mounted() {
+        this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         this.userProfileService = container.get(
             SERVICE_IDENTIFIER.UserProfileService
         );


### PR DESCRIPTION
# Fixed Timeline page caught in infinite loop when navigated from Terms of Service  [AB#11989](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11989)

## Description

When user navigates from Terms of Service to Timeline page, the Timeline page is caught in an infinite loop when re-rendering

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

**NO**

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
