### PR TITLE
Add e2e tests for PCR test kit registration page AB#12408

### DIFF
--- a/Testing/functional/tests/cypress/fixtures/LaboratoryService/authenticatedPcrTestError.json
+++ b/Testing/functional/tests/cypress/fixtures/LaboratoryService/authenticatedPcrTestError.json
@@ -2,8 +2,8 @@
     "resourcePayload": {
         "testTakenMinutesAgo": 5,
         "testKitCid": null,
-        "shortCodeFirst": "45YFKE7",
-        "shortCodeSecond": "XWRQN"
+        "shortCodeFirst": "ABCDEFG",
+        "shortCodeSecond": "12345"
     },
     "totalResultCount": 0,
     "pageIndex": null,

--- a/Testing/functional/tests/cypress/fixtures/LaboratoryService/publicPcrTestNoValidPhn.json
+++ b/Testing/functional/tests/cypress/fixtures/LaboratoryService/publicPcrTestNoValidPhn.json
@@ -1,7 +1,7 @@
 {
     "resourcePayload": {
         "phn": "",
-        "dob": "1928-07-08T00:00:00",
+        "dob": "1928-07-15T00:00:00",
         "firstName": "ZELDA",
         "lastName": "BCYPCST",
         "testTakenMinutesAgo": 360,

--- a/Testing/functional/tests/cypress/fixtures/LaboratoryService/publicPcrTestValidPhn.json
+++ b/Testing/functional/tests/cypress/fixtures/LaboratoryService/publicPcrTestValidPhn.json
@@ -1,7 +1,7 @@
 {
     "resourcePayload": {
         "phn": "9879454009",
-        "dob": "1928-07-15",
+        "dob": "1928-07-15T00:00:00",
         "firstName": "ZELDA",
         "lastName": "BCYPCST",
         "testTakenMinutesAgo": 360,

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
@@ -1,0 +1,359 @@
+import {
+    getYear,
+    getMonth,
+    getDay,
+    selectorShouldBeVisible,
+    getPcrTestTakenTime,
+    selectOption,
+} from "../../../support/utils";
+const { AuthMethod } = require("../../../support/constants");
+
+const landingPagePath = "/";
+
+const successfulTestKitCid = "DBE9D07A-8BAF-4513-8866-63ABD4EAB6E4";
+const processedTestKitCid = "3BC58EAC-9241-4E23-9134-D451D7A18FFB";
+const errorTestKitCid = "ABCDEFGH-1234-IJKL-5678-MNOPQRSTUVWX";
+
+// data test id for all input fields in the form
+const testKitCodeInput = "[data-testid=test-kit-code-input]";
+const testTakenMinutesAgo = "[data-testid=test-taken-minutes-ago]";
+const firstNameInput = "[data-testid=first-name-input]";
+const lastNameInput = "[data-testid=last-name-input]";
+const phnInput = "[data-testid=phn-input]";
+const formSelectYear = "[data-testid=formSelectYear]";
+const formSelectMonth = "[data-testid=formSelectMonth]";
+const formSelectDay = "[data-testid=formSelectDay]";
+const stressAddressInput = "[data-testid=pcr-street-address-input]";
+const cityInput = "[data-testid=pcr-city-input]";
+const zipInput = "[data-testid=pcr-zip-input]";
+const registrationSuccessBanner = "[data-testid=registration-success-banner]";
+const continueBtn = "[data-testid=btn-continue]";
+const logoutBtn = "[data-testid=logoutBtn]";
+const errorBanner = "[data-testid=errorBanner]";
+const processedBanner = "[data-testid=alreadyProcessedBanner]";
+
+function clickManualRegistrationButton() {
+    cy.get("[data-testid=btn-manual]")
+        .should("be.enabled", "be.visible")
+        .click();
+}
+
+function clickRegisterKitButton() {
+    cy.get("[data-testid=btn-register-kit]")
+        .should("be.enabled", "be.visible")
+        .click();
+}
+
+describe("Authenticated PCR Test Kit Registration", () => {
+    beforeEach(() => {
+        cy.enableModules("PcrTest");
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/home"
+        );
+    });
+
+    it("Success with Test Kit CID", () => {
+        cy.visit(`/pcrtest/${successfulTestKitCid}`);
+
+        // populate the form with values from the fixture
+        cy.fixture(
+            "LaboratoryService/authenticatedPcrTestWithTestKit.json"
+        ).then(function (data) {
+            selectOption(
+                testTakenMinutesAgo,
+                getPcrTestTakenTime(data.resourcePayload.testTakenMinutesAgo)
+            );
+        });
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(registrationSuccessBanner);
+
+        selectorShouldBeVisible(logoutBtn);
+        cy.get(logoutBtn).click();
+        cy.url().should("include", "/logout");
+    });
+
+    it("Already Processed with Test Kit CID", () => {
+        cy.visit(`/pcrtest/${processedTestKitCid}`);
+
+        // populate the form with values from the fixture
+        cy.fixture(
+            "LaboratoryService/authenticatedPcrTestDuplicateWithTestKit.json"
+        ).then(function (data) {
+            selectOption(
+                testTakenMinutesAgo,
+                getPcrTestTakenTime(data.resourcePayload.testTakenMinutesAgo)
+            );
+        });
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(processedBanner);
+    });
+
+    it("Error with Test Kit CID", () => {
+        cy.visit(`/pcrtest/${errorTestKitCid}`);
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/authenticatedPcrTestError.json").then(
+            function (data) {
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(errorBanner);
+    });
+
+    it("Error with Test Kit Code", () => {
+        cy.visit("/pcrtest");
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/authenticatedPcrTestError.json").then(
+            function (data) {
+                cy.get(testKitCodeInput).type(
+                    data.resourcePayload.shortCodeFirst +
+                        "-" +
+                        data.resourcePayload.shortCodeSecond
+                );
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(errorBanner);
+    });
+});
+
+describe("Unauthenticated PCR Test Kit Registration", () => {
+    beforeEach(() => {
+        cy.enableModules("PcrTest");
+    });
+
+    it("Success with Test Kit CID and PHN", () => {
+        cy.visit(`/pcrtest/${successfulTestKitCid}`);
+        clickManualRegistrationButton();
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/publicPcrTestValidPhn.json").then(
+            function (data) {
+                cy.get(firstNameInput).type(data.resourcePayload.firstName);
+                cy.get(lastNameInput).type(data.resourcePayload.lastName);
+                cy.get(phnInput).type(data.resourcePayload.phn);
+
+                selectOption(
+                    formSelectYear,
+                    getYear(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectMonth,
+                    getMonth(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectDay,
+                    getDay(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(registrationSuccessBanner);
+
+        selectorShouldBeVisible(continueBtn);
+        cy.get(continueBtn).click();
+        cy.location("pathname").should("eq", landingPagePath);
+    });
+
+    it("Success with Test Kit CID and No PHN", () => {
+        cy.visit(`/pcrtest/${successfulTestKitCid}`);
+        clickManualRegistrationButton();
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/publicPcrTestNoValidPhn.json").then(
+            function (data) {
+                cy.get(firstNameInput).type(data.resourcePayload.firstName);
+                cy.get(lastNameInput).type(data.resourcePayload.lastName);
+
+                cy.get("[data-testid=phn-checkbox]")
+                    .should("be.enabled")
+                    .check({ force: true });
+
+                cy.get(stressAddressInput).type(
+                    data.resourcePayload.streetAddress
+                );
+                cy.get(cityInput).type(data.resourcePayload.city);
+                cy.get(zipInput).type(data.resourcePayload.postalOrZip);
+
+                selectOption(
+                    formSelectYear,
+                    getYear(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectMonth,
+                    getMonth(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectDay,
+                    getDay(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(registrationSuccessBanner);
+
+        selectorShouldBeVisible(continueBtn);
+        cy.get(continueBtn).click();
+        cy.location("pathname").should("eq", landingPagePath);
+    });
+
+    it("Already Processed with Test Kit CID", () => {
+        cy.visit(`/pcrtest/${processedTestKitCid}`);
+        clickManualRegistrationButton();
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/publicPcrTestValidPhn.json").then(
+            function (data) {
+                cy.get(firstNameInput).type(data.resourcePayload.firstName);
+                cy.get(lastNameInput).type(data.resourcePayload.lastName);
+                cy.get(phnInput).type(data.resourcePayload.phn);
+
+                selectOption(
+                    formSelectYear,
+                    getYear(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectMonth,
+                    getMonth(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectDay,
+                    getDay(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(processedBanner);
+    });
+
+    it("Error with Test Kit CID", () => {
+        cy.visit(`/pcrtest/${errorTestKitCid}`);
+        clickManualRegistrationButton();
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/publicPcrTestValidPhn.json").then(
+            function (data) {
+                cy.get(firstNameInput).type(data.resourcePayload.firstName);
+                cy.get(lastNameInput).type(data.resourcePayload.lastName);
+                cy.get(phnInput).type(data.resourcePayload.phn);
+
+                selectOption(
+                    formSelectYear,
+                    getYear(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectMonth,
+                    getMonth(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectDay,
+                    getDay(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(errorBanner);
+    });
+
+    it("Error with Test Kit Code", () => {
+        cy.visit("/pcrtest");
+        clickManualRegistrationButton();
+
+        // populate the form with values from the fixture
+        cy.fixture("LaboratoryService/authenticatedPcrTestError.json").then(
+            function (data) {
+                cy.get(testKitCodeInput).type(
+                    data.resourcePayload.shortCodeFirst +
+                        "-" +
+                        data.resourcePayload.shortCodeSecond
+                );
+                selectOption(
+                    testTakenMinutesAgo,
+                    getPcrTestTakenTime(
+                        data.resourcePayload.testTakenMinutesAgo
+                    )
+                );
+            }
+        );
+        cy.fixture("LaboratoryService/publicPcrTestValidPhn.json").then(
+            function (data) {
+                cy.get(firstNameInput).type(data.resourcePayload.firstName);
+                cy.get(lastNameInput).type(data.resourcePayload.lastName);
+                cy.get(phnInput).type(data.resourcePayload.phn);
+
+                selectOption(
+                    formSelectYear,
+                    getYear(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectMonth,
+                    getMonth(data.resourcePayload.dob).toString()
+                );
+                selectOption(
+                    formSelectDay,
+                    getDay(data.resourcePayload.dob).toString()
+                );
+            }
+        );
+
+        clickRegisterKitButton();
+
+        selectorShouldBeVisible(errorBanner);
+    });
+});

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicPcrTest.js
@@ -215,6 +215,7 @@ describe("Public PcrTest Registration Submission with Valid PHN", () => {
         clickRegisterKitButton();
 
         selectorShouldBeVisible(registrationSuccessBanner);
+
         selectorShouldBeVisible(continueBtn);
         cy.get(continueBtn).click();
         cy.location("pathname").should("eq", landingPagePath);
@@ -277,6 +278,10 @@ describe("Public PcrTest Registration Submission with no valid PHN", () => {
         clickRegisterKitButton();
 
         selectorShouldBeVisible(registrationSuccessBanner);
+
+        selectorShouldBeVisible(continueBtn);
+        cy.get(continueBtn).click();
+        cy.location("pathname").should("eq", landingPagePath);
     });
 });
 

--- a/Testing/functional/tests/cypress/support/utils.js
+++ b/Testing/functional/tests/cypress/support/utils.js
@@ -8,7 +8,8 @@ export function convertStringToDate(stringDate) {
 }
 
 export function getMonth(date) {
-    return convertStringToDate(date).getMonth();
+    // add 1 to the returned month since they're indexed starting at 0
+    return convertStringToDate(date).getMonth() + 1;
 }
 
 export function getYear(date) {


### PR DESCRIPTION
# Implements [AB#12408](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12408)

## Description

Creates e2e tests to confirm proper handling of test kit submissions for authenticated and unauthenticated users who provide a full or simple test kit code, for submissions that should be successful, erroneous, and already processed.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
