### PR TITLE
Add inactivity dialog to Admin project AB#11869

### DIFF
--- a/Apps/Admin/Client/Components/InactivityDialog.razor
+++ b/Apps/Admin/Client/Components/InactivityDialog.razor
@@ -1,0 +1,13 @@
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudDialog>
+    <TitleContent>
+        <MudText Typo="Typo.h6">Are you still there?</MudText>
+    </TitleContent>
+    <DialogContent>
+        You will be automatically logged out in @CountdownTicksRemaining @(CountdownTicksRemaining == 1 ? "second" : "seconds").
+    </DialogContent>
+    <DialogActions>
+        <MudButton Color="Color.Primary" OnClick="RefreshSessionAsync">I'm here!</MudButton>
+    </DialogActions>
+</MudDialog>

--- a/Apps/Admin/Client/Components/InactivityDialog.razor.cs
+++ b/Apps/Admin/Client/Components/InactivityDialog.razor.cs
@@ -1,0 +1,95 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components
+{
+    using System.Threading.Tasks;
+    using System.Timers;
+    using Fluxor.Blazor.Web.Components;
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+    using MudBlazor;
+
+    /// <summary>
+    /// Backing logic for the InactivityDialog component.
+    /// </summary>
+    public partial class InactivityDialog : FluxorComponent
+    {
+        private readonly Timer timer = new(1000);
+
+        private int CountdownTicksRemaining { get; set; } = 60;
+
+        [Inject]
+        private IAccessTokenProvider AccessTokenProvider { get; set; } = default!;
+
+        [Inject]
+        private NavigationManager NavigationManager { get; set; } = default!;
+
+        [Inject]
+        private SignOutSessionStateManager SignOutManager { get; set; } = default!;
+
+
+        [CascadingParameter]
+        private MudDialogInstance MudDialog { get; set; } = default!;
+
+        /// <inheritdoc/>
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync().ConfigureAwait(true);
+            this.timer.Elapsed += new ElapsedEventHandler(this.CountdownTimerTickAsync);
+            this.timer.AutoReset = true;
+            this.timer.Start();
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            this.timer.Stop();
+            this.timer.Dispose();
+        }
+
+        private async void CountdownTimerTickAsync(object? sender, ElapsedEventArgs e)
+        {
+            this.CountdownTicksRemaining--;
+            if (this.CountdownTicksRemaining <= 0)
+            {
+                await this.LogOutAsync().ConfigureAwait(true);
+            }
+
+            this.StateHasChanged();
+        }
+
+        private async Task LogOutAsync()
+        {
+            await this.SignOutManager.SetSignOutState().ConfigureAwait(true);
+            this.NavigationManager.NavigateTo("authentication/logout");
+            this.MudDialog.Close(DialogResult.Ok(false));
+        }
+
+        private async Task RefreshSessionAsync()
+        {
+            AccessTokenResult? tokenResult = await this.AccessTokenProvider.RequestAccessToken().ConfigureAwait(true);
+            if (tokenResult.TryGetToken(out _))
+            {
+                this.MudDialog.Close(DialogResult.Ok(true));
+            }
+            else
+            {
+                await this.LogOutAsync().ConfigureAwait(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Implements [AB#11869](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11869)

## Description

Adds a dialog which will automatically log out the user after 60 seconds, unless the user clicks the button, which instead refreshes their access token.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

YES

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
