### PR TITLE
Fix margins around warning and error alerts AB#13523

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/app.vue
+++ b/Apps/WebClient/src/ClientApp/src/app.vue
@@ -64,11 +64,12 @@ import VueTheMask from "vue-the-mask";
 import { Action, Getter } from "vuex-class";
 
 import CommunicationComponent from "@/components/CommunicationComponent.vue";
-import ErrorCard from "@/components/ErrorCardComponent.vue";
+import ErrorCardComponent from "@/components/ErrorCardComponent.vue";
 import IdleComponent from "@/components/modal/IdleComponent.vue";
 import FooterComponent from "@/components/navmenu/FooterComponent.vue";
 import HeaderComponent from "@/components/navmenu/HeaderComponent.vue";
 import SidebarComponent from "@/components/navmenu/SidebarComponent.vue";
+import ResourceCentreComponent from "@/components/ResourceCentreComponent.vue";
 import Process, { EnvironmentType } from "@/constants/process";
 import ScreenWidth from "@/constants/screenWidth";
 import container from "@/plugins/container";
@@ -82,9 +83,10 @@ const logger: ILogger = container.get(SERVICE_IDENTIFIER.Logger);
         NavHeader: HeaderComponent,
         NavFooter: FooterComponent,
         NavSidebar: SidebarComponent,
-        ErrorCard: ErrorCard,
+        ErrorCardComponent,
         IdleComponent,
         CommunicationComponent,
