### PR TITLE
Added { force: true } to fix flaky test when toast is blocking a button

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
@@ -45,7 +45,9 @@ describe("COVID-19 Orders", () => {
                         expect($div.text().trim()).equal(negativeSummary);
                     }
                 );
-                cy.get("[data-testid=entryCardDetailsTitle]").click();
+                cy.get("[data-testid=entryCardDetailsTitle]").click({
+                    force: true,
+                });
             });
 
         cy.get("[data-testid=entryDetailsModal]")
@@ -82,7 +84,9 @@ describe("COVID-19 Orders", () => {
                 cy.get("[data-testid=laboratoryHeaderDescription]").should(
                     "not.exist"
                 );
-                cy.get("[data-testid=entryCardDetailsTitle]").click();
+                cy.get("[data-testid=entryCardDetailsTitle]").click({
+                    force: true,
+                });
             });
 
         cy.get("[data-testid=entryDetailsModal]")
@@ -116,7 +120,9 @@ describe("COVID-19 Orders", () => {
                 }).should(($div) => {
                     expect($div.text().trim()).equal(positiveSummary);
                 });
-                cy.get("[data-testid=entryCardDetailsTitle]").click();
+                cy.get("[data-testid=entryCardDetailsTitle]").click({
+                    force: true,
+                });
             });
 
         const correctedStatus = "Test Status: Corrected";
@@ -157,7 +163,9 @@ describe("COVID-19 Orders", () => {
                         expect($div.text().trim()).equal(positiveSummary);
                     }
                 );
-                cy.get("[data-testid=entryCardDetailsTitle]").click();
+                cy.get("[data-testid=entryCardDetailsTitle]").click({
+                    force: true,
+                });
             });
 
         const amendedStatus = "Test Status: Amended";


### PR DESCRIPTION
# Fixes [AB#13527](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13527)

## Description

Added { force: true } to prevent flaky tests when toast is blocking a button. Added to all instances where it could happen in the test.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
