### PR TITLE
Create component to display alerts for too many requests AB#13513

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
@@ -8,6 +8,7 @@ import { Component, Ref } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
 import MessageModalComponent from "@/components/modal/MessageModalComponent.vue";
+import TooManyRequestsComponent from "@/components/TooManyRequestsComponent.vue";
 import { DateWrapper } from "@/models/dateWrapper";
 import { BannerError } from "@/models/errors";
 import User from "@/models/user";
@@ -18,6 +19,7 @@ Vue.use(VueClipboard);
 @Component({
     components: {
         MessageModalComponent,
+        TooManyRequestsComponent,
     },
 })
 export default class ErrorCardComponent extends Vue {
@@ -26,7 +28,8 @@ export default class ErrorCardComponent extends Vue {
     })
     dismissBanner!: () => void;
 
-    @Getter("user", { namespace: "user" }) user!: User;
+    @Getter("user", { namespace: "user" })
+    user!: User;
 
     @Getter("isShowing", { namespace: "errorBanner" })
     isShowing!: boolean;
@@ -40,6 +43,7 @@ export default class ErrorCardComponent extends Vue {
     public get haveError(): boolean {
         return this.errors !== undefined && this.errors.length > 0;
     }
+
     private get haveMultipleErrors(): boolean {
         if (this.haveError) {
             return this.errorDetails.length > 1;
@@ -85,77 +89,83 @@ export default class ErrorCardComponent extends Vue {
 </script>
 
 <template>
-    <b-alert
-        data-testid="errorBanner"
-        variant="danger"
-        dismissible
-        class="no-print m-3 m-md-4"
-        :show="isShowing"
-        @dismissed="dismissBanner"
-    >
-        <div>
-            <div v-if="haveMultipleErrors" data-testid="multipleErrorsHeader">
-                <h4>Multiple errors have occurred</h4>
-            </div>
-            <div v-if="!haveMultipleErrors" data-testid="singleErrorHeader">
-                <h4>{{ errorTitle }}</h4>
-            </div>
-            <hg-button
-                v-b-toggle.errorDetails
-                data-testid="errorDetailsBtn"
-                variant="link"
-                class="detailsButton"
-            >
-                <hg-icon
-                    icon="chevron-down"
-                    size="medium"
-                    aria-hidden="true"
-                    class="when-closed mr-2"
-                    data-testid="viewDetailsIcon"
-                />
-                <span class="when-closed">View Details</span>
-                <hg-icon
-                    icon="chevron-up"
-                    size="medium"
-                    aria-hidden="true"
-                    class="when-opened mr-2"
-                    data-testid="hideDetailsIcon"
-                />
-                <span class="when-opened">Hide Details</span>
-            </hg-button>
-            <b-collapse id="errorDetails">
-                <div class="py-2">
-                    <p>
-                        Try refreshing the page. If this issue persists, contact
-                        HealthGateway@gov.bc.ca and provide
-                        <hg-button
-                            v-clipboard:copy="errorDetailsCopyToClipboard"
-                            v-clipboard:success="onCopy"
-                            variant="secondary"
-                            data-testid="copyToClipBoardBtn"
-                        >
-                            <hg-icon :icon="['far', 'copy']" size="small" />
-                            Copy
-                        </hg-button>
-                    </p>
-                    <p
-                        v-for="(error, index) in errorDetails"
-                        :key="index"
-                        class="break-word"
-                        :data-testid="'error-details-span-' + (index + 1)"
-                    >
-                        {{ error }}
-                    </p>
+    <div class="mx-3 mx-md-4 mt-3 mt-md-4">
+        <TooManyRequestsComponent />
+        <b-alert
+            data-testid="errorBanner"
+            variant="danger"
+            dismissible
+            class="no-print"
+            :show="isShowing"
+            @dismissed="dismissBanner"
+        >
+            <div>
+                <div
+                    v-if="haveMultipleErrors"
+                    data-testid="multipleErrorsHeader"
+                >
+                    <h4>Multiple errors have occurred</h4>
                 </div>
-            </b-collapse>
-            <MessageModalComponent
-                ref="copyToClipBoardModal"
-                title="Copy to Clipboard"
-                message="Copied Successfully"
-                :ok-only="true"
-            />
-        </div>
-    </b-alert>
+                <div v-if="!haveMultipleErrors" data-testid="singleErrorHeader">
+                    <h4>{{ errorTitle }}</h4>
+                </div>
+                <hg-button
+                    v-b-toggle.errorDetails
+                    data-testid="errorDetailsBtn"
+                    variant="link"
+                    class="detailsButton"
+                >
+                    <hg-icon
+                        icon="chevron-down"
+                        size="medium"
+                        aria-hidden="true"
+                        class="when-closed mr-2"
+                        data-testid="viewDetailsIcon"
+                    />
+                    <span class="when-closed">View Details</span>
+                    <hg-icon
+                        icon="chevron-up"
+                        size="medium"
+                        aria-hidden="true"
+                        class="when-opened mr-2"
+                        data-testid="hideDetailsIcon"
+                    />
+                    <span class="when-opened">Hide Details</span>
+                </hg-button>
+                <b-collapse id="errorDetails">
+                    <div class="py-2">
+                        <p>
+                            Try refreshing the page. If this issue persists,
+                            contact HealthGateway@gov.bc.ca and provide
+                            <hg-button
+                                v-clipboard:copy="errorDetailsCopyToClipboard"
+                                v-clipboard:success="onCopy"
+                                variant="secondary"
+                                data-testid="copyToClipBoardBtn"
+                            >
+                                <hg-icon :icon="['far', 'copy']" size="small" />
+                                Copy
+                            </hg-button>
+                        </p>
+                        <p
+                            v-for="(error, index) in errorDetails"
+                            :key="index"
+                            class="break-word"
+                            :data-testid="'error-details-span-' + (index + 1)"
+                        >
+                            {{ error }}
+                        </p>
+                    </div>
+                </b-collapse>
+                <MessageModalComponent
+                    ref="copyToClipBoardModal"
+                    title="Copy to Clipboard"
+                    message="Copied Successfully"
+                    :ok-only="true"
+                />
+            </div>
+        </b-alert>
+    </div>
 </template>
 
 <style lang="scss" scoped>

--- a/Apps/WebClient/src/ClientApp/src/components/TooManyRequestsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/TooManyRequestsComponent.vue
@@ -1,0 +1,50 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import { Getter } from "vuex-class";
+
+@Component
+export default class TooManyRequestsComponent extends Vue {
+    @Prop({ default: "page" })
+    location?: string;
+
+    @Getter("tooManyRequestsWarning", { namespace: "errorBanner" })
+    warning!: boolean;
+
+    @Getter("tooManyRequestsError", { namespace: "errorBanner" })
+    error!: string | undefined;
+
+    private get showWarning(): boolean {
+        return this.warning === true;
+    }
+
+    private get showError(): boolean {
+        return this.error === this.location;
+    }
+}
+</script>
+
+<template>
+    <div>
+        <b-alert
+            data-testid="too-many-requests-error"
+            variant="danger"
+            dismissible
+            class="no-print"
+            :show="showError"
+        >
+            Unable to complete action as the site is too busy. Please try again
+            later.
+        </b-alert>
+        <b-alert
+            data-testid="too-many-requests-warning"
+            variant="warning"
+            dismissible
+            class="no-print"
+            :show="showWarning"
+        >
+            We are unable to get your health records because the site is too
+            busy. Please try again later.
+        </b-alert>
+    </div>
+</template>

--- a/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
@@ -13,7 +13,6 @@ import {
 import { Validation } from "vuelidate/vuelidate";
 import { Action, Getter } from "vuex-class";
 
-import ErrorCardComponent from "@/components/ErrorCardComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";
 import HgDateDropdownComponent from "@/components/shared/HgDateDropdownComponent.vue";
 import HgTimeDropdownComponent from "@/components/shared/HgTimeDropdownComponent.vue";
@@ -43,7 +42,6 @@ interface ISelectOption {
 @Component({
     components: {
         LoadingComponent,
-        ErrorCard: ErrorCardComponent,
         "hg-date-dropdown": HgDateDropdownComponent,
         "hg-time-dropdown": HgTimeDropdownComponent,
     },

--- a/Apps/WebClient/src/ClientApp/src/views/PublicCovidTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicCovidTestView.vue
@@ -7,7 +7,6 @@ import { required } from "vuelidate/lib/validators";
 import { Validation } from "vuelidate/vuelidate";
 import { Action, Getter } from "vuex-class";
 
-import ErrorCardComponent from "@/components/ErrorCardComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";
 import HgDateDropdownComponent from "@/components/shared/HgDateDropdownComponent.vue";
 import type { WebClientConfiguration } from "@/models/configData";
@@ -38,7 +37,6 @@ const validPersonalHealthNumber = (value: string): boolean => {
 
 @Component({
     components: {
-        "error-card": ErrorCardComponent,
         loading: LoadingComponent,
         "hg-date-dropdown": HgDateDropdownComponent,
     },

--- a/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
@@ -9,7 +9,6 @@ import { required } from "vuelidate/lib/validators";
 import { Validation } from "vuelidate/vuelidate";
 import { Action, Getter } from "vuex-class";
 
-import ErrorCardComponent from "@/components/ErrorCardComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";
 import MessageModalComponent from "@/components/modal/MessageModalComponent.vue";
 import HgDateDropdownComponent from "@/components/shared/HgDateDropdownComponent.vue";
@@ -37,7 +36,6 @@ const validPersonalHealthNumber = (value: string): boolean => {
 @Component({
     components: {
         "vaccine-card": VaccineCardComponent,
-        "error-card": ErrorCardComponent,
         loading: LoadingComponent,
         "message-modal": MessageModalComponent,
         "hg-date-dropdown": HgDateDropdownComponent,
@@ -136,8 +134,6 @@ export default class PublicVaccineCardView extends Vue {
     private dateOfBirth = "";
     private dateOfVaccine = "";
 
-    private downloadError: BannerError | null = null;
-
     private get loadingStatusMessage(): string {
         if (this.isDownloading) {
             return "Downloading....";
@@ -222,7 +218,6 @@ export default class PublicVaccineCardView extends Vue {
             document.querySelector(".vaccine-card");
 
         if (printingArea !== null) {
-            this.downloadError = null;
             this.isDownloading = true;
 
             SnowPlow.trackEvent({
@@ -318,20 +313,6 @@ export default class PublicVaccineCardView extends Vue {
                     alt="BC Mark"
                 />
             </router-link>
-        </div>
-        <div v-if="downloadError !== null" class="container d-print-none">
-            <b-alert
-                variant="danger"
-                class="no-print my-3 p-3"
-                :show="downloadError !== null"
-                dismissible
-            >
-                <h4>Our Apologies</h4>
-                <div data-testid="errorTextDescription" class="pl-4">
-                    We've found an issue and the Health Gateway team is working
-                    hard to fix it.
-                </div>
-            </b-alert>
         </div>
         <div
             v-if="displayResult"

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -17,7 +17,6 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
-import ErrorCardComponent from "@/components/ErrorCardComponent.vue";
 import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
 import ProtectiveWordComponent from "@/components/modal/ProtectiveWordComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
@@ -78,7 +77,6 @@ enum FilterLabelType {
         NoteEditComponent,
         EntryDetailsComponent,
         LinearTimeline: LinearTimelineComponent,
-        ErrorCard: ErrorCardComponent,
         Filters: FilterComponent,
         "resource-centre": ResourceCentreComponent,
         "add-note-button": AddNoteButtonComponent,


### PR DESCRIPTION
# Implements [AB#13513](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13513)

## Description

- removes unused references to the error card component
- removes the obsolete downloadError property on the public vaccine card view
- adds a component for displaying warnings and errors for too many requests
- displays the alerts for too many requests above the regular error alert on all pages

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
