### PR TITLE
Change timeline card style when hovering AB#11681

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/entrycard.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/entrycard.vue
@@ -39,6 +39,13 @@ export default class EntrycardTimelineComponent extends Vue {
     private eventBus = EventBus;
     private detailsVisible = false;
 
+    private get isInteractive() {
+        return (
+            (!this.isMobileWidth && this.canShowDetails) ||
+            (this.isMobileWidth && !this.isMobileDetails)
+        );
+    }
+
     private get displayTitle(): string {
         if (this.title === "") {
             return this.entry.type.toString();
@@ -101,7 +108,10 @@ export default class EntrycardTimelineComponent extends Vue {
         <b-col class="timelineCard ml-0 ml-md-2">
             <b-row
                 class="entryHeading px-3 py-2"
-                :class="{ mobileDetail: isMobileDetails }"
+                :class="{
+                    mobileDetail: isMobileDetails,
+                    interactive: isInteractive,
+                }"
                 @click="handleCardClick()"
             >
                 <b-col class="leftPane">
@@ -112,11 +122,14 @@ export default class EntrycardTimelineComponent extends Vue {
                 <b-col class="entryTitleWrapper">
                     <b-row>
                         <b-col
-                            :data-testid="entry.type.toLowerCase() + 'Title'"
+                            :data-testid="`${entry.type.toLowerCase()}Title`"
                         >
-                            <span data-testid="entryCardDetailsTitle"
-                                ><strong>{{ displayTitle }}</strong></span
+                            <span
+                                data-testid="entryCardDetailsTitle"
+                                class="entry-title"
                             >
+                                <strong>{{ displayTitle }}</strong>
+                            </span>
                         </b-col>
                         <b-col cols="4" class="text-right">
                             <span
@@ -160,13 +173,13 @@ export default class EntrycardTimelineComponent extends Vue {
             </b-row>
             <b-collapse :id="'entryDetails-' + cardId" v-model="detailsVisible">
                 <b-row>
-                    <b-col class="leftPane d-none d-md-block"></b-col>
+                    <b-col class="leftPane d-none d-md-block" />
                     <b-col class="pb-1 pt-1 px-3">
-                        <slot name="details-body"></slot>
+                        <slot name="details-body" />
                     </b-col>
                 </b-row>
                 <b-row v-if="allowComment && isCommentEnabled">
-                    <b-col class="leftPane d-none d-md-block"></b-col>
+                    <b-col class="leftPane d-none d-md-block" />
                     <b-col class="pb-1 pt-1 px-3">
                         <CommentSection
                             :parent-entry="entry"
@@ -220,7 +233,22 @@ div[class*=" row"] {
 
 .entryHeading {
     background-color: $soft_background;
+
+    &.interactive {
+        &:hover,
+        &:active,
+        &:focus,
+        &:focus-visible {
+            background-color: #ebebeb;
+            cursor: pointer;
+
+            .entry-title {
+                text-decoration: underline;
+            }
+        }
+    }
 }
+
 .mobileDetail {
     background-color: white;
 }


### PR DESCRIPTION
# Implements [AB#11681](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11681)

## Description

- Applies style when hovering over a timeline card that can be expanded or collapsed via click
    - Background is darkened
    - Cursor is changed to pointer
    - Title is underlined

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

![image](https://user-images.githubusercontent.com/16570293/161169539-3d11ae5f-ad57-4165-8a0f-85e783db0104.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
