### PR TITLE
Populate initial Rider and ReSharper settings AB#13367

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,653 +20,653 @@ indent_size = 2
 [*.cs]
 
 # S101: Types should be named in PascalCase
-dotnet_diagnostic.S101.severity = none
+dotnet_diagnostic.s101.severity = none
 
 # CA1000: Do not declare static members on generic types
-dotnet_diagnostic.CA1000.severity = warning
+dotnet_diagnostic.ca1000.severity = warning
 
 # CA1001: Types that own disposable fields should be disposable
-dotnet_diagnostic.CA1001.severity = warning
+dotnet_diagnostic.ca1001.severity = warning
 
 # CA1003: Use generic event handler instances
-dotnet_diagnostic.CA1003.severity = warning
+dotnet_diagnostic.ca1003.severity = warning
 
 # CA1008: Enums should have zero value
-dotnet_diagnostic.CA1008.severity = warning
+dotnet_diagnostic.ca1008.severity = warning
 
 # CA1010: Generic interface should also be implemented
-dotnet_diagnostic.CA1010.severity = warning
+dotnet_diagnostic.ca1010.severity = warning
 
 # CA1012: Abstract types should not have constructors
-dotnet_diagnostic.CA1012.severity = warning
+dotnet_diagnostic.ca1012.severity = warning
 
 # CA1014: Mark assemblies with CLSCompliant
-dotnet_diagnostic.CA1014.severity = warning
+dotnet_diagnostic.ca1014.severity = warning
 
 # CA1016: Mark assemblies with assembly version
-dotnet_diagnostic.CA1016.severity = warning
+dotnet_diagnostic.ca1016.severity = warning
 
 # CA1017: Mark assemblies with ComVisible
-dotnet_diagnostic.CA1017.severity = warning
+dotnet_diagnostic.ca1017.severity = warning
 
 # CA1018: Mark attributes with AttributeUsageAttribute
-dotnet_diagnostic.CA1018.severity = warning
+dotnet_diagnostic.ca1018.severity = warning
 
 # CA1019: Define accessors for attribute arguments
-dotnet_diagnostic.CA1019.severity = warning
+dotnet_diagnostic.ca1019.severity = warning
 
 # CA1021: Avoid out parameters
-dotnet_diagnostic.CA1021.severity = warning
+dotnet_diagnostic.ca1021.severity = warning
 
 # CA1024: Use properties where appropriate
-dotnet_diagnostic.CA1024.severity = warning
+dotnet_diagnostic.ca1024.severity = warning
 
 # CA1027: Mark enums with FlagsAttribute
-dotnet_diagnostic.CA1027.severity = warning
+dotnet_diagnostic.ca1027.severity = warning
 
 # CA1028: Enum Storage should be Int32
-dotnet_diagnostic.CA1028.severity = warning
+dotnet_diagnostic.ca1028.severity = warning
 
 # CA1030: Use events where appropriate
-dotnet_diagnostic.CA1030.severity = warning
+dotnet_diagnostic.ca1030.severity = warning
 
 # CA1031: Do not catch general exception types
-dotnet_diagnostic.CA1031.severity = warning
+dotnet_diagnostic.ca1031.severity = warning
 
 # CA1032: Implement standard exception constructors
-dotnet_diagnostic.CA1032.severity = warning
+dotnet_diagnostic.ca1032.severity = warning
 
 # CA1033: Interface methods should be callable by child types
-dotnet_diagnostic.CA1033.severity = warning
+dotnet_diagnostic.ca1033.severity = warning
 
 # CA1034: Nested types should not be visible
-dotnet_diagnostic.CA1034.severity = warning
+dotnet_diagnostic.ca1034.severity = warning
 
 # CA1036: Override methods on comparable types
-dotnet_diagnostic.CA1036.severity = warning
+dotnet_diagnostic.ca1036.severity = warning
 
 # CA1040: Avoid empty interfaces
-dotnet_diagnostic.CA1040.severity = warning
+dotnet_diagnostic.ca1040.severity = warning
 
 # CA1041: Provide ObsoleteAttribute message
-dotnet_diagnostic.CA1041.severity = warning
+dotnet_diagnostic.ca1041.severity = warning
 
 # CA1043: Use Integral Or String Argument For Indexers
-dotnet_diagnostic.CA1043.severity = warning
+dotnet_diagnostic.ca1043.severity = warning
 
 # CA1044: Properties should not be write only
-dotnet_diagnostic.CA1044.severity = warning
+dotnet_diagnostic.ca1044.severity = warning
 
 # CA1050: Declare types in namespaces
-dotnet_diagnostic.CA1050.severity = warning
+dotnet_diagnostic.ca1050.severity = warning
 
 # CA1051: Do not declare visible instance fields
-dotnet_diagnostic.CA1051.severity = warning
+dotnet_diagnostic.ca1051.severity = warning
 
 # CA1052: Static holder types should be Static or NotInheritable
-dotnet_diagnostic.CA1052.severity = warning
+dotnet_diagnostic.ca1052.severity = warning
 
 # CA1054: Uri parameters should not be strings
-dotnet_diagnostic.CA1054.severity = warning
+dotnet_diagnostic.ca1054.severity = warning
 
 # CA1055: Uri return values should not be strings
-dotnet_diagnostic.CA1055.severity = warning
+dotnet_diagnostic.ca1055.severity = warning
 
 # CA1056: Uri properties should not be strings
-dotnet_diagnostic.CA1056.severity = warning
+dotnet_diagnostic.ca1056.severity = warning
 
 # CA1058: Types should not extend certain base types
-dotnet_diagnostic.CA1058.severity = warning
+dotnet_diagnostic.ca1058.severity = warning
 
 # CA1060: Move pinvokes to native methods class
-dotnet_diagnostic.CA1060.severity = warning
+dotnet_diagnostic.ca1060.severity = warning
 
 # CA1061: Do not hide base class methods
-dotnet_diagnostic.CA1061.severity = warning
+dotnet_diagnostic.ca1061.severity = warning
 
 # CA1062: Validate arguments of public methods
-dotnet_diagnostic.CA1062.severity = none
+dotnet_diagnostic.ca1062.severity = none
 
 # CA1063: Implement IDisposable Correctly
-dotnet_diagnostic.CA1063.severity = warning
+dotnet_diagnostic.ca1063.severity = warning
 
 # CA1064: Exceptions should be public
-dotnet_diagnostic.CA1064.severity = warning
+dotnet_diagnostic.ca1064.severity = warning
 
 # CA1065: Do not raise exceptions in unexpected locations
-dotnet_diagnostic.CA1065.severity = warning
+dotnet_diagnostic.ca1065.severity = warning
 
 # CA1066: Type {0} should implement IEquatable<T> because it overrides Equals
-dotnet_diagnostic.CA1066.severity = warning
+dotnet_diagnostic.ca1066.severity = warning
 
 # CA1067: Override Object.Equals(object) when implementing IEquatable<T>
