### PR TITLE
Enable WASM Client to support appsetting stacking for AB#12882

### DIFF
--- a/Apps/Admin/Client/Admin.Client.csproj
+++ b/Apps/Admin/Client/Admin.Client.csproj
@@ -55,4 +55,18 @@
         <None Remove="Store\" />
         <None Remove="Theme\" />
     </ItemGroup>
+    <ItemGroup>
+      <Content Update="wwwroot\appsettings.hgdev.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Update="wwwroot\appsettings.hgmock.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Update="wwwroot\appsettings.hgpoc.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Update="wwwroot\appsettings.hgtest.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
 </Project>

--- a/Apps/Admin/Client/Admin.Client.csproj
+++ b/Apps/Admin/Client/Admin.Client.csproj
@@ -56,6 +56,12 @@
         <None Remove="Theme\" />
     </ItemGroup>
     <ItemGroup>
+      <Content Update="wwwroot\appsettings.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+      <Content Update="wwwroot\appsettings.Development.json">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>  
       <Content Update="wwwroot\appsettings.hgdev.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </Content>

--- a/Apps/Admin/Client/wwwroot/appsettings.hgdev.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.hgdev.json
@@ -7,6 +7,5 @@
     },
     "Oidc": {
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f"
-    },
-    "PrototypeFeaturesEnabled": true
+    }
 }

--- a/Apps/Admin/Client/wwwroot/appsettings.hgmock.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.hgmock.json
@@ -7,6 +7,5 @@
     },
     "Oidc": {
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f"
-    },
-    "PrototypeFeaturesEnabled": true
+    }
 }

--- a/Apps/Admin/Client/wwwroot/appsettings.hgpoc.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.hgpoc.json
@@ -7,6 +7,5 @@
     },
     "Oidc": {
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f"
-    },
-    "PrototypeFeaturesEnabled": true
+    }
 }

--- a/Apps/Admin/Client/wwwroot/appsettings.hgtest.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.hgtest.json
@@ -1,0 +1,5 @@
+{
+    "Oidc": {
+        "Authority": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f"
+    }
+}

--- a/Apps/Admin/Client/wwwroot/appsettings.json
+++ b/Apps/Admin/Client/wwwroot/appsettings.json
@@ -6,7 +6,7 @@
         }
     },
     "Oidc": {
-        "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f",
+        "Authority": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f",
         "ClientId": "hg-admin-blazor"
     },
     "Services": {

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -104,7 +104,7 @@ namespace HealthGateway.Admin.Server
             WebApplication app = builder.Build();
 
             HttpWeb.UseForwardHeaders(app, logger, configuration);
-            HttpWeb.UseHttp(app, logger, configuration, environment);
+            UseHttp(app, logger, configuration, environment);
             HttpWeb.UseContentSecurityPolicy(app, configuration);
             SwaggerDoc.UseSwagger(app, logger);
             Auth.UseAuth(app, logger);
@@ -125,6 +125,74 @@ namespace HealthGateway.Admin.Server
             app.MapFallbackToFile("index.html");
 
             await app.RunAsync().ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Configures the app to use http.
+        /// This is normally common code but the static files is changed here as per https://github.com/dotnet/aspnetcore/issues/25152 .
+        /// </summary>
+        /// <param name="app">The application builder provider.</param>
+        /// <param name="logger">The logger to use.</param>
+        /// <param name="configuration">The configuration to use.</param>
+        /// <param name="environment">The environment to use.</param>
+        public static void UseHttp(IApplicationBuilder app, ILogger logger, IConfiguration configuration, IWebHostEnvironment environment)
+        {
+            if (environment.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                OnPrepareResponse = context =>
+                {
+                    if (context.File.Name == "service-worker-assets.js")
+                    {
+                        context.Context.Response.Headers.Add("Cache-Control", "no-cache, no-store");
+                        context.Context.Response.Headers.Add("Expires", "-1");
+                    }
+
+                    if (context.File.Name == "blazor.boot.json")
+                    {
+                        if (context.Context.Response.Headers.ContainsKey("blazor-environment"))
+                        {
+                            context.Context.Response.Headers.Remove("blazor-environment");
+                        }
+
+                        context.Context.Response.Headers.Add("blazor-environment", environment.EnvironmentName);
+                    }
+                },
+            });
+            app.UseRouting();
+
+            // Enable health endpoint for readiness probe
+            app.UseHealthChecks("/health");
+
+            // Enable CORS
+            string enableCors = configuration.GetValue("AllowOrigins", string.Empty);
+            if (!string.IsNullOrEmpty(enableCors))
+            {
+                app.UseCors(builder =>
+                {
+                    builder
+                        .WithOrigins(enableCors)
+                        .AllowAnyHeader()
+                        .AllowAnyMethod();
+                });
+            }
+
+            app.UseResponseCompression();
+
+            // Setup response secure headers
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                context.Response.Headers.Add("X-Xss-Protection", "1; mode=block");
+                await next().ConfigureAwait(true);
+            });
+
+            // Enable Cache control and set defaults
+            HttpWeb.UseResponseCaching(app, logger);
         }
 
         private static void RegisterRefitClients(IServiceCollection services, IConfiguration configuration)

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -9,9 +9,6 @@
         "ClientId": "healthgateway-admin-local",
         "RequireHttpsMetadata": "false"
     },
