### PR TITLE
Update front-end  model, service, store and back-end service for AB#12759.

### DIFF
--- a/Apps/Laboratory/src/Models/LaboratoryOrderResult.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrderResult.cs
@@ -32,6 +32,12 @@ public class LaboratoryOrderResult
     public bool Loaded { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the orders have been queued.
+    /// </summary>
+    [JsonPropertyName("queued")]
+    public bool Queued { get; set; }
+
+    /// <summary>
     /// Gets or sets the minimal amount of time that should be waited before another request.
     /// The unit of measurement is in milliseconds.
     /// </summary>

--- a/Apps/Laboratory/src/Services/LaboratoryService.cs
+++ b/Apps/Laboratory/src/Services/LaboratoryService.cs
@@ -153,6 +153,7 @@ namespace HealthGateway.Laboratory.Services
                 PhsaLoadState? loadState = delegateResult.ResourcePayload?.LoadState;
                 if (loadState != null)
                 {
+                    retVal.ResourcePayload.Queued = loadState.Queued;
                     retVal.ResourcePayload.Loaded = !loadState.RefreshInProgress;
                     if (loadState.RefreshInProgress)
                     {

--- a/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
@@ -42,6 +42,7 @@ export interface Covid19LaboratoryTest {
 // result model for retrieving lab orders
 export interface LaboratoryOrderResult {
     loaded: boolean;
+    queued: boolean;
     retryin: number;
     orders: LaboratoryOrder[];
 }

--- a/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
@@ -118,7 +118,12 @@ export class RestLaboratoryService implements ILaboratoryService {
                 resolve({
                     pageIndex: 0,
                     pageSize: 0,
-                    resourcePayload: { loaded: true, retryin: 0, orders: [] },
+                    resourcePayload: {
+                        loaded: true,
+                        queued: false,
+                        retryin: 0,
+                        orders: [],
+                    },
                     resultStatus: ResultType.Success,
                     totalResultCount: 0,
                 });

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
@@ -123,6 +123,7 @@ export const actions: LaboratoryActions = {
         return new Promise((resolve, reject) => {
             const laboratoryOrders: LaboratoryOrder[] =
                 context.getters.laboratoryOrders;
+            const laboratoryQueued: boolean = context.getters.queued;
             if (context.state.authenticated.status === LoadStatus.LOADED) {
                 logger.debug("Laboratory Orders found stored, not querying!");
                 resolve({
@@ -130,6 +131,7 @@ export const actions: LaboratoryActions = {
                     pageSize: 0,
                     resourcePayload: {
                         loaded: true,
+                        queued: laboratoryQueued,
                         retryin: 0,
                         orders: laboratoryOrders,
                     },
@@ -148,10 +150,7 @@ export const actions: LaboratoryActions = {
                                 EntryType.LaboratoryOrder,
                                 result.totalResultCount
                             );
-                            context.commit(
-                                "setLaboratoryOrders",
-                                payload.orders
-                            );
+                            context.commit("setLaboratoryOrders", payload);
                             resolve(result);
                         } else if (
                             result.resultError?.actionCode ===

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/getters.ts
@@ -27,6 +27,9 @@ export const getters: LaboratoryGetters = {
     laboratoryOrdersAreLoading(state: LaboratoryState): boolean {
         return state.authenticated.status === LoadStatus.REQUESTED;
     },
+    laboratoryOrdersAreQueued(state: LaboratoryState): boolean {
+        return state.authenticated.queued;
+    },
     publicCovidTestResponseResult(
         state: LaboratoryState
     ): PublicCovidTestResponseResult | undefined {

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/laboratory.ts
@@ -23,6 +23,7 @@ const state: LaboratoryState = {
         laboratoryOrders: [],
         error: undefined,
         status: LoadStatus.NONE,
+        queued: false,
     },
 };
 

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/mutations.ts
@@ -1,7 +1,7 @@
 import { CustomBannerError } from "@/models/bannerError";
 import {
     Covid19LaboratoryOrder,
-    LaboratoryOrder,
+    LaboratoryOrderResult,
     PublicCovidTestResponseResult,
 } from "@/models/laboratory";
 import { LoadStatus } from "@/models/storeOperations";
@@ -30,12 +30,13 @@ export const mutations: LaboratoryMutations = {
     },
     setLaboratoryOrders(
         state: LaboratoryState,
-        laboratoryOrders: LaboratoryOrder[]
+        laboratoryOrderResult: LaboratoryOrderResult
     ) {
-        state.authenticated.laboratoryOrders = laboratoryOrders;
+        state.authenticated.laboratoryOrders = laboratoryOrderResult.orders;
         state.authenticated.error = undefined;
         state.authenticated.statusMessage = "success";
         state.authenticated.status = LoadStatus.LOADED;
+        state.authenticated.queued = laboratoryOrderResult.queued;
     },
     laboratoryError(state: LaboratoryState, error: Error) {
         state.authenticated.statusMessage = error.message;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/types.ts
@@ -38,6 +38,7 @@ export interface LaboratoryState {
         statusMessage: string;
         error?: ResultError;
         status: LoadStatus;
+        queued: boolean;
     };
 }
 
@@ -49,6 +50,7 @@ export interface LaboratoryGetters
     laboratoryOrders(state: LaboratoryState): LaboratoryOrder[];
     laboratoryOrdersCount(state: LaboratoryState): number;
     laboratoryOrdersAreLoading(state: LaboratoryState): boolean;
+    laboratoryOrdersAreQueued(state: LaboratoryState): boolean;
     publicCovidTestResponseResult(
         state: LaboratoryState
     ): PublicCovidTestResponseResult | undefined;
@@ -99,7 +101,7 @@ export interface LaboratoryMutations extends MutationTree<LaboratoryState> {
     setLaboratoryOrdersRequested(state: LaboratoryState): void;
     setLaboratoryOrders(
         state: LaboratoryState,
-        laboratoryOrders: LaboratoryOrder[]
+        laboratoryOrderResult: LaboratoryOrderResult
     ): void;
     laboratoryError(state: LaboratoryState, error: Error): void;
     setPublicCovidTestResponseResultRequested(state: LaboratoryState): void;

--- a/Apps/WebClient/src/ClientApp/test/stubs/store/laboratoryStub.ts
+++ b/Apps/WebClient/src/ClientApp/test/stubs/store/laboratoryStub.ts
@@ -31,6 +31,7 @@ const laboratoryState: LaboratoryState = {
         laboratoryOrders: [],
         statusMessage: "",
         status: LoadStatus.NONE,
+        queued: false,
     },
 };
 
@@ -51,6 +52,9 @@ const laboratoryGetters: LaboratoryGetters = {
         return 0;
     },
     laboratoryOrdersAreLoading(): boolean {
+        return false;
+    },
+    laboratoryOrdersAreQueued(): boolean {
         return false;
     },
     publicCovidTestResponseResult(): PublicCovidTestResponseResult | undefined {


### PR DESCRIPTION
# Fixes or Implements AB#12759

## Description

- Update back-end service to return 'queued' value from PHSA Result.

- Update front-end service to handle 'queued' value from back-end service

- Update store and model to hold 'queued' value from front-end service.   

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