-dotnet_diagnostic.CA1067.severity = warning
+dotnet_diagnostic.ca1067.severity = warning
 
 # CA1068: CancellationToken parameters must come last
-dotnet_diagnostic.CA1068.severity = warning
+dotnet_diagnostic.ca1068.severity = warning
 
 # CA1069: Enums values should not be duplicated
-dotnet_diagnostic.CA1069.severity = warning
+dotnet_diagnostic.ca1069.severity = warning
 
 # CA1200: Avoid using cref tags with a prefix
-dotnet_diagnostic.CA1200.severity = warning
+dotnet_diagnostic.ca1200.severity = warning
 
 # CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1303.severity = none
+dotnet_diagnostic.ca1303.severity = none
 
 # CA1304: Specify CultureInfo
-dotnet_diagnostic.CA1304.severity = warning
+dotnet_diagnostic.ca1304.severity = warning
 
 # CA1305: Specify IFormatProvider
-dotnet_diagnostic.CA1305.severity = warning
+dotnet_diagnostic.ca1305.severity = warning
 
 # CA1307: Specify StringComparison
-dotnet_diagnostic.CA1307.severity = warning
+dotnet_diagnostic.ca1307.severity = warning
 
 # CA1308: Normalize strings to uppercase
-dotnet_diagnostic.CA1308.severity = warning
+dotnet_diagnostic.ca1308.severity = warning
 
 # CA1309: Use ordinal stringcomparison
-dotnet_diagnostic.CA1309.severity = warning
+dotnet_diagnostic.ca1309.severity = warning
 
 # CA1401: P/Invokes should not be visible
-dotnet_diagnostic.CA1401.severity = warning
+dotnet_diagnostic.ca1401.severity = warning
 
 # CA1501: Avoid excessive inheritance
-dotnet_diagnostic.CA1501.severity = warning
+dotnet_diagnostic.ca1501.severity = warning
 
 # CA1502: Avoid excessive complexity
-dotnet_diagnostic.CA1502.severity = warning
+dotnet_diagnostic.ca1502.severity = warning
 
 # CA1505: Avoid unmaintainable code
-dotnet_diagnostic.CA1505.severity = warning
+dotnet_diagnostic.ca1505.severity = warning
 
 # CA1506: Avoid excessive class coupling
-dotnet_diagnostic.CA1506.severity = warning
+dotnet_diagnostic.ca1506.severity = warning
 
 # CA1507: Use nameof to express symbol names
-dotnet_diagnostic.CA1507.severity = warning
+dotnet_diagnostic.ca1507.severity = warning
 
 # CA1508: Avoid dead conditional code
-dotnet_diagnostic.CA1508.severity = warning
+dotnet_diagnostic.ca1508.severity = warning
 
 # CA1509: Invalid entry in code metrics rule specification file
-dotnet_diagnostic.CA1509.severity = warning
+dotnet_diagnostic.ca1509.severity = warning
 
 # CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = warning
+dotnet_diagnostic.ca1707.severity = warning
 
 # CA1708: Identifiers should differ by more than case
-dotnet_diagnostic.CA1708.severity = warning
+dotnet_diagnostic.ca1708.severity = warning
 
 # CA1710: Identifiers should have correct suffix
-dotnet_diagnostic.CA1710.severity = warning
+dotnet_diagnostic.ca1710.severity = warning
 
 # CA1711: Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1711.severity = none
+dotnet_diagnostic.ca1711.severity = none
 
 # CA1712: Do not prefix enum values with type name
-dotnet_diagnostic.CA1712.severity = warning
+dotnet_diagnostic.ca1712.severity = warning
 
 # CA1714: Flags enums should have plural names
-dotnet_diagnostic.CA1714.severity = warning
+dotnet_diagnostic.ca1714.severity = warning
 
 # CA1715: Identifiers should have correct prefix
-dotnet_diagnostic.CA1715.severity = warning
+dotnet_diagnostic.ca1715.severity = warning
 
 # CA1716: Identifiers should not match keywords
-dotnet_diagnostic.CA1716.severity = warning
+dotnet_diagnostic.ca1716.severity = warning
 
 # CA1717: Only FlagsAttribute enums should have plural names
-dotnet_diagnostic.CA1717.severity = warning
+dotnet_diagnostic.ca1717.severity = warning
 
 # CA1720: Identifier contains type name
-dotnet_diagnostic.CA1720.severity = warning
+dotnet_diagnostic.ca1720.severity = warning
 
 # CA1721: Property names should not match get methods
-dotnet_diagnostic.CA1721.severity = warning
+dotnet_diagnostic.ca1721.severity = warning
 
 # CA1724: Type names should not match namespaces
-dotnet_diagnostic.CA1724.severity = warning
+dotnet_diagnostic.ca1724.severity = warning
 
 # CA1725: Parameter names should match base declaration
-dotnet_diagnostic.CA1725.severity = warning
+dotnet_diagnostic.ca1725.severity = warning
 
 # CA1801: Review unused parameters
-dotnet_diagnostic.CA1801.severity = warning
+dotnet_diagnostic.ca1801.severity = warning
 
 # CA1802: Use literals where appropriate
-dotnet_diagnostic.CA1802.severity = warning
+dotnet_diagnostic.ca1802.severity = warning
 
 # CA1806: Do not ignore method results
-dotnet_diagnostic.CA1806.severity = warning
+dotnet_diagnostic.ca1806.severity = warning
 
 # CA1810: Initialize reference type static fields inline
-dotnet_diagnostic.CA1810.severity = warning
+dotnet_diagnostic.ca1810.severity = warning
 
 # CA1812: Avoid uninstantiated internal classes
-dotnet_diagnostic.CA1812.severity = warning
+dotnet_diagnostic.ca1812.severity = warning
 
 # CA1813: Avoid unsealed attributes
-dotnet_diagnostic.CA1813.severity = warning
+dotnet_diagnostic.ca1813.severity = warning
 
 # CA1814: Prefer jagged arrays over multidimensional
-dotnet_diagnostic.CA1814.severity = warning
+dotnet_diagnostic.ca1814.severity = warning
 
 # CA1815: Override equals and operator equals on value types
-dotnet_diagnostic.CA1815.severity = warning
+dotnet_diagnostic.ca1815.severity = warning
 
 # CA1816: Dispose methods should call SuppressFinalize
-dotnet_diagnostic.CA1816.severity = warning
+dotnet_diagnostic.ca1816.severity = warning
 
 # CA1819: Properties should not return arrays
-dotnet_diagnostic.CA1819.severity = warning
+dotnet_diagnostic.ca1819.severity = warning
 
 # CA1820: Test for empty strings using string length
-dotnet_diagnostic.CA1820.severity = warning
+dotnet_diagnostic.ca1820.severity = warning
 
 # CA1821: Remove empty Finalizers
