### PR TITLE
Update documentation and deployment files for AB#12596

### DIFF
--- a/Tools/Postgres/README.md
+++ b/Tools/Postgres/README.md
@@ -2,14 +2,21 @@
 
 ## Installation
 
-### OpenShift 4
+Ensure you have a Network Securiy Policy that permits pods to communicate with each other within the project.
+The [BaseBuild NSP](../BaseBuild/nsp.yaml) should meet all of the requirements for this.
 
-In OpenShift 4, we don't have a common image for Postgres and have to create our own
+As a common image for Patroni does not exist, we need to create one based
 
 ```console
 oc project 0bd5ad-tools
 oc process -f ./openshift/build.yaml | oc apply -f -
 oc start-build patroni-pg11 | oc apply -f -
+```
+
+You will need to tag patroni:v11-latest with the environment that you're deploying to (mock, dev, test, production)
+
+```console
+oc tag patroni:v11-latest patroni:dev
 ```
 
 Once that has completed, we can then deploy a standard single cluster per namespace by
@@ -24,23 +31,35 @@ Via the command line this looks like
 oc project 0bd5ad-dev
 oc process -f ./openshift/deployment-prereq.yaml -p PATRONI_SUPERUSER_PASSWORD='[The Password]' -p PATRONI_REPLICATION_PASSWORD='[The Password]' -p APP_DB_PASSWORD='[The Password]' | oc apply -f -
 oc process -f ./openshift/rb-pullers.yaml | oc apply -f -
-oc process -f ./openshift/deployment.yaml | oc apply -f -
+oc process -f ./openshift/deployment.yaml -p IMAGE_STREAM_TAG=dev | oc apply -f -
+oc create -f ./openshift/pdb.yaml
 ```
 
 NOTE: The provisioning of disk is fairly slow and you may not notice anything for a few minutes.
 
-#### Clean up
+### Clean up
 
-If you would like to cleanup, you can execute the following which will remove all data associated to Patroni
+CAUTION: If you would like to remove all resources associated to Patroni, you can execute the following
 
 ```console
-# Clean everthing
+oc project obd5ad-dev
 oc delete all -l cluster-name=patroni-postgres
 oc delete pvc,secret,configmap,rolebinding,role,sa -l cluster-name=patroni-postgres
 ```
 
-Volumes left over to cleanup
-Service account
+## Backup Container Deployment
+
+In order to backup/restore the database, we utilize the [bcgov backup container](https://github.com/BCDevOps/backup-container)
+
+On your local machine execute the following commands
+
+```console
+git clone git@github.com:BCDevOps/backup-container.git
+cd backup-container/openshift/templates/backup
+oc process -f backup-build.yaml | oc apply -f -
+oc process -f backup-deploy.yaml -p IMAGE_NAMESPACE=0bd5ad-dev -p ENVIRONMENT_NAME=0bd5ad-dev -p ENVIRONMENT_FRIENDLY_NAME='HEALTH-GATEWAY (dev)'
+oc create configmap backup-conf --from-file=[HG GIT PATH]/healthgateway/Tools/Postgres/backup.conf
+```
 
 ## Troubleshooting
 
@@ -52,19 +71,20 @@ This service should be listing the current master node.
 
 Using the command line:
 
-```bash
+```console
 oc get pods -l role=master
 ```
 
 or
 
-```bash
-oc describe configmaps patroni-postgres-leader;
+```console
+oc describe configmaps patroni-postgres-leader
 ```
 
-### Connection to the database
+### Connect to the database
 
-The connection requires a port tunnel from the pod in openshift to the local computer,
+The connection requires a port tunnel from the pod in openshift to the local computer, generally for a local port we use 5431.
+
 use the following command to create a tunnel:
 
 ```bash
@@ -74,19 +94,108 @@ oc port-forward <pod-name> <local-port>:5432
 example:
 
 ```bash
-oc port-forward patroni-postgres-1 5432:5432
+oc port-forward patroni-postgres-1 5431:5432
 ```
 
-Use pgadmin or psql to connect to server: localhost:5432, username and password defined in the secrets.
+Use pgadmin or psql to connect to server: localhost:5431, username and password defined in the secrets.
 
-### Manual switch of master pod
+### Patroni Maintenance
 
