### PR TITLE
Add functional test for device previews on landing page AB#12848

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/pages/LandingPage.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/LandingPage.js
@@ -1,6 +1,5 @@
 describe("Landing Page", () => {
     beforeEach(() => {
-        cy.enableModules(["VaccinationStatus"]);
         cy.visit("/");
     });
 
@@ -21,6 +20,79 @@ describe("Landing Page", () => {
             .parent()
             .should("have.attr", "href", "/login")
             .contains("Log In");
+    });
+
+    it("Device Previews", () => {
+        cy.log("Laptop preview should be displayed by default");
+        cy.get("[data-testid=preview-device-button-laptop]").should(
+            "be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-tablet]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-smartphone]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-image-laptop]").should("be.visible");
+        cy.get("[data-testid=preview-image-tablet]").should("not.be.visible");
+        cy.get("[data-testid=preview-image-smartphone]").should(
+            "not.be.visible"
+        );
+
+        cy.log(
+            "Tablet preview button should switch the displayed image and enabled buttons"
+        );
+        cy.get("[data-testid=preview-device-button-tablet]").click();
+        cy.get("[data-testid=preview-device-button-laptop]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-tablet]").should(
+            "be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-smartphone]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-image-laptop]").should("not.be.visible");
+        cy.get("[data-testid=preview-image-tablet]").should("be.visible");
+        cy.get("[data-testid=preview-image-smartphone]").should(
+            "not.be.visible"
+        );
+
+        cy.log(
+            "Smartphone preview button should switch the displayed image and enabled buttons"
+        );
+        cy.get("[data-testid=preview-device-button-smartphone]").click();
+        cy.get("[data-testid=preview-device-button-laptop]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-tablet]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-smartphone]").should(
+            "be.disabled"
+        );
+        cy.get("[data-testid=preview-image-laptop]").should("not.be.visible");
+        cy.get("[data-testid=preview-image-tablet]").should("not.be.visible");
+        cy.get("[data-testid=preview-image-smartphone]").should("be.visible");
+
+        cy.log(
+            "Laptop preview button should switch the displayed image and enabled buttons"
+        );
+        cy.get("[data-testid=preview-device-button-laptop]").click();
+        cy.get("[data-testid=preview-device-button-laptop]").should(
+            "be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-tablet]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-device-button-smartphone]").should(
+            "not.be.disabled"
+        );
+        cy.get("[data-testid=preview-image-laptop]").should("be.visible");
+        cy.get("[data-testid=preview-image-tablet]").should("not.be.visible");
+        cy.get("[data-testid=preview-image-smartphone]").should(
+            "not.be.visible"
+        );
     });
 
     it("Offline", () => {


### PR DESCRIPTION
# Implements [AB#12848](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12848)

## Description

- Adds new functional test for landing page functionality
- Removes enabling of vaccination status module in landing page tests since banner has been removed

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
