### PR TITLE
Update PR template AB#13365

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,59 +1,23 @@
-# Fixes or Implements AB#nnnn
+# Fixes or Implements AB#nnnnn
 
 ## Description
 
-A sentence or two describing the overall goals of the pull request's commits.
 
-If you are reviewing this PR, please adhere to the guidelines as [documented](https://github.com/bcgov/healthgateway/wiki/prguidance).
 
 ## Testing
 
--   [ ] Unit Tests Updated
--   [ ] Functional Tests Updated
--   [ ] Not Required
+- [ ] Unit Tests Updated
+- [ ] Functional Tests Updated
+- [ ] Not Required
 
-### UI Changes
+## UI Changes
 
-YES | NO
 
-### Browsers Tested
 
--   [ ] Chrome
--   [ ] Safari
--   [ ] Edge
--   [ ] Firefox
+## Notes
 
-Provide an explanation for any test(s) not completed.
 
-## Notes/Additional Comments
-
-Any additional notes or comments that may be relevant. Include any specialized deployment steps here.
 
 ## Items to Review:
 
 -   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
-
--   Fulfills Work Item Requirements
-
-    -   The changes meet/implement story's acceptance criteria. Fixes identified problems if bug.
-    -   Changes not directly related to the task requirements need to be documented on the PR.
-
--   Compilation / Tests
-
-    -   The changes do not break compilation and/or unit or functional tests; unless other item addresses them specifically.
-
--   Logic Problems / Functional Behaviour
-
-    -   The changes work as intended and do not introduce problems.
-
--   Performance
-
-    -   The changes do not introduce obvious performance issues.
-
--   Documented Standards
-
-    -   The changes adhere to the team's documented [Coding Standards](https://github.com/bcgov/healthgateway/wiki/standards).
-
--   Readability / Maintainability
-    -   The changes can be easily understood/read and allow for future enhancements without major refactoring. Readability is preferred over "clever code".
-    -   Reasoning for changes needs to be clearly articulated. Disagreements should be arbitrated by a third developer.


### PR DESCRIPTION
# Implements [AB#13365](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13365)

## Description

- Removes instructions from PR template
- Removes unused "Browsers Tested" section
- Moves detailed "Items to Review" from PR template to PR review guidelines on the GitHub wiki

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)