### PR TITLE
Add retry logic to lab order requests AB#12259

### DIFF
--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Laboratory.Controllers
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
@@ -58,11 +57,11 @@ namespace HealthGateway.Laboratory.Controllers
         }
 
         /// <summary>
-        /// Gets a json list of COVID-19 orders.
+        /// Gets a result containing a collection of COVID-19 laboratory orders.
         /// </summary>
-        /// <param name="hdid">The hdid resource to request the COVID-19 orders for.</param>
-        /// <returns>A list of COVID-19 records wrapped in a request result.</returns>
-        /// <response code="200">Returns the list of COVID-19 records.</response>
+        /// <param name="hdid">The hdid resource to request the COVID-19 laboratory orders for.</param>
+        /// <returns>Returns collection of COVID-19 laboratory orders if available and information about whether the orders could be retrieved.</returns>
+        /// <response code="200">Returns the result model.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         /// <response code="503">The service is unavailable for use.</response>
@@ -70,20 +69,20 @@ namespace HealthGateway.Laboratory.Controllers
         [Produces("application/json")]
         [Route("Covid19Orders")]
         [Authorize(Policy = LaboratoryPolicy.Read)]
-        public async Task<RequestResult<IEnumerable<Covid19Order>>> GetCovid19Orders([FromQuery] string hdid)
+        public async Task<RequestResult<Covid19OrderResult>> GetCovid19Orders([FromQuery] string hdid)
         {
-            this.logger.LogDebug($"Getting list of COVID-19 orders... ");
-            RequestResult<IEnumerable<Covid19Order>> result = await this.service.GetCovid19Orders(hdid).ConfigureAwait(true);
-            this.logger.LogDebug($"Finished getting COVID-19 orders from controller... {hdid}");
+            this.logger.LogDebug($"Getting COVID-19 laboratory orders...");
+            RequestResult<Covid19OrderResult> result = await this.service.GetCovid19Orders(hdid).ConfigureAwait(true);
+            this.logger.LogDebug($"Finished getting COVID-19 laboratory orders from controller for HDID: {hdid}");
             return result;
         }
 
         /// <summary>
-        /// Gets a json list of Laboratory orders.
+        /// Gets a result containing a collection of laboratory orders.
         /// </summary>
-        /// <param name="hdid">The hdid resource to request the Laboratory orders for.</param>
-        /// <returns>Returns List of lab orders.</returns>
-        /// <response code="200">Returns a list of Laboratory orders.</response>
+        /// <param name="hdid">The hdid resource to request the laboratory orders for.</param>
+        /// <returns>Returns collection of laboratory orders if available and information about whether the orders could be retrieved.</returns>
+        /// <response code="200">Returns the result model.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         /// <response code="503">The service is unavailable for use.</response>
@@ -91,11 +90,11 @@ namespace HealthGateway.Laboratory.Controllers
         [Produces("application/json")]
         [Route("LaboratoryOrders")]
         [Authorize(Policy = LaboratoryPolicy.Read)]
-        public async Task<RequestResult<IEnumerable<LaboratoryOrder>>> GetLaboratoryOrders([FromQuery] string hdid)
+        public async Task<RequestResult<LaboratoryOrderResult>> GetLaboratoryOrders([FromQuery] string hdid)
         {
-            this.logger.LogDebug($"Getting laboratory summary... ");
-            RequestResult<IEnumerable<LaboratoryOrder>> result = await this.service.GetLaboratoryOrders(hdid).ConfigureAwait(true);
-            this.logger.LogDebug("Finished getting laboratory summary from controller for Hdid: {Hdid}...", hdid);
+            this.logger.LogDebug($"Getting laboratory orders...");
+            RequestResult<LaboratoryOrderResult> result = await this.service.GetLaboratoryOrders(hdid).ConfigureAwait(true);
+            this.logger.LogDebug($"Finished getting laboratory orders from controller for HDID: {hdid}");
             return result;
         }
 

--- a/Apps/Laboratory/src/Delegates/ILaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/ILaboratoryDelegate.cs
@@ -36,7 +36,7 @@ namespace HealthGateway.Laboratory.Delegates
         /// <param name="hdid">The requested hdid.</param>
         /// <param name="pageIndex">The page index to return.</param>
         /// <returns>The list of COVID-19 Orders available for the user identified by the bearerToken.</returns>
-        Task<RequestResult<IEnumerable<PhsaCovid19Order>>> GetCovid19Orders(string bearerToken, string hdid, int pageIndex = 0);
+        Task<RequestResult<PHSAResult<List<PhsaCovid19Order>>>> GetCovid19Orders(string bearerToken, string hdid, int pageIndex = 0);
 
         /// <summary>
         /// Gets the Lab report in binary format for the supplied id belonging to the authenticated user.
@@ -54,7 +54,7 @@ namespace HealthGateway.Laboratory.Delegates
         /// <param name="hdid">The requested hdid.</param>
         /// <param name="bearerToken">The security token representing the authenticated user.</param>
         /// <returns>Returns a summary of Provincial Lab Information System Lab Orders.</returns>
