### PR TITLE
Implement Controller, Service and Delegate

### DIFF
--- a/Apps/AdminWebClient/src/AdminWebClient.csproj
+++ b/Apps/AdminWebClient/src/AdminWebClient.csproj
@@ -11,6 +11,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="Refit" Version="6.2.16" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="6.2.16" />
     <PackageReference Include="SSH.NET" Version="2020.0.1" />
     <PackageReference Include="UAParser" Version="3.1.47" />
     <PackageReference Include="VueCliMiddleware" Version="6.0.0" />

--- a/Apps/AdminWebClient/src/Server/Api/IImmunizationAdminClient.cs
+++ b/Apps/AdminWebClient/src/Server/Api/IImmunizationAdminClient.cs
@@ -1,0 +1,45 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Api;
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using HealthGateway.Admin.Server.Models.CovidSupport;
+using Refit;
+
+/// <summary>
+/// Interface that defines a client api to access administrative immunization data.
+/// </summary>
+public interface IImmunizationAdminClient
+{
+    /// <summary>
+    /// Submit a completed Anti Viral screening form.
+    /// </summary>
+    /// <param name="request">The covid therapy assessment request to use for submission.</param>
+    /// <param name="token">The bearer token to authorize the call.</param>
+    /// <returns>The response to the submitted covid anti viral therapeutic assessment form.</returns>
+    [Post("/api/v1/Support/Immunizations/AntiViralSupportDetails")]
+    Task<ApiResponse<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment([Body] CovidTherapyAssessmentRequest request, [Authorize("Bearer")] string token);
+
+    /// <summary>
+    /// Get details to help support the covid anti viral therapeutic assessment form for a phn.
+    /// </summary>
+    /// <param name="phn">The phn used to identity the covid therapy assessment.</param>
+    /// <param name="token">The bearer token to authorize the call.</param>
+    /// <returns>The details to help support covid anti viral therapeutic assessment.</returns>
+    [Post("/api/v1/Support/Immunizations/AntiViralSupportDetails")]
+    Task<ApiResponse<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails(string phn, [Authorize("Bearer")] string token);
+}

--- a/Apps/AdminWebClient/src/Server/Api/IImmunizationAdminClient.cs
+++ b/Apps/AdminWebClient/src/Server/Api/IImmunizationAdminClient.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Server.Api;
 
-using System.Net.Http;
 using System.Threading.Tasks;
 using HealthGateway.Admin.Server.Models.CovidSupport;
 using Refit;
@@ -28,18 +27,18 @@ public interface IImmunizationAdminClient
     /// <summary>
     /// Submit a completed Anti Viral screening form.
     /// </summary>
-    /// <param name="request">The covid therapy assessment request to use for submission.</param>
+    /// <param name="request">The covid assessment request to use for submission.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
     /// <returns>The response to the submitted covid anti viral therapeutic assessment form.</returns>
     [Post("/api/v1/Support/Immunizations/AntiViralSupportDetails")]
-    Task<ApiResponse<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment([Body] CovidTherapyAssessmentRequest request, [Authorize("Bearer")] string token);
+    Task<ApiResponse<CovidAssessmentResponse>> SubmitCovidAssessment([Body] CovidAssessmentRequest request, [Authorize("Bearer")] string token);
 
     /// <summary>
     /// Get details to help support the covid anti viral therapeutic assessment form for a phn.
     /// </summary>
-    /// <param name="phn">The phn used to identity the covid therapy assessment.</param>
+    /// <param name="request">The covid assessment details request to identity the covid therapy assessment.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
     /// <returns>The details to help support covid anti viral therapeutic assessment.</returns>
     [Post("/api/v1/Support/Immunizations/AntiViralSupportDetails")]
-    Task<ApiResponse<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails(string phn, [Authorize("Bearer")] string token);
+    Task<ApiResponse<CovidAssessmentDetailsResponse>> GetCovidAssessmentDetails([Body] CovidAssessmentDetailsRequest request, [Authorize("Bearer")] string token);
 }

