### PR TITLE
Fix flakey cypress functional tests for AB#12653.

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicPcrTest.js
@@ -85,32 +85,40 @@ describe("Public PcrTest Registration Form", () => {
         cy.visit(pcrTestUrl);
     });
 
-    it("Register options buttons are available", () => {
+    it("Validate button options and form inputs", () => {
+        // Register option buttons are available
+        cy.log("Check all button visibility.");
         cy.get("[data-testid=btn-login]").should("be.visible");
         cy.get("[data-testid=btn-manual]").should("be.visible");
-    });
 
-    it("Log in button should not be present in header", () => {
+        // Log in button should not be present in header
         cy.get("[data-testid=loginBtn]").should("not.exist");
-    });
 
-    it("Inputs in the form are visible with valid PHN", () => {
-        cy.get("[data-testid=btn-manual]").should("be.visible").click();
+        // Inputs in the form not including address fields are visible when phn checkbox unchecked
+        cy.log("Click manual button.");
+        clickManualRegistrationButton();
+        //cy.get("[data-testid=btn-manual]").should("be.visible").click();
         inputFieldsShouldBeVisible();
         inputAddressFieldsNotExists();
-    });
 
-    it("Inputs in the form are visible with no valid PHN", () => {
-        cy.get("[data-testid=btn-manual]").should("be.visible").click();
-        inputFieldsShouldBeVisible();
+        // Inputs in the form including address fields are visible when phn checkbox checked
+        cy.log("Check off phn checkbox.");
         cy.get("[data-testid=phn-checkbox]")
             .should("be.enabled")
             .check({ force: true });
+        inputFieldsShouldBeVisible();
         inputAddressFieldsShouldBeVisible();
-    });
 
-    it("Required Validations are visible with valid PHN", () => {
-        clickManualRegistrationButton();
+        // Inputs in the form not including address fields are visible when phn checkbox unchecked
+        cy.log("Un-check phn checkbox.");
+        cy.get("[data-testid=phn-checkbox]")
+            .should("be.enabled")
+            .uncheck({ force: true });
+        inputFieldsShouldBeVisible();
+        inputAddressFieldsNotExists();
+
+        // Required Validations are visible when phn checkbox unchecked
+        cy.log("Click registration kit button.");
         clickRegisterKitButton();
         cy.get(feedbackTestKitCodeIsRequiredSelector).should("be.visible");
         cy.get(feedbackFirstNameIsRequiredSelector).should("be.visible");
@@ -121,34 +129,37 @@ describe("Public PcrTest Registration Form", () => {
         cy.get(feedbackStreetAddressIsRequiredSelector).should("not.exist");
         cy.get(feedbackCityIsRequiredSelector).should("not.exist");
         cy.get(feedbackPostalIsRequiredSelector).should("not.exist");
-    });
 
-    it("No PHN available required validations", () => {
-        clickManualRegistrationButton();
+        // Check off phn checkbox. Inputs in the form including address fields are visible when phn checkbox checked
         cy.get("[data-testid=phn-checkbox]")
             .should("be.enabled")
             .check({ force: true });
         inputAddressFieldsShouldBeVisible();
-        clickRegisterKitButton();
 
-        // Address information should be visible.
+        // Required Validations for Address information are visible when phn checkbox checked.
         cy.get(feedbackStreetAddressIsRequiredSelector).should("be.visible");
         cy.get(feedbackCityIsRequiredSelector).should("be.visible");
         cy.get(feedbackPostalIsRequiredSelector).should("be.visible");
-    });
 
-    it("Test Kit Code Invalid Validations", () => {
-        clickManualRegistrationButton();
+        // Uncheck phn checkbox. Inputs in the form not including address fields are visible when phn checkbox unchecked
+        cy.get("[data-testid=phn-checkbox]")
+            .should("be.enabled")
+            .uncheck({ force: true });
+        inputFieldsShouldBeVisible();
+        inputAddressFieldsNotExists();
+
+        // Test Kit Code Invalid Validations
         cy.get(testKitCodeInput).type("111");
         cy.get(firstNameInput).type("Princess");
         cy.get(feedbackTestKitCodeValidSelector).should("be.visible");
-    });
 
-    it("Phone number Invalid Validations", () => {
-        clickManualRegistrationButton();
+        // Phone number Invalid Validations
+        cy.get(testKitCodeInput).clear();
+        cy.get(testKitCodeInput).type("45YFKE7-EMQY1");
         cy.get(contactPhoneNumberInput).type(" ");
         cy.get(testTakenMinutesAgo).select(getPcrTestTakenTime(5));
         cy.get(feedbackPhoneNumberValidSelector).should("be.visible");
+        cy.get(feedbackTestKitCodeValidSelector).should("not.exist");
     });
 });
 

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -49,7 +49,7 @@ describe("Laboratory Orders", () => {
                 });
         });
 
-        cy.get("[data-testid=backBtn]").click();
+        cy.get("[data-testid=backBtn]").click({ force: true });
         cy.get("[data-testid=filterTextInput]").should("be.visible");
     });
 });


### PR DESCRIPTION
# Fixes or Implements [AB#12653](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12653)

## Description

Fixed a couple of flakey functional tests.

<img width="2360" alt="Screen Shot 2022-03-22 at 1 02 14 PM" src="https://user-images.githubusercontent.com/58790456/159566206-08eb28d2-03a6-4159-ba95-bced893e6935.png">

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