-        Task<RequestResult<PhsaLaboratorySummary>> GetLaboratorySummary(string hdid, string bearerToken);
+        Task<RequestResult<PHSAResult<PhsaLaboratorySummary>>> GetLaboratorySummary(string hdid, string bearerToken);
 
         /// <summary>
         /// Returns the public COVID-19 test results for the given patient.

--- a/Apps/Laboratory/src/Delegates/MockLaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/MockLaboratoryDelegate.cs
@@ -18,14 +18,12 @@ namespace HealthGateway.Laboratory.Delegates
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using System.Linq;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Laboratory.Models;
     using HealthGateway.Laboratory.Models.PHSA;
-    using Microsoft.Extensions.Configuration;
 
     /// <summary>
     /// Implementation that uses HTTP to retrieve laboratory information.
@@ -34,15 +32,15 @@ namespace HealthGateway.Laboratory.Delegates
     public class MockLaboratoryDelegate : ILaboratoryDelegate
     {
         /// <inheritdoc/>
-        public async Task<RequestResult<IEnumerable<PhsaCovid19Order>>> GetCovid19Orders(string bearerToken, string hdid, int pageIndex = 0)
+        public async Task<RequestResult<PHSAResult<List<PhsaCovid19Order>>>> GetCovid19Orders(string bearerToken, string hdid, int pageIndex = 0)
         {
-            RequestResult<IEnumerable<PhsaCovid19Order>> retVal = new()
+            RequestResult<PHSAResult<List<PhsaCovid19Order>>> retVal = new()
             {
                 PageIndex = 0,
                 PageSize = 10000,
                 ResultStatus = ResultType.Success,
             };
-            PhsaCovid19Order[] mockData =
+            List<PhsaCovid19Order> mockData = new()
             {
                 new PhsaCovid19Order()
                 {
@@ -76,8 +74,8 @@ namespace HealthGateway.Laboratory.Delegates
                 },
             };
 
-            retVal.TotalResultCount = mockData.Length;
-            retVal.ResourcePayload = mockData.AsEnumerable();
+            retVal.TotalResultCount = mockData.Count;
+            retVal.ResourcePayload = new() { Result = mockData };
             await Task.Delay(0).ConfigureAwait(true);
             return retVal;
         }
@@ -101,7 +99,7 @@ namespace HealthGateway.Laboratory.Delegates
         }
 
         /// <inheritdoc/>
-        public Task<RequestResult<PhsaLaboratorySummary>> GetLaboratorySummary(string hdid, string bearerToken)
+        public Task<RequestResult<PHSAResult<PhsaLaboratorySummary>>> GetLaboratorySummary(string hdid, string bearerToken)
         {
             throw new NotImplementedException();
         }

--- a/Apps/Laboratory/src/Models/Covid19Order.cs
+++ b/Apps/Laboratory/src/Models/Covid19Order.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Laboratory.Models
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text.Json.Serialization;
     using HealthGateway.Laboratory.Models.PHSA;
 
@@ -102,7 +103,7 @@ namespace HealthGateway.Laboratory.Models
         /// </summary>
         /// <param name="model">The laboratory result to convert.</param>
         /// <returns>The newly created laboratory object.</returns>
-        public static Covid19Order FromPHSAModel(PhsaCovid19Order model)
+        public static Covid19Order FromPhsaModel(PhsaCovid19Order model)
         {
             return new Covid19Order()
             {
@@ -122,22 +123,13 @@ namespace HealthGateway.Laboratory.Models
         }
 
         /// <summary>
-        /// Creates a collection of COVID-19 order models from a collection of PHSA models.
+        /// Creates a collection of <see cref="Covid19Order"/> models from a collection of PHSA models.
         /// </summary>
-        /// <param name="phsaOrders">The list of PHSA models to convert.</param>
-        /// <returns>A collection of COVID-19 order models.</returns>
-        public static IEnumerable<Covid19Order> FromPHSAModelList(IEnumerable<PhsaCovid19Order>? phsaOrders)
+        /// <param name="phsaOrders">The collection of PHSA models to convert.</param>
+        /// <returns>A collection of <see cref="Covid19Order"/> models.</returns>
+        public static IEnumerable<Covid19Order> FromPhsaModelCollection(IEnumerable<PhsaCovid19Order>? phsaOrders)
         {
-            List<Covid19Order> objects = new();
-            if (phsaOrders != null)
-            {
-                foreach (PhsaCovid19Order phsaOrder in phsaOrders)
-                {
-                    objects.Add(FromPHSAModel(phsaOrder));
-                }
-            }
-
-            return objects;
+            return phsaOrders != null ? phsaOrders.Select(FromPhsaModel) : Enumerable.Empty<Covid19Order>();
         }
 
         private static string MaskPHN(string phn)

--- a/Apps/Laboratory/src/Models/Covid19OrderResult.cs
+++ b/Apps/Laboratory/src/Models/Covid19OrderResult.cs
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Laboratory.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// The result model for COVID-19 laboratory orders.
+/// </summary>
+public class Covid19OrderResult
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the orders have been retrieved.
+    /// Will be set to true if the object has been fully loaded.
+    /// When false, only Loaded, and RetryIn will be populated.
+    /// </summary>
+    [JsonPropertyName("loaded")]
+    public bool Loaded { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimal amount of time that should be waited before another request.
+    /// The unit of measurement is in milliseconds.
+    /// </summary>
+    [JsonPropertyName("retryin")]
+    public int RetryIn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection of COVID-19 laboratory orders.
+    /// </summary>
+    [JsonPropertyName("orders")]
+    public IEnumerable<Covid19Order> Covid19Orders { get; set; } = Enumerable.Empty<Covid19Order>();
+}

--- a/Apps/Laboratory/src/Models/LaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrder.cs
@@ -99,7 +99,7 @@ public class LaboratoryOrder
     public IList<LaboratoryTest> LaboratoryTests { get; }
 
     /// <summary>
-    /// Creates a LaboratoryOrder object from a PHSA model.
+    /// Creates a <see cref="LaboratoryOrder"/> object from a PHSA model.
     /// </summary>
     /// <param name="model">The laboratory order result to convert.</param>
     /// <returns>The newly created laboratory order object.</returns>
@@ -122,15 +122,12 @@ public class LaboratoryOrder
     }
 
     /// <summary>
