### PR TITLE
Fixed bug#13254

### DIFF
--- a/Apps/Common/test/unit/Utils/AssetReaderTests.cs
+++ b/Apps/Common/test/unit/Utils/AssetReaderTests.cs
@@ -45,7 +45,7 @@ namespace HealthGateway.CommonTests.Utils
         [Fact]
         public void ShouldReadMockAssetNotEncoded()
         {
-            string mockAssetContent = "Mock Data";
+            string mockAssetContent = "Mock Data\n";
 
             string? actualResult = AssetReader.Read("HealthGateway.CommonTests.MockAsset.txt");
 
@@ -58,7 +58,7 @@ namespace HealthGateway.CommonTests.Utils
         [Fact]
         public void ShouldReadMockAssetEncoded()
         {
-            string mockAssetContent = "Mock Data";
+            string mockAssetContent = "Mock Data\n";
             byte[] mockAssetBytes = Encoding.ASCII.GetBytes(mockAssetContent);
             string mockAssetContentEncoded = Convert.ToBase64String(mockAssetBytes);
 


### PR DESCRIPTION
Fixed bug in AssetReaderTests.cs where the txt file has an added new line character that was unexpected and can't be removed. For bug#13254.

# Fixes or Implements bug#13254

## Description

Fixed test issue with txt file having an added new line so the \n character was present.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
