### PR TITLE
Remove line separating filters from results on timeline AB#13451

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/assets/scss/_variables.scss
+++ b/Apps/WebClient/src/ClientApp/src/assets/scss/_variables.scss
@@ -24,8 +24,6 @@ $z_application_rating: 1100;
 $z_top_layer: 9999;
 
 $header-height: 65px;
-$timeline-filter-height: 62px;
-$timeline-dates-height: 54px;
 
 // Vaccine card colours
 $hg-vaccine-card-header: #ffdd00;

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -299,11 +299,6 @@ export default class LinearTimelineComponent extends Vue {
 <template>
     <div>
         <b-row
-            v-if="!timelineIsEmpty"
-            class="sticky-top sticky-line"
-            :class="{ 'header-offset': isHeaderShown }"
-        />
-        <b-row
             v-if="showDisplayCount"
             id="listControls"
             class="no-print"
@@ -393,20 +388,6 @@ export default class LinearTimelineComponent extends Vue {
 
 .sticky-top {
     transition: all 0.3s;
-}
-
-.sticky-line {
-    top: $timeline-filter-height;
-    background-color: white;
-    border-bottom: solid $primary 2px;
-    margin-top: -2px;
-    z-index: 1;
-    @media (max-width: 575px) {
-        top: $timeline-filter-height - 1px;
-    }
-    &.header-offset {
-        top: $header-height + $timeline-filter-height;
-    }
 }
 
 .noTimelineEntriesText {

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -532,11 +532,11 @@ export default class TimelineView extends Vue {
                 </page-title>
                 <div
                     v-if="showTimelineEntries"
-                    class="sticky-top sticky-offset py-2"
+                    class="sticky-top sticky-offset"
                     :class="{ 'header-offset': isHeaderShown }"
                 >
                     <b-row
-                        class="no-print justify-content-between"
+                        class="no-print justify-content-between py-2"
                         align-v="start"
                     >
                         <b-col class="col-auto">


### PR DESCRIPTION
# Fixes [AB#13451](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13451)

## Description

- removes line separating timeline filters from results
- fixes filter section padding changing while loading due to a CSS animation

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://user-images.githubusercontent.com/16570293/177202082-e1875638-5b85-4690-a3c7-a4e7c8af8046.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