-    /// Creates a collection of Laboratory Order models from a collection of PHSA models.
+    /// Creates a collection of <see cref="LaboratoryOrder"/> models from a collection of PHSA models.
     /// </summary>
     /// <param name="phsaOrders">The list of PHSA models to convert.</param>
-    /// <returns>A collection of COVID-19 order models.</returns>
-    public static IEnumerable<LaboratoryOrder> FromPhsaModelList(IEnumerable<PhsaLaboratoryOrder>? phsaOrders)
+    /// <returns>A collection of <see cref="LaboratoryOrder"/> models.</returns>
+    public static IEnumerable<LaboratoryOrder> FromPhsaModelCollection(IEnumerable<PhsaLaboratoryOrder>? phsaOrders)
     {
-        IEnumerable<LaboratoryOrder> orders = phsaOrders != null
-            ? phsaOrders.Select(LaboratoryOrder.FromPhsaModel)
-            : Enumerable.Empty<LaboratoryOrder>();
-        return orders;
+        return phsaOrders != null ? phsaOrders.Select(FromPhsaModel) : Enumerable.Empty<LaboratoryOrder>();
     }
 }

--- a/Apps/Laboratory/src/Models/LaboratoryOrderResult.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrderResult.cs
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Laboratory.Models;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// The result model for laboratory orders.
+/// </summary>
+public class LaboratoryOrderResult
+{
+    /// <summary>
+    /// Gets or sets a value indicating whether the orders have been retrieved.
+    /// Will be set to true if the object has been fully loaded.
+    /// When false, only Loaded, and RetryIn will be populated.
+    /// </summary>
+    [JsonPropertyName("loaded")]
+    public bool Loaded { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimal amount of time that should be waited before another request.
+    /// The unit of measurement is in milliseconds.
+    /// </summary>
+    [JsonPropertyName("retryin")]
+    public int RetryIn { get; set; }
+
+    /// <summary>
+    /// Gets or sets the collection of laboratory orders.
+    /// </summary>
+    [JsonPropertyName("orders")]
+    public IEnumerable<LaboratoryOrder> LaboratoryOrders { get; set; } = Enumerable.Empty<LaboratoryOrder>();
+}

--- a/Apps/Laboratory/src/Services/ILaboratoryService.cs
+++ b/Apps/Laboratory/src/Services/ILaboratoryService.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Laboratory.Services
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Laboratory.Models;
@@ -27,13 +26,21 @@ namespace HealthGateway.Laboratory.Services
     public interface ILaboratoryService
     {
         /// <summary>
-        /// Returns a List of COVID-19 orders for the authenticated user.
-        /// It has a collection of one or more COVID-19 results depending on the tests ordered.
+        /// Returns result containing a collection of COVID-19 lab orders for the authenticated user.
+        /// Each order has a collection of one or more COVID-19 results depending on the tests ordered.
         /// </summary>
         /// <param name="hdid">The requested hdid.</param>
         /// <param name="pageIndex">The page index to return.</param>
-        /// <returns>The list of COVID-19 orders available for the authenticated user.</returns>
-        Task<RequestResult<IEnumerable<Covid19Order>>> GetCovid19Orders(string hdid, int pageIndex = 0);
+        /// <returns>The collection of COVID-19 lab orders available for the authenticated user.</returns>
+        Task<RequestResult<Covid19OrderResult>> GetCovid19Orders(string hdid, int pageIndex = 0);
+
+        /// <summary>
+        /// Returns result containing a collection of lab orders for the authenticated user.
+        /// Each order has a collection of one or more lab results depending on the tests ordered.
+        /// </summary>
+        /// <param name="hdid">The requested hdid.</param>
+        /// <returns>Returns collection of lab orders available for the authenticated user.</returns>
+        Task<RequestResult<LaboratoryOrderResult>> GetLaboratoryOrders(string hdid);
 
         /// <summary>
         /// Gets the Lab report for the supplied id belonging to the authenticated user.
@@ -43,14 +50,6 @@ namespace HealthGateway.Laboratory.Services
         /// <param name="isCovid19">Indicates whether the COVID-19 report should be returned..</param>
         /// <returns>A base64 encoded PDF.</returns>
         Task<RequestResult<LaboratoryReport>> GetLabReport(Guid id, string hdid, bool isCovid19);
-
-        /// <summary>
-        /// Returns a List of lab orders for the authenticated user.
-        /// It has a collection of one or more Lab Results depending on the tests ordered.
-        /// </summary>
-        /// <param name="hdid">The requested hdid.</param>
-        /// <returns>Returns List of lab orders.</returns>
-        Task<RequestResult<IEnumerable<LaboratoryOrder>>> GetLaboratoryOrders(string hdid);
 
         /// <summary>
         /// Post the rapid test for the given patient info.

--- a/Apps/Laboratory/test/unit/Controllers/LaboratoryControllerTests.cs
+++ b/Apps/Laboratory/test/unit/Controllers/LaboratoryControllerTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.LaboratoryTests
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -45,11 +44,11 @@ namespace HealthGateway.LaboratoryTests
         public async Task ShouldGetCovid19Orders()
         {
             Mock<ILaboratoryService> svcMock = new();
-            svcMock.Setup(s => s.GetCovid19Orders(Hdid, 0)).ReturnsAsync(new RequestResult<IEnumerable<Covid19Order>>()
+            svcMock.Setup(s => s.GetCovid19Orders(Hdid, 0)).ReturnsAsync(new RequestResult<Covid19OrderResult>()
             {
                 ResultStatus = ResultType.Success,
                 TotalResultCount = 0,
-                ResourcePayload = new List<Covid19Order>(),
+                ResourcePayload = new(),
             });
 
             LaboratoryController controller = new(
@@ -57,7 +56,7 @@ namespace HealthGateway.LaboratoryTests
                 svcMock.Object);
 
             // Act
-            RequestResult<IEnumerable<Covid19Order>> actual = await controller.GetCovid19Orders(Hdid).ConfigureAwait(true);
+            RequestResult<Covid19OrderResult> actual = await controller.GetCovid19Orders(Hdid).ConfigureAwait(true);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Success);
@@ -71,11 +70,11 @@ namespace HealthGateway.LaboratoryTests
         public async Task ShouldGetLaboratoryOrders()
         {
             Mock<ILaboratoryService> svcMock = new();
-            svcMock.Setup(s => s.GetLaboratoryOrders(Hdid)).ReturnsAsync(new RequestResult<IEnumerable<LaboratoryOrder>>()
+            svcMock.Setup(s => s.GetLaboratoryOrders(Hdid)).ReturnsAsync(new RequestResult<LaboratoryOrderResult>()
             {
                 ResultStatus = ResultType.Success,
                 TotalResultCount = 0,
-                ResourcePayload = new List<LaboratoryOrder>(),
+                ResourcePayload = new(),
             });
 
             LaboratoryController controller = new(
@@ -83,21 +82,21 @@ namespace HealthGateway.LaboratoryTests
                 svcMock.Object);
 
             // Act
-            RequestResult<IEnumerable<LaboratoryOrder>> actual = await controller.GetLaboratoryOrders(Hdid).ConfigureAwait(true);
+            RequestResult<LaboratoryOrderResult> actual = await controller.GetLaboratoryOrders(Hdid).ConfigureAwait(true);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Success);
         }
 
         /// <summary>
-        /// Test for GetLabOrderError.
+        /// Test for GetCovid19Order errors.
         /// </summary>
         /// <returns>Task.</returns>
         [Fact]
-        public async Task ShouldGetLabOrderError()
+        public async Task ShouldGetCovid19OrderError()
         {
             Mock<ILaboratoryService> svcMock = new();
-            svcMock.Setup(s => s.GetCovid19Orders(Hdid, 0)).ReturnsAsync(new RequestResult<IEnumerable<Covid19Order>>()
+            svcMock.Setup(s => s.GetCovid19Orders(Hdid, 0)).ReturnsAsync(new RequestResult<Covid19OrderResult>()
             {
                 ResultStatus = ResultType.Error,
                 ResultError = new RequestResultError() { ResultMessage = "Test Error" },
@@ -109,7 +108,33 @@ namespace HealthGateway.LaboratoryTests
                 svcMock.Object);
 
             // Act
-            RequestResult<IEnumerable<Covid19Order>> actual = await controller.GetCovid19Orders(Hdid).ConfigureAwait(true);
+            RequestResult<Covid19OrderResult> actual = await controller.GetCovid19Orders(Hdid).ConfigureAwait(true);
+
+            // Verify
+            Assert.True(actual != null && actual.ResultStatus == ResultType.Error);
+        }
+
+        /// <summary>
+        /// Test for GetLaboratoryOrder errors.
+        /// </summary>
+        /// <returns>Task.</returns>
+        [Fact]
+        public async Task ShouldGetLaboratoryOrderError()
+        {
+            Mock<ILaboratoryService> svcMock = new();
+            svcMock.Setup(s => s.GetLaboratoryOrders(Hdid)).ReturnsAsync(new RequestResult<LaboratoryOrderResult>()
+            {
+                ResultStatus = ResultType.Error,
+                ResultError = new RequestResultError() { ResultMessage = "Test Error" },
+                TotalResultCount = 0,
+            });
+
+            LaboratoryController controller = new(
+                new Mock<ILogger<LaboratoryController>>().Object,
+                svcMock.Object);
+
+            // Act
+            RequestResult<LaboratoryOrderResult> actual = await controller.GetLaboratoryOrders(Hdid).ConfigureAwait(true);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Error);

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -79,10 +79,10 @@ namespace HealthGateway.LaboratoryTests
             IHttpClientService httpClientService = GetHttpClientService(httpResponseMessage);
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), httpClientService, CreateValidHttpContext().Object, this.configuration);
 
-            RequestResult<IEnumerable<PhsaCovid19Order>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
+            RequestResult<PHSAResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Equal("9735352542", actualResult.ResourcePayload!.First().PHN);
+            Assert.Equal("9735352542", actualResult.ResourcePayload!.Result.First().PHN);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace HealthGateway.LaboratoryTests
             IHttpClientService httpClientService = GetHttpClientService(httpResponseMessage);
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), httpClientService, CreateValidHttpContext().Object, this.configuration);
 
-            RequestResult<IEnumerable<PhsaCovid19Order>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
+            RequestResult<PHSAResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Contains(ExpectedSubstring, actualResult!.ResultError!.ResultMessage, StringComparison.OrdinalIgnoreCase);
@@ -124,10 +124,10 @@ namespace HealthGateway.LaboratoryTests
             IHttpClientService httpClientService = GetHttpClientService(httpResponseMessage);
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), httpClientService, CreateValidHttpContext().Object, this.configuration);
 
