### PR TITLE
Add backend validation for AB#12264

### DIFF
--- a/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.Success);
         }
 
@@ -74,7 +74,7 @@ namespace HealthGateway.LaboratoryTests
         [Fact]
         public void RegisterPublicLabTestHttpException()
         {
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitServiceException().RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitServiceException().RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -98,7 +98,7 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse, true).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse, true).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -112,7 +112,7 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.Conflict,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.ActionRequired &&
                         actualResult.ResultError != null &&
                         actualResult.ResultError.ActionCodeValue == ActionType.Processed.Value);
@@ -128,7 +128,23 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.UnprocessableEntity,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
+            Assert.True(actualResult.ResultStatus == ResultType.ActionRequired &&
+                        actualResult.ResultError != null &&
+                        actualResult.ResultError.ActionCodeValue == ActionType.Validation.Value);
+        }
+
+        /// <summary>
+        /// Tests when bad data is sent.
+        /// </summary>
+        [Fact]
+        public void RegisterPublicLabTestBadPhn()
+        {
+            using HttpResponseMessage httpResponse = new()
+            {
+                StatusCode = HttpStatusCode.OK,
+            };
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("BADPHN")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.ActionRequired &&
                         actualResult.ResultError != null &&
                         actualResult.ResultError.ActionCodeValue == ActionType.Validation.Value);
@@ -144,7 +160,7 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.Unauthorized,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -158,7 +174,7 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.Forbidden,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -172,8 +188,18 @@ namespace HealthGateway.LaboratoryTests
             {
                 StatusCode = HttpStatusCode.BadGateway,
             };
-            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(new PublicLabTestKit()).Result;
+            RequestResult<PublicLabTestKit> actualResult = this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).Result;
             Assert.True(actualResult.ResultStatus == ResultType.Error);
+        }
+
+        private static PublicLabTestKit CreatePublicLabTestKit(string phn)
+        {
+            PublicLabTestKit testKit = new()
+            {
+                Phn = phn,
+            };
+
+            return testKit;
         }
 
         private LabTestKitService GetLabTestKitServiceException()


### PR DESCRIPTION
# Fixes or Implements [AB#12264](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12264)

## Description

I reviewed validation and believe that we can pass through most data to PHSA as they will either find a record or not.
Added PHN validation to public endpoint.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
