### PR TITLE
Fix delay in showing 0 record cabinet image for AB#13458.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -104,6 +104,63 @@ export default class LinearTimelineComponent extends Vue {
         return fullyLoaded;
     }
 
+    private get isFilterLoading(): boolean {
+        const filtersLoaded = [];
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.MedicationRequest,
+                this.isMedicationRequestLoading
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.Medication,
+                this.isMedicationStatementLoading
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.Immunization,
+                this.isImmunizationLoading
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.Covid19LaboratoryOrder,
+                this.isCovid19LaboratoryLoading
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.LaboratoryOrder,
+                this.isLaboratoryLoading
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.Encounter,
+                this.isEncounterLoading
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.Note,
+                this.isNoteLoading
+            )
+        );
+
+        const filterLoading = filtersLoaded.includes(true);
+        this.logger.debug(`Timeline filter loading: ${filterLoading}`);
+
+        return filterLoading;
+    }
+
     private get numberOfPages(): number {
         let pageCount = 1;
         if (this.timelineEntries.length > this.pageSize) {
@@ -185,7 +242,7 @@ export default class LinearTimelineComponent extends Vue {
     }
 
     private get showEmptyState(): boolean {
-        return this.timelineIsEmpty && this.isFullyLoaded;
+        return this.timelineIsEmpty && !this.isFilterLoading;
     }
 
     private get timelineEntryCount(): number {
@@ -217,6 +274,27 @@ export default class LinearTimelineComponent extends Vue {
 
     private getComponentForEntry(entryType: EntryType): string {
         return entryTypeMap.get(entryType)?.component ?? "";
+    }
+
+    private isFilterApplied(entryType: EntryType): boolean {
+        const entryTypes: EntryType[] = Array.from(this.filter.entryTypes);
+        const filterApplied = !!entryTypes.includes(entryType);
+        this.logger.debug(
+            `Timeline filter entry type: ${entryType} applied: ${filterApplied}`
+        );
+        return filterApplied;
+    }
+
+    private isSelectedFilterModuleLoading(
+        entryType: EntryType,
+        loading: boolean
+    ): boolean {
+        const filterApplied = this.isFilterApplied(entryType);
+        const isLoading = filterApplied && loading;
+        this.logger.debug(
+            `Timeline filter entry type: ${entryType} applied: ${filterApplied} - filter loading: ${loading} and filter isLoading: ${isLoading}`
+        );
+        return isLoading;
     }
 }
 </script>

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -290,53 +290,56 @@ export default class TimelineView extends Vue {
     private get isFilterLoading(): boolean {
         const filtersLoaded = [];
         filtersLoaded.push(
-            this.isFilterResultLoading(
+            this.isSelectedFilterModuleLoading(
                 EntryType.MedicationRequest,
                 this.isMedicationRequestLoading
             )
         );
 
         filtersLoaded.push(
-            this.isFilterResultLoading(
+            this.isSelectedFilterModuleLoading(
                 EntryType.Medication,
                 this.isMedicationStatementLoading
             )
         );
 
         filtersLoaded.push(
-            this.isFilterResultLoading(
+            this.isSelectedFilterModuleLoading(
                 EntryType.Immunization,
                 this.isImmunizationLoading
             )
         );
 
         filtersLoaded.push(
-            this.isFilterResultLoading(
+            this.isSelectedFilterModuleLoading(
                 EntryType.Covid19LaboratoryOrder,
                 this.isCovid19LaboratoryLoading
             )
         );
 
         filtersLoaded.push(
-            this.isFilterResultLoading(
+            this.isSelectedFilterModuleLoading(
                 EntryType.LaboratoryOrder,
                 this.isLaboratoryLoading
             )
         );
 
         filtersLoaded.push(
-            this.isFilterResultLoading(
+            this.isSelectedFilterModuleLoading(
                 EntryType.Encounter,
                 this.isEncounterLoading
             )
         );
 
         filtersLoaded.push(
-            this.isFilterResultLoading(EntryType.Note, this.isNoteLoading)
+            this.isSelectedFilterModuleLoading(
+                EntryType.Note,
+                this.isNoteLoading
+            )
         );
 
         const filterLoading = filtersLoaded.includes(true);
-        this.logger.debug(`Timeline is filter loading: ${filterLoading}`);
+        this.logger.debug(`Timeline filter loading: ${filterLoading}`);
 
         return filterLoading;
     }
@@ -389,7 +392,7 @@ export default class TimelineView extends Vue {
         return filterApplied;
     }
 
-    private isFilterResultLoading(
+    private isSelectedFilterModuleLoading(
         entryType: EntryType,
         loading: boolean
     ): boolean {


### PR DESCRIPTION
# Fixes [AB#13458](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13458)

## Description

Currently when navigating from a Note Quick Link Card in Home to the dashboard, the 0 record cabinet image does not display until all API calls are finished.  This fix addresses this issue.

Also, renamed function name and log message in Timeline.vue for clarity.

<img width="1969" alt="Screen Shot 2022-06-29 at 11 51 36 AM" src="https://user-images.githubusercontent.com/58790456/176515044-792683a5-a361-4f5c-954f-bac31797a9a1.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