-Updates the configmap that stores the current leader node (master),
-The script below sets the leader to node 2:
+Read the Patroni [documentation](https://patroni.readthedocs.io/en/latest/).
 
-```bash
-oc annotate configmaps patroni-postgres-leader leader=patroni-postgres-2 --overwrite=true;
+Connect to the master DB pod using a terminal window
+
+```console
+oc project 0bd5ad-dev
+oc rsh $(oc get pods -l role=master -o template --template '{{range .items}}{{.metadata.name}}{{end}}')
+$
 ```
+
+#### Initialize a broken cluster node
+
+```console
+patronictl reinit patroni-postgres patroni-postgres-[node#]
+$ patronictl reinit patroni-postgres patroni-postgres-#
++ Cluster: patroni-postgres (6891020645577564276) -------+----+-----------+
+| Member             | Host          | Role    | State   | TL | Lag in MB |
++--------------------+---------------+---------+---------+----+-----------+
+| patroni-postgres-0 | 10.0.0.0      | Replica | running | 88 |         0 |
+| patroni-postgres-1 | 10.0.0.0      | Leader  | running | 88 |           |
+| patroni-postgres-2 | 10.0.0.0      | Replica | running | 88 |         0 |
++--------------------+---------------+---------+---------+----+-----------+
+Are you sure you want to reinitialize members patroni-postgres-#? [y/N]:
+```
+
+#### Perform a switch over
+
+```console
+$ patronictl switchover
+Master [patroni-postgres-1]:
+Candidate ['patroni-postgres-0', 'patroni-postgres-2'] []: patroni-postgres-0
+When should the switchover take place (e.g. 2022-03-03T07:03 )  [now]:
+Current cluster topology
++ Cluster: patroni-postgres (6891020645577564276) -------+----+-----------+
+| Member             | Host          | Role    | State   | TL | Lag in MB |
++--------------------+---------------+---------+---------+----+-----------+
+| patroni-postgres-0 | 10.0.0.0      | Replica | running | 88 |         0 |
+| patroni-postgres-1 | 10.0.0.0      | Leader  | running | 88 |           |
+| patroni-postgres-2 | 10.0.0.0      | Replica | running | 88 |         0 |
++--------------------+---------------+---------+---------+----+-----------+
+Are you sure you want to switchover cluster patroni-postgres, demoting current master patroni-postgres-1? [y/N]:
+```
+
+#### Execute queries
+
+Connect to the DB
+
+```console
+psql -h localhost -p 5432 -U postgres
+```
+
+##### Terminate all connections
+
+```console
+select pg_terminate_backend(pid) from pg_stat_activity where datname='gateway';
+```
+
+#### Edit Patroni configuration using Rest API
+
+1. Update config (e.g. postgresql.parameters.max_connections to 500):
+
+    ```console
+    curl -s -XPATCH -d '{"postgresql":{"parameters":{"max_prepared_transactions":500, "max_connections":500}}}' http://localhost:8008/config | jq .
+    ```
+
+1. Restart Cluster:
+
+    ```console
+    $ patronictl restart patroni-postgres
+    + Cluster: patroni-postgres (6891020645577564276) -------+----+-----------+
+    | Member             | Host          | Role    | State   | TL | Lag in MB |
+    +--------------------+---------------+---------+---------+----+-----------+
+    | patroni-postgres-0 | 10.0.0.0      | Replica | running | 88 |         0 |
+    | patroni-postgres-1 | 10.0.0.0      | Leader  | running | 88 |           |
+    | patroni-postgres-2 | 10.0.0.0      | Replica | running | 88 |         0 |
+    +--------------------+---------------+---------+---------+----+-----------+
+    When should the restart take place (e.g. 2022-03-03T07:09)  [now]:
+    Are you sure you want to restart members patroni-postgres-2, patroni-postgres-1, patroni-postgres-0? [y/N]:
+    ```
+
+1. Get/View the current config:
+
+    ```console
+    $ curl -s localhost:8008/config | jq .
+    {
+        "postgresql": {
+            "parameters": {
+            "max_locks_per_transaction": 64,
+            "max_prepared_transactions": 500,
+            "max_connections": 500
+            },
+            "use_pg_rewind": true
+        }
+    }
+    ```
 
 ## Restore Backup Script
 
@@ -94,10 +203,18 @@ Backups are generated daily by the dc "backup" in the production realm and are c
 
 To restore the backup follow these steps:
 
+NOTE:  This section is under review as a local to remote restore will take a very long time with our DB size.
+
 1. Connect to openshift using the terminal/bash and set the project to the production one.
+1. Get the name of the backup pod
+
+    ```console
+    oc get pods -l "name=backup-postgres"
+    ```
+
 1. Download the backup file to your local computer using the command below:
 
-    ```bash
+    ```console
     oc rsync <backup-pod-name>:/backups/daily/<date> <local-folder>
     ```
 
@@ -105,7 +222,7 @@ To restore the backup follow these steps:
 
 1. Extract backup script using gzip:
 
-    ```bash
+    ```console
     gzip -d <file-name>
     ```
 
@@ -121,54 +238,4 @@ To restore the backup follow these steps:
 
     ```bash
     psql -h localhost -d gateway -U postgres -p 5432 -a -q -f <path-to-file>
-    ```
-
-## Delete Database (Cleanup)
-
-1. Drop all current connections:
-
-    ```bash
-    psql -h localhost -p 5432 -U postgres -c "select pg_terminate_backend(pid) from pg_stat_activity where datname='gateway';"
-    ```
-
-1. Drop Database:
-
-    ```bash
-    psql -h localhost -p 5432 -U postgres -c 'drop database gateway;'
-    ```
-
-1. Create Database:
-
-    ```bash
-    psql -h localhost -p 5432 -U postgres -c 'create database gateway;'
-    ```
-
-1. Run Migrations Scripts
-
-    ?
-
-## Edit Patroni configuration using Rest API
-
-1. Connect the terminal to any of the patroni pods running using remote shell:
-
-    ```bash
-    oc rsh patroni-postgres-1
-    ```
-
-1. Update config (e.g. postgresql.parameters.max_connections to 500):
-
-    ```bash
-    curl -s -XPATCH -d '{"postgresql":{"parameters":{"max_prepared_transactions":500, "max_connections":500}}}' http://localhost:8008/config | jq .
-    ```
-
-1. Restart Cluster:
-
-    ```bash
-    patronictl restart patroni-postgres
-    ```
-
-1. Get/View the current config:
-
-    ```bash
-    curl -s localhost:8008/config | jq .
     ```

--- a/Tools/Postgres/backup.conf
+++ b/Tools/Postgres/backup.conf
@@ -1,0 +1,42 @@
+# ============================================================
+# Databases:
+# ------------------------------------------------------------
+# List the databases you want backed up here.
+# Databases will be backed up in the order they are listed.
+#
+# The entries must be in one of the following forms:
+# - <Hostname/>/<DatabaseName/>
+# - <Hostname/>:<Port/>/<DatabaseName/>
+#
+# Examples:
+# - postgresql/my_database
+# - postgresql:5432/my_database
+# -----------------------------------------------------------
+# Cron Scheduling:
+# -----------------------------------------------------------
+# List your backup and verification schedule(s) here as well.
+# The schedule(s) must be listed as cron tabs that 
+# execute the script in 'scheduled' mode:
+#   - ./backup.sh -s
+#
+# Examples (assuming system's TZ is set to UTC):
+# - 0 9 * * * default ./backup.sh -s
+#   - Run a backup at 9am UTC (1am Pacific) every day.
+#
+# - 0 12 * * * default ./backup.sh -s -v all
+#   - Verify the most recent backups for all datbases
+#     at 12pm UTC (4am Pacific) every day.
+# -----------------------------------------------------------
+# Full Example:
+# -----------------------------------------------------------
+# postgresql:5432/OrgBook
+# wallet-db:5432/tob_holder
+# wallet-db/tob_issuer
+#
+# 0 9 * * * default ./backup.sh -s
+# 0 12 * * * default ./backup.sh -s -v all
+# ============================================================
+patroni-postgres-master:5432/gateway
+
+# Schedule backup for 1am PST; system TZ is PST
+0 1 * * * default ./backup.sh -s

--- a/Tools/Postgres/openshift/deployment.yaml
+++ b/Tools/Postgres/openshift/deployment.yaml
@@ -204,7 +204,7 @@ objects:
                   value: 0.0.0.0:5432
                 - name: PATRONI_RESTAPI_LISTEN
                   value: 0.0.0.0:8008
-              image: ${IMAGE_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/${IMAGE_STREAM_TAG}
+              image: ${IMAGE_REGISTRY}/${IMAGE_STREAM_NAMESPACE}/patroni:${IMAGE_STREAM_TAG}
               # Because we are using image reference to a tag, we need to always pull the image otherwise
               #   we end up with outdated/out-of-sync image depending on the node where it is running
               imagePullPolicy: Always
@@ -300,8 +300,9 @@ parameters:
     name: IMAGE_STREAM_NAMESPACE
     value: "0bd5ad-tools"
   - name: IMAGE_STREAM_TAG
-    description: Patroni ImageTag
-    value: patroni:v11-latest
+    displayName: Patroni ImageTag to use
+    description: The environment tag to use mock, dev, test, production
+    required: true
   - description: The size of the persistent volume to create.
     displayName: Persistent Volume Size
     name: PVC_SIZE

--- a/Tools/Postgres/openshift/pdb.yaml
+++ b/Tools/Postgres/openshift/pdb.yaml
@@ -1,0 +1,9 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: patroni-pdb
+spec:
+  minAvailable: 2  
+  selector:  
+    matchLabels:
+      statefulset: patroni-postgres


### PR DESCRIPTION
# Fixes or Implements [AB#12596](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12596)

## Description

Updates the documentation for Patroni/Postgres.
Added yaml for Pod Disruption Budget.
Updated Patroni Deployment to support tags. 

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
