### PR TITLE
Update 'CollectionDateTime' to nullable for AB#12802.

### DIFF
--- a/Apps/Laboratory/src/Models/LaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrder.cs
@@ -66,7 +66,7 @@ public class LaboratoryOrder
     /// Gets or sets the date time when the lab collection took place.
     /// </summary>
     [JsonPropertyName("collectionDateTime")]
-    public DateTime CollectionDateTime { get; set; }
+    public DateTime? CollectionDateTime { get; set; }
 
     /// <summary>
     /// Gets or sets a value for common name.

--- a/Apps/Laboratory/src/Models/LaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrder.cs
@@ -69,6 +69,12 @@ public class LaboratoryOrder
     public DateTime? CollectionDateTime { get; set; }
 
     /// <summary>
+    /// Gets or sets the date time for the most relevant date when displaying on a timeline.
+    /// </summary>
+    [JsonPropertyName("timelineDateTime")]
+    public DateTime TimelineDateTime { get; set; }
+
+    /// <summary>
     /// Gets or sets a value for common name.
     /// </summary>
     [JsonPropertyName("commonName")]
@@ -114,6 +120,7 @@ public class LaboratoryOrder
             ReportingSource = model.ReportingSource,
             ReportId = model.ReportId,
             CollectionDateTime = model.CollectionDateTime,
+            TimelineDateTime = model.TimelineDateTime,
             CommonName = model.CommonName,
             OrderingProvider = model.OrderingProvider,
             TestStatus = model.PlisTestStatus,

--- a/Apps/Laboratory/src/Models/PHSA/PhsaLaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/PHSA/PhsaLaboratoryOrder.cs
@@ -46,7 +46,7 @@ public class PhsaLaboratoryOrder
     /// Gets or sets the date time when the lab collection took place.
     /// </summary>
     [JsonPropertyName("collectionDateTime")]
-    public DateTime CollectionDateTime { get; set; }
+    public DateTime? CollectionDateTime { get; set; }
 
     /// <summary>
     /// Gets or sets a value for common name.

--- a/Apps/Laboratory/src/Models/PHSA/PhsaLaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/PHSA/PhsaLaboratoryOrder.cs
@@ -49,6 +49,12 @@ public class PhsaLaboratoryOrder
     public DateTime? CollectionDateTime { get; set; }
 
     /// <summary>
+    /// Gets or sets the date time for the most relevant date when displaying on a timeline.
+    /// </summary>
+    [JsonPropertyName("timelineDateTime")]
+    public DateTime TimelineDateTime { get; set; }
+
+    /// <summary>
     /// Gets or sets a value for common name.
     /// </summary>
     [JsonPropertyName("commonName")]