--- a/Apps/AdminWebClient/src/Server/Constants/CovidTherapyAssessmentOption.cs
+++ b/Apps/AdminWebClient/src/Server/Constants/CovidTherapyAssessmentOption.cs
@@ -16,10 +16,12 @@
 namespace HealthGateway.Admin.Server.Constants;
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// Represents the options that can be selected from yes/no radio button options.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CovidTherapyAssessmentOption
 {
     /// <summary>

--- a/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
@@ -22,7 +22,6 @@ namespace HealthGateway.Admin.Controllers
     using HealthGateway.Common.Data.ViewModels;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
-    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Web API to handle Covid support requests.
@@ -118,6 +117,7 @@ namespace HealthGateway.Admin.Controllers
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         /// <response code="503">The service is unavailable for use.</response>
         [HttpGet]
+        [Produces("application/json")]
         [Route("CovidAssessmentDetails")]
         public async Task<RequestResult<CovidAssessmentDetailsResponse>> GetCovidAssessmentDetails([FromHeader] string phn)
         {

--- a/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
@@ -95,33 +95,33 @@ namespace HealthGateway.Admin.Controllers
         /// Submitting a completed anti viral screening form.
         /// </summary>
         /// <param name="request">The covid therapy assessment request to use for submission.</param>
-        /// <returns>A CovidTherapyAssessmentResponse object wrapped in a request result.</returns>
-        /// <response code="200">The CovidTherapyAssessmentRequest was submitted.</response>
+        /// <returns>A CovidAssessmentResponse object wrapped in a request result.</returns>
+        /// <response code="200">The CovidAssessmentRequest was submitted.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         /// <response code="503">The service is unavailable for use.</response>
         [HttpPost]
         [Produces("application/json")]
         [Route("CovidAssessment")]
-        public async Task<RequestResult<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment([FromBody] CovidTherapyAssessmentRequest request)
+        public async Task<RequestResult<CovidAssessmentResponse>> SubmitCovidAssessment([FromBody] CovidAssessmentRequest request)
         {
-            return await this.covidSupportService.SubmitCovidTherapyAssessment(request).ConfigureAwait(true);
+            return await this.covidSupportService.SubmitCovidAssessmentAsync(request).ConfigureAwait(true);
         }
 
         /// <summary>
         /// Get details to help support the covid anti viral therapeutic assessment form for a phn.
         /// </summary>
         /// <param name="phn">The covid therapy assessment request to use for submission.</param>
-        /// <returns>A CovidTherapyAssessmentResponse object wrapped in a request result.</returns>
-        /// <response code="200">The CovidTherapyAssessmentRequest was submitted.</response>
+        /// <returns>A CovidAssessmentResponse object wrapped in a request result.</returns>
+        /// <response code="200">The CovidAssessmentRequest was submitted.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         /// <response code="503">The service is unavailable for use.</response>
         [HttpGet]
         [Route("CovidAssessmentDetails")]
-        public async Task<RequestResult<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails([FromHeader] string phn)
+        public async Task<RequestResult<CovidAssessmentDetailsResponse>> GetCovidAssessmentDetails([FromHeader] string phn)
         {
-            return await this.covidSupportService.GetCovidTherapyAssessmentDetails(phn).ConfigureAwait(true);
+            return await this.covidSupportService.GetCovidAssessmentDetailsAsync(phn).ConfigureAwait(true);
         }
     }
 }

--- a/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/CovidSupportController.cs
@@ -17,9 +17,12 @@ namespace HealthGateway.Admin.Controllers
 {
     using System.Threading.Tasks;
     using HealthGateway.Admin.Models.CovidSupport;
+    using HealthGateway.Admin.Server.Models.CovidSupport;
     using HealthGateway.Admin.Services;
+    using HealthGateway.Common.Data.ViewModels;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Web API to handle Covid support requests.
@@ -86,6 +89,39 @@ namespace HealthGateway.Admin.Controllers
         public async Task<IActionResult> RetrieveVaccineRecord([FromHeader] string phn)
         {
             return new JsonResult(await this.covidSupportService.RetrieveVaccineRecordAsync(phn).ConfigureAwait(true));
+        }
+
+        /// <summary>
+        /// Submitting a completed anti viral screening form.
+        /// </summary>
+        /// <param name="request">The covid therapy assessment request to use for submission.</param>
+        /// <returns>A CovidTherapyAssessmentResponse object wrapped in a request result.</returns>
+        /// <response code="200">The CovidTherapyAssessmentRequest was submitted.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        /// <response code="503">The service is unavailable for use.</response>
+        [HttpPost]
+        [Produces("application/json")]
+        [Route("CovidAssessment")]
+        public async Task<RequestResult<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment([FromBody] CovidTherapyAssessmentRequest request)
+        {
+            return await this.covidSupportService.SubmitCovidTherapyAssessment(request).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Get details to help support the covid anti viral therapeutic assessment form for a phn.
+        /// </summary>
+        /// <param name="phn">The covid therapy assessment request to use for submission.</param>
+        /// <returns>A CovidTherapyAssessmentResponse object wrapped in a request result.</returns>
+        /// <response code="200">The CovidTherapyAssessmentRequest was submitted.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        /// <response code="503">The service is unavailable for use.</response>
+        [HttpGet]
+        [Route("CovidAssessmentDetails")]
+        public async Task<RequestResult<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails([FromHeader] string phn)
+        {
+            return await this.covidSupportService.GetCovidTherapyAssessmentDetails(phn).ConfigureAwait(true);
         }
     }
 }

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentDetailsRequest.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentDetailsRequest.cs
@@ -15,17 +15,13 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Server.Models.CovidSupport;
 
