### PR TITLE
Add UTC Local Time conversion support for AB#12159.

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/views/Stats.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Stats.vue
@@ -45,7 +45,11 @@ export default class StatsView extends Vue {
     private downloadInactiveUsersCSV(): void {
         if ((this.$refs.form as Vue & { validate: () => boolean }).validate()) {
             window.open(
-                `${this.serviceEndpoints.CsvExportBaseUri}/GetInactiveUsers?inactiveDays=${this.inactiveDays}`
+                `${
+                    this.serviceEndpoints.CsvExportBaseUri
+                }/GetInactiveUsers?inactiveDays=${
+                    this.inactiveDays
+                }&timeOffset=${new Date().getTimezoneOffset() * -1}`
             );
         }
     }

--- a/Apps/AdminWebClient/src/Server/Controllers/CsvExportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/CsvExportController.cs
@@ -66,6 +66,7 @@ namespace HealthGateway.Admin.Controllers
         /// Retrieves a list of inactive users created exclusive of the days inactive.
         /// </summary>
         /// <param name="inactiveDays">The days inactive to filter the users last login.</param>
+        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
         /// <returns>A CSV of inactive users.</returns>
         /// <response code="200">Returns the list of beta requests.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
@@ -73,9 +74,9 @@ namespace HealthGateway.Admin.Controllers
         [HttpGet]
         [Route("GetInactiveUsers")]
         [Produces("text/csv")]
-        public async Task<IActionResult> GetInactiveAdminUser(int inactiveDays)
+        public async Task<IActionResult> GetInactiveAdminUser(int inactiveDays, int timeOffset)
         {
-            return SendContentResponse("InactiveUsers", await this.dataExportService.GetInactiveUsers(inactiveDays).ConfigureAwait(true));
+            return SendContentResponse("InactiveUsers", await this.dataExportService.GetInactiveUsers(inactiveDays, timeOffset).ConfigureAwait(true));
         }
 
         /// <summary>

--- a/Apps/AdminWebClient/src/Server/Services/CsvExportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CsvExportService.cs
@@ -25,10 +25,8 @@ namespace HealthGateway.Admin.Services
     using HealthGateway.Admin.Server.Mappers;
     using HealthGateway.Admin.Server.Models;
     using HealthGateway.Admin.Server.Services;
-    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -95,9 +93,9 @@ namespace HealthGateway.Admin.Services
         }
 
         /// <inheritdoc />
-        public async Task<Stream> GetInactiveUsers(int inactiveDays)
+        public async Task<Stream> GetInactiveUsers(int inactiveDays, int timeOffset)
         {
-            RequestResult<List<AdminUserProfileView>> inactiveUsersResult = await this.inactiveUserService.GetInactiveUsers(inactiveDays).ConfigureAwait(true);
+            RequestResult<List<AdminUserProfileView>> inactiveUsersResult = await this.inactiveUserService.GetInactiveUsers(inactiveDays, timeOffset).ConfigureAwait(true);
 
             if (inactiveUsersResult.ResultStatus == ResultType.Success)
             {

--- a/Apps/AdminWebClient/src/Server/Services/ICsvExportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/ICsvExportService.cs
@@ -60,7 +60,8 @@ namespace HealthGateway.Admin.Services
         /// Retrieves a stream of inactive users in CSV format exclusive of the days inactive.
         /// </summary>
         /// <param name="inactiveDays">The days inactive to filter the users last login.</param>
+        /// <param name="timeOffset">The clients offset to get to UTC.</param>
         /// <returns>returns a stream representing a CSV of inactive users.</returns>
-        Task<Stream> GetInactiveUsers(int inactiveDays);
+        Task<Stream> GetInactiveUsers(int inactiveDays, int timeOffset);
     }
 }

--- a/Apps/AdminWebClient/src/Server/Services/IInactiveUserService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/IInactiveUserService.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Server.Services
 {
+    using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Server.Models;
@@ -29,7 +30,8 @@ namespace HealthGateway.Admin.Server.Services
         /// Returns inactive users exclusive of the days inactive.
         /// </summary>
         /// <param name="inactiveDays">The days inactive to filter the users last login.</param>
+        /// <param name="timeOffset">The clients offset to get to UTC.</param>
         /// <returns>returns a Request Result of List.</returns>
-        Task<RequestResult<List<AdminUserProfileView>>> GetInactiveUsers(int inactiveDays);
+        Task<RequestResult<List<AdminUserProfileView>>> GetInactiveUsers(int inactiveDays, int timeOffset);
     }
 }

--- a/Apps/AdminWebClient/src/Server/Services/InactiveUserService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/InactiveUserService.cs
@@ -73,7 +73,7 @@ public class InactiveUserService : IInactiveUserService
     }
 
     /// <inheritdoc />
