### PR TITLE
Sort assessment history descending by date AB#12486

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -41,8 +41,7 @@ interface ImmunizationRow {
 }
 
 interface AssessmentHistoryRow {
-    dateOfAssessment: string;
-    timeOfAssessment: string;
+    dateTimeOfAssessment: string;
     formId: string;
 }
 
@@ -96,9 +95,8 @@ export default class CovidCardView extends Vue {
     ];
 
     private assessmentHistoryTableHeaders = [
-        { text: "Date", value: "dateOfAssessment" },
-        { text: "Time", value: "timeOfAssessment" },
-        { text: "ID", value: "formId" },
+        { text: "Date", value: "dateTimeOfAssessment" },
+        { text: "ID", value: "formId", sortable: false },
     ];
 
     private get covid19TreatmentAssessmentEnabled(): boolean {
@@ -252,8 +250,9 @@ export default class CovidCardView extends Vue {
                         isUtc: true,
                     });
                     return {
-                        dateOfAssessment: date.format(),
-                        timeOfAssessment: date.format("h:mm a"),
+                        dateTimeOfAssessment: date.format(
+                            DateWrapper.defaultDateTimeFormat
+                        ),
                         formId: entry.formId,
                     };
                 }
@@ -681,6 +680,9 @@ export default class CovidCardView extends Vue {
                                 :items="assessmentHistory"
                                 :items-per-page="5"
                                 :hide-default-footer="false"
+                                sort-by="dateTimeOfAssessment"
+                                sort-desc
+                                must-sort
                             />
                         </v-col>
                     </v-row>


### PR DESCRIPTION
# Implements [AB#12486](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12486)

## Description

- Merges Date and Time columns in assessment history table
- Sorts the table descending by date by default, with the option to reverse the sorting by clicking the table header

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
