### PR TITLE
Fixed recurring user count query for AB#13371.

### DIFF
--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -244,7 +244,7 @@ namespace HealthGateway.Database.Delegates
                 .Select(x => new { x.HdId, x.LastLoginDateTime })
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime }))
-                .Where(x => x.LastLoginDateTime >= startDate && x.LastLoginDateTime <= endDate)
+                .Where(x => GatewayDbContext.DateTrunc("days", x.LastLoginDateTime)  >= startDate && GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) <= endDate)
                 .Distinct()
                 .GroupBy(x => x.HdId).Select(x => new { HdId = x.Key, count = x.Count() })
                 .Where(x => x.count >= dayCount).Count();

--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -244,7 +244,7 @@ namespace HealthGateway.Database.Delegates
                 .Select(x => new { x.HdId, x.LastLoginDateTime })
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime }))
-                .Where(x => GatewayDbContext.DateTrunc("days", x.LastLoginDateTime)  >= startDate && GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) <= endDate)
+                .Where(x => GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) >= startDate && GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) <= endDate)
                 .Distinct()
                 .GroupBy(x => x.HdId).Select(x => new { HdId = x.Key, count = x.Count() })
                 .Where(x => x.count >= dayCount).Count();


### PR DESCRIPTION
# Fixes [AB#13371](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13371)

## Description

Recurring user count was returning back the correct count.  Date time in where clause was not being truncated. As a result, the group by clause was not accurate and was returning back an invalid count.

Previously 100 unique days would return back an invalid count. That has been addressed.  100 unique days should return 0 as there is no user that has logged in 100 recurring days in the database. Note: date range is one month.

<img width="1194" alt="Screen Shot 2022-06-15 at 8 28 16 PM" src="https://user-images.githubusercontent.com/58790456/173985533-15fd94e2-e05f-4e70-8bb2-41f527ac300d.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
