### PR TITLE
Include tag functionality in functional tests for filters AB#13424

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
@@ -94,7 +94,7 @@ describe("Filters", () => {
         cy.get("[data-testid=btnFilterApply]").click();
         cy.get("[data-testid=noTimelineEntriesText]").should("be.visible");
         cy.contains("[data-testid=filter-label]", '"xxxx"')
-            .siblings("button")
+            .children("button")
             .click();
         cy.get("[data-testid=noTimelineEntriesText]").should("not.exist");
     });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -18,8 +18,10 @@ describe("Filters", () => {
     });
 
     it("Verify filtered record count", () => {
+        const unfilteredRecordsMessage = "Displaying 25 out of 32 records";
+
         cy.get("[data-testid=timeline-record-count]").contains(
-            "Displaying 25 out of 32 records"
+            unfilteredRecordsMessage
         );
 
         cy.get("[data-testid=filterDropdown]").click();
@@ -32,7 +34,14 @@ describe("Filters", () => {
             "Displaying 9 out of 9 records"
         );
 
-        cy.get("[data-testid=clear-filters-button]").click();
+        cy.contains("[data-testid=filter-label]", "Immunizations")
+            .children("button")
+            .click();
+
+        cy.get("[data-testid=timeline-record-count]").contains(
+            unfilteredRecordsMessage
+        );
+
         cy.get("[data-testid=filterDropdown]").click();
         cy.get("[data-testid=filterStartDateInput] input")
             .clear()
@@ -42,8 +51,18 @@ describe("Filters", () => {
             .clear()
             .focus()
             .type("2022-JUN-09");
-        cy.get("[data-testid=btnFilterApply]").click();
+        cy.get("[data-testid=btnFilterApply]").focus().click();
+
+        cy.contains(
+            "[data-testid=filter-label]",
+            "From 2022-Jun-09 To 2022-Jun-09"
+        );
 
         cy.get("[data-testid=noTimelineEntriesText]").should("be.visible");
+
+        cy.get("[data-testid=clear-filters-button]").click();
+        cy.get("[data-testid=timeline-record-count]").contains(
+            unfilteredRecordsMessage
+        );
     });
 });


### PR DESCRIPTION
# Implements [AB#13424](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13424)

## Description

- updates the functional tests for timeline filters to validate that:
    - applying a filter results in a filter tag appearing
    - clicking the X button on a filter tag removes the filter
    - clicking the "Clear All" button removes all filters

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
