### PR TITLE
Fix loading spinner disappearing prematurely AB#12379

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/pcrTest.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/pcrTest.vue
@@ -264,7 +264,9 @@ export default class PcrTestView extends Vue {
             !this.oidcIsAuthenticated
         ) {
             this.loading = true;
-            this.oidcLogin(this.identityProviders[0].hint).finally(
+            // don't need to reset loading property if login succeeds
+            // since redirect will kick in and component will be recreated after
+            this.oidcLogin(this.identityProviders[0].hint).catch(
                 () => (this.loading = false)
             );
         }


### PR DESCRIPTION
# Fixes [AB#12379](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12379)

## Description

Adjusts the loading spinner on the PCR Test page that appears when clicking the Log In button so it doesn't disappear before the redirect to the login page takes effect.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
