### PR TITLE
Rewrite event processing for Communication banner updates for AB#13533

### DIFF
--- a/Apps/CommonData/src/ViewModels/RequestResult.cs
+++ b/Apps/CommonData/src/ViewModels/RequestResult.cs
@@ -25,7 +25,7 @@ namespace HealthGateway.Common.Data.ViewModels
     /// <typeparam name="T">The payload type.</typeparam>
     [ExcludeFromCodeCoverage]
     public class RequestResult<T>
-        where T : class
+        where T : class?
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestResult{T}"/> class.

--- a/Apps/Database/src/Delegates/DBCommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/DBCommunicationDelegate.cs
@@ -53,9 +53,9 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc />
-        public DBResult<Communication?> Find(CommunicationType communicationType)
+        public DBResult<Communication?> GetNext(CommunicationType communicationType)
         {
-            this.logger.LogTrace($"Getting active Communication from DB...");
+            this.logger.LogTrace($"Getting next non-expired Communication from DB...");
             Communication? communication = this.dbContext.Communication
                 .Where(c => c.CommunicationTypeCode == communicationType &&
                             c.CommunicationStatusCode == CommunicationStatus.New &&

--- a/Apps/Database/src/Delegates/DBCommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/DBCommunicationDelegate.cs
@@ -53,25 +53,20 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc />
-        public DBResult<Communication> GetActiveBanner(CommunicationType communicationType)
+        public DBResult<Communication?> Find(CommunicationType communicationType)
         {
             this.logger.LogTrace($"Getting active Communication from DB...");
-            DBResult<Communication> result = new DBResult<Communication>()
-            {
-                Status = DBStatusCode.NotFound,
-            };
             Communication? communication = this.dbContext.Communication
-                .OrderByDescending(c => c.CreatedDateTime)
-                .Where(c => c.CommunicationTypeCode == communicationType)
-                .Where(c => c.CommunicationStatusCode == CommunicationStatus.New)
-                .Where(c => DateTime.UtcNow >= c.EffectiveDateTime && DateTime.UtcNow <= c.ExpiryDateTime)
+                .Where(c => c.CommunicationTypeCode == communicationType &&
+                            c.CommunicationStatusCode == CommunicationStatus.New &&
+                            DateTime.UtcNow < c.ExpiryDateTime)
+                .OrderBy(c => c.EffectiveDateTime)
                 .FirstOrDefault();
-
-            if (communication != null)
+            DBResult<Communication?> result = new()
             {
-                result.Status = DBStatusCode.Read;
-                result.Payload = communication;
-            }
+                Status = communication != null ? DBStatusCode.Read : DBStatusCode.NotFound,
+                Payload = communication,
+            };
 
             return result;
         }

--- a/Apps/Database/src/Delegates/ICommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/ICommunicationDelegate.cs
@@ -26,11 +26,11 @@ namespace HealthGateway.Database.Delegates
     public interface ICommunicationDelegate
     {
         /// <summary>
-        /// Gets the active communication banner from the DB by type.
+        /// Find the oldest by effective date, non-expired communication banner by type.
         /// </summary>
-        /// <param name="communicationType">The active communiction type to retrieve.</param>
+        /// <param name="communicationType">The active communication type to retrieve.</param>
         /// <returns>The Communication wrapped in a DBResult.</returns>
-        DBResult<Communication> GetActiveBanner(CommunicationType communicationType);
+        DBResult<Communication?> Find(CommunicationType communicationType);
 
         /// <summary>
         /// Add the given communication.

--- a/Apps/Database/src/Delegates/ICommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/ICommunicationDelegate.cs
@@ -26,11 +26,11 @@ namespace HealthGateway.Database.Delegates
     public interface ICommunicationDelegate
     {
         /// <summary>
-        /// Find the oldest by effective date, non-expired communication banner by type.
+        /// Gets the next oldest by effective date, non-expired communication banner by type.
         /// </summary>
         /// <param name="communicationType">The active communication type to retrieve.</param>
         /// <returns>The Communication wrapped in a DBResult.</returns>
-        DBResult<Communication?> Find(CommunicationType communicationType);
+        DBResult<Communication?> GetNext(CommunicationType communicationType);
 
         /// <summary>
         /// Add the given communication.

--- a/Apps/Database/src/Wrapper/DBResult.cs
+++ b/Apps/Database/src/Wrapper/DBResult.cs
@@ -22,7 +22,7 @@ namespace HealthGateway.Database.Wrapper
     /// </summary>
     /// <typeparam name="T">The payload type.</typeparam>
     public class DBResult<T>
-        where T : class
+        where T : class?
     {
         /// <summary>
         /// Gets or sets the result payload.

--- a/Apps/GatewayApi/src/Controllers/CommunicationController.cs
+++ b/Apps/GatewayApi/src/Controllers/CommunicationController.cs
@@ -49,7 +49,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <response code="200">Returns the communication json.</response>
         [HttpGet]
         [Route("{bannerType}")]
-        public RequestResult<Communication> Get(CommunicationType bannerType = CommunicationType.Banner)
+        public RequestResult<Communication?> Get(CommunicationType bannerType = CommunicationType.Banner)
         {
             return this.communicationService.GetActiveBanner(bannerType);
         }

--- a/Apps/GatewayApi/src/Converters/DateTimeConverter.cs
+++ b/Apps/GatewayApi/src/Converters/DateTimeConverter.cs
@@ -1,0 +1,39 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Converters
+{
+    using System;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Json Converter to put Postgres +00 dates into c# UTC DateTimes.
+    /// </summary>
+    public class DateTimeConverter : JsonConverter<DateTime>
+    {
+        /// <inheritdoc />
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.GetDateTime().ToUniversalTime();
+        }
+
+        /// <inheritdoc />
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToUniversalTime());
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Listeners/BannerListener.cs
+++ b/Apps/GatewayApi/src/Listeners/BannerListener.cs
@@ -22,9 +22,8 @@ namespace HealthGateway.GatewayApi.Listeners
     using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
-    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Database.Context;
-    using HealthGateway.Database.Models;
+    using HealthGateway.GatewayApi.Converters;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Services;
     using Microsoft.EntityFrameworkCore;
@@ -59,14 +58,12 @@ namespace HealthGateway.GatewayApi.Listeners
             this.services = services;
         }
 
-        private ICommunicationService? CommunicationService { get; set; }
-
         /// <summary>
         /// Creates a new DB Connection for push notifications from the DB for a specific channel.
         /// </summary>
         /// <param name="stoppingToken">The cancellation token to use.</param>
         /// <returns>The task.</returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Abstract class property")]
+        [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Abstract class property")]
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             this.logger.LogInformation("DBChangeListener is starting");
@@ -79,13 +76,12 @@ namespace HealthGateway.GatewayApi.Listeners
                 this.logger.LogInformation($"Registering Channel Notification on channel {Channel}, attempts = {attempts}");
                 try
                 {
-                    using var scope = this.services.CreateScope();
+                    using IServiceScope scope = this.services.CreateScope();
                     using GatewayDbContext dbContext = scope.ServiceProvider.GetRequiredService<GatewayDbContext>();
-                    this.CommunicationService = scope.ServiceProvider.GetRequiredService<ICommunicationService>();
                     using NpgsqlConnection con = (NpgsqlConnection)dbContext.Database.GetDbConnection();
                     await con.OpenAsync(stoppingToken).ConfigureAwait(true);
                     con.Notification += this.ReceiveEvent;
-                    using NpgsqlCommand cmd = new NpgsqlCommand();
+                    using NpgsqlCommand cmd = new();
                     cmd.CommandText = @$"LISTEN ""{Channel}"";";
                     cmd.CommandType = CommandType.Text;
                     cmd.Connection = con;
@@ -101,7 +97,7 @@ namespace HealthGateway.GatewayApi.Listeners
                 }
                 catch (NpgsqlException e)
                 {
-                    this.logger.LogError($"DB Error encountered in WaitChannelNotification: {Channel}\n{e.ToString()}");
+                    this.logger.LogError($"DB Error encountered in WaitChannelNotification: {Channel}\n{e}");
                     if (!stoppingToken.IsCancellationRequested)
                     {
                         await Task.Delay(SleepDuration, stoppingToken).ConfigureAwait(true);
@@ -114,32 +110,18 @@ namespace HealthGateway.GatewayApi.Listeners
 
         private void ReceiveEvent(object sender, NpgsqlNotificationEventArgs e)
         {
-            this.logger.LogInformation($"Event received on channel {Channel}");
+            this.logger.LogDebug($"Banner Event received on channel {Channel}");
             var options = new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
             };
+            options.Converters.Add(new DateTimeConverter());
             options.Converters.Add(new JsonStringEnumConverter());
             BannerChangeEvent? changeEvent = JsonSerializer.Deserialize<BannerChangeEvent>(e.Payload, options);
-            if (this.CommunicationService != null && changeEvent != null && changeEvent.Data != null)
-            {
-                Communication comm = changeEvent.Data;
-                DateTime utcnow = DateTime.UtcNow;
-                if (utcnow >= comm.EffectiveDateTime && utcnow <= comm.ExpiryDateTime)
-                {
-                    // shortcut - Active comm, remove from cache
-                    this.CommunicationService.RemoveBannerCache(comm.CommunicationTypeCode);
-                }
-                else
-                {
-                    // Change to the current comm, remove from cache
-                    RequestResult<Communication>? cacheComm = this.CommunicationService.GetBannerCache(comm.CommunicationTypeCode);
-                    if (cacheComm != null && cacheComm.ResourcePayload != null && cacheComm.ResourcePayload.Id == comm.Id)
-                    {
-                        this.CommunicationService.RemoveBannerCache(comm.CommunicationTypeCode);
-                    }
-                }
-            }
+            using IServiceScope scope = this.services.CreateScope();
+            ICommunicationService cs = scope.ServiceProvider.GetRequiredService<ICommunicationService>();
+            this.logger.LogInformation($"Banner Event received and being processed");
+            cs.ProcessChange(changeEvent);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/CommunicationService.cs
+++ b/Apps/GatewayApi/src/Services/CommunicationService.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
+    using HealthGateway.GatewayApi.Models;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
 
@@ -31,6 +32,8 @@ namespace HealthGateway.GatewayApi.Services
     {
         private const string BannerCacheKey = "BannerCacheKey";
         private const string InAppCacheKey = "InAppCacheKey";
+        private const string Update = "UPDATE";
+        private const string Insert = "INSERT";
 
         private readonly ILogger logger;
         private readonly ICommunicationDelegate communicationDelegate;
@@ -50,77 +53,147 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc />
-        public RequestResult<Communication> GetActiveBanner(CommunicationType communicationType)
+        public RequestResult<Communication?> GetActiveBanner(CommunicationType communicationType)
         {
             if (communicationType != CommunicationType.Banner && communicationType != CommunicationType.InApp)
             {
-                throw new ArgumentOutOfRangeException(nameof(communicationType), "Communiction Type must be Banner or InApp");
+                throw new ArgumentOutOfRangeException(nameof(communicationType), "Communication Type must be Banner or InApp");
             }
 
-            RequestResult<Communication>? cacheEntry = this.GetBannerCache(communicationType);
+            RequestResult<Communication?>? cacheEntry = this.GetCommunicationFromCache(communicationType);
             if (cacheEntry == null)
             {
                 this.logger.LogInformation("Active Communication not found in cache, getting from DB...");
-                cacheEntry = new();
-                DBResult<Communication> dbResult = this.communicationDelegate.GetActiveBanner(communicationType);
+                DBResult<Communication?> dbResult = this.communicationDelegate.Find(communicationType);
                 if (dbResult.Status == DBStatusCode.Read || dbResult.Status == DBStatusCode.NotFound)
                 {
-                    cacheEntry.ResourcePayload = dbResult.Payload;
-                    cacheEntry.ResultStatus = ResultType.Success;
-                    cacheEntry.TotalResultCount = dbResult.Status == DBStatusCode.Read ? 1 : 0;
-                    this.AddBannerCache(cacheEntry, communicationType);
+                    cacheEntry = this.AddCommunicationToCache(dbResult.Payload, communicationType);
                 }
                 else
                 {
                     this.logger.LogInformation($"Error getting Communication from DB {dbResult.Message}");
-                    cacheEntry.ResultStatus = ResultType.Error;
-                    cacheEntry.ResultError = new()
+                    cacheEntry = new()
                     {
-                        ResultMessage = dbResult.Message,
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                        ResultStatus = ResultType.Error,
+                        ResultError = new()
+                        {
+                            ResultMessage = dbResult.Message,
+                            ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                        },
                     };
                 }
             }
-            else
+
+            if (DateTime.UtcNow < cacheEntry.ResourcePayload?.EffectiveDateTime)
             {
-                this.logger.LogDebug("Active Banner was found in cache, returning...");
+                this.logger.LogDebug("Banner is future dated, returning empty RequestResult");
+                cacheEntry = new()
+                {
+                    ResultStatus = ResultType.Success,
+                    TotalResultCount = 0,
+                };
             }
 
             return cacheEntry;
         }
 
         /// <inheritdoc />
-        public void RemoveBannerCache(CommunicationType cacheType)
+        public void ProcessChange(BannerChangeEvent changeEvent)
+        {
+            Communication? communication = changeEvent.Data;
+            if (communication is not null &&
+                (communication.CommunicationTypeCode == CommunicationType.Banner ||
+                 communication.CommunicationTypeCode == CommunicationType.InApp))
+            {
+                RequestResult<Communication?>? cacheEntry = this.GetCommunicationFromCache(communication.CommunicationTypeCode);
+                if (cacheEntry?.ResourcePayload != null)
+                {
+                    Communication cachedComm = cacheEntry.ResourcePayload;
+                    if (cachedComm.Id == communication.Id)
+                    {
+                        this.logger.LogInformation($"{changeEvent.Action} ChangeEvent for Communication {communication.Id} found in Cache");
+                        this.RemoveCommunicationFromCache(communication.CommunicationTypeCode);
+                        if (changeEvent.Action == Insert || changeEvent.Action == Update)
+                        {
+                            this.AddCommunicationToCache(communication, communication.CommunicationTypeCode);
+                        }
+                        else
+                        {
+                            // Delete: We don't cache the empty result as a future dated comm may exist and the next call to GetActiveBanner will find it.
+                            this.logger.LogInformation($"{changeEvent.Action} ChangeEvent for Communication {communication.Id} was processed and removed from Cache");
+                        }
+                    }
+                    else
+                    {
+                        // Check the new comm to see if it is effective earlier and not expired
+                        if (DateTime.UtcNow < communication.ExpiryDateTime && communication.EffectiveDateTime < cachedComm.EffectiveDateTime)
+                        {
+                            this.logger.LogInformation($"{changeEvent.Action} ChangeEvent for Communication {communication.Id} replacing {cachedComm.Id}");
+                            this.AddCommunicationToCache(communication, communication.CommunicationTypeCode);
+                        }
+                        else
+                        {
+                            this.logger.LogInformation($"{changeEvent.Action} ChangeEvent for Communication {communication.Id} being ignored");
+                        }
+                    }
+                }
+                else
+                {
+                    this.logger.LogInformation($"No Communications in the Cache, processing {changeEvent.Action} for communication {communication.Id}");
+                    if (changeEvent.Action == Insert || changeEvent.Action == Update)
+                    {
+                        this.AddCommunicationToCache(communication, communication.CommunicationTypeCode);
+                    }
+                }
+            }
+        }
+
+        private void RemoveCommunicationFromCache(CommunicationType cacheType)
         {
             string cacheKey = cacheType == CommunicationType.Banner ? BannerCacheKey : InAppCacheKey;
             this.memoryCache.Remove(cacheKey);
         }
 
-        /// <inheritdoc />
-        public RequestResult<Communication>? GetBannerCache(CommunicationType cacheType)
+        private RequestResult<Communication?>? GetCommunicationFromCache(CommunicationType cacheType)
         {
             string cacheKey = cacheType == CommunicationType.Banner ? BannerCacheKey : InAppCacheKey;
-            this.memoryCache.TryGetValue(cacheKey, out RequestResult<Communication> cacheEntry);
+            this.memoryCache.TryGetValue(cacheKey, out RequestResult<Communication?> cacheEntry);
             return cacheEntry;
         }
 
-        /// <inheritdoc />
-        public void AddBannerCache(RequestResult<Communication> cacheEntry, CommunicationType cacheType)
+        private RequestResult<Communication?> AddCommunicationToCache(Communication? communication, CommunicationType cacheType)
         {
-            MemoryCacheEntryOptions cacheEntryOptions = new();
-            if (cacheEntry.ResultStatus == ResultType.Success &&
-                cacheEntry.ResourcePayload != null)
+            RequestResult<Communication?> cacheEntry = new()
             {
-                this.logger.LogInformation($"Active Banner found, setting expiration to {cacheEntry.ResourcePayload.ExpiryDateTime}");
-                cacheEntryOptions.AbsoluteExpiration = new System.DateTimeOffset(cacheEntry.ResourcePayload.ExpiryDateTime);
+                ResourcePayload = communication,
+                ResultStatus = ResultType.Success,
+                TotalResultCount = 0,
+            };
+            MemoryCacheEntryOptions cacheEntryOptions = new();
+            DateTime now = DateTime.UtcNow;
+            if (communication != null && now < communication.ExpiryDateTime)
+            {
+                if (now < communication.EffectiveDateTime)
+                {
+                    this.logger.LogInformation($"Communication {communication.Id} is not effective, cached empty communication until {communication.EffectiveDateTime}");
+                    cacheEntryOptions.AbsoluteExpiration = new DateTimeOffset(communication.EffectiveDateTime);
+                }
+                else
+                {
+                    this.logger.LogInformation($"Caching communication {communication.Id} until {communication.ExpiryDateTime}");
+                    cacheEntryOptions.AbsoluteExpiration = new DateTimeOffset(communication.ExpiryDateTime);
+                    cacheEntry.TotalResultCount = 1;
+                }
             }
             else
             {
-                this.logger.LogInformation($"No Active Banner found, caching empty result indefinitely");
+                this.logger.LogInformation("Communication is expired or null, caching Empty RequestResult forever");
+                cacheEntry.ResourcePayload = null;
             }
 
             string cacheKey = cacheType == CommunicationType.Banner ? BannerCacheKey : InAppCacheKey;
             this.memoryCache.Set(cacheKey, cacheEntry, cacheEntryOptions);
+            return cacheEntry;
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/CommunicationService.cs
+++ b/Apps/GatewayApi/src/Services/CommunicationService.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.GatewayApi.Services
             if (cacheEntry == null)
             {
                 this.logger.LogInformation("Active Communication not found in cache, getting from DB...");
-                DBResult<Communication?> dbResult = this.communicationDelegate.Find(communicationType);
+                DBResult<Communication?> dbResult = this.communicationDelegate.GetNext(communicationType);
                 if (dbResult.Status == DBStatusCode.Read || dbResult.Status == DBStatusCode.NotFound)
                 {
                     cacheEntry = this.AddCommunicationToCache(dbResult.Payload, communicationType);

--- a/Apps/GatewayApi/src/Services/ICommunicationService.cs
+++ b/Apps/GatewayApi/src/Services/ICommunicationService.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Database.Models;
+    using HealthGateway.GatewayApi.Models;
 
     /// <summary>
     /// Service to interact with the Communication Delegate.
@@ -30,26 +31,12 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="communicationType">The type of communication banner to retrieve.</param>
         /// <returns>The active communication wrapped in a RequestResult.</returns>
-        RequestResult<Communication> GetActiveBanner(CommunicationType communicationType);
+        RequestResult<Communication?> GetActiveBanner(CommunicationType communicationType);
 
         /// <summary>
-        /// Adds the associated banner to the local cache.
+        /// Processes a change event from the DB for Communication banners.
         /// </summary>
-        /// <param name="cacheEntry">The communication to be cached..</param>
-        /// <param name="cacheType">The communication type to be removed.</param>
-        public void AddBannerCache(RequestResult<Communication> cacheEntry, CommunicationType cacheType);
-
-        /// <summary>
-        /// Removes the associated banner from the local cache.
-        /// </summary>
-        /// <param name="cacheType">The communication type to be removed.</param>
-        void RemoveBannerCache(CommunicationType cacheType);
-
-        /// <summary>
-        /// Gets the associated banner from the local cache.
-        /// </summary>
-        /// <param name="cacheType">The communication type to be removed.</param>
-        /// <returns>The cached object.</returns>
-        RequestResult<Communication>? GetBannerCache(CommunicationType cacheType);
+        /// <param name="changeEvent">The change event that was triggered.</param>
+        void ProcessChange(BannerChangeEvent changeEvent);
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
@@ -37,7 +37,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         [Fact]
         public void ShouldGetCommunication()
         {
-            RequestResult<Communication> expectedResult = new()
+            RequestResult<Communication?> expectedResult = new()
             {
                 ResourcePayload = new Communication()
                 {
@@ -51,7 +51,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             communicationServiceMock.Setup(s => s.GetActiveBanner(CommunicationType.Banner)).Returns(expectedResult);
 
             CommunicationController controller = new(communicationServiceMock.Object);
-            RequestResult<Communication> actualResult = controller.Get();
+            RequestResult<Communication?> actualResult = controller.Get();
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/GatewayApi/test/unit/Services.Test/CommunicationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommunicationServiceTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.GatewayApi.Test.Services
 {
     using System;
-    using System.Text.Json;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -126,7 +125,7 @@ namespace HealthGateway.GatewayApi.Test.Services
 
             IMemoryCache memoryCache = CreateCache();
             Mock<ICommunicationDelegate> communicationDelegateMock = new();
-            communicationDelegateMock.Setup(s => s.Find(It.IsAny<CommunicationType>())).Returns(dbResult);
+            communicationDelegateMock.Setup(s => s.GetNext(It.IsAny<CommunicationType>())).Returns(dbResult);
 
             ICommunicationService service = new CommunicationService(
                 new Mock<ILogger<CommunicationService>>().Object,

--- a/Apps/GatewayApi/test/unit/Services.Test/Scenario.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Scenario.cs
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Test.Services
+{
+    /// <summary>
+    /// Scenario enum to use for testing purposes.
+    /// </summary>
+    public enum Scenario
+    {
+        /// <summary>
+        /// The communication is Active.
+        /// </summary>
+        Active,
+
+        /// <summary>
+        /// The communication is expired.
+        /// </summary>
+        Expired,
+
+        /// <summary>
+        /// The communication should be removed.
+        /// </summary>
+        Deleted,
+
+        /// <summary>
+        /// The communication should be future effective dated.
+        /// </summary>
+        Future,
+    }
+}


### PR DESCRIPTION
# Fixes or Implements [AB#13533](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13533)

## Description
**DBResult and RequestResult updated to allow nullable reference types.**
Declare the nullable return now that we can officially do it
Found and fixed deserialization issue on dates on push event
Updated DB Query to fetch active or future Communications.
Moved the BannerEvent processing to the Communication service and overhauled it.
Cache can now store future dated items - remove those on GetActiveBanner call

Lots of new tests - still not enough to cover all scenarios.



## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
None


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
