### PR TITLE
Refactor server code to handle multiple admin tag ids for AB#13366.

### DIFF
--- a/Apps/Admin/Server/Controllers/TagController.cs
+++ b/Apps/Admin/Server/Controllers/TagController.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Common.Data.ViewModels;
@@ -94,17 +95,17 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Associate an existing admin tag to the feedback with matching id.
         /// </summary>
-        /// <returns>The added tag model wrapped in a request result.</returns>
+        /// <returns>Returns the associated admin tag wrapped in a request result.</returns>
         /// <param name="feedbackId">The feedback id.</param>
-        /// <param name="tag">The tag model.</param>
-        /// <response code="200">Returns the list of dependents.</response>
+        /// <param name="tagIds">A list of admin tag ids.</param>
+        /// <response code="200">The user feedback containing the added tag model wrapped in a request result.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpPut]
         [Route("UserFeedback/{feedbackId}/[controller]")]
-        public RequestResult<UserFeedbackTagView> AssociateTag(string feedbackId, [FromBody] AdminTagView tag)
+        public RequestResult<UserFeedbackView> AssociateTag(string feedbackId, [FromBody] Collection<Guid> tagIds)
         {
-            RequestResult<UserFeedbackTagView> result = this.feedbackService.AssociateFeedbackTag(Guid.Parse(feedbackId), tag);
+            RequestResult<UserFeedbackView> result = this.feedbackService.AssociateFeedbackTag(Guid.Parse(feedbackId), tagIds);
             return result;
         }
 

--- a/Apps/Admin/Server/Converters/UserFeedbackConverter.cs
+++ b/Apps/Admin/Server/Converters/UserFeedbackConverter.cs
@@ -49,6 +49,50 @@ public static class UserFeedbackConverter
     /// Creates a UI model from a DB model.
     /// </summary>
     /// <param name="model">The DB model to convert.</param>
+    /// <param name="tagViews">List of converted user feedback tag view objects.</param>
+    /// <returns>The created UI model.</returns>
+    public static UserFeedbackView ToUiBaseModel(this Database.Models.UserFeedback model)
+    {
+        UserFeedbackView retVal = new()
+        {
+            Id = model.Id,
+            UserProfileId = model.UserProfileId,
+            Comment = model.Comment,
+            CreatedDateTime = model.CreatedDateTime,
+            IsReviewed = model.IsReviewed,
+            IsSatisfied = model.IsSatisfied,
+            Version = model.Version,
+        };
+
+        return retVal;
+    }
+
+    /// <summary>
+    /// Creates a UI model from a DB model.
+    /// </summary>
+    /// <param name="model">The DB model to convert.</param>
+    /// <param name="tagViews">List of converted user feedback tag view objects.</param>
+    /// <returns>The created UI model.</returns>
+    public static UserFeedbackView ToUiModel(this Database.Models.UserFeedback model, IList<UserFeedbackTagView> tagViews)
+    {
+        UserFeedbackView retVal = new(tagViews)
+        {
+            Id = model.Id,
+            UserProfileId = model.UserProfileId,
+            Comment = model.Comment,
+            CreatedDateTime = model.CreatedDateTime,
+            IsReviewed = model.IsReviewed,
+            IsSatisfied = model.IsSatisfied,
+            Version = model.Version,
+        };
+
+        return retVal;
+    }
+
+    /// <summary>
+    /// Creates a UI model from a DB model.
+    /// </summary>
+    /// <param name="model">The DB model to convert.</param>
     /// <returns>The created UI model.</returns>
     public static UserFeedbackView ToUiModel(this Database.Models.UserFeedbackAdmin model)
     {

--- a/Apps/Admin/Server/Converters/UserFeedbackTagConverter.cs
+++ b/Apps/Admin/Server/Converters/UserFeedbackTagConverter.cs
@@ -44,7 +44,7 @@ public static class UserFeedbackTagConverter
 
         if (model.UserFeedback != null)
         {
-            retVal.Feedback = model.UserFeedback.ToUiModel();
+            retVal.Feedback = model.UserFeedback.ToUiBaseModel();
         }
 
         return retVal;

--- a/Apps/Admin/Server/Services/IUserFeedbackService.cs
+++ b/Apps/Admin/Server/Services/IUserFeedbackService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.ViewModels;
 
@@ -62,9 +63,9 @@ namespace HealthGateway.Admin.Server.Services
         /// Associates an admin tag to a feedback.
         /// </summary>
         /// <param name="userFeedbackId">The user feedback id to be associated to the tag.</param>
-        /// <param name="tag">The admin tag.</param>
-        /// <returns>returns the associated admin tag wrapped in a request result.</returns>
-        RequestResult<UserFeedbackTagView> AssociateFeedbackTag(Guid userFeedbackId, AdminTagView tag);
+        /// <param name="adminTagIds">The admin tag ids.</param>
+        /// <returns>Returns the associated admin tag wrapped in a request result.</returns>
+        RequestResult<UserFeedbackView> AssociateFeedbackTag(Guid userFeedbackId, Collection<Guid> adminTagIds);
 
         /// <summary>
         /// Dissociates an admin tag from a user feedback.

--- a/Apps/Database/src/Delegates/DBAdminTagDelegate.cs
+++ b/Apps/Database/src/Delegates/DBAdminTagDelegate.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Text.Json;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
@@ -112,6 +113,16 @@ namespace HealthGateway.Database.Delegates
                     .OrderBy(o => o.Name)
                     .ToList();
             result.Status = result.Payload != null ? DBStatusCode.Read : DBStatusCode.NotFound;
+            return result;
+        }
+
+        /// <inheritdoc />
+        public DBResult<IEnumerable<AdminTag>> GetAdminTags(ICollection<Guid> adminTagIds)
+        {
+            this.logger.LogTrace("Getting admin tags from DB for Admin Tag Ids: {AdminTagId}", adminTagIds.ToString());
+            DBResult<IEnumerable<AdminTag>> result = new DBResult<IEnumerable<AdminTag>>();
+            result.Payload = this.dbContext.AdminTag.Where(t => adminTagIds.Contains(t.AdminTagId)).ToList();
+            result.Status = DBStatusCode.Read;
             return result;
         }
     }

