### PR TITLE
Display status on lab result timeline header AB#13044

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -113,9 +113,9 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
         :has-attachment="entry.reportAvailable"
     >
         <div slot="header-description">
-            <span>Number of Tests: </span>
-            <strong data-testid="laboratory-header-result-count">
-                {{ entry.tests.length }}
+            <span>Order Status: </span>
+            <strong data-testid="laboratory-header-order-status">
+                {{ entry.orderStatus }}
             </strong>
         </div>
         <div slot="details-body">

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
@@ -8,6 +8,7 @@ const resultOutOfRange = "Out of Range";
 const resultInRange = "In Range";
 const statusCancelled = "Cancelled";
 const statusCompleted = "Completed";
+const statusPending = "Pending";
 
 // The laboratory order timeline entry model
 export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
@@ -18,7 +19,7 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
     public timelineDateTime: DateWrapper;
     public commonName: string;
     public orderingProvider: string;
-    public testStatus: string;
+    public orderStatus: string;
     public reportAvailable: boolean;
     public downloadLabel: string | null = null;
 
@@ -58,7 +59,23 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
         this.reportingLab = model.reportingSource;
 
         this.reportId = model.reportId;
-        this.testStatus = model.testStatus;
+
+        switch (model.testStatus.toLowerCase()) {
+            case "held":
+            case "partial":
+            case "pending":
+                this.orderStatus = statusPending;
+                break;
+            case "completed":
+                this.orderStatus = statusCompleted;
+                break;
+            case "cancelled":
+                this.orderStatus = statusCancelled;
+                break;
+            default:
+                this.orderStatus = model.testStatus;
+                break;
+        }
 
         this.tests = [];
         model.laboratoryTests.forEach((test) => {
@@ -68,7 +85,7 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
         this.sortResults();
 
         this.downloadLabel = "Incomplete";
-        if (this.testStatus === statusCompleted) {
+        if (this.orderStatus === statusCompleted) {
             this.downloadLabel = "Final";
         }
 

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/laboratoryOrder.js
@@ -21,7 +21,7 @@ describe("Laboratory Orders", () => {
 
         cy.get("[data-testid=backBtn]").should("be.visible");
         cy.get("[data-testid=entryCardDetailsTitle]").should("be.visible");
-        cy.get("[data-testid=laboratory-header-result-count").should(
+        cy.get("[data-testid=laboratory-header-order-status").should(
             "be.visible"
         );
         cy.get("[data-testid=laboratory-collection-date]").should("be.visible");

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -24,7 +24,7 @@ describe("Laboratory Orders", () => {
 
         cy.get("[data-testid=backBtn]").should("be.visible");
         cy.get("[data-testid=entryCardDetailsTitle]").should("be.visible");
-        cy.get("[data-testid=laboratory-header-result-count").should(
+        cy.get("[data-testid=laboratory-header-order-status").should(
             "be.visible"
         );
         cy.get("[data-testid=laboratory-collection-date]").should("be.visible");


### PR DESCRIPTION
# Implements [AB#13044](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13044)

## Description

Replaces the "Number of Tests" label on the timeline card header for lab results with "Order Status", which is a mapping of the testStatus values.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

![image](https://user-images.githubusercontent.com/16570293/167498442-0d494102-fd4e-4412-8535-d7128b9eceb6.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