-    "SwaggerSettings": {
-        "RoutePrefix": "swagger"
-    },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -11,7 +11,7 @@
         "RoutePrefix": "swagger"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
         "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
     },

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -7,9 +7,6 @@
     "OpenIdConnect": {
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f",
     },
-    "SwaggerSettings": {
-        "RoutePrefix": "swagger"
-    },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -11,7 +11,7 @@
         "RoutePrefix": "swagger"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
         "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
     },

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -7,9 +7,6 @@
     "OpenIdConnect": {
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f",
     },
-    "SwaggerSettings": {
-        "RoutePrefix": "swagger"
-    },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -1,4 +1,9 @@
 {
+    "ContentSecurityPolicy": {
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/",
+        "FrameSource": "'self' https://test.oidc.gov.bc.ca/",
+        "FrameAncestors": "'self' https://test.oidc.gov.bc.ca/"
+    },
     "PatientService": {
         "ClientRegistry": {
             "ServiceUrl": "https://hiat2.hcim.ehealth.gov.bc.ca/HCIM.HIALServices.Portal/QUPA_AR101102.asmx",

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -1,4 +1,12 @@
 {
+    "Logging": {
+        "LogLevel": {
+            "HealthGateway": "Debug"
+        }
+    },
+    "OpenIdConnect": {
+        "Authority": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f"
+    },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/",
         "FrameSource": "'self' https://test.oidc.gov.bc.ca/",

--- a/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
@@ -231,7 +231,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// </summary>
         /// <param name="app">The application build provider.</param>
         /// <param name="logger">The logger to use.</param>
-        private static void UseResponseCaching(IApplicationBuilder app, ILogger logger)
+        public static void UseResponseCaching(IApplicationBuilder app, ILogger logger)
         {
             logger.LogDebug("Setting up Response Cache");
             app.UseResponseCaching();

--- a/Build/hg-steps-template.yaml
+++ b/Build/hg-steps-template.yaml
@@ -120,7 +120,7 @@ steps:
       command: "publish"
       publishWebProjects: false
       projects: "$(App.Home)/Server"
-      arguments: "-o $(Build.BinariesDirectory)"
+      arguments: "-c Release -o $(Build.BinariesDirectory)"
       zipAfterPublish: false
 
   - task: Docker@2


### PR DESCRIPTION
# Fixes or Implements [AB#12882](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12882)

## Description

Added configuration files for all HG environments for Blazor Admin Client and Server.
Added fix code to add Blazor-Environment header to blazor.boot.json and no cache on the service worker.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

No

### Browsers Tested

-   [ X] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
