### PR TITLE
Cleanup and use only displayable HDIDs for AB#13046

### DIFF
--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -74,6 +74,7 @@ namespace HealthGateway.CommonTests.Delegates
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6",
                             extension = expectedHdId,
+                            displayable = true,
                         },
                     },
                 addr = new AD[]
@@ -382,6 +383,7 @@ namespace HealthGateway.CommonTests.Delegates
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6",
                             extension = expectedHdId,
+                            displayable = true,
                         },
                     },
                 identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
@@ -505,6 +507,7 @@ namespace HealthGateway.CommonTests.Delegates
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6",
                             extension = expectedHdId,
+                            displayable = true,
                         },
                     },
                 identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()


### PR DESCRIPTION
# Fixes or Implements [AB#13046](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13046)

## Description

Apparently multiple HDIDs can be returned when a merge occurs and we should be pulling the one that is displayable.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
