### PR TITLE
Fetch UserPreferences when updating terms for AB#13301

### DIFF
--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -119,18 +119,7 @@ namespace HealthGateway.GatewayApi.Controllers
             DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(user);
 
             RequestResult<UserProfileModel> result = this.userProfileService.GetUserProfile(hdid, jwtAuthTime);
-
-            if (result.ResourcePayload != null)
-            {
-                RequestResult<Dictionary<string, UserPreferenceModel>> userPreferences = this.userProfileService.GetUserPreferences(hdid);
-                if (userPreferences.ResourcePayload != null)
-                {
-                    foreach (var preference in userPreferences.ResourcePayload)
-                    {
-                        result.ResourcePayload.Preferences.Add(preference);
-                    }
-                }
-            }
+            this.AddUserPreferences(result.ResourcePayload);
 
             return result;
         }
@@ -363,7 +352,25 @@ namespace HealthGateway.GatewayApi.Controllers
         [Authorize(Policy = UserProfilePolicy.Write)]
         public RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, [FromBody] Guid termsOfServiceId)
         {
-            return this.userProfileService.UpdateAcceptedTerms(hdid, termsOfServiceId);
+            RequestResult<UserProfileModel> result = this.userProfileService.UpdateAcceptedTerms(hdid, termsOfServiceId);
+            this.AddUserPreferences(result.ResourcePayload);
+
+            return result;
+        }
+
+        private void AddUserPreferences(UserProfileModel profile)
+        {
+            if (profile != null)
+            {
+                RequestResult<Dictionary<string, UserPreferenceModel>> userPreferences = this.userProfileService.GetUserPreferences(profile.HdId);
+                if (userPreferences.ResourcePayload != null)
+                {
+                    foreach (KeyValuePair<string, UserPreferenceModel> preference in userPreferences.ResourcePayload)
+                    {
+                        profile.Preferences.Add(preference);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements AB#13301

## Description

After updating the terms only a partial UserProfile object is returned which causes preference based options to not be displayed.  

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
