### PR TITLE
Fix spinner on Profile page when Patient fails for AB#13232

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
@@ -38,7 +38,7 @@ export class RestPatientService implements IPatientService {
                     reject(
                         ErrorTranslator.internalNetworkError(
                             err,
-                            ServiceName.Immunization
+                            ServiceName.Patient
                         )
                     );
                 });

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -182,7 +182,7 @@ export default class ProfileView extends Vue {
     }
 
     private get isPostalAddressShown(): boolean {
-        return this.patientData.postalAddress !== null;
+        return this.patientData.postalAddress != null;
     }
 
     private get postalAddressLabel(): string {
@@ -527,25 +527,34 @@ export default class ProfileView extends Vue {
     }
 
     private isSameAddress(): boolean {
-        const equals = (a: string[], b: string[]) =>
-            a.length === b.length && a.every((v, i) => v === b[i]);
+        let result = false;
+        if (this.postalAddress != null && this.physicalAddress != null) {
+            const equals = (a: string[], b: string[]) =>
+                a.length === b.length && a.every((v, i) => v === b[i]);
 
-        const isStreetLineSame = equals(
-            this.postalAddress.streetLines,
-            this.physicalAddress.streetLines
-        );
+            const isStreetLineSame = equals(
+                this.postalAddress.streetLines,
+                this.physicalAddress.streetLines
+            );
 
-        const isCitySame =
-            this.postalAddress.city === this.physicalAddress.city;
+            const isCitySame =
+                this.postalAddress.city === this.physicalAddress.city;
 
-        const isStateSame =
-            this.postalAddress.state === this.physicalAddress.state;
+            const isStateSame =
+                this.postalAddress.state === this.physicalAddress.state;
 
-        const isPostalCodeSame =
-            this.postalAddress.postalCode === this.physicalAddress.postalCode;
+            const isPostalCodeSame =
+                this.postalAddress.postalCode ===
+                this.physicalAddress.postalCode;
 
-        const result =
-            isStreetLineSame && isCitySame && isStateSame && isPostalCodeSame;
+            result =
+                isStreetLineSame &&
+                isCitySame &&
+                isStateSame &&
+                isPostalCodeSame;
+        } else {
+            result = this.postalAddress == null && this.physicalAddress == null;
+        }
 
         this.logger.debug(
             `Physical Address and Postal Address same: ${result}`


### PR DESCRIPTION
# Fixes or Implements [AB#13232](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13232)

## Description

Resolves the endless spinner when Patient call fails.
Fix incorrect label on Patient error.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
