### PR TITLE
Functional Test Seed Data - update terms of service id to latest for AB#13243.

### DIFF
--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -8,6 +8,7 @@ TRUNCATE gateway."UserPreference" CASCADE;
 TRUNCATE gateway."Comment" CASCADE;
 TRUNCATE gateway."MessagingVerification" CASCADE;
 TRUNCATE gateway."Note" CASCADE;
+TRUNCATE gateway."GenericCache" CASCADE;
 
 /* Registered HealthGateway User */
 INSERT INTO gateway."UserProfile"(
@@ -29,7 +30,7 @@ VALUES (
 	current_timestamp, 
 	'System', 
 	current_timestamp, 
-	'c99fd839-b4a2-40f9-b103-529efccd0dcd', 
+	'eafeee76-8a64-49ee-81ba-ddfe2c01deb8', 
 	null,
 	null,
 	null,
@@ -58,7 +59,7 @@ VALUES (
 	current_timestamp, 
 	'System', 
 	current_timestamp, 
-	'c99fd839-b4a2-40f9-b103-529efccd0dcd', 
+	'eafeee76-8a64-49ee-81ba-ddfe2c01deb8', 
 	null,
 	null,
 	null,
@@ -87,7 +88,7 @@ VALUES (
 	current_timestamp, 
 	'System', 
 	current_timestamp, 
-	'c99fd839-b4a2-40f9-b103-529efccd0dcd', 
+	'eafeee76-8a64-49ee-81ba-ddfe2c01deb8', 
 	null,
 	null,
 	null,
@@ -116,7 +117,7 @@ VALUES (
 	current_timestamp, 
 	'System', 
 	current_timestamp, 
-	'c99fd839-b4a2-40f9-b103-529efccd0dcd', 
+	'eafeee76-8a64-49ee-81ba-ddfe2c01deb8', 
 	null,
 	null,
 	null,
@@ -145,7 +146,7 @@ VALUES (
 	current_timestamp, 
 	'System', 
 	current_timestamp, 
-	'c99fd839-b4a2-40f9-b103-529efccd0dcd', 
+	'eafeee76-8a64-49ee-81ba-ddfe2c01deb8', 
 	null,
 	null,
 	null,


### PR DESCRIPTION
# Fixes or Implements [AB#13243](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13243)

## Description

Update TermsOfServiceId to latest for UserProfile to avoid having 'Accept Terms of Service' from appearing.  Existing functional tests have not been coded to accept terms of service.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
