### PR TITLE
Fix intercepts unintentionally calling back-end AB#13461

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard.cy.js
@@ -4,36 +4,26 @@ describe("Dashboard", () => {
     beforeEach(() => {
         verifyTestingEnvironment();
 
-        cy.intercept("GET", "**/Dashboard/RegisteredCount*", (req) => {
-            req.reply({
-                fixture: "DashboardService/registered-count.json",
-            });
+        cy.intercept("GET", "**/Dashboard/RegisteredCount*", {
+            fixture: "DashboardService/registered-count.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/LoggedInCount*", (req) => {
-            req.reply({
-                fixture: "DashboardService/logged-in-count.json",
-            });
+        cy.intercept("GET", "**/Dashboard/LoggedInCount*", {
+            fixture: "DashboardService/logged-in-count.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/DependentCount*", (req) => {
-            req.reply({
-                fixture: "DashboardService/dependent-count.json",
-            });
+        cy.intercept("GET", "**/Dashboard/DependentCount*", {
+            fixture: "DashboardService/dependent-count.json",
         });
 
         // used to calculate [data-testid=average-rating]
-        cy.intercept("GET", "**/Dashboard/Ratings/Summary*", (req) => {
-            req.reply({
-                fixture: "DashboardService/summary.json",
-            });
+        cy.intercept("GET", "**/Dashboard/Ratings/Summary*", {
+            fixture: "DashboardService/summary.json",
         });
 
         // matches [data-testid=total-unique-users]
-        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=3*", (req) => {
-            req.reply({
-                body: 2,
-            });
+        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=3*", {
+            body: 2,
         });
 
         cy.log("Logging in.");
@@ -60,53 +50,39 @@ describe("Dashboard", () => {
             });
 
         cy.log("Change value in unique days input field.");
-        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=5*", (req) => {
-            req.reply({
-                body: 0,
-            });
+        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=5*", {
+            body: 0,
         });
         cy.log("Updating unique days input value.");
         cy.get("[data-testid=unique-days-input]").clear().type(5);
         cy.get("[data-testid=total-unique-users]").click().contains(0);
 
-        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=2*", (req) => {
-            req.reply({
-                body: 3,
-            });
+        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=2*", {
+            body: 3,
         });
         cy.log("Updating unique days input value.");
         cy.get("[data-testid=unique-days-input]").clear().type(2);
         cy.get("[data-testid=total-unique-users]").click().contains(3);
 
         cy.log("Clicking refresh button.");
-        cy.intercept("GET", "**/Dashboard/RegisteredCount*", (req) => {
-            req.reply({
-                fixture: "DashboardService/registered-count-refresh.json",
-            });
+        cy.intercept("GET", "**/Dashboard/RegisteredCount*", {
+            fixture: "DashboardService/registered-count-refresh.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/LoggedInCount*", (req) => {
-            req.reply({
-                fixture: "DashboardService/logged-in-count-refresh.json",
-            });
+        cy.intercept("GET", "**/Dashboard/LoggedInCount*", {
+            fixture: "DashboardService/logged-in-count-refresh.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/DependentCount*", (req) => {
-            req.reply({
-                fixture: "DashboardService/dependent-count-refresh.json",
-            });
+        cy.intercept("GET", "**/Dashboard/DependentCount*", {
+            fixture: "DashboardService/dependent-count-refresh.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/Ratings/Summary*", (req) => {
-            req.reply({
-                fixture: "DashboardService/summary-refresh.json",
-            });
+        cy.intercept("GET", "**/Dashboard/Ratings/Summary*", {
+            fixture: "DashboardService/summary-refresh.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=2*", (req) => {
-            req.reply({
-                body: 10,
-            });
+        cy.intercept("GET", "**/Dashboard/RecurringUsers?days=2*", {
+            body: 10,
         });
 
         cy.get("[data-testid=refresh-btn]").click();

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicCovidTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicCovidTest.js
@@ -229,10 +229,8 @@ describe("Public COVID-19 Test Results", () => {
         const collectionDateMonth = "January";
         const collectionDateDay = "20";
 
-        cy.intercept("GET", "**/PublicLaboratory/CovidTests", (req) => {
-            req.reply({
-                fixture: "LaboratoryService/covidTest.json",
-            });
+        cy.intercept("GET", "**/PublicLaboratory/CovidTests", {
+            fixture: "LaboratoryService/covidTest.json",
         });
 
         enterCovidTestPHN(phn);
@@ -280,10 +278,8 @@ describe("Public COVID-19 Test Results", () => {
         const collectionDateMonth = "January";
         const collectionDateDay = "20";
 
-        cy.intercept("GET", "**/PublicLaboratory/CovidTests", (req) => {
-            req.reply({
-                fixture: "LaboratoryService/emptyCovidTest.json",
-            });
+        cy.intercept("GET", "**/PublicLaboratory/CovidTests", {
+            fixture: "LaboratoryService/emptyCovidTest.json",
         });
 
         enterCovidTestPHN(phn);
@@ -311,10 +307,8 @@ describe("Public COVID-19 Test Results", () => {
         const collectionDateMonth = "January";
         const collectionDateDay = "20";
 
-        cy.intercept("GET", "**/PublicLaboratory/CovidTests", (req) => {
-            req.reply({
-                fixture: "LaboratoryService/dataMismatchCovidTest.json",
-            });
+        cy.intercept("GET", "**/PublicLaboratory/CovidTests", {
+            fixture: "LaboratoryService/dataMismatchCovidTest.json",
         });
 
         enterCovidTestPHN(phn);
@@ -337,10 +331,8 @@ describe("Public COVID-19 Test Results", () => {
         const collectionDateMonth = "January";
         const collectionDateDay = "20";
 
-        cy.intercept("GET", "**/PublicLaboratory/CovidTests", (req) => {
-            req.reply({
-                fixture: "LaboratoryService/invalidCovidTest.json",
-            });
+        cy.intercept("GET", "**/PublicLaboratory/CovidTests", {
+            fixture: "LaboratoryService/invalidCovidTest.json",
         });
 
         enterCovidTestPHN(phn);
@@ -363,10 +355,8 @@ describe("Public COVID-19 Test Results", () => {
         const collectionDateMonth = "January";
         const collectionDateDay = "20";
 
-        cy.intercept("GET", "**/PublicLaboratory/CovidTests", (req) => {
-            req.reply({
-                fixture: "LaboratoryService/emptyCovidTest.json",
-            });
+        cy.intercept("GET", "**/PublicLaboratory/CovidTests", {
+            fixture: "LaboratoryService/emptyCovidTest.json",
         });
 
         enterCovidTestPHN(phn);

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicVaccineCard.js
@@ -240,10 +240,8 @@ describe("Public Vaccine Card Downloads", () => {
     });
 
     it("Error Displayed When PDF Unavailable", () => {
-        cy.intercept("GET", "**/PublicVaccineStatus/pdf", (req) => {
-            req.reply({
-                fixture: "ImmunizationService/vaccineProofLoadedNoPdf.json",
-            });
+        cy.intercept("GET", "**/PublicVaccineStatus/pdf", {
+            fixture: "ImmunizationService/vaccineProofLoadedNoPdf.json",
         });
         cy.get("[data-testid=save-dropdown-btn]")
             .should("be.visible", "be.enabled")

--- a/Testing/functional/tests/cypress/integration/ui/report/immunizationReport.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/immunizationReport.js
@@ -9,18 +9,16 @@ describe("Immunization History Report", () => {
         let isLoading = false;
         cy.enableModules("Immunization");
         cy.intercept("GET", "**/Immunization?*", (req) => {
-            req.reply((res) => {
-                if (!isLoading) {
-                    res.send({
-                        fixture: "ImmunizationService/immunizationrefresh.json",
-                    });
-                } else {
-                    res.send({
-                        fixture: "ImmunizationService/immunization.json",
-                    });
-                }
-                isLoading = !isLoading;
-            });
+            if (!isLoading) {
+                req.reply({
+                    fixture: "ImmunizationService/immunizationrefresh.json",
+                });
+            } else {
+                req.reply({
+                    fixture: "ImmunizationService/immunization.json",
+                });
+            }
+            isLoading = !isLoading;
         });
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
@@ -19,10 +19,8 @@ describe("Reports - Medication", () => {
     });
 
     it("Validate Medication Statement Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/MedicationStatement/${HDID}`, (req) => {
-            req.reply({
-                fixture: "Report/medicationStatementUnSorted.json",
-            });
+        cy.intercept("GET", `**/MedicationStatement/${HDID}`, {
+            fixture: "Report/medicationStatementUnSorted.json",
         });
         cy.get("[data-testid=reportType]").select("Medications");
         cy.get("[data-testid=reportSample]").should("be.visible");
@@ -54,10 +52,8 @@ describe("Reports - Medication", () => {
     });
 
     it("Validate Medication Request Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/MedicationRequest/${HDID}`, (req) => {
-            req.reply({
-                fixture: "Report/medicationRequestUnSorted.json",
-            });
+        cy.intercept("GET", `**/MedicationRequest/${HDID}`, {
+            fixture: "Report/medicationRequestUnSorted.json",
         });
         cy.get("[data-testid=reportType]").select("Special Authority Requests");
 
@@ -109,15 +105,9 @@ describe("Reports - Covid19", () => {
     });
 
     it("Validate Covid19 Report with Unsorted Data", () => {
-        cy.intercept(
-            "GET",
-            `**/Laboratory/Covid19Orders?hdid=${HDID}`,
-            (req) => {
-                req.reply({
-                    fixture: "Report/covid19UnSorted.json",
-                });
-            }
-        );
+        cy.intercept("GET", `**/Laboratory/Covid19Orders?hdid=${HDID}`, {
+            fixture: "Report/covid19UnSorted.json",
+        });
         cy.get("[data-testid=reportType]").select("COVID-19 Test Results");
 
         cy.get("[data-testid=reportSample]").should("be.visible");
@@ -167,10 +157,8 @@ describe("Reports - Immunization", () => {
     });
 
     it("Validate Immunization Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/Immunization?hdid=${HDID}`, (req) => {
-            req.reply({
-                fixture: "Report/immunizationUnSorted.json",
-            });
+        cy.intercept("GET", `**/Immunization?hdid=${HDID}`, {
+            fixture: "Report/immunizationUnSorted.json",
         });
         cy.get("[data-testid=reportType]").select("Immunizations");
 
@@ -246,10 +234,8 @@ describe("Reports - MSP Visit", () => {
     });
 
     it("Validate MSP Visit Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/Encounter/${HDID}`, (req) => {
-            req.reply({
-                fixture: "Report/mspVisitUnSorted.json",
-            });
+        cy.intercept("GET", `**/Encounter/${HDID}`, {
+            fixture: "Report/mspVisitUnSorted.json",
         });
         cy.get("[data-testid=reportType]").select("Health Visits");
 
@@ -301,10 +287,8 @@ describe("Reports - Notes (User-Entered)", () => {
     });
 
     it("Validate Note (User-Entered) Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/Note/${HDID}`, (req) => {
-            req.reply({
-                fixture: "Report/noteUnSorted.json",
-            });
+        cy.intercept("GET", `**/Note/${HDID}`, {
+            fixture: "Report/noteUnSorted.json",
         });
         cy.get("[data-testid=reportType]").select("My Notes");
 
@@ -357,15 +341,9 @@ describe("Reports - Laboratory Tests", () => {
     });
 
     it("Validate Laboratory Report with Unsorted Data", () => {
-        cy.intercept(
-            "GET",
-            `**/Laboratory/LaboratoryOrders?hdid=${HDID}`,
-            (req) => {
-                req.reply({
-                    fixture: "Report/laboratoryUnSorted.json",
-                });
-            }
-        );
+        cy.intercept("GET", `**/Laboratory/LaboratoryOrders?hdid=${HDID}`, {
+            fixture: "Report/laboratoryUnSorted.json",
+        });
         cy.get("[data-testid=reportType]").select("Laboratory Tests");
 
         cy.get("[data-testid=reportSample]").should("be.visible");

--- a/Testing/functional/tests/cypress/integration/ui/resourceCentre/covidcard.js
+++ b/Testing/functional/tests/cypress/integration/ui/resourceCentre/covidcard.js
@@ -2,12 +2,8 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Resource Centre", () => {
     it("Validate Disabled Covid Card", () => {
-        cy.intercept("GET", "**/Immunization", (req) => {
-            req.reply((res) => {
-                res.send({
-                    fixture: "ImmunizationService/immunizationNoRecords.json",
-                });
-            });
+        cy.intercept("GET", "**/Immunization", {
+            fixture: "ImmunizationService/immunizationNoRecords.json",
         });
         cy.enableModules("Immunization");
         cy.login(
@@ -24,12 +20,8 @@ describe("Resource Centre", () => {
     });
 
     it("Validate on Timeline", () => {
-        cy.intercept("GET", "**/Immunization", (req) => {
-            req.reply((res) => {
-                res.send({
-                    fixture: "ImmunizationService/immunization.json",
-                });
-            });
+        cy.intercept("GET", "**/Immunization", {
+            fixture: "ImmunizationService/immunization.json",
         });
         cy.enableModules(["Immunization", "VaccinationStatus"]);
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/errors.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/errors.js
@@ -2,10 +2,8 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Banner Error", () => {
     beforeEach(() => {
-        cy.intercept("GET", "**/Note/*", (req) => {
-            req.reply((res) => {
-                res.send({ fixture: "WebClientService/dbError.json" });
-            });
+        cy.intercept("GET", "**/Note/*", {
+            fixture: "WebClientService/dbError.json",
         });
         cy.enableModules("Note");
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/immunization.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/immunization.js
@@ -4,18 +4,16 @@ describe("Immunization - With Refresh", () => {
     beforeEach(() => {
         let isLoading = false;
         cy.intercept("GET", "**/Immunization?*", (req) => {
-            req.reply((res) => {
-                if (!isLoading) {
-                    res.send({
-                        fixture: "ImmunizationService/immunizationrefresh.json",
-                    });
-                } else {
-                    res.send({
-                        fixture: "ImmunizationService/immunization.json",
-                    });
-                }
-                isLoading = !isLoading;
-            });
+            if (!isLoading) {
+                req.reply({
+                    fixture: "ImmunizationService/immunizationrefresh.json",
+                });
+            } else {
+                req.reply({
+                    fixture: "ImmunizationService/immunization.json",
+                });
+            }
+            isLoading = !isLoading;
         });
         cy.enableModules([
             "Immunization",

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -172,19 +172,16 @@ describe("Laboratory Orders Refresh", () => {
     beforeEach(() => {
         let isLoading = false;
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", (req) => {
-            req.reply((res) => {
-                if (!isLoading) {
-                    res.send({
-                        fixture:
-                            "LaboratoryService/laboratoryOrdersRefresh.json",
-                    });
-                } else {
-                    res.send({
-                        fixture: "LaboratoryService/laboratoryOrders.json",
-                    });
-                }
-                isLoading = !isLoading;
-            });
+            if (!isLoading) {
+                req.reply({
+                    fixture: "LaboratoryService/laboratoryOrdersRefresh.json",
+                });
+            } else {
+                req.reply({
+                    fixture: "LaboratoryService/laboratoryOrders.json",
+                });
+            }
+            isLoading = !isLoading;
         });
         cy.enableModules("AllLaboratory");
         cy.viewport("iphone-6");

--- a/Testing/functional/tests/cypress/integration/ui/user/acceptTermsOfService.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/acceptTermsOfService.js
@@ -3,10 +3,8 @@ const HDID = "K6HL4VX67CZ2PGSZ2ZOIR4C3PGMFFBW5CIOXM74D6EQ7RYYL7P4A";
 
 describe("Need to accept terms of service", () => {
     beforeEach(() => {
-        cy.intercept("GET", `**/UserProfile/${HDID}`, (req) => {
-            req.reply({
-                fixture: "UserProfileService/userProfileAcceptTos.json",
-            });
+        cy.intercept("GET", `**/UserProfile/${HDID}`, {
+            fixture: "UserProfileService/userProfileAcceptTos.json",
         });
         cy.login(
             Cypress.env("keycloak.accept.tos.username"),
@@ -33,10 +31,8 @@ describe("Need to accept terms of service", () => {
 
 describe("Does not need to accept terms of service", () => {
     beforeEach(() => {
-        cy.intercept("GET", `**/UserProfile/${HDID}`, (req) => {
-            req.reply({
-                fixture: "UserProfileService/userProfile.json",
-            });
+        cy.intercept("GET", `**/UserProfile/${HDID}`, {
+            fixture: "UserProfileService/userProfile.json",
         });
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/profile.js
@@ -4,10 +4,8 @@ const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 
 describe("User Profile", () => {
     beforeEach(() => {
-        cy.intercept("GET", `**/UserProfile/${HDID}`, (req) => {
-            req.reply({
-                fixture: "UserProfileService/userProfile.json",
-            });
+        cy.intercept("GET", `**/UserProfile/${HDID}`, {
+            fixture: "UserProfileService/userProfile.json",
         });
 
         cy.login(
@@ -88,10 +86,8 @@ describe("User Profile", () => {
         });
 
         cy.log("Verify SMS number");
-        cy.intercept("GET", `**/UserProfile/${HDID}`, (req) => {
-            req.reply({
-                fixture: "UserProfileService/userProfile.json",
-            });
+        cy.intercept("GET", `**/UserProfile/${HDID}`, {
+            fixture: "UserProfileService/userProfile.json",
         });
         cy.get("[data-testid=smsStatusNotVerified]").should("be.visible");
         cy.get("[data-testid=verifySMSBtn]")
@@ -143,10 +139,8 @@ describe("User Profile - Validate Address", () => {
         cy.intercept(
             "GET",
             `**/Patient/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A`,
-            (req) => {
-                req.reply({
-                    fixture: "PatientService/patientCombinedAddress.json",
-                });
+            {
+                fixture: "PatientService/patientCombinedAddress.json",
             }
         );
         cy.visit("/profile");
@@ -167,10 +161,8 @@ describe("User Profile - Validate Address", () => {
         cy.intercept(
             "GET",
             `**/Patient/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A`,
-            (req) => {
-                req.reply({
-                    fixture: "PatientService/patientDifferentAddress.json",
-                });
+            {
+                fixture: "PatientService/patientDifferentAddress.json",
             }
         );
         cy.visit("/profile");
@@ -200,10 +192,8 @@ describe("User Profile - Validate Address", () => {
         cy.intercept(
             "GET",
             `**/Patient/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A`,
-            (req) => {
-                req.reply({
-                    fixture: "PatientService/patientNoAddress.json",
-                });
+            {
+                fixture: "PatientService/patientNoAddress.json",
             }
         );
         cy.visit("/profile");
@@ -222,10 +212,8 @@ describe("User Profile - Validate Address", () => {
         cy.intercept(
             "GET",
             `**/Patient/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A`,
-            (req) => {
-                req.reply({
-                    fixture: "PatientService/patientOnlyPhysicalAddress.json",
-                });
+            {
+                fixture: "PatientService/patientOnlyPhysicalAddress.json",
             }
         );
         cy.visit("/profile");
@@ -250,10 +238,8 @@ describe("User Profile - Validate Address", () => {
         cy.intercept(
             "GET",
             `**/Patient/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A`,
-            (req) => {
-                req.reply({
-                    fixture: "PatientService/patientOnlyPostalAddress.json",
-                });
+            {
+                fixture: "PatientService/patientOnlyPostalAddress.json",
             }
         );
         cy.visit("/profile");


### PR DESCRIPTION
# Fixes [AB#13461](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13461)

## Description

Rewrites Cypress intercepts that provide fixtures to ensure they don't call the back-end.

The issue is using `res.send()`, as in this example:
```
cy.intercept("GET", "**/url-path", (req) => {
    req.reply((res) => {
        res.send({ fixture: "path/to/fixture.json" });
    });
});
````

It can be resolved by rewriting the intercept like this:
```
cy.intercept("GET", "**/url-path", (req) => {
    req.reply({ fixture: "path/to/fixture.json" });
});
````

Or like this:
```
cy.intercept("GET", "**/url-path", { fixture: "path/to/fixture.json" });
````

The PR also cleans up some intercepts that were providing fixtures via a callback instead of passing an object as a parameter.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
