### PR TITLE
Fix Admin Web Client local development refresh issue for AB#13580.

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/vue.config.js
+++ b/Apps/AdminWebClient/src/ClientApp/vue.config.js
@@ -3,7 +3,10 @@ module.exports = {
     publicPath: process.env.NODE_ENV === "production" ? "/admin/" : "/",
     productionSourceMap: false,
     lintOnSave: true,
-    integrity: true,
+    integrity:
+        process.env.VUE_APP_CONFIG_INTEGRITY === undefined
+            ? true
+            : process.env.VUE_APP_CONFIG_INTEGRITY === "true",
     devServer: {
         client: {
             logging: "info",


### PR DESCRIPTION
# Fixes [AB#13580](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13580)

## Description

In order to make changes and then have the admin client web application to refresh without having to restart the server when developing locally, a local environment file i.e., '.env.local' will need to be created in the project's root directory.

The VUE environment variable defined in the local environment file will disable 'Integrity' in VUE config file. When working locally. Integrity will be disabled.

Using this '.env.local' file will allow developers to utilize refresh without having to restart the server. Do not check in this file. Please create one for local use.

```bash
cd $GATEWAYHOME/Apps/AdminWebClient/src/ClientApp/
code .env.local
```
Add the following text:

```bash
VUE_APP_CONFIG_INTEGRITY=false
```

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
