### PR TITLE
Add navigation label type to nav banners for AB#13378.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/BreadcrumbComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/BreadcrumbComponent.vue
@@ -49,6 +49,7 @@ export default class BreadcrumbComponent extends Vue {
         v-if="displayBreadcrumbs"
         data-testid="breadcrumbs"
         class="pt-0"
+        aria-label="Breadcrumb Nav"
     >
         <b-breadcrumb-item
             v-for="item in allBreadcrumbItems"

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/FooterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/FooterComponent.vue
@@ -16,6 +16,7 @@ export default class FooterComponent extends Vue {
         data-testid="footer"
         toggleable="lg"
         type="dark"
+        aria-label="Footer Nav"
     >
         <!-- Navbar content -->
         <b-navbar-nav>

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/HeaderComponent.vue
@@ -166,7 +166,7 @@ export default class HeaderComponent extends Vue {
 
 <template>
     <header class="sticky-top" :class="{ 'nav-up': !isHeaderShown }">
-        <b-navbar toggleable="md" type="dark">
+        <b-navbar toggleable="md" type="dark" aria-label="Top Nav">
             <!-- Hamburger toggle -->
             <hg-button
                 v-if="isSidebarButtonShown"

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
@@ -209,7 +209,12 @@ export default class SidebarComponent extends Vue {
 <template>
     <div v-if="isSidebarAvailable" class="wrapper">
         <!-- Sidebar -->
-        <nav id="sidebar" data-testid="sidebar" :class="{ collapsed: !isOpen }">
+        <nav
+            id="sidebar"
+            data-testid="sidebar"
+            :class="{ collapsed: !isOpen }"
+            aria-label="Side Nav"
+        >
             <b-row class="row-container">
                 <b-col>
                     <!-- Home button -->


### PR DESCRIPTION
# Fixes or Implements AB#13378

## Description

Add aria label attribute values to:

1. Header: Top Nav
2. Footer: Footer Nav
3. Side Bar: Side Nav
4. Breadcrumb Breadcrumb Nav

**Top Nav:**

<img width="1277" alt="Screen Shot 2022-07-19 at 11 23 56 AM" src="https://user-images.githubusercontent.com/58790456/179833860-5b9c8361-bf4d-4d3b-9dbd-1c79113236d8.png">

**Footer Nav**

<img width="2552" alt="Screen Shot 2022-07-19 at 11 24 15 AM" src="https://user-images.githubusercontent.com/58790456/179834072-fe6de785-0886-4d52-b8bd-85ad35597c66.png">

**Side Nav**

<img width="2535" alt="Screen Shot 2022-07-19 at 11 24 33 AM" src="https://user-images.githubusercontent.com/58790456/179834142-0925db0b-6c4e-468f-9f49-d1744b7e24df.png">

**Breadcrumb Nav**

<img width="2540" alt="Screen Shot 2022-07-19 at 11 24 58 AM" src="https://user-images.githubusercontent.com/58790456/179834201-7a3aa2d4-779f-4bf6-bfe0-ec75192badae.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
