### PR TITLE
Fix feedback review table tags column collapsing too small AB#13466

### DIFF
--- a/Apps/Admin/Client/Pages/FeedbackPage.razor
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor
@@ -1,10 +1,9 @@
 ﻿@page "/feedback"
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer}")]
-@inherits Fluxor.Blazor.Web.Components.FluxorComponent
-
 @using HealthGateway.Admin.Client.Store.Tag
 @using HealthGateway.Admin.Common.Models
 @using HealthGateway.Common.Data.Utils
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <PageTitle>Feedback Review</PageTitle>
 <HgPageHeading>Feedback Review</HgPageHeading>
@@ -98,7 +97,7 @@ else
                         Comments
                     </MudTableSortLabel>
                 </MudTh>
-                <MudTh>
+                <MudTh Style="min-width: 252px;">
                     <MudTableSortLabel SortBy="new Func<FeedbackRow, object>(x => x.TagIds.Count())">
                         Tags
                     </MudTableSortLabel>
@@ -119,7 +118,7 @@ else
                         <MudIconButton Icon="@Icons.Material.Filled.PersonSearch"
                                        Color="@Color.Dark"
                                        data-testid="feedback-person-search-button"
-                                       OnClick="() => NavigateToSupport(context.Hdid)"/>
+                                       OnClick="() => NavigateToSupport(context.Hdid)" />
                     }
                     @if (context.Email.Length > 0)
                     {
@@ -149,11 +148,11 @@ else
                                    Color="@(context.IsReviewed ? Color.Success : Color.Error)"
                                    Disabled="@FeedbackUpdating"
                                    data-testid="feedback-review-button"
-                                   @onclick="@(() => ToggleIsReviewed(context.Id))"/>
+                                   @onclick="@(() => ToggleIsReviewed(context.Id))" />
                 </MudTd>
             </RowTemplate>
             <PagerContent>
-                <MudTablePager data-testid="feedback-table-pagination"/>
+                <MudTablePager data-testid="feedback-table-pagination" />
             </PagerContent>
         </MudTable>
     </MudForm>


### PR DESCRIPTION
# Fixes [AB#13466](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13466)

## Description

Prevents tags column in the admin feedback review table from becoming too small to use effectively.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://user-images.githubusercontent.com/16570293/179643442-80456b61-1c46-49bf-80f7-700dc1a2e871.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
