### PR TITLE
Fix incorrect DateTime specification AB#11965

### DIFF
--- a/Apps/Encounter/test/unit/Controllers/EncounterControllerTests.cs
+++ b/Apps/Encounter/test/unit/Controllers/EncounterControllerTests.cs
@@ -13,61 +13,79 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.EncounterTests
+namespace HealthGateway.Encounter.Test.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Encounter.Controllers;
     using HealthGateway.Encounter.Models;
     using HealthGateway.Encounter.Services;
+    using Microsoft.Extensions.Logging;
     using Moq;
+    using Xunit;
 
     /// <summary>
-    /// EncounterController's Unit Tests.
+    /// Unit Tests for EncounterController.
     /// </summary>
     public class EncounterControllerTests
     {
-        private readonly Mock<IEncounterService> encounterService;
+        private const string Hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="EncounterControllerTests"/> class.
+        /// GetEncounters - Happy Path.
         /// </summary>
-        public EncounterControllerTests()
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetEncounters()
         {
-            this.encounterService = new Mock<IEncounterService>();
-            this.encounterService.Setup(x => x.GetEncounters(It.IsAny<string>())).ReturnsAsync(GetEncounters());
-        }
-
-        private static RequestResult<IEnumerable<EncounterModel>> GetEncounters()
-        {
-            RequestResult<IEnumerable<EncounterModel>> result = new();
-            List<EncounterModel> encounters = new()
+            RequestResult<IEnumerable<EncounterModel>> expectedRequestResult = new()
             {
-                new EncounterModel()
+                ResultStatus = ResultType.Success,
+                TotalResultCount = 2,
+                ResourcePayload = new List<EncounterModel>()
                 {
-                    Id = "1",
-                    EncounterDate = new DateTime(2020 - 05 - 27),
-                    SpecialtyDescription = "LABORATORY MEDICINE",
-                    PractitionerName = "PRACTITIONER NAME",
-                    Clinic = new Clinic()
+                    new EncounterModel()
                     {
-                        Name = "LOCATION NAME",
+                        Id = "1",
+                        EncounterDate = new DateTime(2020 - 05 - 27),
+                        SpecialtyDescription = "LABORATORY MEDICINE",
+                        PractitionerName = "PRACTITIONER NAME",
+                        Clinic = new Clinic()
+                        {
+                            Name = "LOCATION NAME",
+                        },
                     },
-                },
-                new EncounterModel()
-                {
-                    Id = "2",
-                    EncounterDate = new DateTime(2020 - 06 - 27),
-                    SpecialtyDescription = "LABORATORY MEDICINE",
-                    PractitionerName = "PRACTITIONER NAME",
-                    Clinic = new Clinic()
+                    new EncounterModel()
                     {
-                        Name = "LOCATION NAME",
+                        Id = "2",
+                        EncounterDate = new DateTime(2020 - 06 - 27),
+                        SpecialtyDescription = "LABORATORY MEDICINE",
+                        PractitionerName = "PRACTITIONER NAME",
+                        Clinic = new Clinic()
+                        {
+                            Name = "LOCATION NAME",
+                        },
                     },
                 },
             };
-            result.ResourcePayload = encounters;
-            return result;
+
+            Mock<IEncounterService> svcMock = new();
+            svcMock.Setup(s => s.GetEncounters(Hdid)).ReturnsAsync(expectedRequestResult);
+
+            EncounterController controller = new(new Mock<ILogger<EncounterController>>().Object, svcMock.Object);
+
+            // Act
+            RequestResult<IEnumerable<EncounterModel>> actual = await controller.GetEncounters(Hdid).ConfigureAwait(true);
+
+            // Verify
+            Assert.True(actual != null && actual.ResultStatus == ResultType.Success);
+
+            Assert.Equal(2, actual?.ResourcePayload?.Count());
+            Assert.Equal(2, actual?.TotalResultCount);
         }
     }
 }

--- a/Apps/Encounter/test/unit/Controllers/EncounterControllerTests.cs
+++ b/Apps/Encounter/test/unit/Controllers/EncounterControllerTests.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.Encounter.Test.Controllers
                     new EncounterModel()
                     {
                         Id = "1",
-                        EncounterDate = new DateTime(2020 - 05 - 27),
+                        EncounterDate = new DateTime(2020, 05, 27),
                         SpecialtyDescription = "LABORATORY MEDICINE",
                         PractitionerName = "PRACTITIONER NAME",
                         Clinic = new Clinic()
@@ -62,7 +62,7 @@ namespace HealthGateway.Encounter.Test.Controllers
                     new EncounterModel()
                     {
                         Id = "2",
-                        EncounterDate = new DateTime(2020 - 06 - 27),
+                        EncounterDate = new DateTime(2020, 06, 27),
                         SpecialtyDescription = "LABORATORY MEDICINE",
                         PractitionerName = "PRACTITIONER NAME",
                         Clinic = new Clinic()


### PR DESCRIPTION
# Fixes [AB#11965](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11965)

## Description

- Finishes implementing unit test for EncounterController
- Fixes an incorrect DateTime specification in EncounterControllerTests [AB#11965](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11965)

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