-dotnet_diagnostic.CA1821.severity = warning
+dotnet_diagnostic.ca1821.severity = warning
 
 # CA1822: Mark members as static
-dotnet_diagnostic.CA1822.severity = warning
+dotnet_diagnostic.ca1822.severity = warning
 
 # CA1823: Avoid unused private fields
-dotnet_diagnostic.CA1823.severity = warning
+dotnet_diagnostic.ca1823.severity = warning
 
 # CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
-dotnet_diagnostic.CA1824.severity = warning
+dotnet_diagnostic.ca1824.severity = warning
 
 # CA1825: Avoid zero-length array allocations.
-dotnet_diagnostic.CA1825.severity = warning
+dotnet_diagnostic.ca1825.severity = warning
 
 # CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
-dotnet_diagnostic.CA1826.severity = warning
+dotnet_diagnostic.ca1826.severity = warning
 
 # CA1827: Do not use Count() or LongCount() when Any() can be used
-dotnet_diagnostic.CA1827.severity = warning
+dotnet_diagnostic.ca1827.severity = warning
 
 # CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
-dotnet_diagnostic.CA1828.severity = warning
+dotnet_diagnostic.ca1828.severity = warning
 
 # CA1829: Use Length/Count property instead of Count() when available
-dotnet_diagnostic.CA1829.severity = warning
+dotnet_diagnostic.ca1829.severity = warning
 
 # CA2000: Dispose objects before losing scope
-dotnet_diagnostic.CA2000.severity = warning
+dotnet_diagnostic.ca2000.severity = warning
 
 # CA2002: Do not lock on objects with weak identity
-dotnet_diagnostic.CA2002.severity = warning
+dotnet_diagnostic.ca2002.severity = warning
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = warning
+dotnet_diagnostic.ca2007.severity = warning
 
 # CA2008: Do not create tasks without passing a TaskScheduler
-dotnet_diagnostic.CA2008.severity = warning
+dotnet_diagnostic.ca2008.severity = warning
 
 # CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
-dotnet_diagnostic.CA2009.severity = warning
+dotnet_diagnostic.ca2009.severity = warning
 
 # CA2010: Always consume the value returned by methods marked with PreserveSigAttribute
-dotnet_diagnostic.CA2010.severity = warning
+dotnet_diagnostic.ca2010.severity = warning
 
 # CA2011: Avoid infinite recursion
-dotnet_diagnostic.CA2011.severity = warning
+dotnet_diagnostic.ca2011.severity = warning
 
 # CA2012: Use ValueTasks correctly
-dotnet_diagnostic.CA2012.severity = warning
+dotnet_diagnostic.ca2012.severity = warning
 
 # CA2013: Do not use ReferenceEquals with value types
-dotnet_diagnostic.CA2013.severity = warning
+dotnet_diagnostic.ca2013.severity = warning
 
 # CA2100: Review SQL queries for security vulnerabilities
-dotnet_diagnostic.CA2100.severity = warning
+dotnet_diagnostic.ca2100.severity = warning
 
 # CA2101: Specify marshaling for P/Invoke string arguments
-dotnet_diagnostic.CA2101.severity = warning
+dotnet_diagnostic.ca2101.severity = warning
 
 # CA2119: Seal methods that satisfy private interfaces
-dotnet_diagnostic.CA2119.severity = warning
+dotnet_diagnostic.ca2119.severity = warning
 
 # CA2153: Do Not Catch Corrupted State Exceptions
-dotnet_diagnostic.CA2153.severity = warning
+dotnet_diagnostic.ca2153.severity = warning
 
 # CA2200: Rethrow to preserve stack details.
-dotnet_diagnostic.CA2200.severity = warning
+dotnet_diagnostic.ca2200.severity = warning
 
 # CA2201: Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = warning
+dotnet_diagnostic.ca2201.severity = warning
 
 # CA2207: Initialize value type static fields inline
-dotnet_diagnostic.CA2207.severity = warning
+dotnet_diagnostic.ca2207.severity = warning
 
 # CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2208.severity = warning
+dotnet_diagnostic.ca2208.severity = warning
 
 # CA2211: Non-constant fields should not be visible
-dotnet_diagnostic.CA2211.severity = warning
+dotnet_diagnostic.ca2211.severity = warning
 
 # CA2213: Disposable fields should be disposed
-dotnet_diagnostic.CA2213.severity = warning
+dotnet_diagnostic.ca2213.severity = warning
 
 # CA2214: Do not call overridable methods in constructors
-dotnet_diagnostic.CA2214.severity = warning
+dotnet_diagnostic.ca2214.severity = warning
 
 # CA2215: Dispose methods should call base class dispose
-dotnet_diagnostic.CA2215.severity = warning
+dotnet_diagnostic.ca2215.severity = warning
 
 # CA2216: Disposable types should declare finalizer
-dotnet_diagnostic.CA2216.severity = warning
+dotnet_diagnostic.ca2216.severity = warning
 
 # CA2217: Do not mark enums with FlagsAttribute
-dotnet_diagnostic.CA2217.severity = warning
+dotnet_diagnostic.ca2217.severity = warning
 
 # CA2218: Override GetHashCode on overriding Equals
-dotnet_diagnostic.CA2218.severity = warning
+dotnet_diagnostic.ca2218.severity = warning
 
 # CA2219: Do not raise exceptions in finally clauses
-dotnet_diagnostic.CA2219.severity = warning
+dotnet_diagnostic.ca2219.severity = warning
 
 # CA2224: Override Equals on overloading operator equals
-dotnet_diagnostic.CA2224.severity = warning
+dotnet_diagnostic.ca2224.severity = warning
 
 # CA2225: Operator overloads have named alternates
-dotnet_diagnostic.CA2225.severity = warning
+dotnet_diagnostic.ca2225.severity = warning
 
 # CA2226: Operators should have symmetrical overloads
-dotnet_diagnostic.CA2226.severity = warning
+dotnet_diagnostic.ca2226.severity = warning
 
 # CA2227: Collection properties should be read only
-dotnet_diagnostic.CA2227.severity = warning
+dotnet_diagnostic.ca2227.severity = warning
 
 # CA2229: Implement serialization constructors
-dotnet_diagnostic.CA2229.severity = warning
+dotnet_diagnostic.ca2229.severity = warning
 
 # CA2231: Overload operator equals on overriding value type Equals
-dotnet_diagnostic.CA2231.severity = warning
+dotnet_diagnostic.ca2231.severity = warning
 
 # CA2234: Pass system uri objects instead of strings
-dotnet_diagnostic.CA2234.severity = warning
+dotnet_diagnostic.ca2234.severity = warning
 
 # CA2235: Mark all non-serializable fields
-dotnet_diagnostic.CA2235.severity = warning
+dotnet_diagnostic.ca2235.severity = warning
 
 # CA2237: Mark ISerializable types with serializable
