### PR TITLE
Update error store to support too many request errors and warnings AB#13512

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/actions.ts
@@ -43,4 +43,18 @@ export const actions: ErrorBannerActions = {
     clearError(context) {
         context.commit("clearError");
     },
+    setTooManyRequestsWarning(context) {
+        context.commit("setTooManyRequestsWarning");
+    },
+    setTooManyRequestsError(
+        context,
+        params: {
+            key: string;
+        }
+    ) {
+        context.commit("setTooManyRequestsError", params.key);
+    },
+    clearTooManyRequests(context) {
+        context.commit("clearTooManyRequests");
+    },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/errorBanner.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/errorBanner.ts
@@ -4,8 +4,9 @@ import { mutations } from "./mutations";
 import { ErrorBannerModule, ErrorBannerState } from "./types";
 
 const state: ErrorBannerState = {
-    isShowing: false,
-    errors: [],
+    genericErrorBanner: { isShowing: false, errors: [] },
+    tooManyRequestsWarning: false,
+    tooManyRequestsError: undefined,
 };
 
 const namespaced = true;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/getters.ts
@@ -4,9 +4,15 @@ import { ErrorBannerGetters, ErrorBannerState } from "./types";
 
 export const getters: ErrorBannerGetters = {
     isShowing(state: ErrorBannerState): boolean {
-        return state.isShowing;
+        return state.genericErrorBanner.isShowing;
     },
     errors(state: ErrorBannerState): BannerError[] {
-        return state.errors;
+        return state.genericErrorBanner.errors;
+    },
+    tooManyRequestsWarning(state: ErrorBannerState): boolean {
+        return state.tooManyRequestsWarning;
+    },
+    tooManyRequestsError(state: ErrorBannerState): string | undefined {
+        return state.tooManyRequestsError;
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/mutations.ts
@@ -4,17 +4,28 @@ import { ErrorBannerMutations, ErrorBannerState } from "./types";
 
 export const mutations: ErrorBannerMutations = {
     dismiss(state: ErrorBannerState) {
-        state.errors = [];
-        state.isShowing = !state.isShowing;
+        state.genericErrorBanner.errors = [];
+        state.genericErrorBanner.isShowing =
+            !state.genericErrorBanner.isShowing;
     },
     show(state: ErrorBannerState) {
-        state.isShowing = true;
+        state.genericErrorBanner.isShowing = true;
     },
     addError(state: ErrorBannerState, bannerError: BannerError) {
-        state.isShowing = true;
-        state.errors.push(bannerError);
+        state.genericErrorBanner.isShowing = true;
+        state.genericErrorBanner.errors.push(bannerError);
     },
     clearError(state: ErrorBannerState) {
-        state.errors = [];
+        state.genericErrorBanner.errors = [];
+    },
+    setTooManyRequestsWarning(state: ErrorBannerState) {
+        state.tooManyRequestsWarning = true;
+    },
+    setTooManyRequestsError(state: ErrorBannerState, key: string) {
+        state.tooManyRequestsError = key;
+    },
+    clearTooManyRequests(state: ErrorBannerState) {
+        state.tooManyRequestsWarning = false;
+        state.tooManyRequestsError = undefined;
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/types.ts
@@ -11,14 +11,20 @@ import { BannerError } from "@/models/errors";
 import { RootState } from "@/store/types";
 
 export interface ErrorBannerState {
-    isShowing: boolean;
-    errors: BannerError[];
+    genericErrorBanner: {
+        isShowing: boolean;
+        errors: BannerError[];
+    };
+    tooManyRequestsWarning: boolean;
+    tooManyRequestsError?: string;
 }
 
 export interface ErrorBannerGetters
     extends GetterTree<ErrorBannerState, RootState> {
     isShowing(state: ErrorBannerState): boolean;
     errors(state: ErrorBannerState): BannerError[];
+    tooManyRequestsWarning(state: ErrorBannerState): boolean;
+    tooManyRequestsError(state: ErrorBannerState): string | undefined;
 }
 
 type StoreContext = ActionContext<ErrorBannerState, RootState>;
@@ -43,6 +49,14 @@ export interface ErrorBannerActions
         }
     ): void;
     clearError(context: StoreContext): void;
+    setTooManyRequestsWarning(context: StoreContext): void;
+    setTooManyRequestsError(
+        context: StoreContext,
+        params: {
+            key: string;
+        }
+    ): void;
+    clearTooManyRequests(context: StoreContext): void;
 }
 
 export interface ErrorBannerMutations extends MutationTree<ErrorBannerState> {
@@ -50,6 +64,9 @@ export interface ErrorBannerMutations extends MutationTree<ErrorBannerState> {
     show(state: ErrorBannerState): void;
     addError(state: ErrorBannerState, bannerError: BannerError): void;
     clearError(state: ErrorBannerState): void;
+    setTooManyRequestsWarning(state: ErrorBannerState): void;
+    setTooManyRequestsError(state: ErrorBannerState, key: string): void;
+    clearTooManyRequests(state: ErrorBannerState): void;
 }
 
 export interface ErrorBannerModule extends Module<ErrorBannerState, RootState> {


### PR DESCRIPTION
# Implements [AB#13512](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13512)

## Description

Added tooManyRequestsWarning and tooManyRequestsError to errors store for use in retrievals and authenticated too many requests features.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
