### PR TITLE
Add feedback table AB#12673

### DIFF
--- a/Apps/Admin/Client/Pages/FeedbackPage.razor
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor
@@ -4,6 +4,7 @@
 
 @using HealthGateway.Admin.Client.Store.Tag
 @using HealthGateway.Admin.Common.Models
+@using HealthGateway.Common.Data.Utils
 
 <PageTitle>Feedback Review</PageTitle>
 <HgPageHeading>Feedback Review</HgPageHeading>
@@ -15,44 +16,112 @@
     </HgBannerFeedback>
 }
 
-<MudGrid>
-    <MudItem xs="12">
-        <MudForm @ref="@AddTagForm" Class="d-flex">
-            <MudTextField T="string"
-                          @bind-Value="@ActiveTag"
-                          Immediate="true"
-                          MaxLength="20"
-                          Label="Tag Name"
-                          Class="flex-grow-1"
-                          @onkeydown="@HandleKeyDownActiveTag"/>
-            <HgButton TopMargin="@Breakpoint.Always"
-                      LeftMargin="@Breakpoint.Always"
-                      Class="flex-grow-0"
-                      EndIcon="@Icons.Material.Filled.Add"
-                      Variant="@Variant.Filled"
-                      Color="@Color.Success"
-                      Disabled="@(!ActiveTagIsValid)"
-                      Loading="@TagState.Value.Add.IsLoading"
-                      @onclick="@AddTag">
-                Add Tag
-            </HgButton>
-        </MudForm>
-    </MudItem>
-    <MudItem xs="12">
-        <MudChipSet @bind-SelectedChips="@SelectedTagChips"
-                    Class="pt-4"
-                    MultiSelection="true"
-                    Filter="true">
-            @foreach (AdminTagView tag in Tags)
-            {
-                <MudChip Text="@tag.Name"
-                         Class="my-2"
-                         Variant="@Variant.Text"
-                         Size="@Size.Small"
-                         Color="@Color.Tertiary"
-                         Disabled="@(TagState.Value.Add.IsLoading || TagState.Value.Delete.IsLoading)"
-                         OnClose="@RemoveTag"/>
-            }
-        </MudChipSet>
-    </MudItem>
-</MudGrid>
+<MudForm Class="d-flex">
+    <MudTextField T="string"
+                  @bind-Value="@ActiveTag"
+                  Immediate="true"
+                  MaxLength="20"
+                  Label="Tag Name"
+                  Class="flex-grow-1"
+                  @onkeydown="@HandleKeyDownActiveTag"/>
+    <HgButton TopMargin="@Breakpoint.Always"
+              LeftMargin="@Breakpoint.Always"
+              Class="flex-grow-0"
+              EndIcon="@Icons.Material.Filled.Add"
+              Variant="@Variant.Filled"
+              Color="@Color.Success"
+              Disabled="@(!ActiveTagIsValid)"
+              Loading="@TagState.Value.Add.IsLoading"
+              @onclick="@AddTag">
+        Add Tag
+    </HgButton>
+</MudForm>
+<MudChipSet @bind-SelectedChips="@SelectedTagChips"
+            Class="my-4"
+            MultiSelection="true"
+            Filter="true">
+    @foreach (AdminTagView tag in Tags)
+    {
+        <MudChip Text="@tag.Name"
+                 Class="my-2"
+                 Variant="@Variant.Text"
+                 Size="@Size.Small"
+                 Color="@Color.Tertiary"
+                 Disabled="@(TagState.Value.Add.IsLoading || TagState.Value.Delete.IsLoading)"
+                 OnClose="@RemoveTag"/>
+    }
+</MudChipSet>
+@if (FeedbackLoaded || FeedbackLoading)
+{
+    <MudForm>
+        <MudTable Class="mt-3" Items="@FeedbackRows" Loading="@(FeedbackLoading || FeedbackUpdating)" Breakpoint="@Breakpoint.Md" HorizontalScrollbar="true" Striped="true" Dense="true">
+            <HeaderContent>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<FeedbackRow, object>(x => x.DateTime)"
+                                       InitialDirection="@SortDirection.Descending">
+                        Date
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<FeedbackRow, object>(x => x.Email)">
+                        Email
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<FeedbackRow, object>(x => x.Comments)">
+                        Comments
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<FeedbackRow, object>(x => x.TagIds.Count())">
+                        Tags
+                    </MudTableSortLabel>
+                </MudTh>
+                <MudTh>
+                    <MudTableSortLabel SortBy="new Func<FeedbackRow, object>(x => x.IsReviewed)">
+                        Reviewed?
+                    </MudTableSortLabel>
+                </MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd DataLabel="Date">@DateFormatter.ToShortDateAndTime(context.DateTime)</MudTd>
+                <MudTd DataLabel="Email">
+                    @if (context.Hdid.Length > 0)
+                    {
+                        <MudIconButton Icon="@Icons.Material.Filled.PersonSearch" Color="@Color.Dark" Size="Size.Small"/>
+                    }
+                    @if (context.Email.Length > 0)
+                    {
+                        @context.Email
+                    }
+                </MudTd>
+                <MudTd DataLabel="Comments">@context.Comments</MudTd>
+                <MudTd DataLabel="Tags">
+                    <MudSelect T="Guid"
+                               MultiSelection="true"
+                               @bind-SelectedValues="@context.TagIds"
+                               MultiSelectionTextFunc="@DescribeTags"
+                               Disabled="@FeedbackUpdating"
+                               Variant="@Variant.Filled"
+                               Margin="@Margin.Dense"
+                               Dense="true">
+                        @foreach (AdminTagView tag in Tags)
+                        {
+                            <MudSelectItem T="Guid" Value="@tag.Id">@tag.Name</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudTd>
+                <MudTd DataLabel="Reviewed">
+                    <MudIconButton Icon="@(context.IsReviewed ? Icons.Material.Filled.Check : Icons.Material.Filled.Close)"
+                                   Color="@(context.IsReviewed ? Color.Success : Color.Error)"
+                                   Size="@Size.Small"
+                                   Disabled="@FeedbackUpdating"
+                                   @onclick="@(() => ToggleIsReviewed(context.Id))"/>
+                </MudTd>
+            </RowTemplate>
+            <PagerContent>
+                <MudTablePager/>
+            </PagerContent>
+        </MudTable>
+    </MudForm>
+}

--- a/Apps/Admin/Client/Services/ITagApi.cs
+++ b/Apps/Admin/Client/Services/ITagApi.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Services;
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using HealthGateway.Admin.Common.Models;
@@ -48,4 +49,13 @@ public interface ITagApi
     /// <returns>The wrapped model.</returns>
     [Delete("/")]
     Task<ApiResponse<RequestResult<AdminTagView>>> Delete([Body] AdminTagView tag);
+
+    /// <summary>
+    /// Associate an existing admin tag to the feedback with matching id.
+    /// </summary>
+    /// <returns>The feedback model wrapped in a request result.</returns>
+    /// <param name="tagIds">The collection of tag IDs.</param>
+    /// <param name="feedbackId">The feedback ID.</param>
+    [Put("/{feedbackId}/Tag")]
+    Task<ApiResponse<RequestResult<UserFeedbackView>>> AssociateTags([Body] IEnumerable<Guid> tagIds, Guid feedbackId);
 }

