### PR TITLE
Fix recurring user query for AB#13371.

### DIFF
--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -244,7 +244,8 @@ namespace HealthGateway.Database.Delegates
                 .Select(x => new { x.HdId, x.LastLoginDateTime })
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime }))
-                .Where(x => GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) >= startDate && GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) <= endDate)
+                .Where(x => x.LastLoginDateTime >= startDate && x.LastLoginDateTime <= endDate)
+                .Select(x => new { x.HdId, lastLoginDate = GatewayDbContext.DateTrunc("days", x.LastLoginDateTime) })
                 .Distinct()
                 .GroupBy(x => x.HdId).Select(x => new { HdId = x.Key, count = x.Count() })
                 .Where(x => x.count >= dayCount).Count();


### PR DESCRIPTION
# Fixes [AB#13371](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13371)

## Description

1. Fixed group clause in EF query.  Last Login Date Time needed to be truncated so that query could group by HDID properly
2. There was no need to truncate Last Login Date Time on the database side in where clause as that would reduce the number of rows being returned since date passed in already included proper time in UTC 

**Generated Query:**

<img width="1622" alt="Screen Shot 2022-06-16 at 2 41 14 PM" src="https://user-images.githubusercontent.com/58790456/174170657-b11feb5a-bd88-4b63-9856-38706d3cd480.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