-            RequestResult<IEnumerable<PhsaCovid19Order>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
+            RequestResult<PHSAResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Empty(actualResult.ResourcePayload);
+            Assert.Empty(actualResult.ResourcePayload!.Result);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace HealthGateway.LaboratoryTests
             IHttpClientService httpClientService = GetHttpClientService(httpResponseMessage);
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(loggerFactory.CreateLogger<RestLaboratoryDelegate>(), httpClientService, CreateValidHttpContext().Object, this.configuration);
 
-            RequestResult<IEnumerable<PhsaCovid19Order>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
+            RequestResult<PHSAResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(string.Empty, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }

--- a/Apps/Laboratory/test/unit/Mock/LaboratoryDelegateMock.cs
+++ b/Apps/Laboratory/test/unit/Mock/LaboratoryDelegateMock.cs
@@ -34,7 +34,7 @@ namespace HealthGateway.LaboratoryTests.Mock
         /// Initializes a new instance of the <see cref="LaboratoryDelegateMock"/> class.
         /// </summary>
         /// <param name="delegateResult">List of COVID-19 Orders.</param>
-        public LaboratoryDelegateMock(RequestResult<IEnumerable<PhsaCovid19Order>> delegateResult)
+        public LaboratoryDelegateMock(RequestResult<PHSAResult<List<PhsaCovid19Order>>> delegateResult)
         {
             this.Setup(s => s.GetCovid19Orders(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns(Task.FromResult(delegateResult));
         }
@@ -63,7 +63,7 @@ namespace HealthGateway.LaboratoryTests.Mock
         /// Initializes a new instance of the <see cref="LaboratoryDelegateMock"/> class.
         /// </summary>
         /// <param name="delegateResult">List of Laboratory Orders.</param>
-        public LaboratoryDelegateMock(RequestResult<PhsaLaboratorySummary> delegateResult)
+        public LaboratoryDelegateMock(RequestResult<PHSAResult<PhsaLaboratorySummary>> delegateResult)
         {
             this.Setup(s => s.GetLaboratorySummary(It.IsAny<string>(), It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
         }

--- a/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
+++ b/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
@@ -20,7 +20,6 @@ namespace HealthGateway.LaboratoryTests.Mock
     using System.Security.Claims;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authentication.Models;
-    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Laboratory.Factories;
@@ -65,7 +64,7 @@ namespace HealthGateway.LaboratoryTests.Mock
         /// <param name="token">token needed for authentication.</param>
         /// <param name="mockHttpContextAccessor">IHttpContextAccessor Mock.</param>
         /// <param name="claimsPrincipal">exposes a collection of identities.</param>
-        public LaboratoryServiceMock(RequestResult<IEnumerable<PhsaCovid19Order>> delegateResult, Mock<IHttpContextAccessor> mockHttpContextAccessor, string token, ClaimsPrincipal claimsPrincipal)
+        public LaboratoryServiceMock(RequestResult<PHSAResult<List<PhsaCovid19Order>>> delegateResult, Mock<IHttpContextAccessor> mockHttpContextAccessor, string token, ClaimsPrincipal claimsPrincipal)
         {
             SetupAuthenticationMock(mockHttpContextAccessor, token, claimsPrincipal);
 
@@ -133,7 +132,7 @@ namespace HealthGateway.LaboratoryTests.Mock
         /// <param name="token">token needed for authentication.</param>
         /// <param name="mockHttpContextAccessor">IHttpContextAccessor Mock.</param>
         /// <param name="claimsPrincipal">exposes a collection of identities.</param>
-        public LaboratoryServiceMock(RequestResult<PhsaLaboratorySummary> delegateResult, Mock<IHttpContextAccessor> mockHttpContextAccessor, string token, ClaimsPrincipal claimsPrincipal)
+        public LaboratoryServiceMock(RequestResult<PHSAResult<PhsaLaboratorySummary>> delegateResult, Mock<IHttpContextAccessor> mockHttpContextAccessor, string token, ClaimsPrincipal claimsPrincipal)
         {
             SetupAuthenticationMock(mockHttpContextAccessor, token, claimsPrincipal);
 

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -90,25 +90,25 @@ namespace HealthGateway.LaboratoryTests
                 },
             };
 
-            RequestResult<IEnumerable<PhsaCovid19Order>> delegateResult = new()
+            RequestResult<PHSAResult<List<PhsaCovid19Order>>> delegateResult = new()
             {
                 ResultStatus = expectedResultType,
                 PageSize = 100,
                 PageIndex = 1,
-                ResourcePayload = covid19Orders,
+                ResourcePayload = new() { Result = covid19Orders },
             };
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new HttpContextAccessorMock(TOKEN, this.claimsPrincipal);
 
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, mockHttpContextAccessor, TOKEN, this.claimsPrincipal).LaboratoryServiceMockInstance();
 
-            Task<RequestResult<IEnumerable<Covid19Order>>> actualResult = service.GetCovid19Orders(HDID, 0);
+            Task<RequestResult<Covid19OrderResult>> actualResult = service.GetCovid19Orders(HDID, 0);
 
             if (expectedResultType == ResultType.Success)
             {
                 Assert.Equal(ResultType.Success, actualResult.Result.ResultStatus);
                 int count = 0;
-                foreach (Covid19Order model in actualResult.Result!.ResourcePayload!)
+                foreach (Covid19Order model in actualResult.Result!.ResourcePayload!.Covid19Orders)
                 {
                     count++;
                     Assert.True(model.MessageID.Equals(MockedMessageID + count, StringComparison.Ordinal));
@@ -183,14 +183,16 @@ namespace HealthGateway.LaboratoryTests
                         },
                     },
                 },
+                LabOrderCount = 2,
             };
 
-            RequestResult<PhsaLaboratorySummary> delegateResult = new()
+            RequestResult<PHSAResult<PhsaLaboratorySummary>> delegateResult = new()
             {
                 ResultStatus = expectedResultType,
                 PageSize = 100,
                 PageIndex = 1,
-                ResourcePayload = laboratorySummary,
+                ResourcePayload = new() { Result = laboratorySummary },
+                TotalResultCount = 2,
             };
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new HttpContextAccessorMock(TOKEN, this.claimsPrincipal);
@@ -198,18 +200,19 @@ namespace HealthGateway.LaboratoryTests
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, mockHttpContextAccessor, TOKEN, this.claimsPrincipal).LaboratoryServiceMockInstance();
 
             // Act
