### PR TITLE
Update PDF button display for "Cancelled" test

### DIFF
--- a/Apps/Laboratory/src/Models/LaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrder.cs
@@ -143,7 +143,7 @@ public class LaboratoryOrder
             },
             DownloadLabel = model.PlisTestStatus switch
             {
-                "Completed" or "Corrected" => "Final",
+                "Completed" or "Corrected" or "Completed w/Modification" => "Final",
                 _ => "Incomplete",
             },
             ReportAvailable = model.PdfReportAvailable,


### PR DESCRIPTION
# Fixes or Implements [AB#13174](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13174)

## Description

Add logic to display "Final" on pdf button (link) for order status of "Completed w/Modification", which is a result of one of many tests being cancelled.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