-dotnet_diagnostic.CA2237.severity = warning
+dotnet_diagnostic.ca2237.severity = warning
 
 # CA2241: Provide correct arguments to formatting methods
-dotnet_diagnostic.CA2241.severity = warning
+dotnet_diagnostic.ca2241.severity = warning
 
 # CA2242: Test for NaN correctly
-dotnet_diagnostic.CA2242.severity = warning
+dotnet_diagnostic.ca2242.severity = warning
 
 # CA2243: Attribute string literals should parse correctly
-dotnet_diagnostic.CA2243.severity = warning
+dotnet_diagnostic.ca2243.severity = warning
 
 # CA2244: Do not duplicate indexed element initializations
-dotnet_diagnostic.CA2244.severity = warning
+dotnet_diagnostic.ca2244.severity = warning
 
 # CA2245: Do not assign a property to itself.
-dotnet_diagnostic.CA2245.severity = warning
+dotnet_diagnostic.ca2245.severity = warning
 
 # CA2246: Assigning symbol and its member in the same statement.
-dotnet_diagnostic.CA2246.severity = warning
+dotnet_diagnostic.ca2246.severity = warning
 
 # CA2300: Do not use insecure deserializer BinaryFormatter
-dotnet_diagnostic.CA2300.severity = warning
+dotnet_diagnostic.ca2300.severity = warning
 
 # CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
-dotnet_diagnostic.CA2301.severity = warning
+dotnet_diagnostic.ca2301.severity = warning
 
 # CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
-dotnet_diagnostic.CA2302.severity = warning
+dotnet_diagnostic.ca2302.severity = warning
 
 # CA2305: Do not use insecure deserializer LosFormatter
-dotnet_diagnostic.CA2305.severity = warning
+dotnet_diagnostic.ca2305.severity = warning
 
 # CA2310: Do not use insecure deserializer NetDataContractSerializer
-dotnet_diagnostic.CA2310.severity = warning
+dotnet_diagnostic.ca2310.severity = warning
 
 # CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
-dotnet_diagnostic.CA2311.severity = warning
+dotnet_diagnostic.ca2311.severity = warning
 
 # CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
-dotnet_diagnostic.CA2312.severity = warning
+dotnet_diagnostic.ca2312.severity = warning
 
 # CA2315: Do not use insecure deserializer ObjectStateFormatter
-dotnet_diagnostic.CA2315.severity = warning
+dotnet_diagnostic.ca2315.severity = warning
 
 # CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
-dotnet_diagnostic.CA2321.severity = warning
+dotnet_diagnostic.ca2321.severity = warning
 
 # CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
-dotnet_diagnostic.CA2322.severity = warning
+dotnet_diagnostic.ca2322.severity = warning
 
 # CA2326: Do not use TypeNameHandling values other than None
-dotnet_diagnostic.CA2326.severity = warning
+dotnet_diagnostic.ca2326.severity = warning
 
 # CA2327: Do not use insecure JsonSerializerSettings
-dotnet_diagnostic.CA2327.severity = warning
+dotnet_diagnostic.ca2327.severity = warning
 
 # CA2328: Ensure that JsonSerializerSettings are secure
-dotnet_diagnostic.CA2328.severity = warning
+dotnet_diagnostic.ca2328.severity = warning
 
 # CA2329: Do not deserialize with JsonSerializer using an insecure configuration
-dotnet_diagnostic.CA2329.severity = warning
+dotnet_diagnostic.ca2329.severity = warning
 
 # CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
-dotnet_diagnostic.CA2330.severity = warning
+dotnet_diagnostic.ca2330.severity = warning
 
 # CA3001: Review code for SQL injection vulnerabilities
-dotnet_diagnostic.CA3001.severity = warning
+dotnet_diagnostic.ca3001.severity = warning
 
 # CA3002: Review code for XSS vulnerabilities
-dotnet_diagnostic.CA3002.severity = warning
+dotnet_diagnostic.ca3002.severity = warning
 
 # CA3003: Review code for file path injection vulnerabilities
-dotnet_diagnostic.CA3003.severity = warning
+dotnet_diagnostic.ca3003.severity = warning
 
 # CA3004: Review code for information disclosure vulnerabilities
-dotnet_diagnostic.CA3004.severity = warning
+dotnet_diagnostic.ca3004.severity = warning
 
 # CA3005: Review code for LDAP injection vulnerabilities
-dotnet_diagnostic.CA3005.severity = warning
+dotnet_diagnostic.ca3005.severity = warning
 
 # CA3006: Review code for process command injection vulnerabilities
-dotnet_diagnostic.CA3006.severity = warning
+dotnet_diagnostic.ca3006.severity = warning
 
 # CA3007: Review code for open redirect vulnerabilities
-dotnet_diagnostic.CA3007.severity = warning
+dotnet_diagnostic.ca3007.severity = warning
 
 # CA3008: Review code for XPath injection vulnerabilities
-dotnet_diagnostic.CA3008.severity = warning
+dotnet_diagnostic.ca3008.severity = warning
 
 # CA3009: Review code for XML injection vulnerabilities
-dotnet_diagnostic.CA3009.severity = warning
+dotnet_diagnostic.ca3009.severity = warning
 
 # CA3010: Review code for XAML injection vulnerabilities
-dotnet_diagnostic.CA3010.severity = warning
+dotnet_diagnostic.ca3010.severity = warning
 
 # CA3011: Review code for DLL injection vulnerabilities
-dotnet_diagnostic.CA3011.severity = warning
+dotnet_diagnostic.ca3011.severity = warning
 
 # CA3012: Review code for regex injection vulnerabilities
-dotnet_diagnostic.CA3012.severity = warning
+dotnet_diagnostic.ca3012.severity = warning
 
 # CA3061: Do Not Add Schema By URL
-dotnet_diagnostic.CA3061.severity = warning
+dotnet_diagnostic.ca3061.severity = warning
 
 # CA3075: Insecure DTD processing in XML
-dotnet_diagnostic.CA3075.severity = warning
+dotnet_diagnostic.ca3075.severity = warning
 
 # CA3076: Insecure XSLT script processing.
-dotnet_diagnostic.CA3076.severity = warning
+dotnet_diagnostic.ca3076.severity = warning
 
 # CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
-dotnet_diagnostic.CA3077.severity = warning
+dotnet_diagnostic.ca3077.severity = warning
 
 # CA3147: Mark Verb Handlers With Validate Antiforgery Token
-dotnet_diagnostic.CA3147.severity = warning
+dotnet_diagnostic.ca3147.severity = warning
 
 # CA5350: Do Not Use Weak Cryptographic Algorithms
-dotnet_diagnostic.CA5350.severity = warning
+dotnet_diagnostic.ca5350.severity = warning
 
 # CA5351: Do Not Use Broken Cryptographic Algorithms
-dotnet_diagnostic.CA5351.severity = warning
+dotnet_diagnostic.ca5351.severity = warning
 
 # CA5358: Review cipher mode usage with cryptography experts