--- a/Apps/Database/src/Delegates/DBFeedbackTagDelegate.cs
+++ b/Apps/Database/src/Delegates/DBFeedbackTagDelegate.cs
@@ -103,5 +103,15 @@ namespace HealthGateway.Database.Delegates
             this.logger.LogDebug($"Finished deleting UserFeedbackTag in DB");
             return result;
         }
+
+        /// <inheritdoc />
+        public DBResult<IEnumerable<UserFeedbackTag>> GetUserFeedbackTagsByFeedbackId(Guid feedbackId)
+        {
+            this.logger.LogTrace("Getting user feedback tags from DB for Feedback Id: {FeedbackId}", feedbackId.ToString());
+            DBResult<IEnumerable<UserFeedbackTag>> result = new DBResult<IEnumerable<UserFeedbackTag>>();
+            result.Payload = this.dbContext.UserFeedbackTag.Where(t => t.UserFeedbackId == feedbackId).ToList();
+            result.Status = DBStatusCode.Read;
+            return result;
+        }
     }
 }

--- a/Apps/Database/src/Delegates/IAdminTagDelegate.cs
+++ b/Apps/Database/src/Delegates/IAdminTagDelegate.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Database.Delegates
 {
+    using System;
     using System.Collections.Generic;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -45,5 +46,12 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <returns>An IEnumerable of AdminTag wrapped in a DBResult.</returns>
         DBResult<IEnumerable<AdminTag>> GetAll();
+
+        /// <summary>
+        /// Gets a list of admin tags by ids.
+        /// </summary>
+        /// <param name="adminTagIds">The admin tag ids to search on.</param>
+        /// <returns>An IEnumerable of AdminTag wrapped in a DBResult.</returns>
+        DBResult<IEnumerable<AdminTag>> GetAdminTags(ICollection<Guid> adminTagIds);
     }
 }

--- a/Apps/Database/src/Delegates/IFeedbackDelegate.cs
+++ b/Apps/Database/src/Delegates/IFeedbackDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Database.Delegates
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
 
@@ -41,11 +42,27 @@ namespace HealthGateway.Database.Delegates
         void UpdateUserFeedback(UserFeedback feedback);
 
         /// <summary>
+        /// Updates the UserFeedback object including user feedback tag associations in the DB.
+        /// Version must be set or a Concurrency exception will occur.
+        /// UpdatedDateTime will overridden by our framework.
+        /// </summary>
+        /// <param name="feedback">The feedback to update.</param>
+        /// <returns>A DB result which encapsulates the return object and status.</returns>
+        DBResult<UserFeedback> UpdateUserFeedbackWithTagAssociations(UserFeedback feedback);
+
+        /// <summary>
         /// Fetches the UserFeedback from the database.
         /// </summary>
         /// <param name="feedbackId">The unique feedback id to find.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
         DBResult<UserFeedback> GetUserFeedback(Guid feedbackId);
+
+        /// <summary>
+        /// Fetches the UserFeedback with FeedbackTag associations from the database.
+        /// </summary>
+        /// <param name="feedbackId">The unique feedback id to find.</param>
+        /// <returns>A DB result which encapsulates the return object and status.</returns>
+        DBResult<UserFeedback> GetUserFeedbackWithFeedbackTags(Guid feedbackId);
 
         /// <summary>
         /// Fetches the UserFeedback from the database with email attached for administratie purposes.

--- a/Apps/Database/src/Delegates/IFeedbackTagDelegate.cs
+++ b/Apps/Database/src/Delegates/IFeedbackTagDelegate.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Database.Delegates
 {
+    using System;
     using System.Collections.Generic;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -39,5 +40,12 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">if true the transaction is persisted immediately.</param>
         /// <returns>The result DBResult.</returns>
         DBResult<UserFeedbackTag> Delete(UserFeedbackTag feedbackTag, bool commit = true);
+
+        /// <summary>
+        /// Gets a list of user feedback tags by feedback id.
+        /// </summary>
+        /// <param name="feedbackId">The feedback id to search on.</param>
+        /// <returns>An IEnumerable of UserFeedbackTag wrapped in a DBResult.</returns>
+        DBResult<IEnumerable<UserFeedbackTag>> GetUserFeedbackTagsByFeedbackId(Guid feedbackId);
     }
 }


### PR DESCRIPTION
# Fixes or Implements AB#nnnnn

## Description

- Update server side (controller, service, delegates and converters) to handle multiple admin tag ids when associating and dissociating  admin tag ids with user feedback ids.
- Changed controller to accept list of admin tag ids and returns request result containing user feedback

**Swagger successfully called:**

<img width="1705" alt="Screen Shot 2022-06-15 at 1 19 33 AM" src="https://user-images.githubusercontent.com/58790456/173779826-087ad40b-7770-42d9-be98-4b6b81dc62da.png">

<img width="1518" alt="Screen Shot 2022-06-15 at 1 19 46 AM" src="https://user-images.githubusercontent.com/58790456/173779849-482decf9-ef06-4d57-9b75-7f0e5ec15c3a.png">



## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