--- a/Apps/Admin/Client/Services/IUserFeedbackApi.cs
+++ b/Apps/Admin/Client/Services/IUserFeedbackApi.cs
@@ -35,20 +35,10 @@ public interface IUserFeedbackApi
     Task<ApiResponse<RequestResult<IEnumerable<UserFeedbackView>>>> GetAll();
 
     /// <summary>
-    /// Associate an existing admin tag to the feedback with matching id.
+    /// Updates a user feedback.
     /// </summary>
-    /// <returns>The added tag model wrapped in a request result.</returns>
-    /// <param name="tag">The tag model.</param>
-    /// <param name="feedbackId">The feedback id.</param>
-    [Put("/{feedbackId}/Tag")]
-    Task<ApiResponse<RequestResult<UserFeedbackTagView>>> AssociateTag([Body] AdminTagView tag, Guid feedbackId);
-
-    /// <summary>
-    /// Dissociate an existing admin tag from the feedback.
-    /// </summary>
-    /// <returns>A boolean indicating success or failure of dissociation of tag.</returns>
-    /// <param name="feedbackTag">The user feedback tag model.</param>
-    /// <param name="feedbackId">The feedback id.</param>
-    [Delete("/{feedbackId}/Tag")]
-    Task<ApiResponse<PrimitiveRequestResult<bool>>> DissociateTag([Body] UserFeedbackTagView feedbackTag, Guid feedbackId);
+    /// <param name="userFeedbackView">The model to update.</param>
+    /// <returns>The wrapped model.</returns>
+    [Patch("/")]
+    Task<ApiResponse<RequestResult<UserFeedbackView>>> Update([Body] UserFeedbackView userFeedbackView);
 }

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackActions.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackActions.cs
@@ -28,139 +28,6 @@ using HealthGateway.Common.Data.ViewModels;
 public static class UserFeedbackActions
 {
     /// <summary>
-    /// The action representing the initiation of an associated tag.
-    /// </summary>
-    public class AssociateTagAction
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AssociateTagAction"/> class.
-        /// </summary>
-        /// <param name="adminTag">Represents the AdminTagView model.</param>
-        /// <param name="feedbackId">The feedback id.</param>
-        public AssociateTagAction(AdminTagView adminTag, Guid feedbackId)
-        {
-            this.AdminTag = adminTag;
-            this.FeedbackId = feedbackId;
-        }
-
-        /// <summary>
-        /// Gets or sets the admin tag view.
-        /// </summary>
-        public AdminTagView AdminTag { get; set; }
-
-        /// <summary>
-        /// Gets or sets feedback id.
-        /// </summary>
-        public Guid FeedbackId { get; set; }
-    }
-
-    /// <summary>
-    /// The action representing a failed associate tag.
-    /// </summary>
-    public class AssociateTagFailAction : BaseFailAction
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AssociateTagFailAction"/> class.
-        /// </summary>
-        /// <param name="error">The request error.</param>
-        public AssociateTagFailAction(RequestError error)
-            : base(error)
-        {
-        }
-    }
-
-    /// <summary>
-    /// The action representing a successful associated tag.
-    /// </summary>
-    public class AssociateTagSuccessAction : BaseSuccessAction<RequestResult<UserFeedbackTagView>>
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AssociateTagSuccessAction"/> class.
-        /// </summary>
-        /// <param name="data">User feedback view data.</param>
-        public AssociateTagSuccessAction(RequestResult<UserFeedbackTagView> data)
-            : base(data)
-        {
-        }
-    }
-
-    /// <summary>
-    /// The action representing the initiation of a dissociated tag.
-    /// </summary>
-    public class DissociateTagAction
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DissociateTagAction"/> class.
-        /// </summary>
-        /// <param name="feedbackTag">Represents the user feedback tag view model.</param>
-        /// <param name="feedbackId">The feedback id.</param>
-        public DissociateTagAction(UserFeedbackTagView feedbackTag, Guid feedbackId)
-        {
-            this.FeedbackTag = feedbackTag;
-            this.FeedbackId = feedbackId;
-        }
-
-        /// <summary>
-        /// Gets or sets the user feedback tag view.
-        /// </summary>
-        public UserFeedbackTagView FeedbackTag { get; set; }
-
-        /// <summary>
-        /// Gets or sets the feedback id.
-        /// </summary>
-        public Guid FeedbackId { get; set; }
-    }
-
-    /// <summary>
-    /// The action representing a failed dissociated tag.
-    /// </summary>
-    public class DissociateTagFailAction : BaseFailAction
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DissociateTagFailAction"/> class.
-        /// </summary>
-        /// <param name="error">The request error.</param>
-        public DissociateTagFailAction(RequestError error)
-            : base(error)
-        {
-        }
-    }
-
-    /// <summary>
-    /// The action representing a successful dissociated tag.
-    /// </summary>
-    public class DissociateTagSuccessAction
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DissociateTagSuccessAction"/> class.
-        /// </summary>
-        /// <param name="result">True if the dissociation was successful.</param>
-        /// <param name="feedbackTag">The feedback tag that is being dissociated.</param>
-        /// <param name="feedbackId">The id for the feedback that the tag is being dissociated from.</param>
-        public DissociateTagSuccessAction(PrimitiveRequestResult<bool> result, UserFeedbackTagView feedbackTag, Guid feedbackId)
-        {
-            this.Result = result;
-            this.FeedbackTag = feedbackTag;
-            this.FeedbackId = feedbackId;
-        }
-
-        /// <summary>
-        /// Gets or sets the result.
-        /// </summary>
-        public PrimitiveRequestResult<bool> Result { get; set; }
-
-        /// <summary>
-        /// Gets or sets the user feedback tag view.
-        /// </summary>
-        public UserFeedbackTagView FeedbackTag { get; set; }
-
-        /// <summary>
-        /// Gets or sets the feedback id.
-        /// </summary>
-        public Guid FeedbackId { get; set; }
-    }
-
-    /// <summary>
     /// The action representing the initiation of a load.
     /// </summary>
     public class LoadAction
