### PR TITLE
Fixed dashboard dates bug so dates reflected as PST AB#13275

### DIFF
--- a/Apps/Admin/Client/Pages/DashboardPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor.cs
@@ -155,7 +155,7 @@ public partial class DashboardPage : FluxorComponent
         }
     }
 
-    private int TimeOffset { get; set; } = (int)TimeZoneInfo.Local.GetUtcOffset(DateTime.Now).TotalMinutes * -1;
+    private int TimeOffset { get; set; } = (int)TimeZoneInfo.Local.GetUtcOffset(DateTime.Now).TotalMinutes;
 
     private int TotalRegisteredUsers => this.RegisteredUsersResult?.Result?.Sum(r => r.Value) ?? 0;
 

--- a/Apps/Admin/Server/Controllers/DashboardController.cs
+++ b/Apps/Admin/Server/Controllers/DashboardController.cs
@@ -45,7 +45,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Retrieves the count of registered users.
         /// </summary>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <returns>The count of registered users.</returns>
         /// <response code="200">Returns the count of registered users.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -60,7 +60,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Retrieves the count of logged in user in the last day.
         /// </summary>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <returns>The count of logged in users in the current day.</returns>
         /// <response code="200">Returns the list of user feedbacks.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -75,7 +75,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Retrieves the count of dependents.
         /// </summary>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <returns>The count of logged in users in the current day.</returns>
         /// <response code="200">Returns the list of user feedbacks.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -93,7 +93,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <param name="days">The number of unique days for evaluating a user.</param>
         /// <param name="startPeriod">The period start over which to evaluate the user.</param>
         /// <param name="endPeriod">The period end over which to evaluate the user.</param>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <returns>The count of recurrent users.</returns>
         /// <response code="200">Returns the list of user feedbacks.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -110,7 +110,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// </summary>
         /// <param name="startPeriod">The period start to calculate the summary.</param>
         /// <param name="endPeriod">The period end to calculate the summary.</param>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <returns>A dictionary pairing the ratings with the counts.</returns>
         /// <response code="200">Returns the ratings summary.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>

--- a/Apps/Admin/Server/Services/DashboardService.cs
+++ b/Apps/Admin/Server/Services/DashboardService.cs
@@ -64,7 +64,6 @@ namespace HealthGateway.Admin.Server.Services
         /// <inheritdoc />
         public IDictionary<DateTime, int> GetDailyRegisteredUsersCount(int timeOffset)
         {
-            // Javascript offset is positive # of minutes if the local timezone is behind UTC, and negative if it is ahead.
             TimeSpan ts = new(0, timeOffset, 0);
             return this.userProfileDelegate.GetDailyRegisteredUsersCount(ts);
         }
@@ -72,7 +71,6 @@ namespace HealthGateway.Admin.Server.Services
         /// <inheritdoc />
         public IDictionary<DateTime, int> GetDailyLoggedInUsersCount(int timeOffset)
         {
-            // Javascript offset is positive # of minutes if the local timezone is behind UTC, and negative if it is ahead.
             TimeSpan ts = new(0, timeOffset, 0);
             return this.userProfileDelegate.GetDailyLoggedInUsersCount(ts);
         }
@@ -80,7 +78,6 @@ namespace HealthGateway.Admin.Server.Services
         /// <inheritdoc />
         public IDictionary<DateTime, int> GetDailyDependentCount(int timeOffset)
         {
-            // Javascript offset is positive # of minutes if the local timezone is behind UTC, and negative if it is ahead.
             TimeSpan ts = new(0, timeOffset, 0);
             return this.dependentDelegate.GetDailyDependentCount(ts);
         }
@@ -88,7 +85,6 @@ namespace HealthGateway.Admin.Server.Services
         /// <inheritdoc />
         public int GetRecurrentUserCount(int dayCount, string startPeriod, string endPeriod, int timeOffset)
         {
-            // Javascript offset is positive # of minutes if the local timezone is behind UTC, and negative if it is ahead.
             TimeSpan ts = new(0, timeOffset, 0);
             DateTime startDate = DateTime.Parse(startPeriod, CultureInfo.InvariantCulture).Date.Add(ts);
             startDate = DateTime.SpecifyKind(startDate, DateTimeKind.Utc);


### PR DESCRIPTION
# Fixes or Implements [AB#13275](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13275)

## Description

Changed the TimeOffset calculation on DashboardPage to return the correct negative value.
Updated some comments to more accurately say what is happening from the controller level.

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [x] Not Required

### UI Changes

NO

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
