### PR TITLE
Add new endpoint for updating the accepted terms for AB#13237

### DIFF
--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -33,7 +33,8 @@ namespace HealthGateway.Database.Delegates
         DBResult<UserProfile> InsertUserProfile(UserProfile profile);
 
         /// <summary>
-        /// Updates the UserProfile object in the DB.
+        /// Updates select attributes of the UserProfile object in the DB.
+        /// This method re-reads the UserProfile to ensure all other attributes are not overwritten.
         /// Version must be set or a Concurrency exception will occur.
         /// UpdatedDateTime will overridden by our framework.
         /// </summary>
@@ -41,6 +42,16 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">if true the transaction is persisted immediately.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
         DBResult<UserProfile> Update(UserProfile profile, bool commit = true);
+
+        /// <summary>
+        /// Updates the specified UserProfile object in the DB.
+        /// Version must be set or a Concurrency exception will occur.
+        /// UpdatedDateTime will overridden by our framework.
+        /// </summary>
+        /// <param name="profile">The profile to update.</param>
+        /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <returns>A DB result which encapsulates the return object and status.</returns>
+        public DBResult<UserProfile> UpdateComplete(UserProfile profile, bool commit = true);
 
         /// <summary>
         /// Fetches the UserProfile from the database.

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -348,5 +348,22 @@ namespace HealthGateway.GatewayApi.Controllers
             userPreferenceModel.UpdatedBy = hdid;
             return this.userProfileService.CreateUserPreference(userPreferenceModel);
         }
+
+        /// <summary>
+        /// Updates the terms of service the user has agreed to.
+        /// </summary>
+        /// <returns>The user profile model wrapped in a request result.</returns>
+        /// <param name="hdid">The user hdid.</param>
+        /// <param name="termsOfServiceId">The id of the terms of service to update for this user.</param>
+        /// <response code="200">Returns the user profile json.</response>
+        /// <response code="401">the client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
+        [HttpPut]
+        [Route("{hdid}/acceptedterms")]
+        [Authorize(Policy = UserProfilePolicy.Write)]
+        public RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, [FromBody] Guid termsOfServiceId)
+        {
+            return this.userProfileService.UpdateAcceptedTerms(hdid, termsOfServiceId);
+        }
     }
 }

--- a/Apps/GatewayApi/src/Services/IUserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileService.cs
@@ -94,5 +94,13 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="hdid">The requested user hdid.</param>
         /// <returns>A boolean result.</returns>
         Task<PrimitiveRequestResult<bool>> ValidateMinimumAge(string hdid);
+
+        /// <summary>
+        /// Updates the user profile and sets the acceepted terms of service to the supplied value.
+        /// </summary>
+        /// <param name="hdid">The users hdid.</param>
+        /// <param name="termsOfServiceId">The terms of service id accepted.</param>
+        /// <returns>A user profile model wrapped in a RequestResult.</returns>
+        RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, Guid termsOfServiceId);
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -439,6 +439,31 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             Assert.Equal(false, result?.ResourcePayload);
         }
 
+        /// <summary>
+        /// Validates the controller update terms of service method.
+        /// </summary>
+        [Fact]
+        public void ShouldUpdateTerms()
+        {
+            RequestResult<UserProfileModel> expected = new()
+            {
+                ResultStatus = ResultType.Success,
+            };
+            Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
+            Mock<IUserProfileService> userProfileServiceMock = new();
+            userProfileServiceMock.Setup(s => s.UpdateAcceptedTerms(this.hdid, It.IsAny<Guid>())).Returns(expected);
+
+            UserProfileController controller = new(
+                new Mock<ILogger<UserProfileController>>().Object,
+                userProfileServiceMock.Object,
+                httpContextAccessorMock.Object,
+                new Mock<IUserEmailService>().Object,
+                new Mock<IUserSMSService>().Object);
+
+            RequestResult<UserProfileModel> actualResult = controller.UpdateAcceptedTerms(this.hdid, Guid.Empty);
+            expected.ShouldDeepEqual(actualResult);
+        }
+
         private static Mock<IHttpContextAccessor> CreateValidHttpContext(string token, string userId, string hdid)
         {
             IHeaderDictionary headerDictionary = new HeaderDictionary


### PR DESCRIPTION
# Fixes or Implements [AB#13237](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13237)

## Description

A new controller method and associated logic to update a user profiles terms of service id.
This method forces the update to be the inputted terms of service id.
A new DB Delegate method was required as the other Update re-reads the record and supports only a few data attributes.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

No

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
