### PR TITLE
Replace download button for lab reports AB#13248

### DIFF
--- a/Apps/Laboratory/src/Models/LaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrder.cs
@@ -99,12 +99,6 @@ public class LaboratoryOrder
     public string OrderStatus { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value for the download label.
-    /// </summary>
-    [JsonPropertyName("downloadLabel")]
-    public string DownloadLabel { get; set; } = string.Empty;
-
-    /// <summary>
     /// Gets or sets a value indicating whether report is available.
     /// </summary>
     [JsonPropertyName("reportAvailable")]
@@ -140,11 +134,6 @@ public class LaboratoryOrder
             {
                 "Held" or "Partial" or "Pending" => "Pending",
                 _ => model.PlisTestStatus,
-            },
-            DownloadLabel = model.PlisTestStatus switch
-            {
-                "Completed" or "Corrected" or "Completed w/Modification" => "Final",
-                _ => "Incomplete",
             },
             ReportAvailable = model.PdfReportAvailable,
         };

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -119,33 +119,6 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
             </strong>
         </div>
         <div slot="details-body">
-            <div
-                v-if="entry.reportAvailable"
-                data-testid="laboratory-report-available"
-                class="mt-2 mb-n1"
-            >
-                <b-spinner v-if="isLoadingDocument" class="mb-1" />
-                <span v-else data-testid="laboratoryReport">
-                    <strong class="align-bottom d-inline-block pb-1">
-                        Detailed Report:
-                    </strong>
-                    <hg-button
-                        data-testid="laboratory-report-download-btn"
-                        variant="link"
-                        class="p-1 ml-1"
-                        @click="showConfirmationModal()"
-                    >
-                        <hg-icon
-                            icon="download"
-                            size="medium"
-                            square
-                            aria-hidden="true"
-                            class="mr-1"
-                        />
-                        <span>{{ entry.downloadLabel }}</span>
-                    </hg-button>
-                </span>
-            </div>
             <div class="my-2">
                 <div data-testid="laboratory-collection-date">
                     <strong>Collection Date: </strong>
@@ -169,7 +142,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                     <span>{{ entry.reportingLab }}</span>
                 </div>
             </div>
-            <div class="my-2 mb-2">
+            <div class="my-2">
                 <div data-testid="reporting-lab-information-text">
                     <span
                         ><router-link to="/faq">Find resources</router-link> to
@@ -178,11 +151,41 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                     >
                 </div>
             </div>
+            <b-row class="my-3">
+                <b-col />
+                <b-col
+                    v-if="entry.reportAvailable"
+                    data-testid="laboratory-report-available"
+                    cols="auto"
+                >
+                    <hg-button
+                        data-testid="laboratory-report-download-btn"
+                        variant="secondary"
+                        :disabled="isLoadingDocument"
+                        @click="showConfirmationModal()"
+                    >
+                        <b-spinner
+                            v-if="isLoadingDocument"
+                            class="mr-1"
+                            small
+                        />
+                        <hg-icon
+                            v-else
+                            icon="download"
+                            size="medium"
+                            square
+                            aria-hidden="true"
+                            class="mr-1"
+                        />
+                        <span>Download Full Report</span>
+                    </hg-button>
+                </b-col>
+            </b-row>
             <b-table-lite
                 :items="entry.tests"
                 sticky-header
                 head-variant="light"
-                class="mt-4 mb-2"
+                class="my-2"
                 data-testid="laboratoryResultTable"
             >
                 <template #cell(result)="data">

--- a/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratory.ts
@@ -60,7 +60,6 @@ export interface LaboratoryOrder {
     orderingProvider: string;
     testStatus: string;
     orderStatus: string;
-    downloadLabel: string;
     reportAvailable: boolean;
     laboratoryTests: LaboratoryTest[];
 }

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
@@ -18,7 +18,6 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
     public orderingProvider: string;
     public orderStatus: string;
     public reportAvailable: boolean;
-    public downloadLabel: string;
 
     public tests: LaboratoryTestViewModel[];
 
@@ -57,7 +56,6 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
 
         this.reportId = model.reportId;
         this.orderStatus = model.orderStatus;
