### PR TITLE
Add error handling and associated unit test for AB#12470

### DIFF
--- a/Apps/AdminWebClient/src/AdminWebClient.csproj
+++ b/Apps/AdminWebClient/src/AdminWebClient.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="CsvHelper" Version="27.2.1" />
     <PackageReference Include="Refit" Version="6.3.2" />
     <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
+    <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.1" />
     <PackageReference Include="UAParser" Version="3.1.47" />
     <PackageReference Include="VueCliMiddleware" Version="6.0.0" />

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -402,47 +402,58 @@ namespace HealthGateway.Admin.Services
         private static void ProcessResponse<T>(RequestResult<T> requestResult, IApiResponse<T> response)
             where T : class
         {
-            switch (response.StatusCode)
+            if (response.Error is null)
             {
-                case HttpStatusCode.OK:
-                    requestResult.ResultStatus = ResultType.Success;
-                    requestResult.ResourcePayload = response.Content;
-                    requestResult.TotalResultCount = 1;
-                    break;
+                switch (response.StatusCode)
+                {
+                    case HttpStatusCode.OK:
+                        requestResult.ResultStatus = ResultType.Success;
+                        requestResult.ResourcePayload = response.Content;
+                        requestResult.TotalResultCount = 1;
+                        break;
 
-                // Only GetCovidAssessmentDetailsAsync can return HttpStatusCode.NoContent
-                case HttpStatusCode.NoContent:
-                    requestResult.ResultError = new RequestResultError()
-                    {
-                        ResultMessage = $"No Details found",
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
-                    };
-                    break;
+                    // Only GetCovidAssessmentDetailsAsync can return HttpStatusCode.NoContent
+                    case HttpStatusCode.NoContent:
+                        requestResult.ResultError = new RequestResultError()
+                        {
+                            ResultMessage = $"No Details found",
+                            ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                        };
+                        break;
 
-                // SubmitCovidAssessmentAsync and GetCovidAssessmentDetailsAsync can return HttpStatusCode.Unauthorized
-                case HttpStatusCode.Unauthorized:
-                    requestResult.ResultError = new RequestResultError()
-                    {
-                        ResultMessage = $"Request was not authorized",
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
-                    };
-                    break;
+                    // SubmitCovidAssessmentAsync and GetCovidAssessmentDetailsAsync can return HttpStatusCode.Unauthorized
+                    case HttpStatusCode.Unauthorized:
+                        requestResult.ResultError = new RequestResultError()
+                        {
+                            ResultMessage = $"Request was not authorized",
+                            ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                        };
+                        break;
 
-                // SubmitCovidAssessmentAsync and GetCovidAssessmentDetailsAsync can return HttpStatusCode.Forbidden
-                case HttpStatusCode.Forbidden:
-                    requestResult.ResultError = new RequestResultError()
-                    {
-                        ResultMessage = $"Missing Required Data Element, HTTP Error {response.StatusCode}",
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
-                    };
-                    break;
-                default:
-                    requestResult.ResultError = new RequestResultError()
-                    {
-                        ResultMessage = $"An unexpected error occurred, HTTP Error {response.StatusCode}",
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
-                    };
-                    break;
+                    // SubmitCovidAssessmentAsync and GetCovidAssessmentDetailsAsync can return HttpStatusCode.Forbidden
+                    case HttpStatusCode.Forbidden:
+                        requestResult.ResultError = new RequestResultError()
+                        {
+                            ResultMessage = $"Missing Required Data Element, HTTP Error {response.StatusCode}",
+                            ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                        };
+                        break;
+                    default:
+                        requestResult.ResultError = new RequestResultError()
+                        {
+                            ResultMessage = $"An unexpected error occurred, HTTP Error {response.StatusCode}",
+                            ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                        };
+                        break;
+                }
+            }
+            else
+            {
+                requestResult.ResultError = new RequestResultError()
+                {
+                    ResultMessage = $"An unexpected error occurred while processing external call",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
             }
         }
 

--- a/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
@@ -129,12 +129,6 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         [Fact]
         public void ConfirmErrorHandling()
         {
-            using HttpResponseMessage httpResponseMessage = new()
-            {
-                StatusCode = HttpStatusCode.OK,
-                Content = new StringContent("Bad Payload"),
-            };
-
             MockHttpMessageHandler mockHttp = new();
             string baseEndpoint = "https://localhost";
             mockHttp.When($"{baseEndpoint}/api/v1/Support/Immunizations/AntiViralSupportDetails")


### PR DESCRIPTION
# Fixes or Implements [AB#12470](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12470)

## Description

Adds error handling in the event of bad data and adds a unit test.

FYI: Added a new package which is quite useful (and much easier) to mock out http client.  

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