-using System;
 using System.Text.Json.Serialization;
 
-/// <summary>
-/// Model object representing an anti viral screener support submission response.
-/// </summary>
-public class CovidTherapyAssessmentResponse
+public class CovidAssessmentDetailsRequest
 {
     /// <summary>
-    /// Gets or sets the id for covid therapy assessment response.
+    /// Gets or sets the phn used.
     /// </summary>
-    [JsonPropertyName("id")]
-    public Guid Id { get; set; }
+    [JsonPropertyName("phn")]
+    public string? Phn { get; set; }
 }

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentDetailsResponse.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentDetailsResponse.cs
@@ -21,7 +21,7 @@ using System.Text.Json.Serialization;
 /// <summary>
 /// Model object representing covid therapy assessment details.
 /// </summary>
-public class CovidTherapyAssessmentDetails
+public class CovidAssessmentDetailsResponse
 {
     /// <summary>
     /// Gets or sets a value indicating whether there has been known positive covid 19 in past 70 days.

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentRequest.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentRequest.cs
@@ -23,21 +23,21 @@ using HealthGateway.Admin.Server.Constants;
 /// <summary>
 /// Model object representing covid therapy assessment submission request.
 /// </summary>
-public class CovidTherapyAssessmentRequest
+public class CovidAssessmentRequest
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="CovidTherapyAssessmentRequest"/> class.
+    /// Initializes a new instance of the <see cref="CovidAssessmentRequest"/> class.
     /// </summary>
-    public CovidTherapyAssessmentRequest()
+    public CovidAssessmentRequest()
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="CovidTherapyAssessmentRequest"/> class.
+    /// Initializes a new instance of the <see cref="CovidAssessmentRequest"/> class.
     /// </summary>
     /// <param name="streetAddresses">The list of address street lines.</param>
     [JsonConstructor]
-    public CovidTherapyAssessmentRequest(
+    public CovidAssessmentRequest(
         IList<string> streetAddresses)
     {
         this.StreetAddresses = streetAddresses;

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentResponse.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidAssessmentResponse.cs
@@ -1,0 +1,31 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Models.CovidSupport;
+
+using System;
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Model object representing an anti viral screener support submission response.
+/// </summary>
+public class CovidAssessmentResponse
+{
+    /// <summary>
+    /// Gets or sets the id for covid therapy assessment response.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public Guid Id { get; set; }
+}

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidTherapyAssessmentRequest.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidTherapyAssessmentRequest.cs
@@ -35,12 +35,12 @@ public class CovidTherapyAssessmentRequest
     /// <summary>
     /// Initializes a new instance of the <see cref="CovidTherapyAssessmentRequest"/> class.
     /// </summary>
-    /// <param name="streetLines">The list of address street lines.</param>
+    /// <param name="streetAddresses">The list of address street lines.</param>
     [JsonConstructor]
     public CovidTherapyAssessmentRequest(
-        IList<string> streetLines)
+        IList<string> streetAddresses)
     {
-        this.StreetAddress = streetLines;
+        this.StreetAddresses = streetAddresses;
     }
 
     /// <summary>
@@ -72,6 +72,18 @@ public class CovidTherapyAssessmentRequest
     /// </summary>
     [JsonPropertyName("identifiesIndigenous")]
     public CovidTherapyAssessmentOption IdentifiesIndigenous { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifies has a family doctor or np option.
+    /// </summary>
+    [JsonPropertyName("hasAFamilyDoctorOrNp")]
+    public CovidTherapyAssessmentOption HasAFamilyDoctorOrNp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the identifies the confirms over 12 option.
+    /// </summary>
+    [JsonPropertyName("confirmsOver12")]
+    public CovidTherapyAssessmentOption ConfirmsOver12 { get; set; }
 
     /// <summary>
     /// Gets or sets the has severe covid 19 symptoms option.
@@ -118,8 +130,8 @@ public class CovidTherapyAssessmentRequest
     /// <summary>
     /// Gets street address.
     /// </summary>
-    [JsonPropertyName("streetAddress")]
-    public IList<string>? StreetAddress { get; } = new List<string>();
+    [JsonPropertyName("streetAddresses")]
+    public IList<string>? StreetAddresses { get; } = new List<string>();
 
     /// <summary>
     /// Gets or sets the city.

--- a/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidTherapyAssessmentResponse.cs
+++ b/Apps/AdminWebClient/src/Server/Models/CovidSupport/CovidTherapyAssessmentResponse.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Admin.Server.Models.CovidSupport;
 
 using System;
-using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -25,62 +24,8 @@ using System.Text.Json.Serialization;
 public class CovidTherapyAssessmentResponse
 {
     /// <summary>
-    /// Gets or sets the phn.
+    /// Gets or sets the id for covid therapy assessment response.
     /// </summary>
-    [JsonPropertyName("phn")]
-    public string? Phn { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether there has been a reent positive covid result.
-    /// </summary>
-    [JsonPropertyName("hasRecentPositiveCovidResult")]
-    public bool HasRecentPositiveCovidResult { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether cev 10 or cev 2 has been found.
-    /// </summary>
-    [JsonPropertyName("foundCev1OrCev2")]
-    public bool FoundCev1OrCev2 { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether there have been any chronic conditions found.
-    /// </summary>
-    [JsonPropertyName("foundChronicConditions")]
-    public bool FoundChronicConditions { get; set; }
-
-    /// <summary>
-    /// Gets or sets the chronic condition count.
-    /// </summary>
-    [JsonPropertyName("chronicConditionCount")]
-    public int ChronicConditionCount { get; set; }
-
-    /// <summary>
-    /// Gets or sets the dose count.
-    /// </summary>
-    [JsonPropertyName("doseCount")]
-    public int DoseCount { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether there are three doses and 14 days.
-    /// </summary>
-    [JsonPropertyName("threeDoseAnd14Days")]
-    public bool ThreeDoseAnd14Days { get; set; }
-
-    /// <summary>
-    /// Gets or sets the calculated age.
-    /// </summary>
-    [JsonPropertyName("calculatedAge")]
-    public int CalculatedAge { get; set; }
-
-    /// <summary>
-    /// Gets or sets a value indicating whether previous anti viral submissions have been found.
-    /// </summary>
-    [JsonPropertyName("previousAvSubmissionFound")]
-    public bool PreviousAvSubmissionFound { get; set; }
-
-    /// <summary>
-    /// Gets or sets the list of most recent anti viral submission date times.
-    /// </summary>
-    [JsonPropertyName("mostRecentAvSubmissionDateTime")]
-    public IEnumerable<DateTime>? MostRecentAvSubmissionDateTime { get; set; }
+    [JsonPropertyName("id")]
+    public Guid Id { get; set; }
 }

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -17,10 +17,14 @@
 namespace HealthGateway.Admin.Services
 {
     using System;
+    using System.Net;
+    using System.Net.Http;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Models.CovidSupport;
+    using HealthGateway.Admin.Server.Api;
     using HealthGateway.Admin.Server.Delegates;
     using HealthGateway.Admin.Server.Models.CovidSupport;
+    using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Constants.PHSA;
     using HealthGateway.Common.Data.Constants;
@@ -35,6 +39,7 @@ namespace HealthGateway.Admin.Services
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
+    using Refit;
 
     /// <summary>
     /// Service that provides COVID-19 Support functionality.
@@ -51,6 +56,8 @@ namespace HealthGateway.Admin.Services
         private readonly IVaccineProofDelegate vaccineProofDelegate;
         private readonly BCMailPlusConfig bcmpConfig;
         private readonly VaccineCardConfig vaccineCardConfig;
+        private readonly IImmunizationAdminClient immunizationAdminClient;
+        private readonly IAuthenticationDelegate authenticationDelegate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CovidSupportService"/> class.
@@ -62,6 +69,8 @@ namespace HealthGateway.Admin.Services
         /// <param name="httpContextAccessor">The Http Context accessor.</param>
         /// <param name="configuration">The configuration to use.</param>
         /// <param name="vaccineProofDelegate">The injected delegate to get the vaccine proof.</param>
+        /// <param name="immunizationAdminClient">The api client to use for immunization.</param>
+        /// /// <param name="authenticationDelegate">The auth delegate to fetch tokens.</param>
         public CovidSupportService(
             ILogger<CovidSupportService> logger,
             IPatientService patientService,
@@ -69,7 +78,9 @@ namespace HealthGateway.Admin.Services
             IVaccineStatusDelegate vaccineStatusDelegate,
             IHttpContextAccessor httpContextAccessor,
             IConfiguration configuration,
-            IVaccineProofDelegate vaccineProofDelegate)
+            IVaccineProofDelegate vaccineProofDelegate,
+            IImmunizationAdminClient immunizationAdminClient,
+            IAuthenticationDelegate authenticationDelegate)
         {
             this.logger = logger;
             this.patientService = patientService;
@@ -77,6 +88,8 @@ namespace HealthGateway.Admin.Services
             this.vaccineStatusDelegate = vaccineStatusDelegate;
             this.httpContextAccessor = httpContextAccessor;
             this.vaccineProofDelegate = vaccineProofDelegate;
+            this.immunizationAdminClient = immunizationAdminClient;
+            this.authenticationDelegate = authenticationDelegate;
 
             this.bcmpConfig = new();
             configuration.Bind(BCMailPlusConfigSectionKey, this.bcmpConfig);
@@ -312,15 +325,107 @@ namespace HealthGateway.Admin.Services
         }
 
         /// <inheritdoc />
-        public Task<RequestResult<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment(CovidTherapyAssessmentRequest request)
+        public async Task<RequestResult<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment(CovidTherapyAssessmentRequest request)
         {
-            throw new NotImplementedException();
+            RequestResult<CovidTherapyAssessmentResponse> requestResult = new()
+            {
+                TotalResultCount = 0,
+                ResultStatus = ResultType.Error,
+            };
+
+            string? accessToken = this.authenticationDelegate.FetchAuthenticatedUserToken();
+            try
+            {
+                ApiResponse<CovidTherapyAssessmentResponse> response =
+                    await this.immunizationAdminClient.SubmitCovidTherapyAssessment(request, accessToken).ConfigureAwait(true);
+                ProcessResponse(requestResult, response);
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}...", e.ToString());
+                requestResult.ResultError = new RequestResultError()
+                {
+                    ResultMessage = $"Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            return requestResult;
         }
 
         /// <inheritdoc />
-        public Task<RequestResult<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails(string phn)
+        public async Task<RequestResult<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails(string phn)
         {
-            throw new NotImplementedException();
+            RequestResult<CovidTherapyAssessmentDetails> requestResult = new()
+            {
+                TotalResultCount = 0,
+                ResultStatus = ResultType.Error,
+            };
+
+            string? accessToken = this.authenticationDelegate.FetchAuthenticatedUserToken();
+            try
+            {
+                ApiResponse<CovidTherapyAssessmentDetails> response =
+                    await this.immunizationAdminClient.GetCovidTherapyAssessmentDetails(phn, accessToken).ConfigureAwait(true);
+                ProcessResponse(requestResult, response);
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}...", e.ToString());
+                requestResult.ResultError = new RequestResultError()
+                {
+                    ResultMessage = $"Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            return requestResult;
+        }
+
+        private static void ProcessResponse<T>(RequestResult<T> requestResult, ApiResponse<T> response)
+            where T : class
+        {
+            switch (response.StatusCode)
+            {
+                case HttpStatusCode.OK:
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = response.Content;
+                    break;
+
+                // Only GetCovidTherapyAssessmentDetails can return HttpStatusCode.NoContent
+                case HttpStatusCode.NoContent:
+                    requestResult.ResultError = new RequestResultError()
+                    {
+                        ResultMessage = $"No Details found",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                    break;
+
+                // SubmitCovidTherapyAssessment and GetCovidTherapyAssessmentDetails can return HttpStatusCode.Unauthorized
+                case HttpStatusCode.Unauthorized:
+                    requestResult.ResultError = new RequestResultError()
+                    {
+                        ResultMessage = $"Request was not authorized",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                    break;
+
+                // SubmitCovidTherapyAssessment and GetCovidTherapyAssessmentDetails can return HttpStatusCode.Forbidde
+                case HttpStatusCode.Forbidden:
+                    requestResult.ResultError = new RequestResultError()
+                    {
+                        ResultMessage = $"Missing Required Data Element, HTTP Error {response.StatusCode}",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                    break;
+                default:
+                    requestResult.ResultError = new RequestResultError()
+                    {
+                        ResultMessage = $"An unexpected error occurred, HTTP Error {response.StatusCode}",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                    break;
+            }
         }
 
         private async Task<RequestResult<ReportModel>> RetrieveVaccineCardAsync(string phn, DateTime birthdate, string bearerToken)

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -406,6 +406,7 @@ namespace HealthGateway.Admin.Services
                 case HttpStatusCode.OK:
                     requestResult.ResultStatus = ResultType.Success;
                     requestResult.ResourcePayload = response.Content;
+                    requestResult.TotalResultCount = 1;
                     break;
 
                 // Only GetCovidAssessmentDetailsAsync can return HttpStatusCode.NoContent

--- a/Apps/AdminWebClient/src/Server/Services/ICovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/ICovidSupportService.cs
@@ -53,13 +53,13 @@ namespace HealthGateway.Admin.Services
         /// </summary>
         /// <param name="request">The request containing.</param>
         /// <returns>Returns the covid therapy assessment response.</returns>
-        Task<RequestResult<CovidTherapyAssessmentResponse>> SubmitCovidTherapyAssessment(CovidTherapyAssessmentRequest request);
+        Task<RequestResult<CovidAssessmentResponse>> SubmitCovidAssessmentAsync(CovidAssessmentRequest request);
 
         /// <summary>
         /// Gets the covid therapy assessment details for the given phn.
         /// </summary>
         /// <param name="phn">The phn to associate the covid therapy assessment against.</param>
         /// <returns>Returns the covid therapy assessment details.</returns>
-        Task<RequestResult<CovidTherapyAssessmentDetails>> GetCovidTherapyAssessmentDetails(string phn);
+        Task<RequestResult<CovidAssessmentDetailsResponse>> GetCovidAssessmentDetailsAsync(string phn);
     }
 }

--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.AdminWebClient
 {
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Server.Api;
     using HealthGateway.Admin.Server.Delegates;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Admin.Services;
@@ -25,6 +26,7 @@ namespace HealthGateway.AdminWebClient
     using HealthGateway.Common.Authorization.Admin;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
+    using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
     using Microsoft.AspNetCore.Authentication.Cookies;
@@ -39,6 +41,7 @@ namespace HealthGateway.AdminWebClient
     using Microsoft.Extensions.Logging;
     using Microsoft.IdentityModel.Logging;
     using Microsoft.IdentityModel.Tokens;
+    using Refit;
     using VueCliMiddleware;
 
     /// <summary>
@@ -46,6 +49,7 @@ namespace HealthGateway.AdminWebClient
     /// </summary>
     public class Startup
     {
+        private const string PhsaConfigSectionKey = "PHSA";
         private readonly StartupConfiguration startupConfig;
         private readonly IWebHostEnvironment environment;
         private readonly IConfiguration configuration;
@@ -123,6 +127,12 @@ namespace HealthGateway.AdminWebClient
             {
                 configuration.RootPath = "ClientApp/dist";
             });
+
+            // Add API Clients
+            PHSAConfig phsaConfig = new();
+            this.startupConfig.Configuration.Bind(PhsaConfigSectionKey, phsaConfig);
+            services.AddRefitClient<IImmunizationAdminClient>()
+                .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixes or Implements [AB#12441](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12441)

## Description

Implements the controller, service and delegate for Covid Assessment.
After discussion with Brian, we believe that serialization issues will be caught be refit and so leaving it for now.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
