### PR TITLE
Fix behaviour when "VaccinationStatus" module is disabled for AB#13382

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -67,29 +67,15 @@ export default class AddQuickLinkComponent extends Vue {
     }
 
     private get isAddButtonEnabled(): boolean {
-        return (
-            (this.enabledQuickLinkFilter.length > 0 &&
-                this.selectedQuickLinks.length > 0) ||
-            (this.selectedQuickLinks.length > 0 &&
-                (!this.vaccinationStatusModuleEnabled ||
-                    this.preferenceVaccineCardHidden))
-        );
-    }
-
-    private get vaccinationStatusModuleEnabled(): boolean {
-        return this.webClientConfig.modules["VaccinationStatus"];
-    }
-
-    private get preferenceVaccineCardHidden(): boolean {
-        const preferenceName = UserPreferenceType.HideVaccineCardQuickLink;
-        let hideVaccineCard = this.user.preferences[preferenceName];
-        return hideVaccineCard?.value === "true";
+        return this.selectedQuickLinks.length > 0;
     }
 
     private get showVaccineCard(): boolean {
+        const preferenceName = UserPreferenceType.HideVaccineCardQuickLink;
+        let hideVaccineCard = this.user.preferences[preferenceName];
         return (
-            this.preferenceVaccineCardHidden &&
-            this.vaccinationStatusModuleEnabled
+            hideVaccineCard?.value === "true" &&
+            this.webClientConfig.modules["VaccinationStatus"]
         );
     }
 

--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -70,14 +70,27 @@ export default class AddQuickLinkComponent extends Vue {
         return (
             (this.enabledQuickLinkFilter.length > 0 &&
                 this.selectedQuickLinks.length > 0) ||
-            (this.showVaccineCard && this.selectedQuickLinks.length > 0)
+            (this.selectedQuickLinks.length > 0 &&
+                (!this.vaccinationStatusModuleEnabled ||
+                    this.preferenceVaccineCardHidden))
         );
     }
 
-    private get showVaccineCard(): boolean {
+    private get vaccinationStatusModuleEnabled(): boolean {
+        return this.webClientConfig.modules["VaccinationStatus"];
+    }
+
+    private get preferenceVaccineCardHidden(): boolean {
         const preferenceName = UserPreferenceType.HideVaccineCardQuickLink;
         let hideVaccineCard = this.user.preferences[preferenceName];
         return hideVaccineCard?.value === "true";
+    }
+
+    private get showVaccineCard(): boolean {
+        return (
+            this.preferenceVaccineCardHidden &&
+            this.vaccinationStatusModuleEnabled
+        );
     }
 
     private addQuickLink(submittedQuickLinks: QuickLink[]): Promise<void> {

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -157,14 +157,21 @@ export default class HomeView extends Vue {
         return this.config.modules["FederalCardButton"];
     }
 
-    private get showVaccineCardButton(): boolean {
+    private get vaccinationStatusModuleEnabled(): boolean {
+        return this.config.modules["VaccinationStatus"];
+    }
+
+    private get preferenceVaccineCardHidden(): boolean {
         const preferenceName = UserPreferenceType.HideVaccineCardQuickLink;
         let hideVaccineCard = this.user.preferences[preferenceName];
-        if (hideVaccineCard?.value === "true") {
-            return false;
-        } else {
-            return this.config.modules["VaccinationStatus"];
-        }
+        return hideVaccineCard?.value === "true";
+    }
+
+    private get showVaccineCardButton(): boolean {
+        return (
+            !this.preferenceVaccineCardHidden &&
+            this.vaccinationStatusModuleEnabled
+        );
     }
 
     private get enabledQuickLinks(): QuickLink[] {
@@ -209,7 +216,9 @@ export default class HomeView extends Vue {
                             existingLink.filter.modules.length === 1 &&
                             existingLink.filter.modules[0] === details.type
                     ) === undefined
-            ).length === 0 && this.showVaccineCardButton
+            ).length === 0 &&
+            (!this.vaccinationStatusModuleEnabled ||
+                !this.preferenceVaccineCardHidden)
         );
     }
 


### PR DESCRIPTION
# Implements [AB#13382](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13382)

## Description

There is some tricky logic where the "VaccinationStatus" module state was involved for whether the add button should be enabled or not. Clarified with getters and fixed the logic.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