-            Task<RequestResult<IEnumerable<LaboratoryOrder>>> actualResult = service.GetLaboratoryOrders(HDID);
+            Task<RequestResult<LaboratoryOrderResult>> actualResult = service.GetLaboratoryOrders(HDID);
 
             // Assert
             if (expectedResultType == ResultType.Success)
             {
                 Assert.Equal(ResultType.Success, actualResult.Result.ResultStatus);
                 Assert.Equal(expectedOrderCount, actualResult.Result.TotalResultCount);
-                Assert.Equal(expectedOrderCount, actualResult.Result.ResourcePayload.Count());
-                Assert.Equal(expectedReportId1, actualResult.Result.ResourcePayload.ToList()[0].ReportId);
-                Assert.Equal(expectedLabTestCount, actualResult.Result.ResourcePayload.ToList()[0].LaboratoryTests.Count);
-                Assert.Equal(expectedReportId2, actualResult.Result.ResourcePayload.ToList()[1].ReportId);
-                Assert.Equal(expectedLabTestCount, actualResult.Result.ResourcePayload.ToList()[1].LaboratoryTests.Count);
+                Assert.NotNull(actualResult.Result.ResourcePayload);
+                Assert.Equal(expectedOrderCount, actualResult.Result.ResourcePayload!.LaboratoryOrders.Count());
+                Assert.Equal(expectedReportId1, actualResult.Result.ResourcePayload!.LaboratoryOrders.ToList()[0].ReportId);
+                Assert.Equal(expectedLabTestCount, actualResult.Result.ResourcePayload!.LaboratoryOrders.ToList()[0].LaboratoryTests.Count);
+                Assert.Equal(expectedReportId2, actualResult.Result.ResourcePayload!.LaboratoryOrders.ToList()[1].ReportId);
+                Assert.Equal(expectedLabTestCount, actualResult.Result.ResourcePayload!.LaboratoryOrders.ToList()[1].LaboratoryTests.Count);
             }
             else
             {
@@ -230,14 +233,16 @@ namespace HealthGateway.LaboratoryTests
             {
                 LastRefreshDate = DateTime.Now,
                 LabOrders = null,
+                LabOrderCount = 0,
             };
 
-            RequestResult<PhsaLaboratorySummary> delegateResult = new()
+            RequestResult<PHSAResult<PhsaLaboratorySummary>> delegateResult = new()
             {
                 ResultStatus = ResultType.Success,
                 PageSize = 100,
                 PageIndex = 1,
-                ResourcePayload = laboratorySummary,
+                ResourcePayload = new() { Result = laboratorySummary },
+                TotalResultCount = 0,
             };
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new HttpContextAccessorMock(TOKEN, this.claimsPrincipal);
@@ -245,12 +250,13 @@ namespace HealthGateway.LaboratoryTests
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, mockHttpContextAccessor, TOKEN, this.claimsPrincipal).LaboratoryServiceMockInstance();
 
             // Act
