### PR TITLE
Use plain spinner on PCR test kit page AB#12395

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/pcrTest.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/pcrTest.vue
@@ -522,7 +522,7 @@ export default class PcrTestView extends Vue {
     <div>
         <!-- LANDING -->
         <b-container v-if="isLoading">
-            <LoadingComponent :is-loading="isLoading" :is-custom="true" />
+            <LoadingComponent :is-loading="isLoading" />
         </b-container>
         <b-container
             v-if="


### PR DESCRIPTION
# Implements [AB#12395](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12395)

## Description

Swaps the custom loading spinner that displays "Gathering your records..." for a plain one without any text.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

![image](https://user-images.githubusercontent.com/16570293/154372481-9796874d-76dc-42c3-9f84-c5bd38c1eb76.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
