### PR TITLE
Add snowplow tracking for links on home page AB#12709

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -52,7 +52,7 @@ entryTypeMap.set(EntryType.LaboratoryOrder, {
         "View your lab results. Most results are available within 24–48 hours.",
     icon: "microscope",
     component: "LaboratoryOrderComponent",
-    eventName: "all_laboratory",
+    eventName: "lab_results",
 });
 
 entryTypeMap.set(EntryType.Covid19LaboratoryOrder, {
@@ -84,7 +84,7 @@ entryTypeMap.set(EntryType.Note, {
     description: "View and edit notes that you added to your medical records.",
     icon: "edit",
     component: "NoteComponent",
-    eventName: "",
+    eventName: "my_notes",
 });
 
 entryTypeMap.set(EntryType.MedicationRequest, {

--- a/Apps/WebClient/src/ClientApp/src/utility/eventTracker.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/eventTracker.ts
@@ -1,7 +1,4 @@
 import { EntryType, entryTypeMap } from "@/constants/entryType";
-import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
-import container from "@/plugins/inversify.container";
-import { ILogger } from "@/services/interfaces";
 
 import SnowPlow from "./snowPlow";
 
@@ -14,8 +11,6 @@ export default abstract class EventTracker {
         const loadType = entryTypeMap.get(loadEntryType)?.eventName ?? "";
 
         if (loadType !== "") {
-            const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-            logger.debug(`Tracking event: loadData - ${loadType}`);
             SnowPlow.trackEvent({
                 action: "load_data",
                 text: loadType,
@@ -24,8 +19,6 @@ export default abstract class EventTracker {
     }
 
     public static downloadReport(eventName: string): void {
-        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-        logger.debug(`Tracking event: downloadReport - ${eventName}`);
         SnowPlow.trackEvent({
             action: "download_report",
             text: eventName,

--- a/Apps/WebClient/src/ClientApp/src/utility/snowPlow.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/snowPlow.ts
@@ -1,9 +1,14 @@
 import { EventData, SnowplowWindow } from "@/plugins/extensions";
+import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
+import container from "@/plugins/inversify.container";
+import { ILogger } from "@/services/interfaces";
 
 declare let window: SnowplowWindow;
 
 export default abstract class SnowPlow {
     public static trackEvent(data: EventData): void {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        logger.debug(`Tracking event: ${data.action} - ${data.text}`);
         window.snowplow("trackSelfDescribingEvent", {
             schema: "iglu:ca.bc.gov.gateway/action/jsonschema/1-0-0",
             data,

--- a/Apps/WebClient/src/ClientApp/src/views/home.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/home.vue
@@ -199,7 +199,17 @@ export default class HomeView extends Vue {
         );
     }
 
+    private trackClickLink(linkType: string | undefined) {
+        if (linkType) {
+            SnowPlow.trackEvent({
+                action: "click",
+                text: `home_${linkType}`,
+            });
+        }
+    }
+
     private retrieveVaccinePdf() {
+        this.trackClickLink("federal_proof");
         this.retrieveAuthenticatedVaccineRecord({
             hdid: this.user.hdid,
         });
@@ -218,8 +228,14 @@ export default class HomeView extends Vue {
     }
 
     private handleClickHealthRecords(): void {
+        this.trackClickLink("all_records");
         this.clearFilter();
         this.$router.push({ path: "/timeline" });
+    }
+
+    private handleClickVaccineCard(): void {
+        this.trackClickLink("bc_vaccine_card");
+        this.$router.push({ path: "/covid19" });
     }
 
     private handleClickRemoveQuickLink(index: number): void {
@@ -233,6 +249,11 @@ export default class HomeView extends Vue {
         const entryTypes = quickLink.filter.modules
             .map((module) => module as EntryType)
             .filter((entryType) => entryType !== undefined);
+
+        if (entryTypes.length === 1) {
+            const linkType = entryTypeMap.get(entryTypes[0])?.eventName;
+            this.trackClickLink(linkType);
+        }
 
         const builder =
             TimelineFilterBuilder.create().withEntryTypes(entryTypes);
@@ -355,7 +376,7 @@ export default class HomeView extends Vue {
                 <hg-card-button
                     title="Health Records"
                     data-testid="health-records-card-btn"
-                    @click="handleClickHealthRecords"
+                    @click="handleClickHealthRecords()"
                 >
                     <template #icon>
                         <img
@@ -393,8 +414,8 @@ export default class HomeView extends Vue {
             <b-col v-if="showVaccineCardButton" class="p-3">
                 <hg-card-button
                     title="BC Vaccine Card"
-                    to="/covid19"
                     data-testid="bc-vaccine-card-btn"
+                    @click="handleClickVaccineCard()"
                 >
                     <template #icon>
                         <hg-icon


### PR DESCRIPTION
# Implements [AB#12709](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12709)

## Description

- Adds SnowPlow tracking for quick links and other cards on the home page
- Adds debugging statements for easier confirmation of SnowPlow events

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
