### PR TITLE
Ensure GetUsers returns all results from Keycloak for AB#13381

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/analytics.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/analytics.cy.js
@@ -32,7 +32,7 @@ describe("System Analytics", () => {
         cy.visit("/analytics");
     });
 
-    it("Verify system anlytics stats downloads.", () => {
+    it("Verify system analytics stats downloads.", () => {
         cy.log("System Analytics stats download test started.");
 
         cy.get("[data-testid=user-profile-download-btn]")

--- a/Apps/Common/src/AccessManagement/Administration/KeycloakUserAdminDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Administration/KeycloakUserAdminDelegate.cs
@@ -113,7 +113,7 @@ namespace HealthGateway.Common.AccessManagement.Administration
             {
                 Uri baseUri = new Uri(this.configuration.GetSection(KEYCLOAKADMIN).GetValue<string>(GetRolesUrlKey));
                 HttpClient client = this.CreateHttpClient(baseUri, jwtModel.AccessToken);
-                string uri = $"{role}/users";
+                string uri = $"{role}/users?max=-1";
 
                 HttpResponseMessage response = await client.GetAsync(new Uri(uri, UriKind.Relative)).ConfigureAwait(true);
                 string payload = await response.Content.ReadAsStringAsync().ConfigureAwait(true);


### PR DESCRIPTION
# Fixes [AB#13381](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13381)

## Description

GetUers call when calling Keycloak api was only returning the first 100 users instead of returning all users.  Added fix so that GetUsers returns all users.

Also, fixed typo in Admin Analytics functional test.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
