### PR TITLE
Add menu and button for removing quick links AB#12549

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/shared/hgCardButton.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/hgCardButton.vue
@@ -9,6 +9,10 @@ export default class HgCardButtonComponent extends Vue {
     private get hasIconSlot() {
         return this.$slots.icon !== undefined;
     }
+
+    private get hasMenuSlot() {
+        return this.$slots.menu !== undefined;
+    }
 }
 </script>
 
@@ -18,7 +22,7 @@ export default class HgCardButtonComponent extends Vue {
         v-bind="$attrs"
         v-on="$listeners"
     >
-        <b-row no-gutters class="mb-4 mt-n3">
+        <b-row no-gutters align-h="end" class="mb-4 mt-n3 w-100">
             <b-col
                 v-if="hasIconSlot"
                 cols="auto"
@@ -29,6 +33,9 @@ export default class HgCardButtonComponent extends Vue {
             </b-col>
             <b-col class="hg-card-button-title mt-3">
                 {{ title }}
+            </b-col>
+            <b-col v-if="hasMenuSlot" cols="auto" class="mt-2">
+                <slot name="menu" />
             </b-col>
         </b-row>
         <slot />

--- a/Apps/WebClient/src/ClientApp/src/views/home.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/home.vue
@@ -4,6 +4,7 @@ import {
     faCheckCircle,
     faClipboard,
     faEdit,
+    faEllipsisV,
     faFlask,
     faPills,
     faPlus,
@@ -33,6 +34,7 @@ library.add(
     faCheckCircle,
     faClipboard,
     faEdit,
+    faEllipsisV,
     faFlask,
     faPills,
     faPlus,
@@ -69,6 +71,12 @@ export default class HomeView extends Vue {
 
     @Action("clearFilter", { namespace: "timeline" })
     clearFilter!: () => void;
+
+    @Action("updateQuickLinks", { namespace: "user" })
+    updateQuickLinks!: (params: {
+        hdid: string;
+        quickLinks: QuickLink[];
+    }) => Promise<void>;
 
     @Getter("authenticatedVaccineRecordIsLoading", {
         namespace: "vaccinationStatus",
@@ -197,9 +205,26 @@ export default class HomeView extends Vue {
         });
     }
 
+    private removeQuickLink(targetQuickLink: QuickLink): Promise<void> {
+        const updatedLinks =
+            this.quickLinks?.filter(
+                (quickLink) => quickLink !== targetQuickLink
+            ) ?? [];
+
+        return this.updateQuickLinks({
+            hdid: this.user.hdid,
+            quickLinks: updatedLinks,
+        });
+    }
+
     private handleClickHealthRecords(): void {
         this.clearFilter();
         this.$router.push({ path: "/timeline" });
+    }
+
+    private handleClickRemoveQuickLink(index: number): void {
+        const quickLink = this.enabledQuickLinks[index];
+        this.removeQuickLink(quickLink);
     }
 
     private handleClickQuickLink(index: number): void {
@@ -325,7 +350,7 @@ export default class HomeView extends Vue {
             </hg-button>
         </page-title>
         <h2>What do you want to focus on today?</h2>
-        <b-row cols="1" cols-lg="3">
+        <b-row cols="1" cols-lg="2" cols-xl="3">
             <b-col class="p-3">
                 <hg-card-button
                     title="Health Records"
@@ -400,6 +425,33 @@ export default class HomeView extends Vue {
                             square
                         />
                     </template>
+                    <template #menu>
+                        <b-nav align="right">
+                            <b-nav-item-dropdown
+                                right
+                                text=""
+                                :no-caret="true"
+                                menu-class="quick-link-menu"
+                                toggle-class="quick-link-menu-button"
+                            >
+                                <template slot="button-content">
+                                    <hg-icon
+                                        icon="ellipsis-v"
+                                        size="medium"
+                                        data-testid="quick-link-menu-button"
+                                    />
+                                </template>
+                                <b-dropdown-item
+                                    data-testid="remove-quick-link-button"
+                                    @click.stop="
+                                        handleClickRemoveQuickLink(card.index)
+                                    "
+                                >
+                                    Remove
+                                </b-dropdown-item>
+                            </b-nav-item-dropdown>
+                        </b-nav>
+                    </template>
                     <div>{{ card.description }}</div>
                 </hg-card-button>
             </b-col>
@@ -454,6 +506,38 @@ export default class HomeView extends Vue {
 
     .vld-icon {
         text-align: center;
+    }
+}
+
+.quick-link-menu {
+    a {
+        &:focus:not([disabled]):not(:active),
+        &:hover:not([disabled]):not(:active) {
+            color: $hg-text-primary;
+        }
+        &:active:not([disabled]) {
+            color: white;
+        }
+    }
+}
+
+.quick-link-menu-button {
+    color: $soft_text;
+    border: 1px solid rgba(0, 0, 0, 0);
+    border-radius: 0.25rem;
+
+    &:focus:not([disabled]),
+    &:hover:not([disabled]) {
+        color: $soft_text;
+        border: 1px solid rgba(0, 0, 0, 0.15);
+    }
+}
+
+.nav-link.active,
+.nav-item.show .nav-link {
+    &.quick-link-menu-button {
+        background-color: white;
+        border: 1px solid rgba(0, 0, 0, 0.15);
     }
 }
 </style>


### PR DESCRIPTION
# Implements AB#12549

## Description

Adds a drop-down menu on the right side of quick link cards with a single option to remove the quick link.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

![image](https://user-images.githubusercontent.com/16570293/157325469-ac6425b9-9acb-4b52-a1c6-53070e9b56ac.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
