### PR TITLE
Add phn format mask to Blazor Admin Support for AB#13562.

### DIFF
--- a/Apps/Admin/Client/Pages/Support.razor
+++ b/Apps/Admin/Client/Pages/Support.razor
@@ -3,7 +3,7 @@
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 @using HealthGateway.Admin.Client.Store.MessageVerification
-@using HealthGateway.Common.Data.Utils
+@using HealthGateway.Common.Ui.Constants
 
 <PageTitle>Support</PageTitle>
 <HgPageHeading>Support</HgPageHeading>
@@ -23,7 +23,14 @@
             </HgSelect>
         </MudItem>
         <MudItem xs="12" sm="9">
-            <HgTextField LeftMargin="Breakpoint.Sm" T="string" Label="@SelectedQueryType.ToString()" Required="@true" Validation="@ValidateQueryParameter" @bind-Value="QueryParameter" data-testid="query-input"/>
+            @if (PhnSelected)
+            {
+                <HgTextField LeftMargin="Breakpoint.Sm" T="string" Label="@SelectedQueryType.ToString()" Required="@true" Validation="@ValidateQueryParameter" Mask="@(new PatternMask(Mask.PhnMaskTemplate))" @bind-Value="QueryParameter" data-testid="query-input" />
+            }
+            else
+            {
+                <HgTextField LeftMargin="Breakpoint.Sm" T="string" Label="@SelectedQueryType.ToString()" Required="@true" Validation="@ValidateQueryParameter" @bind-Value="QueryParameter" data-testid="query-input" />
+            }
         </MudItem>
         <MudItem Class="d-flex justify-end" xs="12">
             <HgButton TopMargin="Breakpoint.Always" EndIcon="@Icons.Material.Filled.Search" Variant="Variant.Filled" Color="Color.Primary" @onclick="SearchAsync" data-testid="search-btn">Search</HgButton>

--- a/Apps/Admin/Client/Pages/Support.razor.cs
+++ b/Apps/Admin/Client/Pages/Support.razor.cs
@@ -47,7 +47,19 @@ namespace HealthGateway.Admin.Client.Pages
         [Inject]
         private NavigationManager NavigationManager { get; set; } = default!;
 
-        private UserQueryType SelectedQueryType { get; set; } = UserQueryType.PHN;
+        private UserQueryType QueryType { get; set; } = UserQueryType.PHN;
+
+        private UserQueryType SelectedQueryType
+        {
+            get => this.QueryType;
+
+            set
+            {
+                this.ResetState();
+                this.QueryParameter = string.Empty;
+                this.QueryType = value;
+            }
+        }
 
         private string QueryParameter { get; set; } = string.Empty;
 
@@ -56,6 +68,8 @@ namespace HealthGateway.Admin.Client.Pages
         private bool MessagingVerificationsLoading => this.MessageVerificationState.Value.IsLoading;
 
         private bool MessagingVerificationsLoaded => this.MessageVerificationState.Value.Loaded;
+
+        private bool PhnSelected => this.SelectedQueryType == UserQueryType.PHN;
 
         private bool HasError => this.MessageVerificationState.Value.Error != null && this.MessageVerificationState.Value.Error.Message.Length > 0;
 

--- a/Apps/CommonUi/src/Constants/Mask.cs
+++ b/Apps/CommonUi/src/Constants/Mask.cs
@@ -1,0 +1,28 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Ui.Constants
+{
+    /// <summary>
+    /// A class with constants representing the various format masks.
+    /// </summary>
+    public static class Mask
+    {
+        /// <summary>
+        /// Format mask template for PHN.
+        /// </summary>
+        public const string PhnMaskTemplate = "0000 000 000";
+    }
+}


### PR DESCRIPTION
# Implements [AB#13562](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13562)

## Description

1. Add PHN mask to search text when PHN is selected as query type.
2. When query type is changed (PHN to HDID or HDID to email or SMS to PHN, etc), search text and search results are cleared

<img width="2541" alt="Screen Shot 2022-07-22 at 1 38 18 PM" src="https://user-images.githubusercontent.com/58790456/180567917-75d90cb3-1ec4-4eb0-99b1-ea2e39b42403.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

YES - add PHN mask when PHN is entered as search text

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
