### PR TITLE
Remove redundant connection strings from Dev appsettings for AB#13294

### DIFF
--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -14,9 +14,6 @@
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
         "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "PatientService": {
         "ClientRegistry": {
             "ServiceUrl": "https://hiat2.hcim.ehealth.gov.bc.ca/HCIM.HIALServices.Portal/QUPA_AR101102.asmx",

--- a/Apps/AdminWebClient/src/appsettings.Development.json
+++ b/Apps/AdminWebClient/src/appsettings.Development.json
@@ -33,9 +33,6 @@
     "ServiceEndpoints": {
         "JobScheduler": "http://localhost:5005/"
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "ForwardProxies": {
         "Enabled": "false"
     },

--- a/Apps/DBMaintainer/DBMaintainer.csproj
+++ b/Apps/DBMaintainer/DBMaintainer.csproj
@@ -3,6 +3,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>HealthGateway.DBMaintainer</RootNamespace>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
+    <UserSecretsId>84e2fe9a-a1f5-4de7-bef6-4518a33fa8b9</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Database\**" />

--- a/Apps/DBMaintainer/appsettings.Development.json
+++ b/Apps/DBMaintainer/appsettings.Development.json
@@ -6,9 +6,6 @@
             "Microsoft": "Warning"
         }
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;Command Timeout=300"
-    },
     "FedApprovedDatabase": {
         "Url": "https://www.canada.ca/content/dam/hc-sc/documents/services/drug-product-database/allfiles_ap.zip",
         "TargetFolder": "Resources",

--- a/Apps/Encounter/src/appsettings.Development.json
+++ b/Apps/Encounter/src/appsettings.Development.json
@@ -18,9 +18,6 @@
     "Environment": {
         "EnableDebug": true
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "ODR": {
         "DynamicServiceLookup": "false",
         "BaseEndpoint": "https://dev-odrproxy.apps.silver.devops.gov.bc.ca/",

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -15,9 +15,6 @@
     "SwaggerSettings": {
         "RoutePrefix": "swagger"
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
         "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -18,9 +18,6 @@
     "Environment": {
         "EnableDebug": true
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },

--- a/Apps/JobScheduler/src/appsettings.Development.json
+++ b/Apps/JobScheduler/src/appsettings.Development.json
@@ -16,9 +16,6 @@
     "ForwardProxies": {
         "Enabled": "false"
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;Command Timeout=300"
-    },
     "Host": "http://localhost:5000",
     "Smtp": {
         "Host": "mail.shaw.ca",

--- a/Apps/Laboratory/src/appsettings.Development.json
+++ b/Apps/Laboratory/src/appsettings.Development.json
@@ -18,9 +18,6 @@
     "Environment": {
         "EnableDebug": true
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "Laboratory": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net",
         "BackOffMilliseconds": "1000"

--- a/Apps/Medication/src/appsettings.Development.json
+++ b/Apps/Medication/src/appsettings.Development.json
@@ -24,9 +24,6 @@
             }
         }
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "ODR": {
         "DynamicServiceLookup": "false",
         "BaseEndpoint": "https://dev-odrproxy.apps.silver.devops.gov.bc.ca/",

--- a/Apps/Patient/src/appsettings.Development.json
+++ b/Apps/Patient/src/appsettings.Development.json
@@ -24,9 +24,6 @@
             }
         }
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true

--- a/Apps/WebClient/src/appsettings.Development.json
+++ b/Apps/WebClient/src/appsettings.Development.json
@@ -43,9 +43,6 @@
         "Laboratory": "http://localhost:3004/",
         "Encounter": "http://localhost:3005/"
     },
-    "ConnectionStrings": {
-        "GatewayConnection": "Server=localhost;Port=5432;Database=gateway;User ID=gateway;Password=passw0rd;Integrated Security=true;Pooling=true;"
-    },
     "IdentityProviders": [
         {
             "id": "BCSC",


### PR DESCRIPTION
# Fixes or Implements AB#13294

## Description

Removes the Connection string configuration from each of the appsettings.Development.json files and replaces them with a single entry in the secrets.json file.

Add User Secrets to the DBMaintainer app

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [ ] Functional Tests Updated
-   [X] Not Required

### UI Changes

NO

### Browsers Tested

-   [ ] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