-dotnet_diagnostic.CA5358.severity = warning
+dotnet_diagnostic.ca5358.severity = warning
 
 # CA5359: Do Not Disable Certificate Validation
-dotnet_diagnostic.CA5359.severity = warning
+dotnet_diagnostic.ca5359.severity = warning
 
 # CA5360: Do Not Call Dangerous Methods In Deserialization
-dotnet_diagnostic.CA5360.severity = warning
+dotnet_diagnostic.ca5360.severity = warning
 
 # CA5361: Do Not Disable SChannel Use of Strong Crypto
-dotnet_diagnostic.CA5361.severity = warning
+dotnet_diagnostic.ca5361.severity = warning
 
 # CA5362: Do Not Refer Self In Serializable Class
-dotnet_diagnostic.CA5362.severity = warning
+dotnet_diagnostic.ca5362.severity = warning
 
 # CA5363: Do Not Disable Request Validation
-dotnet_diagnostic.CA5363.severity = warning
+dotnet_diagnostic.ca5363.severity = warning
 
 # CA5364: Do Not Use Deprecated Security Protocols
-dotnet_diagnostic.CA5364.severity = warning
+dotnet_diagnostic.ca5364.severity = warning
 
 # CA5365: Do Not Disable HTTP Header Checking
-dotnet_diagnostic.CA5365.severity = warning
+dotnet_diagnostic.ca5365.severity = warning
 
 # CA5366: Use XmlReader For DataSet Read Xml
-dotnet_diagnostic.CA5366.severity = warning
+dotnet_diagnostic.ca5366.severity = warning
 
 # CA5367: Do Not Serialize Types With Pointer Fields
-dotnet_diagnostic.CA5367.severity = warning
+dotnet_diagnostic.ca5367.severity = warning
 
 # CA5368: Set ViewStateUserKey For Classes Derived From Page
-dotnet_diagnostic.CA5368.severity = warning
+dotnet_diagnostic.ca5368.severity = warning
 
 # CA5369: Use XmlReader For Deserialize
-dotnet_diagnostic.CA5369.severity = warning
+dotnet_diagnostic.ca5369.severity = warning
 
 # CA5370: Use XmlReader For Validating Reader
-dotnet_diagnostic.CA5370.severity = warning
+dotnet_diagnostic.ca5370.severity = warning
 
 # CA5371: Use XmlReader For Schema Read
-dotnet_diagnostic.CA5371.severity = warning
+dotnet_diagnostic.ca5371.severity = warning
 
 # CA5372: Use XmlReader For XPathDocument
-dotnet_diagnostic.CA5372.severity = warning
+dotnet_diagnostic.ca5372.severity = warning
 
 # CA5373: Do not use obsolete key derivation function
-dotnet_diagnostic.CA5373.severity = warning
+dotnet_diagnostic.ca5373.severity = warning
 
 # CA5374: Do Not Use XslTransform
-dotnet_diagnostic.CA5374.severity = warning
+dotnet_diagnostic.ca5374.severity = warning
 
 # CA5375: Do Not Use Account Shared Access Signature
-dotnet_diagnostic.CA5375.severity = warning
+dotnet_diagnostic.ca5375.severity = warning
 
 # CA5376: Use SharedAccessProtocol HttpsOnly
-dotnet_diagnostic.CA5376.severity = warning
+dotnet_diagnostic.ca5376.severity = warning
 
 # CA5377: Use Container Level Access Policy
-dotnet_diagnostic.CA5377.severity = warning
+dotnet_diagnostic.ca5377.severity = warning
 
 # CA5378: Do not disable ServicePointManagerSecurityProtocols
-dotnet_diagnostic.CA5378.severity = warning
+dotnet_diagnostic.ca5378.severity = warning
 
 # CA5379: Do Not Use Weak Key Derivation Function Algorithm
-dotnet_diagnostic.CA5379.severity = warning
+dotnet_diagnostic.ca5379.severity = warning
 
 # CA5380: Do Not Add Certificates To Root Store
-dotnet_diagnostic.CA5380.severity = warning
+dotnet_diagnostic.ca5380.severity = warning
 
 # CA5381: Ensure Certificates Are Not Added To Root Store
-dotnet_diagnostic.CA5381.severity = warning
+dotnet_diagnostic.ca5381.severity = warning
 
 # CA5382: Use Secure Cookies In ASP.Net Core
-dotnet_diagnostic.CA5382.severity = warning
+dotnet_diagnostic.ca5382.severity = warning
 
 # CA5383: Ensure Use Secure Cookies In ASP.Net Core
-dotnet_diagnostic.CA5383.severity = warning
+dotnet_diagnostic.ca5383.severity = warning
 
 # CA5384: Do Not Use Digital Signature Algorithm (DSA)
-dotnet_diagnostic.CA5384.severity = warning
+dotnet_diagnostic.ca5384.severity = warning
 
 # CA5385: Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size
-dotnet_diagnostic.CA5385.severity = warning
+dotnet_diagnostic.ca5385.severity = warning
 
 # CA5386: Avoid hardcoding SecurityProtocolType value
-dotnet_diagnostic.CA5386.severity = warning
+dotnet_diagnostic.ca5386.severity = warning
 
 # CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
-dotnet_diagnostic.CA5387.severity = warning
+dotnet_diagnostic.ca5387.severity = warning
 
 # CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
-dotnet_diagnostic.CA5388.severity = warning
+dotnet_diagnostic.ca5388.severity = warning
 
 # CA5389: Do Not Add Archive Item's Path To The Target File System Path
-dotnet_diagnostic.CA5389.severity = warning
+dotnet_diagnostic.ca5389.severity = warning
 
 # CA5390: Do not hard-code encryption key
-dotnet_diagnostic.CA5390.severity = warning
+dotnet_diagnostic.ca5390.severity = warning
 
 # CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
-dotnet_diagnostic.CA5391.severity = warning
+dotnet_diagnostic.ca5391.severity = warning
 
 # CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
-dotnet_diagnostic.CA5392.severity = warning
+dotnet_diagnostic.ca5392.severity = warning
 
 # CA5393: Do not use unsafe DllImportSearchPath value
-dotnet_diagnostic.CA5393.severity = warning
+dotnet_diagnostic.ca5393.severity = warning
 
 # CA5394: Do not use insecure randomness
-dotnet_diagnostic.CA5394.severity = warning
+dotnet_diagnostic.ca5394.severity = warning
 
 # CA5395: Miss HttpVerb attribute for action methods
-dotnet_diagnostic.CA5395.severity = warning
+dotnet_diagnostic.ca5395.severity = warning
 
 # CA5396: Set HttpOnly to true for HttpCookie
-dotnet_diagnostic.CA5396.severity = warning
+dotnet_diagnostic.ca5396.severity = warning
 
 # CA5397: Do not use deprecated SslProtocols values
