### PR TITLE
Fix HasTermsOfServiceUpdated not being populated AB#13273

### DIFF
--- a/Apps/GatewayApi/src/Models/UserProfileModel.cs
+++ b/Apps/GatewayApi/src/Models/UserProfileModel.cs
@@ -110,8 +110,9 @@ namespace HealthGateway.GatewayApi.Models
         /// Constructs a UserProfile model from a UserProfile database model.
         /// </summary>
         /// <param name="model">The user profile database model.</param>
+        /// <param name="latestTermsOfServiceId">The GUID corresponding to the most recent terms of service.</param>
         /// <returns>The user profile model.</returns>
-        public static UserProfileModel CreateFromDbModel(UserProfile model)
+        public static UserProfileModel CreateFromDbModel(UserProfile model, Guid? latestTermsOfServiceId)
         {
             return new UserProfileModel()
             {
@@ -124,6 +125,7 @@ namespace HealthGateway.GatewayApi.Models
                 LastLoginDateTime = model.LastLoginDateTime,
                 ClosedDateTime = model.ClosedDateTime,
                 AcceptedTermsOfService = model.TermsOfServiceId != Guid.Empty,
+                HasTermsOfServiceUpdated = model.TermsOfServiceId != latestTermsOfServiceId,
             };
         }
     }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -92,7 +92,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
 
             RequestResult<UserProfileModel> expected = new()
             {
-                ResourcePayload = UserProfileModel.CreateFromDbModel(userProfile),
+                ResourcePayload = UserProfileModel.CreateFromDbModel(userProfile, userProfile.TermsOfServiceId),
                 ResultStatus = ResultType.Success,
             };
 
@@ -134,7 +134,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
 
             RequestResult<UserProfileModel> expected = new()
             {
-                ResourcePayload = UserProfileModel.CreateFromDbModel(userProfile),
+                ResourcePayload = UserProfileModel.CreateFromDbModel(userProfile, userProfile.TermsOfServiceId),
                 ResultStatus = ResultType.Success,
             };
 
@@ -558,7 +558,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
 
             return new RequestResult<UserProfileModel>
             {
-                ResourcePayload = UserProfileModel.CreateFromDbModel(userProfile),
+                ResourcePayload = UserProfileModel.CreateFromDbModel(userProfile, userProfile.TermsOfServiceId),
                 ResultStatus = resultType,
             };
         }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -122,8 +122,7 @@ namespace HealthGateway.GatewayApi.Test.Services
                 Status = DBStatusCode.Read,
             };
 
-            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
-            expected.HasTermsOfServiceUpdated = true;
+            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile, Guid.Empty);
 
             IUserProfileService service = new UserProfileServiceMock(this.hdid, dBStatus, userProfile, userProfileDBResult, readResult, termsOfService, GetIConfigurationRoot(null), userProfileHistoryDBResult).UserProfileServiceMockInstance();
 
@@ -281,7 +280,7 @@ namespace HealthGateway.GatewayApi.Test.Services
                 Status = DBStatusCode.Created,
             };
 
-            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile);
+            UserProfileModel expected = UserProfileModel.CreateFromDbModel(userProfile, userProfile.TermsOfServiceId);
 
             Dictionary<string, string> localConfig = new()
             {


### PR DESCRIPTION
# Fixes [AB#13273](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13273)

## Description

Ensures the HasTermsOfServiceUpdated property on UserProfileModel is populated correctly whenever it is returned to the front-end.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [x] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [ ] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