@@ -199,6 +66,113 @@ public static class UserFeedbackActions
         /// <param name="requestResultModel">User feedback view data.</param>
         public LoadSuccessAction(RequestResult<IEnumerable<UserFeedbackView>> requestResultModel)
             : base(requestResultModel)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of an update.
+    /// </summary>
+    public class UpdateAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateAction"/> class.
+        /// </summary>
+        /// <param name="userFeedbackView">Represents the user feedback model.</param>
+        public UpdateAction(UserFeedbackView userFeedbackView)
+        {
+            this.UserFeedbackView = userFeedbackView;
+        }
+
+        /// <summary>
+        /// Gets or sets the user feedback view.
+        /// </summary>
+        public UserFeedbackView UserFeedbackView { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed update.
+    /// </summary>
+    public class UpdateFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public UpdateFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful update.
+    /// </summary>
+    public class UpdateSuccessAction : BaseSuccessAction<RequestResult<UserFeedbackView>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateSuccessAction"/> class.
+        /// </summary>
+        /// <param name="requestResultModel">User feedback view data.</param>
+        public UpdateSuccessAction(RequestResult<UserFeedbackView> requestResultModel)
+            : base(requestResultModel)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of an associated tag.
+    /// </summary>
+    public class AssociateTagsAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociateTagsAction"/> class.
+        /// </summary>
+        /// <param name="tagIds">The tag IDs.</param>
+        /// <param name="feedbackId">The feedback ID.</param>
+        public AssociateTagsAction(IList<Guid> tagIds, Guid feedbackId)
+        {
+            this.TagIds = tagIds;
+            this.FeedbackId = feedbackId;
+        }
+
+        /// <summary>
+        /// Gets the tag IDs.
+        /// </summary>
+        public IList<Guid> TagIds { get; }
+
+        /// <summary>
+        /// Gets or sets the feedback ID.
+        /// </summary>
+        public Guid FeedbackId { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed tag association.
+    /// </summary>
+    public class AssociateTagsFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociateTagsFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public AssociateTagsFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful tag association.
+    /// </summary>
+    public class AssociateTagsSuccessAction : BaseSuccessAction<RequestResult<UserFeedbackView>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AssociateTagsSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">User feedback view data.</param>
+        public AssociateTagsSuccessAction(RequestResult<UserFeedbackView> data)
+            : base(data)
         {
         }
     }

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackReducers.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackReducers.cs
@@ -29,121 +29,7 @@ using HealthGateway.Common.Data.ViewModels;
 public static class UserFeedbackReducers
 {
     /// <summary>
-    /// The reducer for associating tag to user feedback.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <returns>The new state.</returns>
-    [ReducerMethod(typeof(UserFeedbackActions.AssociateTagAction))]
-    public static UserFeedbackState ReduceAssociateTagAction(UserFeedbackState state)
-    {
-        return state with
-        {
-            AssociateTag = state.AssociateTag with
-            {
-                IsLoading = true,
-            },
-        };
-    }
-
-    /// <summary>
-    /// The reducer for associating tag to user feedback success action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
-    [ReducerMethod]
-    public static UserFeedbackState ReduceAssociateTagSuccessAction(UserFeedbackState state, UserFeedbackActions.AssociateTagSuccessAction action)
-    {
-        IImmutableDictionary<Guid, UserFeedbackView> data = state.FeedbackData ?? new Dictionary<Guid, UserFeedbackView>().ToImmutableDictionary();
-
-        UserFeedbackTagView? tag = action.Data.ResourcePayload;
-        if (tag != null && data.TryGetValue(tag.Id, out UserFeedbackView? feedback))
-        {
-            feedback?.Tags.Add(tag);
-        }
-
-        return state with
-        {
-            AssociateTag = state.AssociateTag with
-            {
-                IsLoading = true,
-                Error = null,
-                Result = action.Data,
-            },
-            FeedbackData = data,
-        };
-    }
-
-    /// <summary>
-    /// The reducer for the associating tag to user fail action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The add fail action.</param>
-    /// <returns>The new state.</returns>
-    [ReducerMethod]
-    public static UserFeedbackState ReduceAssociateTagFailAction(UserFeedbackState state, UserFeedbackActions.AssociateTagFailAction action)
-    {
-        return state with
-        {
-            AssociateTag = state.AssociateTag with
-            {
-                IsLoading = false,
-                Error = action.Error,
-            },
-        };
-    }
-
-    /// <summary>
-    /// The reducer for dissociating tag from user feedback.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <returns>The new state.</returns>
-    [ReducerMethod(typeof(UserFeedbackActions.DissociateTagAction))]
-    public static UserFeedbackState ReduceDissociateTagAction(UserFeedbackState state)
-    {
-        return state with
-        {
-            DissociateTag = state.DissociateTag with
-            {
-                IsLoading = true,
-            },
-        };
-    }
-
-    /// <summary>
-    /// The reducer for disassociating tag from user feedback success action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
-    [ReducerMethod]
-    public static UserFeedbackState ReduceDissociateTagSuccessAction(UserFeedbackState state, UserFeedbackActions.DissociateTagSuccessAction action)
-    {
-        IImmutableDictionary<Guid, UserFeedbackView> data = state.FeedbackData ?? new Dictionary<Guid, UserFeedbackView>().ToImmutableDictionary();
-
-        if (action.Result.ResourcePayload && data.TryGetValue(action.FeedbackId, out UserFeedbackView? feedback))
-        {
-            UserFeedbackTagView? tag = feedback.Tags.SingleOrDefault(t => t.Tag.Id == action.FeedbackTag.Id);
-            if (tag != null)
-            {
-                feedback.Tags.Remove(tag);
-            }
-        }
-
-        return state with
-        {
-            DissociateTag = state.DissociateTag with
-            {
-                IsLoading = true,
-                Error = null,
-                Result = action.Result,
-            },
-            FeedbackData = data,
-        };
-    }
-
-    /// <summary>
-    /// The reducer for loading User Feedback.
+    /// The reducer for loading user feedback.
     /// </summary>
     /// <param name="state">The user feedback state.</param>
     /// <returns>The new state.</returns>
@@ -200,6 +86,136 @@ public static class UserFeedbackReducers
     }
 
     /// <summary>
+    /// The reducer for updating user feedback.
+    /// </summary>
+    /// <param name="state">The user feedback state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(UserFeedbackActions.UpdateAction))]
+    public static UserFeedbackState ReduceUpdateAction(UserFeedbackState state)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = true,
+            },
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the update success action.
+    /// </summary>
+    /// <param name="state">The user feedback state.</param>
+    /// <param name="action">The update success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static UserFeedbackState ReduceUpdateSuccessAction(UserFeedbackState state, UserFeedbackActions.UpdateSuccessAction action)
+    {
+        IImmutableDictionary<Guid, UserFeedbackView> data = state.FeedbackData ?? new Dictionary<Guid, UserFeedbackView>().ToImmutableDictionary();
+
+        UserFeedbackView? feedback = action.Data.ResourcePayload;
+        if (feedback != null)
+        {
+            data = data.Remove(feedback.Id).Add(feedback.Id, feedback);
+        }
+
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            FeedbackData = data,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the update fail action.
+    /// </summary>
+    /// <param name="state">The user feedback state.</param>
+    /// <param name="action">The update fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static UserFeedbackState ReduceUpdateFailAction(UserFeedbackState state, UserFeedbackActions.UpdateFailAction action)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+        };
+    }
+
+    /// <summary>
+    /// The reducer for initiating the association of tags to user feedback.
+    /// </summary>
+    /// <param name="state">The Tag state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(UserFeedbackActions.AssociateTagsAction))]
+    public static UserFeedbackState ReduceAssociateTagsAction(UserFeedbackState state)
+    {
+        return state with
+        {
+            AssociateTags = state.AssociateTags with
+            {
+                IsLoading = true,
+            },
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the successful association of tags to user feedback.
+    /// </summary>
+    /// <param name="state">The user feedback state.</param>
+    /// <param name="action">The load success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static UserFeedbackState ReduceAssociateTagsSuccessAction(UserFeedbackState state, UserFeedbackActions.AssociateTagsSuccessAction action)
+    {
+        IImmutableDictionary<Guid, UserFeedbackView> data = state.FeedbackData ?? new Dictionary<Guid, UserFeedbackView>().ToImmutableDictionary();
+
+        UserFeedbackView? feedback = action.Data.ResourcePayload;
+        if (feedback != null)
+        {
+            data = data.Remove(feedback.Id).Add(feedback.Id, feedback);
+        }
+
+        return state with
+        {
+            AssociateTags = state.AssociateTags with
+            {
+                IsLoading = true,
+                Error = null,
+                Result = action.Data,
+            },
+            FeedbackData = data,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the failed association of tags to user feedback.
+    /// </summary>
+    /// <param name="state">The user feedback state.</param>
+    /// <param name="action">The add fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static UserFeedbackState ReduceAssociateTagsFailAction(UserFeedbackState state, UserFeedbackActions.AssociateTagsFailAction action)
+    {
+        return state with
+        {
+            AssociateTags = state.AssociateTags with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+        };
+    }
+
+    /// <summary>
     /// The reducer for the reset state action.
     /// </summary>
     /// <param name="state">The user feedback state.</param>
@@ -209,7 +225,7 @@ public static class UserFeedbackReducers
     {
         return state with
         {
-            AssociateTag = new(),
+            AssociateTags = new(),
             Load = new(),
         };
     }

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackState.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackState.cs
@@ -30,19 +30,19 @@ using HealthGateway.Common.Data.ViewModels;
 public record UserFeedbackState
 {
     /// <summary>
-    /// Gets the request state for associating tag to user feedback.
-    /// </summary>
-    public BaseRequestState<RequestResult<UserFeedbackTagView>> AssociateTag { get; init; } = new();
-
-    /// <summary>
-    /// Gets the request state for dissociating tag from user feedback tag.
-    /// </summary>
-    public BaseRequestState<PrimitiveRequestResult<bool>> DissociateTag { get; init; } = new();
-
-    /// <summary>
     /// Gets the request state for loading user feedback.
     /// </summary>
     public BaseRequestState<RequestResult<IEnumerable<UserFeedbackView>>> Load { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for updating user feedback.
+    /// </summary>
+    public BaseRequestState<RequestResult<UserFeedbackView>> Update { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for associating tags to user feedback.
+    /// </summary>
+    public BaseRequestState<RequestResult<UserFeedbackView>> AssociateTags { get; init; } = new();
 
     /// <summary>
     /// Gets the collection of user feedback data.

--- a/Apps/Admin/Server/Controllers/TagController.cs
+++ b/Apps/Admin/Server/Controllers/TagController.cs
@@ -92,7 +92,7 @@ namespace HealthGateway.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Associate an existing admin tag to the feedback with matching id.
+        /// Associate a collection of existing admin tags to the feedback with matching id.
         /// </summary>
         /// <returns>Returns the user feedback view with the associated admin tag(s) wrapped in a request result.</returns>
         /// <param name="feedbackId">The feedback id.</param>
@@ -102,26 +102,9 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpPut]
         [Route("UserFeedback/{feedbackId}/[controller]")]
-        public RequestResult<UserFeedbackView> AssociateTag(string feedbackId, [FromBody] IList<Guid> tagIds)
+        public RequestResult<UserFeedbackView> AssociateTags(Guid feedbackId, [FromBody] IList<Guid> tagIds)
         {
-            RequestResult<UserFeedbackView> result = this.feedbackService.AssociateFeedbackTag(Guid.Parse(feedbackId), tagIds);
-            return result;
-        }
-
-        /// <summary>
-        /// Dissociates the tag from the given feedback id.
-        /// </summary>
-        /// <returns>True if the operation was successful.</returns>
-        /// <param name="feedbackId">The feedback id.</param>
-        /// <param name="tag">The tag model.</param>
-        /// <response code="200">Returns the list of dependents.</response>
-        /// <response code="401">the client must authenticate itself to get the requested response.</response>
-        /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
-        [HttpDelete]
-        [Route("UserFeedback/{feedbackId}/[controller]")]
-        public bool DissociateTag(string feedbackId, [FromBody] UserFeedbackTagView tag)
-        {
-            bool result = this.feedbackService.DissociateFeedbackTag(Guid.Parse(feedbackId), tag);
+            RequestResult<UserFeedbackView> result = this.feedbackService.AssociateFeedbackTags(feedbackId, tagIds);
             return result;
         }
     }

--- a/Apps/Admin/Server/Controllers/UserFeedbackController.cs
+++ b/Apps/Admin/Server/Controllers/UserFeedbackController.cs
@@ -13,10 +13,13 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
+
 namespace HealthGateway.Admin.Server.Controllers
 {
+    using System.Collections.Generic;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Common.Data.ViewModels;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
@@ -36,8 +39,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// Initializes a new instance of the <see cref="UserFeedbackController"/> class.
         /// </summary>
         /// <param name="feedbackService">The injected user feedback service.</param>
-        public UserFeedbackController(
-            IUserFeedbackService feedbackService)
+        public UserFeedbackController(IUserFeedbackService feedbackService)
         {
             this.feedbackService = feedbackService;
         }
@@ -50,13 +52,13 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpGet]
-        public IActionResult GetFeedbackList()
+        public RequestResult<IList<UserFeedbackView>> GetFeedbackList()
         {
-            return new JsonResult(this.feedbackService.GetUserFeedback());
+            return this.feedbackService.GetUserFeedback();
         }
 
         /// <summary>
-        /// Sends email invites to the beta requets with the given ids.
+        /// Sends email invites to the beta requests with the given ids.
         /// </summary>
         /// <returns>A list of ids of the beta requests that where successfully processed.</returns>
         /// <param name="feedback">user feedback to update.</param>
@@ -64,9 +66,9 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content; that is, it is unauthorized, so the server is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.</response>
         [HttpPatch]
-        public IActionResult UpdateUserFeedback(UserFeedbackView feedback)
+        public RequestResult<UserFeedbackView> UpdateUserFeedback(UserFeedbackView feedback)
         {
-            return new JsonResult(this.feedbackService.UpdateFeedbackReview(feedback));
+            return this.feedbackService.UpdateFeedbackReview(feedback);
         }
     }
 }

--- a/Apps/Admin/Server/Services/IUserFeedbackService.cs
+++ b/Apps/Admin/Server/Services/IUserFeedbackService.cs
@@ -35,8 +35,8 @@ namespace HealthGateway.Admin.Server.Services
         /// Updates the user feedback.
         /// </summary>
         /// <param name="feedback">The user feedback to update.</param>
-        /// <returns>A value indicating if the call was successful.</returns>
-        bool UpdateFeedbackReview(UserFeedbackView feedback);
+        /// <returns>Returns the user feedback view with its associated admin tag(s) wrapped in a request result.</returns>
+        RequestResult<UserFeedbackView> UpdateFeedbackReview(UserFeedbackView feedback);
 
         /// <summary>
         /// Retrieves the admin tags.
@@ -59,19 +59,11 @@ namespace HealthGateway.Admin.Server.Services
         RequestResult<AdminTagView> DeleteTag(AdminTagView tag);
 
         /// <summary>
-        /// Associates an admin tag to a feedback.
+        /// Associates a collection of tags to a feedback item.
         /// </summary>
-        /// <param name="userFeedbackId">The user feedback id to be associated to the tag.</param>
+        /// <param name="userFeedbackId">The user feedback id to be associated to the tags.</param>
         /// <param name="adminTagIds">The admin tag ids.</param>
-        /// <returns>Returns the user feedback view with the associated admin tag(s) wrapped in a request result.</returns>
-        RequestResult<UserFeedbackView> AssociateFeedbackTag(Guid userFeedbackId, IList<Guid> adminTagIds);
-
-        /// <summary>
-        /// Dissociates an admin tag from a user feedback.
-        /// </summary>
-        /// <param name="userFeedbackId">The user feedback id to be dissociated to the tag.</param>
-        /// <param name="tag">The admin tag.</param>
-        /// <returns>returns the associated admin tag wrapped in a request result.</returns>
-        bool DissociateFeedbackTag(Guid userFeedbackId, UserFeedbackTagView tag);
+        /// <returns>Returns the user feedback view with its associated admin tag(s) wrapped in a request result.</returns>
+        RequestResult<UserFeedbackView> AssociateFeedbackTags(Guid userFeedbackId, IList<Guid> adminTagIds);
     }
 }


### PR DESCRIPTION
#  Implements [AB#12673](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12673)

## Description

- updates store and back-end to support associating multiple tags to a feedback at a time
- displays feedback in a table on the Feedback Review page in the Admin app
   - feedback can be reviewed by clicking the button

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://user-images.githubusercontent.com/16570293/174212477-d3371cbb-1ebc-41ae-953a-817788f6e42b.png)

## Notes

- The MudSelect control for associating feedback tags is not working yet, so [AB#13384](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13384) has been created to address that

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