-            Task<RequestResult<IEnumerable<LaboratoryOrder>>> actualResult = service.GetLaboratoryOrders(HDID);
+            Task<RequestResult<LaboratoryOrderResult>> actualResult = service.GetLaboratoryOrders(HDID);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.Result.ResultStatus);
             Assert.Equal(expectedOrderCount, actualResult.Result.TotalResultCount);
-            Assert.Equal(expectedOrderCount, actualResult.Result.ResourcePayload.Count());
+            Assert.NotNull(actualResult.Result.ResourcePayload);
+            Assert.Equal(expectedOrderCount, actualResult.Result.ResourcePayload!.LaboratoryOrders.Count());
         }
 
         /// <summary>
@@ -262,18 +268,20 @@ namespace HealthGateway.LaboratoryTests
             int expectedOrderCount = 0;
 
             // Arrange
-            PhsaLaboratorySummary laboratorySummary = new PhsaLaboratorySummary()
+            PhsaLaboratorySummary laboratorySummary = new()
             {
                 LastRefreshDate = DateTime.Now,
                 LabOrders = new List<PhsaLaboratoryOrder>(),
+                LabOrderCount = 0,
             };
 
-            RequestResult<PhsaLaboratorySummary> delegateResult = new()
+            RequestResult<PHSAResult<PhsaLaboratorySummary>> delegateResult = new()
             {
                 ResultStatus = ResultType.Success,
                 PageSize = 100,
                 PageIndex = 1,
-                ResourcePayload = laboratorySummary,
+                ResourcePayload = new() { Result = laboratorySummary },
+                TotalResultCount = 0,
             };
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new HttpContextAccessorMock(TOKEN, this.claimsPrincipal);
@@ -281,12 +289,13 @@ namespace HealthGateway.LaboratoryTests
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, mockHttpContextAccessor, TOKEN, this.claimsPrincipal).LaboratoryServiceMockInstance();
 
             // Act
