### PR TITLE
Fix date string comparisons in unit tests AB#13239

### DIFF
--- a/Apps/Common/test/unit/Utils/ClaimsPrincipalReaderTests.cs
+++ b/Apps/Common/test/unit/Utils/ClaimsPrincipalReaderTests.cs
@@ -46,7 +46,7 @@ public class ClaimsPrincipalReaderTests
         DateTime jwtAuthDateTime = ClaimsPrincipalReader.GetAuthDateTime(principal);
 
         // Assert
-        Assert.Equal(expected, jwtAuthDateTime.ToString(CultureInfo.CurrentCulture));
+        Assert.Equal(expected, jwtAuthDateTime.ToString(CultureInfo.InvariantCulture));
     }
 
     /// <summary>
@@ -69,7 +69,7 @@ public class ClaimsPrincipalReaderTests
         DateTime jwtAuthDateTime = ClaimsPrincipalReader.GetAuthDateTime(principal);
 
         // Assert
-        Assert.Equal(expected, jwtAuthDateTime.ToString(CultureInfo.CurrentCulture));
+        Assert.Equal(expected, jwtAuthDateTime.ToString(CultureInfo.InvariantCulture));
     }
 
     /// <summary>


### PR DESCRIPTION
# Fixes [AB#13239](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13239)

## Description

Swaps to using the InvariantCulture when formatting dates in ClaimsPrincipalReaderTests to avoid failures on certain systems.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
