### PR TITLE
Move PrimitiveRequestResult to Common.Data.ViewModels for AB#13189.

### DIFF
--- a/Apps/CommonData/src/ViewModels/PrimitiveRequestResult.cs
+++ b/Apps/CommonData/src/ViewModels/PrimitiveRequestResult.cs
@@ -13,11 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.Common.Models
+namespace HealthGateway.Common.Data.ViewModels
 {
     using System.Text.Json.Serialization;
     using HealthGateway.Common.Data.Constants;
-    using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
     /// Class that represents the result of a request with a primitive values.

--- a/Apps/GatewayApi/src/Services/IUserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/IUserEmailService.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.GatewayApi.Services
 {
     using System;
-    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
     /// The User Email service.

--- a/Apps/GatewayApi/src/Services/IUserSMSService.cs
+++ b/Apps/GatewayApi/src/Services/IUserSMSService.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.GatewayApi.Services
 {
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
     /// The User SMS service.

--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using Microsoft.AspNetCore.Http;

--- a/Apps/GatewayApi/src/Services/UserSMSService.cs
+++ b/Apps/GatewayApi/src/Services/UserSMSService.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.GatewayApi.Services
     using System.Text.RegularExpressions;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSMSServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSMSServiceTests.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApi.Test.Services
     using System;
     using System.Linq;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Constants;

--- a/Apps/WebClient/src/Server/Services/IUserEmailService.cs
+++ b/Apps/WebClient/src/Server/Services/IUserEmailService.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.WebClient.Services
 {
     using System;
-    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
     /// The User Email service.

--- a/Apps/WebClient/src/Server/Services/IUserSMSService.cs
+++ b/Apps/WebClient/src/Server/Services/IUserSMSService.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.WebClient.Services
 {
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
     /// The User SMS service.

--- a/Apps/WebClient/src/Server/Services/UserEmailService.cs
+++ b/Apps/WebClient/src/Server/Services/UserEmailService.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.WebClient.Services
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using Microsoft.AspNetCore.Http;

--- a/Apps/WebClient/src/Server/Services/UserSMSService.cs
+++ b/Apps/WebClient/src/Server/Services/UserSMSService.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.WebClient.Services
     using System.Text.RegularExpressions;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;

--- a/Apps/WebClient/test/unit/Services.Test/UserSMSServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services.Test/UserSMSServiceTests.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.WebClient.Test.Services
     using System;
     using System.Linq;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Constants;


### PR DESCRIPTION
# Fixes or Implements [AB#13189](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13189)

## Description

Moved PrimitiveRequestResult.cs to Common.Data.ViewModels so that it can be accessed from Blazor Admin. Also, removed unnecessary imports.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