-            Task<RequestResult<IEnumerable<LaboratoryOrder>>> actualResult = service.GetLaboratoryOrders(HDID);
+            Task<RequestResult<LaboratoryOrderResult>> actualResult = service.GetLaboratoryOrders(HDID);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.Result.ResultStatus);
             Assert.Equal(expectedOrderCount, actualResult.Result.TotalResultCount);
-            Assert.Equal(expectedOrderCount, actualResult.Result.ResourcePayload.Count());
+            Assert.NotNull(actualResult.Result.ResourcePayload);
+            Assert.Equal(expectedOrderCount, actualResult.Result.ResourcePayload!.LaboratoryOrders.Count());
         }
 
         /// <summary>

--- a/Apps/WebClient/src/ClientApp/src/components/dependentCard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependentCard.vue
@@ -117,10 +117,10 @@ export default class DependentCardComponent extends Vue {
         this.isLoading = true;
         this.laboratoryService
             .getCovid19LaboratoryOrders(this.dependent.ownerId)
-            .then((results) => {
-                if (results.resultStatus == ResultType.Success) {
+            .then((result) => {
+                if (result.resultStatus == ResultType.Success) {
                     this.testRows =
-                        results.resourcePayload.flatMap<Covid19LaboratoryTestRow>(
+                        result.resourcePayload.orders.flatMap<Covid19LaboratoryTestRow>(
                             (o) => {
                                 return o.labResults.map<Covid19LaboratoryTestRow>(
                                     (r) => {
@@ -137,13 +137,13 @@ export default class DependentCardComponent extends Vue {
                     this.isDataLoaded = true;
                 } else {
                     this.logger.error(
-                        "Error returned from the laboratory call: " +
-                            JSON.stringify(results.resultError)
+                        "Error returned from the COVID-19 Laboratory Orders call: " +
+                            JSON.stringify(result.resultError)
                     );
                     this.addError(
                         ErrorTranslator.toBannerError(
-                            "Fetch Laboratory Error",
-                            results.resultError
+                            "Fetch COVID-19 Laboratory Orders Error",
+                            result.resultError
                         )
                     );
                 }

--- a/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
@@ -1,5 +1,12 @@
 import { StringISODate, StringISODateTime } from "@/models/dateWrapper";
 
+// result model for retrieving COVID-19 lab orders
+export interface Covid19LaboratoryOrderResult {
+    loaded: boolean;
+    retryin: number;
+    orders: Covid19LaboratoryOrder[];
+}
+
 // COVID-19 lab order model
 export interface Covid19LaboratoryOrder {
     id: string;
@@ -30,6 +37,13 @@ export interface Covid19LaboratoryTest {
     resultDateTime: StringISODateTime;
     loinc: string | null;
     loincName: string | null;
+}
+
+// result model for retrieving lab orders
+export interface LaboratoryOrderResult {
+    loaded: boolean;
+    retryin: number;
+    orders: LaboratoryOrder[];
 }
 
 // laboratory order model

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -20,8 +20,8 @@ import type ImmunizationResult from "@/models/immunizationResult";
 import {
     AuthenticatedRapidTestRequest,
     AuthenticatedRapidTestResponse,
-    Covid19LaboratoryOrder,
-    LaboratoryOrder,
+    Covid19LaboratoryOrderResult,
+    LaboratoryOrderResult,
     LaboratoryReport,
     PublicCovidTestResponseResult,
 } from "@/models/laboratory";
@@ -116,10 +116,10 @@ export interface ILaboratoryService {
     ): Promise<RequestResult<PublicCovidTestResponseResult>>;
     getCovid19LaboratoryOrders(
         hdid: string
-    ): Promise<RequestResult<Covid19LaboratoryOrder[]>>;
+    ): Promise<RequestResult<Covid19LaboratoryOrderResult>>;
     getLaboratoryOrders(
         hdid: string
-    ): Promise<RequestResult<LaboratoryOrder[]>>;
+    ): Promise<RequestResult<LaboratoryOrderResult>>;
     getReportDocument(
         reportId: string,
         hdid: string,

--- a/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
@@ -7,8 +7,8 @@ import { ServiceName } from "@/models/errorInterfaces";
 import {
     AuthenticatedRapidTestRequest,
     AuthenticatedRapidTestResponse,
-    Covid19LaboratoryOrder,
-    LaboratoryOrder,
+    Covid19LaboratoryOrderResult,
+    LaboratoryOrderResult,
     LaboratoryReport,
     PublicCovidTestResponseResult,
 } from "@/models/laboratory";
@@ -77,20 +77,20 @@ export class RestLaboratoryService implements ILaboratoryService {
 
     public getCovid19LaboratoryOrders(
         hdid: string
-    ): Promise<RequestResult<Covid19LaboratoryOrder[]>> {
+    ): Promise<RequestResult<Covid19LaboratoryOrderResult>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
                 resolve({
                     pageIndex: 0,
                     pageSize: 0,
-                    resourcePayload: [],
+                    resourcePayload: { loaded: true, retryin: 0, orders: [] },
                     resultStatus: ResultType.Success,
                     totalResultCount: 0,
                 });
                 return;
             }
             this.http
-                .getWithCors<RequestResult<Covid19LaboratoryOrder[]>>(
+                .getWithCors<RequestResult<Covid19LaboratoryOrderResult>>(
                     `${this.baseUri}${this.LABORATORY_BASE_URI}/Covid19Orders?hdid=${hdid}`
                 )
                 .then((requestResult) => {
@@ -110,20 +110,20 @@ export class RestLaboratoryService implements ILaboratoryService {
 
     public getLaboratoryOrders(
         hdid: string
-    ): Promise<RequestResult<LaboratoryOrder[]>> {
+    ): Promise<RequestResult<LaboratoryOrderResult>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
                 resolve({
                     pageIndex: 0,
                     pageSize: 0,
-                    resourcePayload: [],
+                    resourcePayload: { loaded: true, retryin: 0, orders: [] },
                     resultStatus: ResultType.Success,
                     totalResultCount: 0,
                 });
                 return;
             }
             this.http
-                .getWithCors<RequestResult<LaboratoryOrder[]>>(
+                .getWithCors<RequestResult<LaboratoryOrderResult>>(
                     `${this.baseUri}${this.LABORATORY_BASE_URI}/LaboratoryOrders?hdid=${hdid}`
                 )
                 .then((requestResult) => {

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/types.ts
@@ -10,7 +10,9 @@ import BannerError from "@/models/bannerError";
 import { StringISODate } from "@/models/dateWrapper";
 import {
     Covid19LaboratoryOrder,
+    Covid19LaboratoryOrderResult,
     LaboratoryOrder,
+    LaboratoryOrderResult,
     PublicCovidTestResponseResult,
 } from "@/models/laboratory";
 import RequestResult, { ResultError } from "@/models/requestResult";
@@ -62,7 +64,7 @@ export interface LaboratoryActions
     retrieveCovid19LaboratoryOrders(
         context: StoreContext,
         params: { hdid: string }
-    ): Promise<RequestResult<Covid19LaboratoryOrder[]>>;
+    ): Promise<RequestResult<Covid19LaboratoryOrderResult>>;
     handleCovid19LaboratoryError(
         context: StoreContext,
         error: ResultError
@@ -70,7 +72,7 @@ export interface LaboratoryActions
     retrieveLaboratoryOrders(
         context: StoreContext,
         params: { hdid: string }
-    ): Promise<RequestResult<LaboratoryOrder[]>>;
+    ): Promise<RequestResult<LaboratoryOrderResult>>;
     handleLaboratoryError(context: StoreContext, error: ResultError): void;
     retrievePublicCovidTests(
         context: StoreContext,


### PR DESCRIPTION
# Implements [AB#12259](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12259)

## Description

- Adds wrappers for the laboratory order and COVID-19 laboratory order result models and populates them with information on whether the retrievals were successful and how long to wait before retrying.
- Updates the front-end to expect the new models and retry if needed.
- Updates the unit tests in the back-end.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