-dotnet_diagnostic.CA5397.severity = warning
+dotnet_diagnostic.ca5397.severity = warning
 
 # CA5398: Avoid hardcoded SslProtocols values
-dotnet_diagnostic.CA5398.severity = warning
+dotnet_diagnostic.ca5398.severity = warning
 
 # CA5399: HttpClients should enable certificate revocation list checks
-dotnet_diagnostic.CA5399.severity = warning
+dotnet_diagnostic.ca5399.severity = warning
 
 # CA5400: Ensure HttpClient certificate revocation list check is not disabled
-dotnet_diagnostic.CA5400.severity = warning
+dotnet_diagnostic.ca5400.severity = warning
 
 # CA5401: Do not use CreateEncryptor with non-default IV
-dotnet_diagnostic.CA5401.severity = warning
+dotnet_diagnostic.ca5401.severity = warning
 
 # CA5402: Use CreateEncryptor with the default IV 
-dotnet_diagnostic.CA5402.severity = warning
+dotnet_diagnostic.ca5402.severity = warning
 
 # CA5403: Do not hard-code certificate
-dotnet_diagnostic.CA5403.severity = warning
+dotnet_diagnostic.ca5403.severity = warning
 
 # CA9999: Analyzer version mismatch
-dotnet_diagnostic.CA9999.severity = warning
+dotnet_diagnostic.ca9999.severity = warning
 
 # CS8604: Possible null reference argument.
-dotnet_diagnostic.CS8604.severity = silent
+dotnet_diagnostic.cs8604.severity = silent
 
-dotnet_diagnostic.CS8600.severity = error
+dotnet_diagnostic.cs8600.severity = error
 
 # CS8602: Dereference of a possibly null reference.
-dotnet_diagnostic.CS8602.severity = error
+dotnet_diagnostic.cs8602.severity = error
 
-dotnet_diagnostic.CS8603.severity = error
+dotnet_diagnostic.cs8603.severity = error
 
 # S1135: Complete the task associated to this 'TODO' comment.
-dotnet_diagnostic.S1135.severity = warning
+dotnet_diagnostic.s1135.severity = warning
 
 # SA1000: Keywords should be spaced correctly
-dotnet_diagnostic.SA1000.severity = error
+dotnet_diagnostic.sa1000.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -8,16 +8,16 @@ indent_size = 4
 trim_trailing_whitespace = true
 charset = utf-8
 
+# ReSharper properties
+resharper_html_space_before_self_closing = true
+
 [*.{yml,yaml}]
 indent_size = 2
 
-# NOTE: Requires **VS2019 16.3** or later
-
-# All Rules Enabled with default severity
-# Description: All Rules are enabled with default severity. Rules with IsEnabledByDefault = false are force enabled with default severity.
-
-# Code files
 [*.cs]
+
+# All Rules are enabled with default severity.
+# Rules with IsEnabledByDefault = false are force-enabled with default severity.
 
 # S101: Types should be named in PascalCase
 dotnet_diagnostic.s101.severity = none
@@ -655,18 +655,125 @@ dotnet_diagnostic.ca5403.severity = warning
 # CA9999: Analyzer version mismatch
 dotnet_diagnostic.ca9999.severity = warning
 
-# CS8604: Possible null reference argument.
-dotnet_diagnostic.cs8604.severity = silent
-
+# CS8600: Converting null literal or possible null value to non-nullable type
 dotnet_diagnostic.cs8600.severity = error
 
-# CS8602: Dereference of a possibly null reference.
+# CS8602: Dereference of a possibly null reference
 dotnet_diagnostic.cs8602.severity = error
 
+# CS8603: Possible null reference return
 dotnet_diagnostic.cs8603.severity = error
 
-# S1135: Complete the task associated to this 'TODO' comment.
+# CS8604: Possible null reference argument
+dotnet_diagnostic.cs8604.severity = silent
+
+# S1135: Complete the task associated to this 'TODO' comment
 dotnet_diagnostic.s1135.severity = warning
 
 # SA1000: Keywords should be spaced correctly
 dotnet_diagnostic.sa1000.severity = error
+
+# Microsoft .NET properties
+csharp_new_line_before_members_in_object_initializers = false
+csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_using_directive_placement = inside_namespace:silent
+dotnet_naming_rule.private_constants_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_constants_rule.severity = warning
+dotnet_naming_rule.private_constants_rule.style = upper_camel_case_style
+dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
+dotnet_naming_rule.private_instance_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_instance_fields_rule.severity = warning
+dotnet_naming_rule.private_instance_fields_rule.style = lower_camel_case_style
+dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields_symbols
+dotnet_naming_rule.private_static_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_fields_rule.severity = warning
+dotnet_naming_rule.private_static_fields_rule.style = lower_camel_case_style
+dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
+dotnet_naming_rule.private_static_readonly_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_readonly_rule.severity = warning
+dotnet_naming_rule.private_static_readonly_rule.style = upper_camel_case_style
+dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
+dotnet_naming_style.lower_camel_case_style.capitalization = camel_case
+dotnet_naming_style.upper_camel_case_style.capitalization = pascal_case
+dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_qualification_for_event = true:none
+dotnet_style_qualification_for_field = true:none
+dotnet_style_qualification_for_method = true:none
+dotnet_style_qualification_for_property = true:none
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+# ReSharper properties
+resharper_add_imports_to_deepest_scope = true
+resharper_arguments_skip_single = true
+resharper_autodetect_indent_settings = true
+resharper_blank_lines_after_start_comment = 0
+resharper_blank_lines_around_accessor = 1
+resharper_braces_for_for = required
+resharper_braces_for_foreach = required
+resharper_braces_for_ifelse = required
+resharper_braces_for_while = required
+resharper_braces_redundant = false
+resharper_csharp_blank_lines_around_field = 0
+resharper_csharp_max_line_length = 200
+resharper_enforce_line_ending_style = true
+resharper_for_built_in_types = use_explicit_type
+resharper_for_other_types = use_explicit_type
+resharper_for_simple_types = use_explicit_type
+resharper_indent_pars = outside
+resharper_instance_members_qualify_members = none, field, property, event, method
+resharper_keep_existing_attribute_arrangement = true
+resharper_keep_existing_declaration_block_arrangement = true
+resharper_max_attribute_length_for_same_line = 120
+resharper_max_initializer_elements_on_line = 1
+resharper_namespace_body = block_scoped
+resharper_new_line_before_while = true
+resharper_parentheses_redundancy_style = remove
+resharper_parentheses_same_type_operations = true
+resharper_place_accessorholder_attribute_on_same_line = false
+resharper_place_field_attribute_on_same_line = false
+resharper_place_simple_accessor_on_single_line = false
+resharper_place_simple_initializer_on_single_line = false
+resharper_qualified_using_at_nested_scope = true
+resharper_trailing_comma_in_multiline_lists = true
+resharper_use_indent_from_vs = false
+resharper_wrap_array_initializer_style = chop_if_long
+resharper_xmldoc_indent_child_elements = DoNotTouch
+resharper_xmldoc_indent_text = DoNotTouch
+
+# ReSharper inspection severities
+resharper_arrange_object_creation_when_type_not_evident_highlighting = none
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_this_qualifier_highlighting = none
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+resharper_invert_if_highlighting = none
+resharper_member_can_be_private_global_highlighting = hint
+resharper_property_can_be_made_init_only_global_highlighting = hint
+resharper_return_type_can_be_enumerable_global_highlighting = none
+resharper_suggest_var_or_type_built_in_types_highlighting = hint
+resharper_suggest_var_or_type_elsewhere_highlighting = hint
+resharper_suggest_var_or_type_simple_types_highlighting = hint
+resharper_unused_auto_property_accessor_global_highlighting = hint
+resharper_web_config_module_not_resolved_highlighting = warning
+resharper_web_config_type_not_resolved_highlighting = warning
+resharper_web_config_wrong_module_highlighting = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ resharper_html_space_before_self_closing = true
 [*.{yml,yaml}]
 indent_size = 2
 
