### PR TITLE
Implement add vaccine card quick link button for AB#13359

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -160,7 +160,7 @@ export default class HomeView extends Vue {
     private get showVaccineCardButton(): boolean {
         const preferenceName = UserPreferenceType.HideVaccineCardQuickLink;
         let hideVaccineCard = this.user.preferences[preferenceName];
-        if (hideVaccineCard?.value == "true") {
+        if (hideVaccineCard?.value === "true") {
             return false;
         } else {
             return this.config.modules["VaccinationStatus"];
@@ -209,7 +209,7 @@ export default class HomeView extends Vue {
                             existingLink.filter.modules.length === 1 &&
                             existingLink.filter.modules[0] === details.type
                     ) === undefined
-            ).length === 0
+            ).length === 0 && this.showVaccineCardButton
         );
     }
 


### PR DESCRIPTION
# Implements AB#13359

## Description

BC Vaccine Card button can be added back in "add quick link" selector type "BC Vaccine Card" 

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screen Shot 2022-06-15 at 9 32 01 AM](https://user-images.githubusercontent.com/5408101/173879117-70c0d976-f026-468e-80c6-d09a04632097.png)
![Screen Shot 2022-06-15 at 9 33 14 AM](https://user-images.githubusercontent.com/5408101/173879317-28e94757-cd49-409f-a205-f6d46d2a548f.png)
![Screen Shot 2022-06-15 at 9 33 39 AM](https://user-images.githubusercontent.com/5408101/173879403-0a6e0193-a578-4c4a-be6d-9f60845599f9.png)


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