--- a/Apps/WebClient/src/ClientApp/src/components/report/laboratory.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/laboratory.vue
@@ -46,11 +46,11 @@ export default class LaboratoryReportComponent extends Vue {
 
     private get visibleRecords(): LaboratoryOrder[] {
         let records = this.laboratoryOrders.filter((record) => {
-            return this.filter.allowsDate(record.collectionDateTime);
+            return this.filter.allowsDate(record.timelineDateTime);
         });
         records.sort((a, b) => {
-            const firstDate = new DateWrapper(a.collectionDateTime);
-            const secondDate = new DateWrapper(b.collectionDateTime);
+            const firstDate = new DateWrapper(a.timelineDateTime);
+            const secondDate = new DateWrapper(b.timelineDateTime);
 
             if (firstDate.isBefore(secondDate)) {
                 return 1;
@@ -72,10 +72,10 @@ export default class LaboratoryReportComponent extends Vue {
 
     private get items(): LabTestRow[] {
         return this.visibleRecords.flatMap<LabTestRow>((x) => {
-            const collectionDateTime = DateWrapper.format(x.collectionDateTime);
+            const timelineDateTime = DateWrapper.format(x.timelineDateTime);
             return x.laboratoryTests.map<LabTestRow>((y) => {
                 return {
-                    date: collectionDateTime,
+                    date: timelineDateTime,
                     test: y.batteryType || "",
                     result: this.getResult(y.testStatus, y.outOfRange),
                     status: y.testStatus || "",

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratoryOrder.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratoryOrder.vue
@@ -140,10 +140,12 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                     </hg-button>
                 </span>
             </div>
-            <div v-if="entry.collectionDateTime !== undefined" class="my-2">
+            <div class="my-2">
                 <div data-testid="laboratoryCollectionDate">
                     <strong>Collection Date:</strong>
-                    {{ formatDate(entry.collectionDateTime) }}
+                    <span v-if="entry.collectionDateTime !== undefined">
+                        {{ formatDate(entry.collectionDateTime) }}
+                    </span>
                 </div>
             </div>
             <div class="my-2">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratoryOrder.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/laboratoryOrder.vue
@@ -78,7 +78,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
             .getReportDocument(this.entry.id, this.user.hdid, false)
             .then((result) => {
                 let dateString =
-                    this.entry.collectionDateTime.format("YYYY_MM_DD-HH_mm");
+                    this.entry.timelineDateTime.format("YYYY_MM_DD-HH_mm");
                 let report: LaboratoryReport = result.resourcePayload;
                 fetch(
                     `data:${report.mediaType};${report.encoding},${report.data}`
@@ -140,7 +140,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                     </hg-button>
                 </span>
             </div>
-            <div class="my-2">
+            <div v-if="entry.collectionDateTime !== undefined" class="my-2">
                 <div data-testid="laboratoryCollectionDate">
                     <strong>Collection Date:</strong>
                     {{ formatDate(entry.collectionDateTime) }}

--- a/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
@@ -52,7 +52,8 @@ export interface LaboratoryOrder {
     labPdfId: string;
     reportingSource: string;
     reportId: string;
-    collectionDateTime: StringISODateTime;
+    collectionDateTime: StringISODateTime | undefined;
+    timelineDateTime: StringISODateTime;
     commonName: string;
     orderingProvider: string;
     testStatus: string;

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
@@ -13,7 +13,8 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
     public labPdfId: string;
     public reportingLab: string;
     public reportId: string;
-    public collectionDateTime: DateWrapper;
+    public collectionDateTime: DateWrapper | undefined;
+    public timelineDateTime: DateWrapper;
     public commonName: string;
     public orderingProvider: string;
     public testStatus: string;
@@ -39,7 +40,17 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
         this.commonName = model.commonName;
         this.reportAvailable = model.reportAvailable;
         this.labPdfId = model.labPdfId;
-        this.collectionDateTime = new DateWrapper(model.collectionDateTime, {
+
+        if (model.collectionDateTime !== undefined) {
+            this.collectionDateTime = new DateWrapper(
+                model.collectionDateTime,
+                {
+                    hasTime: true,
+                }
+            );
+        }
+
+        this.timelineDateTime = new DateWrapper(model.timelineDateTime, {
             hasTime: true,
         });
         this.orderingProvider = model.orderingProvider;

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
@@ -32,7 +32,7 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
         super(
             model.reportId,
             EntryType.LaboratoryOrder,
-            new DateWrapper(model.collectionDateTime, {
+            new DateWrapper(model.timelineDateTime, {
                 hasTime: true,
             })
         );


### PR DESCRIPTION
# Fixes or Implements [AB#12802](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12802)

## Description

Updated 'CollectionDateTime' to nullable as per PHSA changes.
Added 'TimelineDateTime' non nullable as per PHSA changes.
Also updated timeline entry date to use 'TimelineDateTime' instead of 'CollectionDateTIme'.

<img width="2543" alt="160969876-a8899e7c-50d4-4838-afaa-7b6ba162a65d" src="https://user-images.githubusercontent.com/58790456/161105741-00d3526e-f278-49c4-8886-2b8491587b8a.png">

Collection Date Time value only shows when there is 'CollectionDateTime' value on the entry card.
Timeline Date Time value is used for Date value in Laboratory Reports.

<img width="394" alt="Screen Shot 2022-03-31 at 9 18 40 AM" src="https://user-images.githubusercontent.com/58790456/161103096-0fd2ae7c-6b0a-40f5-afc8-b24953202e0f.png">

<img width="393" alt="Screen Shot 2022-03-31 at 9 18 50 AM" src="https://user-images.githubusercontent.com/58790456/161103109-ab924b7e-b36f-42f7-aef5-aa7627a47762.png">

Changed Laboratory Reports to use 'TimelineDateTime' instead of 'CollectionDateTime' for Date.

<img width="2538" alt="Screen Shot 2022-03-30 at 8 11 12 PM" src="https://user-images.githubusercontent.com/58790456/161106611-fdb74076-f1c0-4436-ad2e-e6b90b33544d.png">


If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
