### PR TITLE
Fix skeleton not showing when no filter has been selected for AB#13464.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -356,7 +356,7 @@ export default class TimelineView extends Vue {
         if (this.isFilterModuleSelected) {
             return this.isFilterLoading;
         }
-        return !this.isFullyLoaded;
+        return !this.isFullyLoaded && this.filteredTimelineEntries.length === 0;
     }
 
     private get showTimelineEntries(): boolean {

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -344,10 +344,19 @@ export default class TimelineView extends Vue {
         return filterLoading;
     }
 
+    private get isFilterModuleSelected(): boolean {
+        const entryTypes: EntryType[] = Array.from(this.filter.entryTypes);
+        this.logger.debug(
+            `Number of imeline filter modules selected: ${entryTypes.length}`
+        );
+        return entryTypes.length > 0;
+    }
+
     private get showContentPlaceholders(): boolean {
-        const showContent = this.isFilterLoading;
-        this.logger.debug(`Timeline show content placeholders: ${showContent}`);
-        return showContent;
+        if (this.isFilterModuleSelected) {
+            return this.isFilterLoading;
+        }
+        return !this.isFullyLoaded;
     }
 
     private get showTimelineEntries(): boolean {


### PR DESCRIPTION
# Fixes [AB#13464](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13464)

## Description

This fix addresses the issue when user clicks on the Health Records card after doing a refresh on the home page and the user is directed to the timeline, the skeleton is not appearing.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
