### PR TITLE
Increase Common Data unit test coverage for AB#13217

### DIFF
--- a/Apps/CommonData/src/ErrorHandling/ActionType.cs
+++ b/Apps/CommonData/src/ErrorHandling/ActionType.cs
@@ -15,9 +15,12 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Data.Models.ErrorHandling
 {
+    using System.Diagnostics.CodeAnalysis;
+
     /// <summary>
     /// Enumerator that defines the different types of required actions.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class ActionType
     {
         private ActionType(string value)

--- a/Apps/CommonData/src/Models/AuditableEntity.cs
+++ b/Apps/CommonData/src/Models/AuditableEntity.cs
@@ -18,12 +18,14 @@ namespace HealthGateway.Common.Data.Models
     using System;
     using System.ComponentModel.DataAnnotations;
     using System.ComponentModel.DataAnnotations.Schema;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.Serialization;
     using HealthGateway.Common.Data.Constants;
 
     /// <summary>
     /// Base class for all DB entities to ensure audit data is saved.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public abstract class AuditableEntity : IAuditable, IConcurrencyGuard
     {
         /// <summary>

--- a/Apps/CommonData/src/Models/Email.cs
+++ b/Apps/CommonData/src/Models/Email.cs
@@ -18,11 +18,13 @@ namespace HealthGateway.Common.Data.Models
     using System;
     using System.ComponentModel.DataAnnotations;
     using System.ComponentModel.DataAnnotations.Schema;
+    using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.Data.Constants;
 
     /// <summary>
     /// Represents an Email to send from the system.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class Email : AuditableEntity
     {
         /// <summary>

--- a/Apps/CommonData/src/Models/IConcurrencyGuard.cs
+++ b/Apps/CommonData/src/Models/IConcurrencyGuard.cs
@@ -15,8 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Common.Data.Models
 {
-    using System;
-
     /// <summary>
     /// Interface representing standard optimistic locking for all DB entities.
     /// </summary>

--- a/Apps/CommonData/src/Models/MessagingVerification.cs
+++ b/Apps/CommonData/src/Models/MessagingVerification.cs
@@ -18,10 +18,12 @@ namespace HealthGateway.Common.Data.Models
     using System;
     using System.ComponentModel.DataAnnotations;
     using System.ComponentModel.DataAnnotations.Schema;
+    using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.Data.Constants;
 
 #pragma warning disable CS1591 // self explanatory simple model
 #pragma warning disable SA1600 // self explanatory simple model
+    [ExcludeFromCodeCoverage]
     public class MessagingVerification : AuditableEntity
     {
         /// <summary>

--- a/Apps/CommonData/src/Utils/DateFormatter.cs
+++ b/Apps/CommonData/src/Utils/DateFormatter.cs
@@ -13,15 +13,16 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-
 namespace HealthGateway.Common.Data.Utils;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 /// <summary>
 /// Formats dates and times for display.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public static class DateFormatter
 {
     /// <summary>

--- a/Apps/CommonData/src/Utils/StringManipulator.cs
+++ b/Apps/CommonData/src/Utils/StringManipulator.cs
@@ -72,12 +72,7 @@ namespace HealthGateway.Common.Data.Utils
         /// <returns>The string with whitespace removed.</returns>
         public static string? StripWhitespace(string? target)
         {
-            if (target is null)
-            {
-                return target;
-            }
-
-            return WhitespaceRegex.Replace(target, string.Empty);
+            return target is null ? target : WhitespaceRegex.Replace(target, string.Empty);
         }
     }
 }

--- a/Apps/CommonData/src/ViewModels/MessagingVerificationModel.cs
+++ b/Apps/CommonData/src/ViewModels/MessagingVerificationModel.cs
@@ -16,11 +16,13 @@
 namespace HealthGateway.Common.Data.ViewModels
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
 
 #pragma warning disable CS1591 // self explanatory simple model
 #pragma warning disable SA1600 // self explanatory simple model
+    [ExcludeFromCodeCoverage]
     public class MessagingVerificationModel
     {
         /// <summary>

--- a/Apps/CommonData/src/ViewModels/RequestResult.cs
+++ b/Apps/CommonData/src/ViewModels/RequestResult.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Data.ViewModels
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
     using HealthGateway.Common.Data.Constants;
 
@@ -22,6 +23,7 @@ namespace HealthGateway.Common.Data.ViewModels
     /// Class that represents the result of a request. Contains members for handling pagination and error resolution.
     /// </summary>
     /// <typeparam name="T">The payload type.</typeparam>
+    [ExcludeFromCodeCoverage]
     public class RequestResult<T>
         where T : class
     {

--- a/Apps/CommonData/src/ViewModels/RequestResultError.cs
+++ b/Apps/CommonData/src/ViewModels/RequestResultError.cs
@@ -16,12 +16,14 @@
 namespace HealthGateway.Common.Data.ViewModels
 {
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
     using HealthGateway.Common.Data.Models.ErrorHandling;
 
     /// <summary>
     /// The RequestResultError model.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public class RequestResultError
     {
         /// <summary>

--- a/Apps/CommonData/test/unit/Utils/StringManipulatorTests.cs
+++ b/Apps/CommonData/test/unit/Utils/StringManipulatorTests.cs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.CommonTests.Utils
+namespace HealthGateway.Common.Data.Tests.Utils
 {
     using System.Collections.Generic;
     using HealthGateway.Common.Data.Utils;
@@ -73,6 +73,27 @@ namespace HealthGateway.CommonTests.Utils
             string? result = StringManipulator.Replace(null, "KEY", "VALUE");
 
             Assert.True(result is null);
+        }
+
+        /// <summary>
+        /// Strip - Whitespace, validates white space removed.
+        /// </summary>
+        [Fact]
+        public void ShouldStripWhitespace()
+        {
+            string clean = " e m p t y  s t r i n g ";
+            string expected = "emptystring";
+            string? actual = StringManipulator.StripWhitespace(clean);
+            Assert.Equal(actual, expected);
+        }
+
+        /// <summary>
+        /// Strip - Whitespace, validates null is returned if null passed in.
+        /// </summary>
+        [Fact]
+        public void ShouldStripWhitespaceNull()
+        {
+            Assert.True(StringManipulator.StripWhitespace(null) is null);
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#13217](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13217)

## Description

Increase Code Coverage for Common Data

- Move StringManiuplator Tests from Common, Cleanup code and add missing whitespace tests

- Ignore things we're not interested in

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [X] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

YES | NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
