### PR TITLE
Add PHN mask to Admin Web Client Support search for AB#13561.

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -90,10 +90,7 @@ export default class SupportView extends Vue {
     }
 
     private get phnSelected(): boolean {
-        return (
-            this.selectedQueryType !== null &&
-            this.selectedQueryType === QueryType.PHN
-        );
+        return this.selectedQueryType === QueryType.PHN;
     }
 
     private get phnMask(): Mask {
@@ -159,6 +156,7 @@ export default class SupportView extends Vue {
             var isValid = PHNValidator.IsValid(phnDigits);
 
             if (!isValid) {
+                this.emailList = [];
                 this.showFeedback = true;
                 this.bannerFeedback = {
                     type: ResultType.Error,

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -126,6 +126,7 @@ export default class SupportView extends Vue {
         this.searchText = "";
         this.searchPhn = "";
         this.emailList = [];
+        this.showFeedback = false;
     }
 
     private formatDateTime(date: StringISODateTime): string {
@@ -138,6 +139,7 @@ export default class SupportView extends Vue {
     }
 
     private handleSearch() {
+        this.showFeedback = false;
         if (
             this.selectedQueryType === null ||
             (this.selectedQueryType !== QueryType.PHN &&

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -12,6 +12,7 @@ import { QueryType } from "@/models/userQuery";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import container from "@/plugins/inversify.config";
 import { ISupportService } from "@/services/interfaces";
+import { Mask, phnMaskTemplate } from "@/utility/masks";
 import PHNValidator from "@/utility/phnValidator";
 
 interface UserSearchRow {
@@ -40,6 +41,7 @@ export default class SupportView extends Vue {
         message: "",
     };
 
+    private searchPhn = "";
     private searchText = "";
     private selectedQueryType: QueryType | null = null;
 
@@ -87,6 +89,17 @@ export default class SupportView extends Vue {
         return phn !== null ? phn : "-";
     }
 
+    private get phnSelected(): boolean {
+        return (
+            this.selectedQueryType !== null &&
+            this.selectedQueryType === QueryType.PHN
+        );
+    }
+
+    private get phnMask(): Mask {
+        return phnMaskTemplate;
+    }
+
     private get userInfo(): UserSearchRow[] {
         return this.emailList.map<UserSearchRow>((x) => {
             return {
@@ -109,6 +122,12 @@ export default class SupportView extends Vue {
         }
     }
 
+    private clearSearch(): void {
+        this.searchText = "";
+        this.searchPhn = "";
+        this.emailList = [];
+    }
+
     private formatDateTime(date: StringISODateTime): string {
         if (!date) {
             return "";
@@ -119,13 +138,23 @@ export default class SupportView extends Vue {
     }
 
     private handleSearch() {
-        if (this.selectedQueryType === null || this.searchText.length === 0) {
+        if (
+            this.selectedQueryType === null ||
+            (this.selectedQueryType !== QueryType.PHN &&
+                this.searchText.length === 0) ||
+            (this.selectedQueryType === QueryType.PHN &&
+                this.searchPhn.length === 0)
+        ) {
             this.emailList = [];
             return;
         }
 
+        let searchText =
+            this.selectedQueryType !== QueryType.PHN ? this.searchText : "";
+
         if (this.selectedQueryType === QueryType.PHN) {
-            var isValid = PHNValidator.IsValid(this.searchText);
+            const phnDigits = this.searchPhn.replace(/[^0-9]/g, "");
+            var isValid = PHNValidator.IsValid(phnDigits);
 
             if (!isValid) {
                 this.showFeedback = true;
@@ -136,10 +165,11 @@ export default class SupportView extends Vue {
                 };
                 return;
             }
+            searchText = phnDigits;
         }
 
         this.supportService
-            .getMessageVerifications(this.selectedQueryType, this.searchText)
+            .getMessageVerifications(this.selectedQueryType, searchText)
             .then((result) => {
                 this.emailList = result;
             })
@@ -172,10 +202,21 @@ export default class SupportView extends Vue {
                         :items="queryTypes"
                         label="Query Type"
                         outlined
+                        @change="clearSearch"
                     />
                 </v-col>
                 <v-col>
-                    <v-text-field v-model="searchText" label="Search Query" />
+                    <v-text-field
+                        v-show="!phnSelected"
+                        v-model="searchText"
+                        label="Search Query"
+                    />
+                    <v-text-field
+                        v-show="phnSelected"
+                        v-model="searchPhn"
+                        v-mask="phnMask"
+                        label="Search Query"
+                    />
                 </v-col>
                 <v-col cols="auto">
                     <v-btn type="submit" class="mt-2">


### PR DESCRIPTION
#Implements [AB#13561](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13561)

## Description

1. Add PHN mask to search text when PHN is selected as query type.
2. When query type is changed (PHN to HDID or HDID to email or SMS to PHN, etc), search text and search results are cleared
3. Clear validation errors if displayed in banner when doing a new search (i.e., there was an error in the previous search) or when query type is changed. 
4. Clear search result if there is a PHN validation error.

<img width="2537" alt="Screen Shot 2022-07-21 at 9 14 27 AM" src="https://user-images.githubusercontent.com/58790456/180269494-88554e2f-9023-4221-9a89-46a0bc64f359.png">

<img width="2536" alt="Screen Shot 2022-07-21 at 9 15 00 AM" src="https://user-images.githubusercontent.com/58790456/180269519-72438398-5c79-4888-8ece-9c5b14598790.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

YES - add PHN mask when PHN is entered as search text

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