-[*.cs]
+[*.{cs,razor,cshtml}]
 
 # All Rules are enabled with default severity.
 # Rules with IsEnabledByDefault = false are force-enabled with default severity.
@@ -741,7 +741,7 @@ resharper_indent_pars = outside
 resharper_instance_members_qualify_members = none, field, property, event, method
 resharper_keep_existing_attribute_arrangement = true
 resharper_keep_existing_declaration_block_arrangement = true
-resharper_max_attribute_length_for_same_line = 120
+resharper_max_attribute_length_for_same_line = 200
 resharper_max_initializer_elements_on_line = 1
 resharper_namespace_body = block_scoped
 resharper_new_line_before_while = true

--- a/Apps/HealthGateway.sln
+++ b/Apps/HealthGateway.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common", "Common\src\Common.csproj", "{8660083F-F582-47C6-BC98-6DCF0F4AC851}"
 EndProject
@@ -9,7 +9,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DBMaintainer", "DBMaintaine
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Immunization", "Immunization\src\Immunization.csproj", "{1842E377-23AD-4A52-881E-F0B82E7893A8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonTests", "Common\test\unit\CommonTests.csproj", "{D55428F4-B07E-46AF-AB09-0F526701173F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonTests", "Common\test\unit\CommonTests.csproj", "{D55428F4-B07E-46AF-AB09-0F526701173F}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ImmunizationTests", "Immunization\test\unit\ImmunizationTests.csproj", "{30741500-8F59-45CF-B753-14EBE6EE275E}"
 EndProject
@@ -17,7 +17,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DatabaseTests", "Database\t
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebClientTests", "WebClient\test\unit\WebClientTests.csproj", "{622DA0CD-5DF2-4FF1-9BE6-524CA0549976}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Medication", "Medication\src\Medication.csproj", "{24607238-4330-4732-8988-9D8E496A0C59}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Medication", "Medication\src\Medication.csproj", "{24607238-4330-4732-8988-9D8E496A0C59}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MedicationTests", "Medication\test\unit\MedicationTests.csproj", "{99BD4ECB-32B2-4429-95E3-3AFFAF89BD02}"
 EndProject
@@ -30,9 +30,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C8C17BF5-0961-4BEC-BC89-73D79D6B1C96}"
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = ../.editorconfig
-		stylecop.json = stylecop.json
-		sonar-config.xml = sonar-config.xml
 		Directory.Build.props = Directory.Build.props
+		sonar-config.xml = sonar-config.xml
+		stylecop.json = stylecop.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Laboratory", "Laboratory\src\Laboratory.csproj", "{A23D2835-87F7-4521-B10F-8E78DAD02929}"
@@ -49,29 +49,29 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encounter", "Encounter\src\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EncounterTests", "Encounter\test\unit\EncounterTests.csproj", "{AE9BCF9A-C2F8-4122-8C46-4FEF1EC4D676}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WebClient", "WebClient\src\WebClient.csproj", "{71D7A3C7-E2BF-4B74-A032-2841B8736F26}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebClient", "WebClient\src\WebClient.csproj", "{71D7A3C7-E2BF-4B74-A032-2841B8736F26}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mock", "Mock\src\Mock.csproj", "{7267BD8D-B2B0-4C12-A938-CE5C40467732}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mock", "Mock\src\Mock.csproj", "{7267BD8D-B2B0-4C12-A938-CE5C40467732}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Data", "CommonData\src\Common.Data.csproj", "{17E4F0B0-6E54-4E5B-8FDF-53150A185CFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Data", "CommonData\src\Common.Data.csproj", "{17E4F0B0-6E54-4E5B-8FDF-53150A185CFB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonDataTests", "CommonData\test\unit\CommonDataTests.csproj", "{B197DE3E-9C29-4CA0-85D6-225D9D22E5A2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonDataTests", "CommonData\test\unit\CommonDataTests.csproj", "{B197DE3E-9C29-4CA0-85D6-225D9D22E5A2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Common.Ui", "CommonUi\src\Common.Ui.csproj", "{6A5DB383-5971-4AFE-9B34-14610D5558CD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Common.Ui", "CommonUi\src\Common.Ui.csproj", "{6A5DB383-5971-4AFE-9B34-14610D5558CD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommonUiTests", "CommonUi\test\unit\CommonUiTests.csproj", "{A339FDC0-7796-4F7C-A3A9-34261E83655B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommonUiTests", "CommonUi\test\unit\CommonUiTests.csproj", "{A339FDC0-7796-4F7C-A3A9-34261E83655B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Admin.Server", "Admin\Server\Admin.Server.csproj", "{76F24907-B4C1-4370-97A3-F38F28292A6F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Admin.Server", "Admin\Server\Admin.Server.csproj", "{76F24907-B4C1-4370-97A3-F38F28292A6F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Admin.Tests", "Admin\Tests\Admin.Tests.csproj", "{33F20A22-6911-4BFF-99D8-F166C7D018BA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Admin.Tests", "Admin\Tests\Admin.Tests.csproj", "{33F20A22-6911-4BFF-99D8-F166C7D018BA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Admin.Common", "Admin\Common\Admin.Common.csproj", "{60053FA0-4716-4427-BFA9-4E5734697224}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Admin.Common", "Admin\Common\Admin.Common.csproj", "{60053FA0-4716-4427-BFA9-4E5734697224}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Admin.Client", "Admin\Client\Admin.Client.csproj", "{EC80FE0A-DF60-4497-93AE-4506C6F3E747}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Admin.Client", "Admin\Client\Admin.Client.csproj", "{EC80FE0A-DF60-4497-93AE-4506C6F3E747}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GatewayApi", "GatewayApi\src\GatewayApi.csproj", "{79313AFE-0E91-4098-AFF7-558918855874}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GatewayApi", "GatewayApi\src\GatewayApi.csproj", "{79313AFE-0E91-4098-AFF7-558918855874}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "GatewayApiTests", "GatewayApi\test\unit\GatewayApiTests.csproj", "{4C1B9864-FE24-4E58-B8A9-5554BF08AF0B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GatewayApiTests", "GatewayApi\test\unit\GatewayApiTests.csproj", "{4C1B9864-FE24-4E58-B8A9-5554BF08AF0B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{11B7A6AA-39F8-407D-8817-2BF5A175F56A}"
 EndProject
@@ -461,6 +461,21 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D55428F4-B07E-46AF-AB09-0F526701173F} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{30741500-8F59-45CF-B753-14EBE6EE275E} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{A57A0B42-FF66-4989-96B9-FE9DB4B03FC0} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{622DA0CD-5DF2-4FF1-9BE6-524CA0549976} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{99BD4ECB-32B2-4429-95E3-3AFFAF89BD02} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{66487699-BD22-4707-99F8-CBDE347ECE94} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{01C73638-BCE4-4336-9849-54D7CB6E7DF2} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{62D7B7CE-05C2-4997-A346-6088DD33A5E2} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{AE9BCF9A-C2F8-4122-8C46-4FEF1EC4D676} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{B197DE3E-9C29-4CA0-85D6-225D9D22E5A2} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{A339FDC0-7796-4F7C-A3A9-34261E83655B} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{33F20A22-6911-4BFF-99D8-F166C7D018BA} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+		{4C1B9864-FE24-4E58-B8A9-5554BF08AF0B} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
+	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {80946C82-3F9C-4F96-B46F-59A297C44E36}
 	EndGlobalSection
@@ -468,20 +483,5 @@ Global
 		Policies = $0
 		$0.StandardHeader = $1
 		$1.Text = @-------------------------------------------------------------------------\r\n Copyright © 2019 Province of British Columbia\r\n\r\n Licensed under the Apache License, Version 2.0 (the "License");\r\n you may not use this file except in compliance with the License.\r\n You may obtain a copy of the License at\r\n\r\n http://www.apache.org/licenses/LICENSE-2.0\r\n\r\n Unless required by applicable law or agreed to in writing, software\r\n distributed under the License is distributed on an "AS IS" BASIS,\r\n WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\r\n See the License for the specific language governing permissions and\r\n limitations under the License.\r\n-------------------------------------------------------------------------
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		{33F20A22-6911-4BFF-99D8-F166C7D018BA} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{62D7B7CE-05C2-4997-A346-6088DD33A5E2} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{B197DE3E-9C29-4CA0-85D6-225D9D22E5A2} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{A339FDC0-7796-4F7C-A3A9-34261E83655B} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{A57A0B42-FF66-4989-96B9-FE9DB4B03FC0} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{AE9BCF9A-C2F8-4122-8C46-4FEF1EC4D676} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{4C1B9864-FE24-4E58-B8A9-5554BF08AF0B} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{30741500-8F59-45CF-B753-14EBE6EE275E} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{01C73638-BCE4-4336-9849-54D7CB6E7DF2} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{99BD4ECB-32B2-4429-95E3-3AFFAF89BD02} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{66487699-BD22-4707-99F8-CBDE347ECE94} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{622DA0CD-5DF2-4FF1-9BE6-524CA0549976} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
-		{D55428F4-B07E-46AF-AB09-0F526701173F} = {11B7A6AA-39F8-407D-8817-2BF5A175F56A}
 	EndGlobalSection
 EndGlobal

--- a/Apps/HealthGateway.sln
+++ b/Apps/HealthGateway.sln
@@ -29,7 +29,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "JobScheduler", "JobSchedule
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C8C17BF5-0961-4BEC-BC89-73D79D6B1C96}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = ../.editorconfig
+		..\.editorconfig = ..\.editorconfig
 		Directory.Build.props = Directory.Build.props
 		sonar-config.xml = sonar-config.xml
 		stylecop.json = stylecop.json

--- a/Apps/HealthGateway.sln.DotSettings
+++ b/Apps/HealthGateway.sln.DotSettings
@@ -2,6 +2,16 @@
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=7267BD8D_002DB2B0_002D4C12_002DA938_002DCE5C40467732_002Fd_003ASoap_002Fd_003AServices/@EntryIndexedValue">7267BD8D-B2B0-4C12-A938-CE5C40467732/d:Soap/d:Services</s:String>
 	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=8660083F_002DF582_002D47C6_002DBC98_002D6DCF0F4AC851_002Fd_003AServiceReference/@EntryIndexedValue">8660083F-F582-47C6-BC98-6DCF0F4AC851/d:ServiceReference</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/SweaWarningsMode/@EntryValue">ShowAndRun</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_DECLARATION_LPAR/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_AFTER_INVOCATION_LPAR/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARGUMENTS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_ARRAY_INITIALIZER_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_DECLARATION_RPAR/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_FIRST_TYPE_PARAMETER_CONSTRAINT/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_BEFORE_INVOCATION_RPAR/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_CHAINED_METHOD_CALLS/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_EXTENDS_LIST_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_PARAMETERS_STYLE/@EntryValue">CHOP_IF_LONG</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=AHFS/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCMP/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Blazored/@EntryIndexedValue">True</s:Boolean>

--- a/Apps/HealthGateway.sln.DotSettings
+++ b/Apps/HealthGateway.sln.DotSettings
@@ -1,0 +1,18 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=7267BD8D_002DB2B0_002D4C12_002DA938_002DCE5C40467732_002Fd_003ASoap_002Fd_003AServices/@EntryIndexedValue">7267BD8D-B2B0-4C12-A938-CE5C40467732/d:Soap/d:Services</s:String>
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=8660083F_002DF582_002D47C6_002DBC98_002D6DCF0F4AC851_002Fd_003AServiceReference/@EntryIndexedValue">8660083F-F582-47C6-BC98-6DCF0F4AC851/d:ServiceReference</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/SweaWarningsMode/@EntryValue">ShowAndRun</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=AHFS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCMP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Blazored/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CDOGS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=DIN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=EMPI/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HDID/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HDIDs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=IDIR/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=LOINC/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PharmaNet/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PHSA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PLIS/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>


### PR DESCRIPTION
# Implements [AB#13367](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13367)

## Description

- initializes ReSharper code style settings to match our code base
- updates the solution-wide analysis used by Rider to include warnings
- populates the dictionary used by Rider with names and acronyms used in our code base
- designates Common\ServiceReference and Mock\Soap\Services as generated code (to reduce inspections and reports from them)
    - migrations are already detected as generated code by default

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

We should be able to enable Rider's "Reformat and Cleanup Code" action when saving to apply a lot of the ReSharper code style changes automatically for C# files, similar to how Prettier works on the Vue projects.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
