### PR TITLE
Add PHN column to admin support table AB#13280

### DIFF
--- a/Apps/Admin/Client/Pages/Support.razor
+++ b/Apps/Admin/Client/Pages/Support.razor
@@ -35,6 +35,7 @@
     <MudTable Class="mt-3" Items="MessagingVerificationRows" Loading="MessagingVerificationsLoading" Breakpoint="Breakpoint.Md" HorizontalScrollbar="true" Striped="true" Dense="true">
         <HeaderContent>
             <MudTh><MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.Hdid)">HDID</MudTableSortLabel></MudTh>
+            <MudTh><MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.PersonalHealthNumber)">PHN</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.EmailOrSms)">Email or SMS</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.Verified)">Verified</MudTableSortLabel></MudTh>
             <MudTh><MudTableSortLabel InitialDirection="SortDirection.Descending" SortBy="new Func<MessagingVerificationRow, object>(x => x.VerificationDate)">Verification Date</MudTableSortLabel></MudTh>
@@ -42,6 +43,7 @@
         </HeaderContent>
         <RowTemplate>
             <MudTd DataLabel="HDID">@context.Hdid</MudTd>
+            <MudTd DataLabel="PHN">@context.PersonalHealthNumber</MudTd>
             <MudTd DataLabel="Email or SMS">@context.EmailOrSms</MudTd>
             <MudTd DataLabel="Verified">@context.Verified</MudTd>
             <MudTd DataLabel="Verification Date">@context.VerificationDate</MudTd>

--- a/Apps/Admin/Client/Pages/Support.razor.cs
+++ b/Apps/Admin/Client/Pages/Support.razor.cs
@@ -104,6 +104,7 @@ namespace HealthGateway.Admin.Client.Pages
             public MessagingVerificationRow(MessagingVerificationModel model)
             {
                 this.Hdid = model.UserProfileId ?? string.Empty;
+                this.PersonalHealthNumber = model.PersonalHealthNumber ?? string.Empty;
                 this.EmailOrSms = model.VerificationType switch
                 {
                     MessagingVerificationType.Email => model.Email?.To ?? "N/A",
@@ -120,6 +121,8 @@ namespace HealthGateway.Admin.Client.Pages
             }
 
             public string Hdid { get; init; }
+
+            public string PersonalHealthNumber { get; init; }
 
             public string EmailOrSms { get; init; }
 


### PR DESCRIPTION
# Fixes [AB#13280](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13280)

## Description

Includes the PHN (when available) in the table on the support page.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

![image](https://user-images.githubusercontent.com/16570293/172264169-94903369-1f4f-43ba-bb03-a39cad1bb0fd.png)

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
