### PR TITLE
Add new annotations for AB#12779

### DIFF
--- a/Tools/BaseBuild/route.sh
+++ b/Tools/BaseBuild/route.sh
@@ -18,4 +18,7 @@ else
   echo Creating route with path $routePath and HTTP redirect set to $redirect
   oc create route edge "$route"-https --ca-cert="./caCertificate.pem" --cert="./wildcard.healthgateway.gov.bc.ca.pem" --key="./HealthGatewayPrivateKey.pem" --hostname="$env.healthgateway.gov.bc.ca" --path="$routePath" --service="$service" --insecure-policy="$redirect"
   oc annotate route "$route"-https haproxy.router.openshift.io/hsts_header="max-age=31536000;includeSubDomains;preload"
+  oc annotate route "$route"-https haproxy.router.openshift.io/balance="roundrobin"
+  oc annotate route "$route"-https haproxy.router.openshift.io/disable_cookies="true"
+  oc annotate route "$route"-https haproxy.router.openshift.io/timeout="60s"
 fi


### PR DESCRIPTION
# Fixes or Implements [AB#12779](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12779)

## Description

Adds the annotations to disable the route cookie, set a default timeout of 60 seconds, and balance requests round robin.
The annotations have been added in Dev, Test, and Production.
Mock will be done after.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
