### PR TITLE
Add Admin Support Query parm to audit subject for AB#13379

### DIFF
--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -27,8 +27,9 @@ namespace HealthGateway.Common.Auditing
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Routing;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Primitives;
 
-    #pragma warning disable CA1303 // Do not pass literals as localized parameters
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
 
     /// <summary>
     /// The Authorization service.
@@ -78,13 +79,17 @@ namespace HealthGateway.Common.Auditing
             string? idir = idirClaim?.Value;
 
             // Query PHN header for Admin WebClient CovidCard actions
-            context.Request.Headers.TryGetValue("phn", out var phnHeader);
+            context.Request.Headers.TryGetValue("phn", out StringValues phnHeader);
             string? subjectPhn = phnHeader.FirstOrDefault();
+
+            // Query Request Parameters for queryString for AdminWebClient Support actions
+            context.Request.Query.TryGetValue("queryString", out StringValues queryString);
+            string? subjectQuery = queryString.FirstOrDefault();
 
             auditEvent.ApplicationType = GetApplicationType();
             auditEvent.TransactionResultCode = GetTransactionResultType(context.Response.StatusCode);
 
-            auditEvent.ApplicationSubject = hdid ?? subjectPhn;
+            auditEvent.ApplicationSubject = hdid ?? subjectPhn ?? subjectQuery;
             auditEvent.CreatedBy = hdid ?? idir ?? UserId.DefaultUser;
 
             RouteValueDictionary routeValues = context.Request.RouteValues;


### PR DESCRIPTION
# Fixes or Implements AB#13379

## Description

Add the Admin Support page QueryParm request parameter as the application subject for auditing


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