-        this.downloadLabel = model.downloadLabel;
 
         this.tests = [];
         model.laboratoryTests.forEach((test) => {

--- a/Testing/functional/tests/cypress/fixtures/LaboratoryService/laboratoryOrders.json
+++ b/Testing/functional/tests/cypress/fixtures/LaboratoryService/laboratoryOrders.json
@@ -14,7 +14,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": true,
                 "laboratoryTests": [
                     {
@@ -82,7 +81,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -277,7 +275,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -310,7 +307,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -334,7 +330,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -357,7 +352,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -381,7 +375,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -549,7 +542,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {
@@ -573,7 +565,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {

--- a/Testing/functional/tests/cypress/fixtures/LaboratoryService/laboratoryOrdersRefresh.json
+++ b/Testing/functional/tests/cypress/fixtures/LaboratoryService/laboratoryOrdersRefresh.json
@@ -14,7 +14,6 @@
                 "orderingProvider": "PLISBVCC, TREVOR",
                 "testStatus": "Not Set",
                 "orderStatus": "Not Set",
-                "downloadLabel": "Incomplete",
                 "reportAvailable": false,
                 "laboratoryTests": [
                     {

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/covid19Order.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/covid19Order.js
@@ -20,7 +20,8 @@ describe("COVID-19 Orders", () => {
             .parents("[data-testid=timelineCard]")
             .click();
 
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=covid-result-download-btn]")

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/laboratoryOrderReport.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/laboratoryOrderReport.js
@@ -24,10 +24,13 @@ describe("Laboratory Orders - Download Report", () => {
             .contains("2021-Jul-04")
             .click({ force: true });
 
-        cy.get("[data-testid=laboratory-report-download-btn]")
+        cy.get("[id=entry-details-modal]")
             .should("be.visible")
-            .contains("Final")
-            .click({ force: true });
+            .within(() => {
+                cy.get("[data-testid=laboratory-report-download-btn]")
+                    .should("be.visible")
+                    .click({ force: true });
+            });
 
         cy.get("[data-testid=genericMessageSubmitBtn]")
             .should("be.visible")

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/laboratoryOrderReport.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/mobile/laboratoryOrderReport.js
@@ -24,7 +24,8 @@ describe("Laboratory Orders - Download Report", () => {
             .contains("2021-Jul-04")
             .click({ force: true });
 
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=laboratory-report-download-btn]")

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
@@ -49,7 +49,8 @@ describe("COVID-19 Orders", () => {
                 cy.get("[data-testid=entryCardDetailsTitle]").click();
             });
 
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=laboratoryTestStatus-0]").should(
@@ -86,7 +87,8 @@ describe("COVID-19 Orders", () => {
                 cy.get("[data-testid=entryCardDetailsTitle]").click();
             });
 
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get(
@@ -121,7 +123,8 @@ describe("COVID-19 Orders", () => {
             });
 
         const correctedStatus = "Test Status: Corrected";
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=laboratoryTestStatus-0]").should(
@@ -163,7 +166,8 @@ describe("COVID-19 Orders", () => {
             });
 
         const amendedStatus = "Test Status: Amended";
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=laboratoryTestStatus-0]").should(
@@ -205,7 +209,8 @@ describe("COVID-19 Orders", () => {
             .parents("[data-testid=timelineCard]")
             .click();
 
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=covid-result-download-btn]")

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrderReport.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrderReport.js
@@ -26,7 +26,8 @@ describe("Laboratory Orders - Report", () => {
         cy.log("Verifying Laboratory Report PDF download");
         cy.get("[data-testid=timelineCard]").last().scrollIntoView().click();
 
-        cy.get("[id=entry-details-modal]")
+        cy.get("[data-testid=entryDetailsModal]")
+            .children()
             .should("be.visible")
             .within(() => {
                 cy.get("[data-testid=laboratory-report-download-btn]")

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrderReport.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrderReport.js
@@ -26,10 +26,13 @@ describe("Laboratory Orders - Report", () => {
         cy.log("Verifying Laboratory Report PDF download");
         cy.get("[data-testid=timelineCard]").last().scrollIntoView().click();
 
-        cy.get("[data-testid=laboratory-report-download-btn]")
+        cy.get("[id=entry-details-modal]")
             .should("be.visible")
-            .contains("Incomplete")
-            .click({ force: true });
+            .within(() => {
+                cy.get("[data-testid=laboratory-report-download-btn]")
+                    .should("be.visible")
+                    .click({ force: true });
+            });
 
         cy.get("[data-testid=genericMessageSubmitBtn]")
             .should("be.visible")


### PR DESCRIPTION
# Implements [AB#13248](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13248)

## Description

- Replaces download link for lab reports on the timeline with a button above the tests table
- Removes obsolete computations for downloadLabel property
- Updates functional tests to match the new behaviour

If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).

## Testing

-   [ ] Unit Tests Updated
-   [x] Functional Tests Updated
-   [ ] Not Required

### UI Changes

![image](https://user-images.githubusercontent.com/16570293/172914372-86273b10-9a94-4b80-86b7-ba7c5f341c7c.png)

### Browsers Tested

-   [x] Chrome
-   [ ] Safari
-   [ ] Edge
-   [ ] Firefox

Provide an explanation for any test(s) not completed.

## Notes/Additional Comments

Any additional notes or comments that may be relevant. Include any specialized deployment steps here.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)

-   Fulfills Work Item Requirements

    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
    -   Changes not directly related to the task requirements need to be documented on the PR.

-   Compilation / Tests

    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.

-   Logic Problems / Functional Behaviour

    -   The changes work as intended and do not introduce problems.

-   Performance

    -   The changes do not introduce obvious performance issues.

-   Documented Standards

    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).

-   Readability / Maintainability
    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.
