### PR TITLE
Hide COVID-19 button on home page if module is disabled AB#12403

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/home.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/home.vue
@@ -124,6 +124,10 @@ export default class HomeView extends Vue {
         return this.config.modules["FederalCardButton"];
     }
 
+    private get showVaccineCardButton(): boolean {
+        return this.config.modules["VaccinationStatus"];
+    }
+
     private get cardColumnSize(): number {
         return this.showFederalCardButton ? 4 : 6;
     }
@@ -243,7 +247,12 @@ export default class HomeView extends Vue {
                     </div>
                 </hg-card-button>
             </b-col>
-            <b-col cols="12" :lg="cardColumnSize" class="p-3">
+            <b-col
+                v-if="showVaccineCardButton"
+                cols="12"
+                :lg="cardColumnSize"
+                class="p-3"
+            >
                 <hg-card-button
                     title="BC Vaccine Card"
                     to="/covid19"

--- a/Apps/WebClient/src/ClientApp/src/views/login.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/login.vue
@@ -47,10 +47,8 @@ export default class LoginView extends Vue {
     private mounted() {
         if (this.$route.query.redirect && this.$route.query.redirect !== "") {
             this.redirectPath = this.$route.query.redirect.toString();
-        } else if (this.config.modules["VaccinationStatus"]) {
-            this.redirectPath = "/home";
         } else {
-            this.redirectPath = "/timeline";
+            this.redirectPath = "/home";
         }
 
         this.routeHandler = this.$router;

--- a/Apps/WebClient/src/ClientApp/test/login.test.ts
+++ b/Apps/WebClient/src/ClientApp/test/login.test.ts
@@ -74,7 +74,7 @@ describe("Login view", () => {
     test("sets default route if no redirect", () => {
         $route.query.redirect = "";
         const wrapper = createWrapper();
-        expect(wrapper.vm.$data.redirectPath).toBe("/timeline");
+        expect(wrapper.vm.$data.redirectPath).toBe("/home");
     });
 
     test("if authenticated but not registered sets router path to registration", () => {


### PR DESCRIPTION
# Fixes [AB#12403](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12403)

## Description

Hides the COVID-19 card on the home page when the VaccinationStatus module is disabled, since the link wouldn't work in that case.

Also removes a redirect that would go to the timeline instead of the home page when the VaccinationStatus module is disabled.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
