### PR TITLE
Handle component error when module is disabled AB#12393

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
@@ -48,7 +48,9 @@ export class RestLaboratoryService implements ILaboratoryService {
     ): Promise<RequestResult<PublicCovidTestResponseResult>> {
         return new Promise((resolve, reject) => {
             if (!this.isCovid19Enabled) {
-                reject();
+                reject(
+                    ErrorTranslator.moduleDisabledError(ServiceName.Laboratory)
+                );
                 return;
             }
             const headers: Dictionary<string> = {};

--- a/Apps/WebClient/src/ClientApp/src/services/restVaccinationStatusService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restVaccinationStatusService.ts
@@ -43,7 +43,11 @@ export class RestVaccinationStatusService implements IVaccinationStatusService {
     ): Promise<RequestResult<VaccinationStatus>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
-                reject();
+                reject(
+                    ErrorTranslator.moduleDisabledError(
+                        ServiceName.Immunization
+                    )
+                );
                 return;
             }
 
@@ -81,7 +85,11 @@ export class RestVaccinationStatusService implements IVaccinationStatusService {
     ): Promise<RequestResult<CovidVaccineRecord>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
-                reject();
+                reject(
+                    ErrorTranslator.moduleDisabledError(
+                        ServiceName.Immunization
+                    )
+                );
                 return;
             }
 
@@ -116,7 +124,11 @@ export class RestVaccinationStatusService implements IVaccinationStatusService {
     ): Promise<RequestResult<VaccinationStatus>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
-                reject();
+                reject(
+                    ErrorTranslator.moduleDisabledError(
+                        ServiceName.Immunization
+                    )
+                );
                 return;
             }
 
@@ -146,7 +158,11 @@ export class RestVaccinationStatusService implements IVaccinationStatusService {
     ): Promise<RequestResult<CovidVaccineRecord>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
-                reject();
+                reject(
+                    ErrorTranslator.moduleDisabledError(
+                        ServiceName.Immunization
+                    )
+                );
                 return;
             }
 

--- a/Apps/WebClient/src/ClientApp/src/utility/errorTranslator.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/errorTranslator.ts
@@ -42,6 +42,14 @@ export default class ErrorTranslator {
         };
     }
 
+    public static moduleDisabledError(service: ServiceName): ResultError {
+        return {
+            errorCode: "ClientApp-I-" + service,
+            resultMessage: "Module Disabled",
+            traceId: "",
+        };
+    }
+
     private static getErrorTitle(
         errorType: ErrorType,
         source: ErrorSourceType


### PR DESCRIPTION
# Handle component error when module is disabled [AB#12393](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12393)

## Description

Functional test failed due to unhandled error when module is disabled.

![image](https://user-images.githubusercontent.com/92187402/153066718-78f067a0-aaee-49ed-8b77-92b3baa6f288.png)


If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [] Functional Tests Updated
-   [ ] Not Required

### UI Changes

**NO**

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
