### PR TITLE
Add Refresh Button test for Blazor Admin Dashboard for AB#13353.

### DIFF
--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -16,7 +16,7 @@
 <MudGrid>
     <MudItem xs="12" lg="12">
         <MudPaper Class="my-2 pa-4 d-flex justify-end" Elevation="0">
-            <HgButton EndIcon="@Icons.Material.Filled.Refresh" @onclick="ReloadDispatchActions">Refresh</HgButton>
+            <HgButton EndIcon="@Icons.Material.Filled.Refresh" @onclick="ReloadDispatchActions" data-testid="refresh-btn">Refresh</HgButton>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard/dashboard.cy.js
@@ -8,11 +8,6 @@ describe("Dashboard", () => {
         cy.login(Cypress.env("idir_username"), Cypress.env("idir_password"));
     });
 
-    afterEach(() => {
-        cy.log("Logging out.");
-        cy.logout();
-    });
-
     it("Verify dashboards counts.", () => {
         cy.log("Dashboard test started.");
         cy.get("[data-testid=total-registered-users]").contains(6);

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard/dashboard.cy.js
@@ -41,11 +41,6 @@ describe("Dashboard", () => {
         cy.login(Cypress.env("idir_username"), Cypress.env("idir_password"));
     });
 
-    afterEach(() => {
-        cy.log("Logging out.");
-        cy.logout();
-    });
-
     it("Verify dashboards counts.", () => {
         cy.log("Dashboard test started.");
         cy.get("[data-testid=total-registered-users]").contains(6);
@@ -73,6 +68,7 @@ describe("Dashboard", () => {
             });
         });
 
+        cy.log("Updating unique days input value.");
         cy.get("[data-testid=unique-days]").clear().type(5);
         cy.get("[data-testid=total-unique-users]").click();
         cy.get("[data-testid=total-unique-users]").contains(0);
@@ -83,9 +79,39 @@ describe("Dashboard", () => {
             });
         });
 
+        cy.log("Updating unique days input value.");
         cy.get("[data-testid=unique-days]").clear().type(2);
         cy.get("[data-testid=total-unique-users]").click();
         cy.get("[data-testid=total-unique-users]").contains(3);
+
+        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=2*", (req) => {
+            req.reply({
+                body: 10,
+            });
+        });
+
+        cy.log("Clicking refresh button.");
+        cy.get("[data-testid=refresh-btn]").click();
+
+        // Unique users
+        cy.get("[data-testid=total-unique-users]").contains(10);
+
+        // All other data remains same as fixtures were not changed
+        cy.get("[data-testid=total-registered-users]").contains(6);
+        cy.get("[data-testid=total-dependents]").contains(2);
+        cy.get("[data-testid=average-rating]").contains("4.00");
+
+        cy.get("[data-testid=daily-data-table]")
+            .first()
+            .within(() => {
+                cy.get(
+                    "[data-testid=daily-data-total-registered-users]"
+                ).contains("2");
+                cy.get(
+                    "[data-testid=daily-data-total-logged-in-users]"
+                ).contains("6");
+                cy.get("[data-testid=daily-data-dependents]").contains("2");
+            });
 
         cy.log("Dashboard test finished.");
     });

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -33,7 +33,6 @@ Cypress.Commands.add("login", (username, password) => {
         .should("not.be.disabled")
         .click();
     cy.log("Username: " + username);
-    cy.log("Password: " + password);
     cy.get("#user").should("be.visible").type(username);
     cy.get("#password").should("be.visible").type(password);
     cy.get('input[name="btnSubmit"]').should("be.visible").click();


### PR DESCRIPTION
# Implements [AB#13353](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13353)

## Description

- Add refresh button test on Blazor Admin Dashboard
- Removed logout and after each calls on both ui and e2e dashboard tests
- Removed log of password in login call.

**Cypress Run Tests:**

<img width="2044" alt="Screen Shot 2022-06-20 at 4 26 49 PM" src="https://user-images.githubusercontent.com/58790456/174688821-2541355e-e310-40e6-b608-2e62e5f623d0.png">

<img width="2032" alt="Screen Shot 2022-06-20 at 4 27 02 PM" src="https://user-images.githubusercontent.com/58790456/174688825-a4e12b2c-4c5a-42da-8d29-1e366a50c6ca.png">

<img width="2027" alt="Screen Shot 2022-06-20 at 4 27 13 PM" src="https://user-images.githubusercontent.com/58790456/174688831-4a9b72c2-a774-4f45-b320-1dc1fb4b0389.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