+        ResourceCentreComponent,
     },
 })
 export default class App extends Vue {
@@ -120,7 +122,10 @@ export default class App extends Vue {
     private loginCallbackPath = "/logincallback";
     private registrationPath = "/registration";
     private pcrTestPath = "/pcrtest";
-    private acceptTermsOfServicePath = "/acceptTermsOfService";
+    private acceptTermsOfServicePath = "/accepttermsofservice";
+    private dependentsPath = "/dependents";
+    private reportsPath = "/reports";
+    private timelinePath = "/timeline";
 
     constructor() {
         super();
@@ -170,60 +175,62 @@ export default class App extends Vue {
         }
     }
 
-    private get isPublicDestinationPath(): boolean {
-        const routePath = this.$route.path.toLowerCase();
-        return (
-            routePath === this.vaccineCardPath ||
-            routePath === this.covidTestPath
-        );
+    private currentPathMatches(...paths: string[]): boolean {
+        const currentPath = this.$route.path.toLowerCase();
+        return paths.some((path) => path === currentPath);
     }
 
-    private get isLoginCallbackPath(): boolean {
-        return this.$route.path.toLowerCase() === this.loginCallbackPath;
-    }
-
-    private get isRegistrationPath(): boolean {
-        return this.$route.path.toLowerCase() === this.registrationPath;
-    }
-
-    private get isPcrTestPath(): boolean {
-        return this.$route.path.toLowerCase().startsWith(this.pcrTestPath);
-    }
-
-    private get isAcceptTermsOfServicePath(): boolean {
-        return (
-            this.$route.path.toLowerCase() ===
-            this.acceptTermsOfServicePath.toLowerCase()
+    private get pageHasCustomLayout(): boolean {
+        return this.currentPathMatches(
+            this.vaccineCardPath,
+            this.covidTestPath
         );
     }
 
     private get isHeaderVisible(): boolean {
-        return !this.isPublicDestinationPath && !this.isLoginCallbackPath;
+        return !this.currentPathMatches(
+            this.loginCallbackPath,
+            this.vaccineCardPath,
+            this.covidTestPath
+        );
     }
 
     private get isFooterVisible(): boolean {
-        return (
-            !this.isPublicDestinationPath &&
-            !this.isLoginCallbackPath &&
-            !this.isRegistrationPath
+        return !this.currentPathMatches(
+            this.loginCallbackPath,
+            this.registrationPath,
+            this.vaccineCardPath,
+            this.covidTestPath
         );
     }
 
     private get isSidebarVisible(): boolean {
         return (
-            !this.isLoginCallbackPath &&
-            !this.isRegistrationPath &&
-            !this.isPcrTestPath &&
-            !this.isAcceptTermsOfServicePath &&
+            !this.currentPathMatches(
+                this.loginCallbackPath,
+                this.registrationPath,
+                this.acceptTermsOfServicePath
+            ) &&
+            !this.$route.path.toLowerCase().startsWith(this.pcrTestPath) &&
             !this.hasTermsOfServiceUpdated
         );
     }
 
     private get isCommunicationVisible(): boolean {
         return (
-            !this.isPublicDestinationPath &&
-            !this.isLoginCallbackPath &&
-            !this.isPcrTestPath
+            !this.currentPathMatches(
+                this.loginCallbackPath,
+                this.vaccineCardPath,
+                this.covidTestPath
+            ) && !this.$route.path.toLowerCase().startsWith(this.pcrTestPath)
+        );
+    }
+
+    private get isResourceCentreVisible(): boolean {
+        return this.currentPathMatches(
+            this.dependentsPath,
+            this.reportsPath,
+            this.timelinePath
         );
     }
 }
@@ -249,9 +256,10 @@ export default class App extends Vue {
                 class="d-print-none sticky-top vh-100"
             />
             <main class="col fill-height d-flex flex-column">
-                <CommunicationComponent v-show="isCommunicationVisible" />
-                <ErrorCard />
+                <CommunicationComponent v-if="isCommunicationVisible" />
+                <ErrorCardComponent v-if="!pageHasCustomLayout" />
                 <router-view />
+                <ResourceCentreComponent v-if="isResourceCentreVisible" />
                 <IdleComponent ref="idleModal" />
             </main>
         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/app.vue
+++ b/Apps/WebClient/src/ClientApp/src/app.vue
@@ -126,6 +126,7 @@ export default class App extends Vue {
     private dependentsPath = "/dependents";
     private reportsPath = "/reports";
     private timelinePath = "/timeline";
+    private landingPath = "/";
 
     constructor() {
         super();
@@ -183,7 +184,8 @@ export default class App extends Vue {
     private get pageHasCustomLayout(): boolean {
         return this.currentPathMatches(
             this.vaccineCardPath,
-            this.covidTestPath
+            this.covidTestPath,
+            this.landingPath
         );
     }
 
@@ -257,8 +259,13 @@ export default class App extends Vue {
             />
             <main class="col fill-height d-flex flex-column">
                 <CommunicationComponent v-if="isCommunicationVisible" />
-                <ErrorCardComponent v-if="!pageHasCustomLayout" />
-                <router-view />
+
+                <router-view v-if="pageHasCustomLayout" />
+                <div v-else class="m-3 m-md-4">
+                    <ErrorCardComponent />
+                    <router-view />
+                </div>
+
                 <ResourceCentreComponent v-if="isResourceCentreVisible" />
                 <IdleComponent ref="idleModal" />
             </main>

--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -1091,7 +1091,7 @@ export default class DependentCardComponent extends Vue {
         <LoadingComponent
             :is-loading="isGeneratingReport"
             :full-screen="false"
-        ></LoadingComponent>
+        />
         <delete-modal-component
             ref="deleteModal"
             title="Remove Dependent"

--- a/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
@@ -89,7 +89,7 @@ export default class ErrorCardComponent extends Vue {
 </script>
 
 <template>
-    <div class="mx-3 mx-md-4 mt-3 mt-md-4">
+    <div>
         <TooManyRequestsComponent />
         <b-alert
             data-testid="errorBanner"

--- a/Apps/WebClient/src/ClientApp/src/components/PageErrorComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/PageErrorComponent.vue
@@ -11,17 +11,11 @@ export default class PageErrorComponent extends Vue {
 </script>
 
 <template>
-    <div class="col d-flex justify-content-center">
-        <div class="error-template">
+    <div class="d-flex justify-content-center">
+        <div class="px-3 py-5">
             <h1>{{ error.code }}</h1>
             <h2>{{ error.name }}</h2>
             <p>{{ error.message }}</p>
         </div>
     </div>
 </template>
-
-<style lang="scss" scoped>
-.error-template {
-    padding: 40px 15px;
-}
-</style>

--- a/Apps/WebClient/src/ClientApp/src/components/TooManyRequestsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/TooManyRequestsComponent.vue
@@ -27,16 +27,6 @@ export default class TooManyRequestsComponent extends Vue {
 <template>
     <div>
         <b-alert
-            data-testid="too-many-requests-error"
-            variant="danger"
-            dismissible
-            class="no-print"
-            :show="showError"
-        >
-            Unable to complete action as the site is too busy. Please try again
-            later.
-        </b-alert>
-        <b-alert
             data-testid="too-many-requests-warning"
             variant="warning"
             dismissible
@@ -45,6 +35,16 @@ export default class TooManyRequestsComponent extends Vue {
         >
             We are unable to get your health records because the site is too
             busy. Please try again later.
+        </b-alert>
+        <b-alert
+            data-testid="too-many-requests-error"
+            variant="danger"
+            dismissible
+            class="no-print"
+            :show="showError"
+        >
+            Unable to complete action as the site is too busy. Please try again
+            later.
         </b-alert>
     </div>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
@@ -354,7 +354,7 @@ export default class NewDependentComponent extends Vue {
                 </div>
             </b-row>
         </template>
-        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
+        <LoadingComponent :is-loading="isLoading" />
     </b-modal>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
@@ -303,7 +303,7 @@ export default class VerifySMSComponent extends Vue {
                 </b-col>
             </b-row>
         </template>
-        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
+        <LoadingComponent :is-loading="isLoading" />
     </b-modal>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/views/AcceptTermsOfServiceView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/AcceptTermsOfServiceView.vue
@@ -149,7 +149,7 @@ export default class AcceptTermsOfServiceView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <LoadingComponent :is-loading="isLoading" />
         <b-container v-if="!isLoading && termsOfService !== ''">
             <div>

--- a/Apps/WebClient/src/ClientApp/src/views/ContactUsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ContactUsView.vue
@@ -25,7 +25,7 @@ export default class ContactUsView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <b-row>
             <b-col>
                 <BreadcrumbComponent :items="breadcrumbItems" />

--- a/Apps/WebClient/src/ClientApp/src/views/Covid19View.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/Covid19View.vue
@@ -323,10 +323,7 @@ export default class Covid19View extends Vue {
 
 <template>
     <div class="background flex-grow-1 d-flex flex-column">
-        <BreadcrumbComponent
-            class="mt-3 mt-md-4 ml-3 ml-md-4"
-            :items="breadcrumbItems"
-        />
+        <BreadcrumbComponent :items="breadcrumbItems" />
         <loading :is-loading="isLoading" :text="loadingStatusMessage" />
         <div
             v-if="!isVaccineCardLoading && !vaccinationStatusError"

--- a/Apps/WebClient/src/ClientApp/src/views/DependentsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentsView.vue
@@ -9,7 +9,6 @@ import DependentCardComponent from "@/components/DependentCardComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";
 import NewDependentComponent from "@/components/modal/NewDependentComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
-import ResourceCentreComponent from "@/components/ResourceCentreComponent.vue";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
@@ -29,7 +28,6 @@ library.add(faUserPlus);
         LoadingComponent,
         DependentCardComponent,
         NewDependentComponent,
-        "resource-centre": ResourceCentreComponent,
     },
 })
 export default class DependentsView extends Vue {
@@ -173,7 +171,6 @@ export default class DependentsView extends Vue {
                 </b-row>
             </b-col>
         </b-row>
-        <resource-centre />
         <NewDependentComponent
             ref="newDependentModal"
             @show="showModal"

--- a/Apps/WebClient/src/ClientApp/src/views/DependentsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentsView.vue
@@ -128,7 +128,7 @@ export default class DependentsView extends Vue {
 }
 </script>
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <BreadcrumbComponent :items="breadcrumbItems" />
         <LoadingComponent :is-loading="isLoading" />
         <b-row>

--- a/Apps/WebClient/src/ClientApp/src/views/FaqView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/FaqView.vue
@@ -22,7 +22,7 @@ export default class FaqView extends Vue {
 }
 </script>
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <BreadcrumbComponent :items="breadcrumbItems" />
         <page-title title="Frequently Asked Questions" />
         <b-row class="mb-1 fluid text-right">

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -341,7 +341,7 @@ export default class HomeView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <LoadingComponent
             :is-loading="isLoading"
             :text="loadingStatusMessage"

--- a/Apps/WebClient/src/ClientApp/src/views/LoginView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LoginView.vue
@@ -84,79 +84,70 @@ export default class LoginView extends Vue {
 
 <template>
     <div class="container my-5">
-        <LoadingComponent :is-loading="isLoading"></LoadingComponent>
-        <b-row>
-            <b-col>
-                <b-alert
-                    style="max-width: 25rem"
-                    :show="isRetry"
-                    dismissible
-                    variant="danger"
+        <LoadingComponent :is-loading="isLoading" />
+        <b-alert
+            style="max-width: 25rem"
+            :show="isRetry"
+            dismissible
+            variant="danger"
+        >
+            <h4>Error</h4>
+            <span
+                >An unexpected error occured while processing the request,
+                please try again.</span
+            >
+        </b-alert>
+        <b-card
+            v-if="identityProviders && identityProviders.length > 0"
+            id="loginPicker"
+            class="shadow-lg bg-white mx-auto"
+            style="max-width: 25rem"
+            align="center"
+        >
+            <h3 slot="header">Log In</h3>
+            <b-card-body v-if="hasMultipleProviders || isRetry">
+                <div v-for="provider in identityProviders" :key="provider.id">
+                    <b-row>
+                        <b-col>
+                            <hg-button
+                                :id="`${provider.id}Btn`"
+                                :data-testid="`${provider.id}Btn`"
+                                :disabled="provider.disabled"
+                                variant="primary"
+                                block
+                                @click="signInAndRedirect(provider.hint)"
+                            >
+                                <b-row>
+                                    <b-col class="col-2">
+                                        <hg-icon
+                                            :icon="`${provider.icon}`"
+                                            size="medium"
+                                        />
+                                    </b-col>
+                                    <b-col class="text-left">
+                                        <span>{{ provider.name }}</span>
+                                    </b-col>
+                                </b-row>
+                            </hg-button>
+                        </b-col>
+                    </b-row>
+                    <b-row
+                        v-if="
+                            identityProviders.indexOf(provider) <
+                            identityProviders.length - 1
+                        "
+                        ><b-col>or</b-col>
+                    </b-row>
+                </div>
+            </b-card-body>
+            <b-card-body v-else>
+                <span
+                    >Redirecting to
+                    <strong>{{ identityProviders[0].name }}</strong
+                    >...</span
                 >
-                    <h4>Error</h4>
-                    <span
-                        >An unexpected error occured while processing the
-                        request, please try again.</span
-                    >
-                </b-alert>
-                <b-card
-                    v-if="identityProviders && identityProviders.length > 0"
-                    id="loginPicker"
-                    class="shadow-lg bg-white mx-auto"
-                    style="max-width: 25rem"
-                    align="center"
-                >
-                    <h3 slot="header">Log In</h3>
-                    <b-card-body v-if="hasMultipleProviders || isRetry">
-                        <div
-                            v-for="provider in identityProviders"
-                            :key="provider.id"
-                        >
-                            <b-row>
-                                <b-col>
-                                    <hg-button
-                                        :id="`${provider.id}Btn`"
-                                        :data-testid="`${provider.id}Btn`"
-                                        :disabled="provider.disabled"
-                                        variant="primary"
-                                        block
-                                        @click="
-                                            signInAndRedirect(provider.hint)
-                                        "
-                                    >
-                                        <b-row>
-                                            <b-col class="col-2">
-                                                <hg-icon
-                                                    :icon="`${provider.icon}`"
-                                                    size="medium"
-                                                />
-                                            </b-col>
-                                            <b-col class="text-left">
-                                                <span>{{ provider.name }}</span>
-                                            </b-col>
-                                        </b-row>
-                                    </hg-button>
-                                </b-col>
-                            </b-row>
-                            <b-row
-                                v-if="
-                                    identityProviders.indexOf(provider) <
-                                    identityProviders.length - 1
-                                "
-                                ><b-col>or</b-col>
-                            </b-row>
-                        </div>
-                    </b-card-body>
-                    <b-card-body v-else>
-                        <span
-                            >Redirecting to
-                            <strong>{{ identityProviders[0].name }}</strong
-                            >...</span
-                        >
-                    </b-card-body>
-                </b-card>
-                <div v-else>No login providers configured</div>
-            </b-col>
-        </b-row>
+            </b-card-body>
+        </b-card>
+        <div v-else>No login providers configured</div>
     </div>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/LogoutCompleteView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LogoutCompleteView.vue
@@ -21,14 +21,14 @@ export default class LogoutCompleteView extends Vue {
 </script>
 
 <template>
-    <div class="row justify-content-center h-100 pt-5">
-        <div class="col-lg-6 col-md-6 pt-2">
+    <b-row class="justify-content-center h-100 pt-5">
+        <b-col md="6">
             <div class="shadow-lg p-3 mb-5 bg-white rounded border">
                 <h3>
                     <strong>You signed out of your account</strong>
                 </h3>
                 <p>It's a good idea to close all browser windows.</p>
             </div>
-        </div>
-    </div>
+        </b-col>
+    </b-row>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/LogoutView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LogoutView.vue
@@ -17,11 +17,11 @@ export default class LogoutView extends Vue {
 </script>
 
 <template>
-    <div class="row justify-content-center h-100 pt-5">
-        <div class="col-lg-6 col-md-6 pt-2">
-            <div>
+    <b-row class="justify-content-center h-100 pt-5">
+        <b-col md="6">
+            <div class="p-3 mb-5">
                 <h3>Signing out...</h3>
             </div>
-        </div>
-    </div>
+        </b-col>
+    </b-row>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
@@ -469,7 +469,7 @@ export default class PcrTestView extends Vue {
                 !registrationComplete && pcrDataSource === DSNONE && !isLoading
             "
         >
-            <b-row class="pt-4">
+            <b-row class="pt-3">
                 <b-col>
                     <strong>
                         Register your COVID-19 test kit using one of the
@@ -526,7 +526,7 @@ export default class PcrTestView extends Vue {
             v-if="!registrationComplete && pcrDataSource !== DSNONE"
             v-show="!isLoading"
         >
-            <b-row id="title" class="mt-4">
+            <b-row id="title" class="mt-3">
                 <b-col>
                     <h1 class="h4 mb-2 font-weight-normal">
                         <strong>Register a Test Kit</strong>

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -591,7 +591,7 @@ export default class ProfileView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <BreadcrumbComponent :items="breadcrumbItems" />
         <LoadingComponent :is-loading="isLoading" />
         <b-alert

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -308,7 +308,7 @@ export default class RegistrationView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <LoadingComponent :is-loading="isLoading" />
         <b-container v-if="termsOfServiceLoaded">
             <div v-if="isRegistrationClosed">

--- a/Apps/WebClient/src/ClientApp/src/views/ReleaseNotesView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReleaseNotesView.vue
@@ -25,7 +25,7 @@ export default class ReleaseNotesView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <BreadcrumbComponent :items="breadcrumbItems" />
         <page-title title="Health Gateway Release Notes" />
         <release-note

--- a/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
@@ -18,7 +18,6 @@ import MedicationHistoryReportComponent from "@/components/report/MedicationHist
 import MedicationRequestReportComponent from "@/components/report/MedicationRequestReportComponent.vue";
 import MSPVisitsReportComponent from "@/components/report/MSPVisitsReportComponent.vue";
 import NotesReportComponent from "@/components/report/NotesReportComponent.vue";
-import ResourceCentreComponent from "@/components/ResourceCentreComponent.vue";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
@@ -55,7 +54,6 @@ const laboratoryReport = "laboratory-report";
         medicationRequestReport: MedicationRequestReportComponent,
         "hg-date-picker": DatePickerComponent,
         MultiSelectComponent,
-        "resource-centre": ResourceCentreComponent,
         noteReport: NotesReportComponent,
         laboratoryReport: LaboratoryReportComponent,
     },
@@ -557,7 +555,6 @@ export default class ReportsView extends Vue {
             </b-row>
         </div>
 
-        <resource-centre />
         <message-modal
             ref="messageModal"
             data-testid="messageModal"

--- a/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
@@ -335,7 +335,7 @@ export default class ReportsView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <BreadcrumbComponent :items="breadcrumbItems" />
         <b-alert
             v-if="showLaboratoryOrderQueuedMessage"
@@ -519,7 +519,7 @@ export default class ReportsView extends Vue {
             :is-loading="isLoading || isGeneratingReport"
             :is-custom="!isGeneratingReport"
             :full-screen="false"
-        ></LoadingComponent>
+        />
         <div
             v-if="reportComponentName"
             data-testid="reportSample"

--- a/Apps/WebClient/src/ClientApp/src/views/TermsOfServiceView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TermsOfServiceView.vue
@@ -71,7 +71,7 @@ export default class TermsOfServiceView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <BreadcrumbComponent :items="breadcrumbItems" />
         <LoadingComponent :is-loading="isLoading" />
         <b-row>
@@ -90,11 +90,7 @@ export default class TermsOfServiceView extends Vue {
                 </b-row>
                 <page-title title="Terms of Service" />
                 <div v-if="!isLoading">
-                    <b-row class="mb-3">
-                        <b-col>
-                            <HtmlTextAreaComponent :input="termsOfService" />
-                        </b-col>
-                    </b-row>
+                    <HtmlTextAreaComponent :input="termsOfService" />
                 </div>
             </b-col>
         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -20,7 +20,6 @@ import { Action, Getter } from "vuex-class";
 import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
 import ProtectiveWordComponent from "@/components/modal/ProtectiveWordComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
-import ResourceCentreComponent from "@/components/ResourceCentreComponent.vue";
 import AddNoteButtonComponent from "@/components/timeline/AddNoteButtonComponent.vue";
 import EntryDetailsComponent from "@/components/timeline/entryCard/EntryDetailsComponent.vue";
 import FilterComponent from "@/components/timeline/FilterComponent.vue";
@@ -78,7 +77,6 @@ enum FilterLabelType {
         EntryDetailsComponent,
         LinearTimeline: LinearTimelineComponent,
         Filters: FilterComponent,
-        "resource-centre": ResourceCentreComponent,
         "add-note-button": AddNoteButtonComponent,
     },
 })
@@ -579,7 +577,6 @@ export default class TimelineView extends Vue {
                 </b-row>
             </b-col>
         </b-row>
-        <resource-centre />
         <ProtectiveWordComponent :is-loading="isMedicationStatementLoading" />
         <NoteEditComponent :is-loading="isNoteLoading" />
         <EntryDetailsComponent />

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -484,7 +484,7 @@ export default class TimelineView extends Vue {
 </script>
 
 <template>
-    <div class="m-3 m-md-4 flex-grow-1 d-flex flex-column">
+    <div>
         <b-toast
             id="loading-toast"
             :visible="!isFullyLoaded"

--- a/Apps/WebClient/src/ClientApp/src/views/ValidateEmailView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ValidateEmailView.vue
@@ -63,69 +63,65 @@ export default class ValidateEmailView extends Vue {
 </script>
 
 <template>
-    <b-container>
-        <b-row class="pt-5">
-            <b-col class="text-center mb-5 title">
-                <h4 v-if="isLoading" data-testid="verifingInvite">
-                    We are verifying your email...
-                </h4>
-                <div v-else-if="isVerified">
-                    <hg-icon
-                        icon="check-circle"
-                        size="extra-large"
-                        aria-hidden="true"
-                        class="text-success"
-                    />
-                    <h4 data-testid="verifiedInvite">
-                        Your email address has been verified
-                    </h4>
-                    <hg-button
-                        data-testid="continueButton"
-                        variant="primary"
-                        to="/home"
-                    >
-                        Continue
-                    </hg-button>
-                </div>
-                <div v-else-if="isAlreadyVerified">
-                    <hg-icon
-                        icon="check-circle"
-                        size="extra-large"
-                        aria-hidden="true"
-                        class="text-success"
-                    />
-                    <h4 data-testid="alreadyVerifiedInvite">
-                        Your email address is already verified
-                    </h4>
-                    <hg-button
-                        data-testid="continueButton"
-                        variant="primary"
-                        to="/home"
-                    >
-                        Continue
-                    </hg-button>
-                </div>
-                <div v-else>
-                    <hg-icon
-                        icon="times-circle"
-                        size="large"
-                        aria-hidden="true"
-                        class="text-danger"
-                    />
-                    <h4 data-testid="expiredInvite">
-                        Your link is expired or incorrect. Please resend
-                        verification email from your profile page
-                    </h4>
-                    <hg-button
-                        data-testid="continueButton"
-                        variant="primary"
-                        @click="$router.push({ path: '/profile' })"
-                    >
-                        Continue
-                    </hg-button>
-                </div>
-            </b-col>
-        </b-row>
+    <b-container class="text-center title pt-4">
+        <h4 v-if="isLoading" data-testid="verifingInvite">
+            We are verifying your email...
+        </h4>
+        <div v-else-if="isVerified">
+            <hg-icon
+                icon="check-circle"
+                size="extra-large"
+                aria-hidden="true"
+                class="text-success"
+            />
+            <h4 data-testid="verifiedInvite">
+                Your email address has been verified
+            </h4>
+            <hg-button
+                data-testid="continueButton"
+                variant="primary"
+                to="/home"
+            >
+                Continue
+            </hg-button>
+        </div>
+        <div v-else-if="isAlreadyVerified">
+            <hg-icon
+                icon="check-circle"
+                size="extra-large"
+                aria-hidden="true"
+                class="text-success"
+            />
+            <h4 data-testid="alreadyVerifiedInvite">
+                Your email address is already verified
+            </h4>
+            <hg-button
+                data-testid="continueButton"
+                variant="primary"
+                to="/home"
+            >
+                Continue
+            </hg-button>
+        </div>
+        <div v-else>
+            <hg-icon
+                icon="times-circle"
+                size="large"
+                aria-hidden="true"
+                class="text-danger"
+            />
+            <h4 data-testid="expiredInvite">
+                Your link is expired or incorrect. Please resend verification
+                email from your profile page
+            </h4>
+            <hg-button
+                data-testid="continueButton"
+                variant="primary"
+                @click="$router.push({ path: '/profile' })"
+            >
+                Continue
+            </hg-button>
+        </div>
     </b-container>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/views/errors/IdirLoggedInView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/IdirLoggedInView.vue
@@ -7,7 +7,7 @@ import { PageError } from "@/models/errors";
 
 @Component({
     components: {
-        ErrorComponent: PageErrorComponent,
+        PageErrorComponent,
     },
 })
 export default class IdirLoggedInView extends Vue {
@@ -20,7 +20,5 @@ export default class IdirLoggedInView extends Vue {
 </script>
 
 <template>
-    <div>
-        <ErrorComponent :error="errorDescription" />
-    </div>
+    <PageErrorComponent :error="errorDescription" />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/NotFoundView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/NotFoundView.vue
@@ -7,7 +7,7 @@ import { PageError } from "@/models/errors";
 
 @Component({
     components: {
-        ErrorComponent: PageErrorComponent,
+        PageErrorComponent,
     },
 })
 export default class NotFoundView extends Vue {
@@ -20,7 +20,5 @@ export default class NotFoundView extends Vue {
 </script>
 
 <template>
-    <div>
-        <ErrorComponent :error="errorDescription" />
-    </div>
+    <PageErrorComponent :error="errorDescription" />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/UnauthorizedView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/UnauthorizedView.vue
@@ -7,7 +7,7 @@ import { PageError } from "@/models/errors";
 
 @Component({
     components: {
-        ErrorComponent: PageErrorComponent,
+        PageErrorComponent,
     },
 })
 export default class UnauthorizedView extends Vue {
@@ -20,7 +20,5 @@ export default class UnauthorizedView extends Vue {
 </script>
 
 <template>
-    <div>
-        <ErrorComponent :error="errorDescription" />
-    </div>
+    <PageErrorComponent :error="errorDescription" />
 </template>


### PR DESCRIPTION
# Fixes [AB#13523](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13523)

## Description

- moves page margins out of the individual views and into app.vue
    - removes unnecessary wrapper elements and classes from the individual views
    - the landing page, public COVID-19 test page, and public vaccine card pages are excluded from the shared margins (since their page content includes custom headers or banners)
- moves the resource centre floating action button out of the individual views and into app.vue
- refactors the getters in app.vue for determining which components to display based on route
- reorders the position of the too many requests warning and error alerts to match the story criteria

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://user-images.githubusercontent.com/16570293/178804645-b58b1875-6c23-4159-ad65-ec4001073dcd.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