-    public async Task<RequestResult<List<AdminUserProfileView>>> GetInactiveUsers(int inactiveDays)
+    public async Task<RequestResult<List<AdminUserProfileView>>> GetInactiveUsers(int inactiveDays, int timeOffset)
     {
         List<AdminUserProfileView> inactiveUsers = new List<AdminUserProfileView>();
 
@@ -87,10 +87,11 @@ public class InactiveUserService : IInactiveUserService
         this.logger.LogDebug("Getting inactive users past {InactiveDays} day(s) from last login....", inactiveDays);
 
         // Inactive admin user profiles from DB
-        DBResult<IEnumerable<AdminUserProfile>> inactiveProfileResult = this.adminUserProfileDelegate.GetInactiveAdminUserProfiles(inactiveDays);
+        TimeSpan timeSpan = new(0, timeOffset, 0);
+        DBResult<IEnumerable<AdminUserProfile>> inactiveProfileResult = this.adminUserProfileDelegate.GetInactiveAdminUserProfiles(inactiveDays, timeSpan);
 
         // Active admin user profiles from DB
-        DBResult<IEnumerable<AdminUserProfile>> activeProfileResult = this.adminUserProfileDelegate.GetActiveAdminUserProfiles(inactiveDays);
+        DBResult<IEnumerable<AdminUserProfile>> activeProfileResult = this.adminUserProfileDelegate.GetActiveAdminUserProfiles(inactiveDays, timeSpan);
 
         // Compare inactive users in DB to users in Keycloak
         if (inactiveProfileResult.Status == DBStatusCode.Read && activeProfileResult.Status == DBStatusCode.Read)

--- a/Apps/AdminWebClient/test/unit/Services.Test/InactiveUserServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/InactiveUserServiceTests.cs
@@ -119,8 +119,8 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             };
 
             Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
-            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>())).Returns(activeProfileResult);
-            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>())).Returns(inactiveProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(activeProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(inactiveProfileResult);
 
             Guid userId1 = Guid.NewGuid();
             Guid userId2 = Guid.NewGuid();
@@ -224,7 +224,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 this.configuration);
 
             // Act
-            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10);
+            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10, It.IsAny<int>());
 
             // Assert
             Assert.Equal(expectedInactiveUserCount, result.Result.TotalResultCount);
@@ -256,8 +256,8 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             };
 
             Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
-            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>())).Returns(activeProfileResult);
-            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>())).Returns(inactiveProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(activeProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(inactiveProfileResult);
 
             Guid userId1 = Guid.NewGuid();
             Guid userId2 = Guid.NewGuid();
@@ -328,7 +328,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 this.configuration);
 
             // Act
-            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10);
+            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10, It.IsAny<int>());
 
             // Assert
             Assert.Equal(expectedInactiveUserCount, result.Result.TotalResultCount);
@@ -360,8 +360,8 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             };
 
             Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
-            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>())).Returns(activeProfileResult);
-            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>())).Returns(inactiveProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(activeProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(inactiveProfileResult);
 
             RequestResult<IEnumerable<UserRepresentation>> adminUserResult = new()
             {
@@ -387,7 +387,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 this.configuration);
 
             // Act
-            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10);
+            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10, It.IsAny<int>());
 
             // Assert
             Assert.Equal(expectedInactiveUserCount, result.Result.TotalResultCount);
@@ -429,8 +429,8 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             };
 
             Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
-            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>())).Returns(activeProfileResult);
-            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>())).Returns(inactiveProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(activeProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(inactiveProfileResult);
 
             RequestResult<IEnumerable<UserRepresentation>> adminUserResult = new()
             {
@@ -456,7 +456,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 this.configuration);
 
             // Act
-            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10);
+            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10, It.IsAny<int>());
 
             // Assert
             Assert.Equal(expectedInactiveUserCount, result.Result.TotalResultCount);
@@ -494,8 +494,8 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             };
 
             Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
-            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>())).Returns(activeProfileResult);
-            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>())).Returns(inactiveProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(activeProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(inactiveProfileResult);
 
             RequestResult<IEnumerable<UserRepresentation>> adminUserResult = new()
             {
@@ -521,7 +521,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 this.configuration);
 
             // Act
-            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10);
+            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10, It.IsAny<int>());
 
             // Assert
             Assert.Equal(expectedResult, result.Result.ResultStatus);
@@ -558,8 +558,8 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             };
 
             Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
-            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>())).Returns(activeProfileResult);
-            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>())).Returns(inactiveProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(activeProfileResult);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfiles(It.IsAny<int>(), It.IsAny<TimeSpan>())).Returns(inactiveProfileResult);
 
             RequestResult<IEnumerable<UserRepresentation>> adminUserResult = new()
             {
@@ -585,7 +585,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 this.configuration);
 
             // Act
-            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10);
+            Task<RequestResult<List<AdminUserProfileView>>> result = service.GetInactiveUsers(10, It.IsAny<int>());
 
             // Assert
             Assert.Equal(expectedResult, result.Result.ResultStatus);

--- a/Apps/Database/src/Delegates/DbAdminUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbAdminUserProfileDelegate.cs
@@ -70,14 +70,14 @@ public class DbAdminUserProfileDelegate : IAdminUserProfileDelegate
     }
 
     /// <inheritdoc />
-    public DBResult<IEnumerable<AdminUserProfile>> GetActiveAdminUserProfiles(int activeDays)
+    public DBResult<IEnumerable<AdminUserProfile>> GetActiveAdminUserProfiles(int activeDays, TimeSpan timeOffset)
     {
         this.logger.LogTrace("Retrieving all the active admin user profiles since {ActiveDays} day(s) ago...", activeDays);
 
         DBResult<IEnumerable<AdminUserProfile>> result = new DBResult<IEnumerable<AdminUserProfile>>()
         {
             Payload = this.dbContext.AdminUserProfile
-                .Where(profile => profile.LastLoginDateTime.Date >= DateTime.UtcNow.AddDays(-activeDays).Date)
+                .Where(profile => profile.LastLoginDateTime.AddMinutes(timeOffset.TotalMinutes).Date >= DateTime.UtcNow.AddMinutes(timeOffset.TotalMinutes).AddDays(-activeDays).Date)
                 .OrderByDescending(profile => profile.LastLoginDateTime)
                 .ToList(),
             Status = DBStatusCode.Read,
@@ -88,14 +88,14 @@ public class DbAdminUserProfileDelegate : IAdminUserProfileDelegate
     }
 
     /// <inheritdoc />
-    public DBResult<IEnumerable<AdminUserProfile>> GetInactiveAdminUserProfiles(int inactiveDays)
+    public DBResult<IEnumerable<AdminUserProfile>> GetInactiveAdminUserProfiles(int inactiveDays, TimeSpan timeOffset)
     {
         this.logger.LogTrace("Retrieving all the inactive admin user profiles for the past {InactiveDays} day(s)...", inactiveDays);
 
         DBResult<IEnumerable<AdminUserProfile>> result = new DBResult<IEnumerable<AdminUserProfile>>()
         {
             Payload = this.dbContext.AdminUserProfile
-                .Where(profile => profile.LastLoginDateTime.Date <= DateTime.UtcNow.AddDays(-inactiveDays).Date)
+                .Where(profile => profile.LastLoginDateTime.AddMinutes(timeOffset.TotalMinutes).Date <= DateTime.UtcNow.AddMinutes(timeOffset.TotalMinutes).AddDays(-inactiveDays).Date)
                 .OrderByDescending(profile => profile.LastLoginDateTime)
                 .ToList(),
             Status = DBStatusCode.Read,

--- a/Apps/Database/src/Delegates/IAdminUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IAdminUserProfileDelegate.cs
@@ -36,15 +36,17 @@ public interface IAdminUserProfileDelegate
     /// Returns Active AdminUserProfile objects from the database.
     /// </summary>
     /// <param name="activeDays">Users active within the last X days".</param>
+    /// <param name="timeOffset">The clients offset to get to UTC.</param>
     /// <returns>An IEnumerable of AdminUserProfile objects wrapped in a DBResult.</returns>
-    DBResult<IEnumerable<AdminUserProfile>> GetActiveAdminUserProfiles(int activeDays);
+    DBResult<IEnumerable<AdminUserProfile>> GetActiveAdminUserProfiles(int activeDays, TimeSpan timeOffset);
 
     /// <summary>
     /// Returns Inactive AdminUserProfile objects from the database.
     /// </summary>
     /// <param name="inactiveDays">Users inactive for at least X days.</param>
+    /// <param name="timeOffset">The clients offset to get to UTC.</param>
     /// <returns>An IEnumerable of AdminUserProfile objects wrapped in a DBResult.</returns>
-    DBResult<IEnumerable<AdminUserProfile>> GetInactiveAdminUserProfiles(int inactiveDays);
+    DBResult<IEnumerable<AdminUserProfile>> GetInactiveAdminUserProfiles(int inactiveDays, TimeSpan timeOffset);
 
     /// <summary>
     /// Creates an AdminUserProfile object in the database.


### PR DESCRIPTION
# Fixes or Implements [AB#12159](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12159)

## Description

When determining active and inactive users, ensure that inactive day parameter is converted appropriately from local time to UTC time when querying database.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
