### PR TITLE
Clear errors and warnings when routing to new page AB#11609 AB#13537

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
@@ -23,10 +23,8 @@ Vue.use(VueClipboard);
     },
 })
 export default class ErrorCardComponent extends Vue {
-    @Action("dismiss", {
-        namespace: "errorBanner",
-    })
-    dismissBanner!: () => void;
+    @Action("clearErrors", { namespace: "errorBanner" })
+    clearErrors!: () => void;
 
     @Getter("user", { namespace: "user" })
     user!: User;
@@ -97,7 +95,7 @@ export default class ErrorCardComponent extends Vue {
             dismissible
             class="no-print"
             :show="isShowing"
-            @dismissed="dismissBanner"
+            @dismissed="clearErrors"
         >
             <div>
                 <div

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -484,6 +484,16 @@ const router = new VueRouter({
 
 router.beforeEach(beforeEachGuard);
 
-router.afterEach(() => window.snowplow("trackPageView"));
+router.afterEach(() => {
+    const storeWrapper = container.get<IStoreProvider>(
+        STORE_IDENTIFIER.StoreProvider
+    );
+    const store = storeWrapper.getStore();
+
+    store.dispatch("errorBanner/clearErrors");
+    store.dispatch("errorBanner/clearTooManyRequests");
+
+    window.snowplow("trackPageView");
+});
 
 export default router;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/actions.ts
@@ -4,9 +4,6 @@ import ErrorTranslator from "@/utility/errorTranslator";
 import { ErrorBannerActions } from "./types";
 
 export const actions: ErrorBannerActions = {
-    dismiss(context) {
-        context.commit("dismiss");
-    },
     show(context) {
         context.commit("show");
     },
@@ -40,8 +37,8 @@ export const actions: ErrorBannerActions = {
         );
         context.commit("addError", bannerError);
     },
-    clearError(context) {
-        context.commit("clearError");
+    clearErrors(context) {
+        context.commit("clearErrors");
     },
     setTooManyRequestsWarning(
         context,

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/mutations.ts
@@ -3,11 +3,6 @@ import { BannerError } from "@/models/errors";
 import { ErrorBannerMutations, ErrorBannerState } from "./types";
 
 export const mutations: ErrorBannerMutations = {
-    dismiss(state: ErrorBannerState) {
-        state.genericErrorBanner.errors = [];
-        state.genericErrorBanner.isShowing =
-            !state.genericErrorBanner.isShowing;
-    },
     show(state: ErrorBannerState) {
         state.genericErrorBanner.isShowing = true;
     },
@@ -15,8 +10,9 @@ export const mutations: ErrorBannerMutations = {
         state.genericErrorBanner.isShowing = true;
         state.genericErrorBanner.errors.push(bannerError);
     },
-    clearError(state: ErrorBannerState) {
+    clearErrors(state: ErrorBannerState) {
         state.genericErrorBanner.errors = [];
+        state.genericErrorBanner.isShowing = false;
     },
     setTooManyRequestsWarning(state: ErrorBannerState, key: string) {
         state.tooManyRequestsWarning = key;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/error/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/error/types.ts
@@ -30,7 +30,6 @@ export interface ErrorBannerGetters
 type StoreContext = ActionContext<ErrorBannerState, RootState>;
 export interface ErrorBannerActions
     extends ActionTree<ErrorBannerState, RootState> {
-    dismiss(context: StoreContext): void;
     show(context: StoreContext): void;
     addError(
         context: StoreContext,
@@ -48,7 +47,7 @@ export interface ErrorBannerActions
             traceId: string | undefined;
         }
     ): void;
-    clearError(context: StoreContext): void;
+    clearErrors(context: StoreContext): void;
     setTooManyRequestsWarning(
         context: StoreContext,
         params: {
@@ -65,10 +64,9 @@ export interface ErrorBannerActions
 }
 
 export interface ErrorBannerMutations extends MutationTree<ErrorBannerState> {
-    dismiss(state: ErrorBannerState): void;
     show(state: ErrorBannerState): void;
     addError(state: ErrorBannerState, bannerError: BannerError): void;
-    clearError(state: ErrorBannerState): void;
+    clearErrors(state: ErrorBannerState): void;
     setTooManyRequestsWarning(state: ErrorBannerState, key: string): void;
     setTooManyRequestsError(state: ErrorBannerState, key: string): void;
     clearTooManyRequests(state: ErrorBannerState): void;

--- a/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
@@ -65,8 +65,8 @@ export default class PcrTestView extends Vue {
         traceId: string | undefined;
     }) => void;
 
-    @Action("clearError", { namespace: "errorBanner" })
-    clearError!: () => void;
+    @Action("clearErrors", { namespace: "errorBanner" })
+    clearErrors!: () => void;
 
     @Action("signIn", { namespace: "auth" })
     signIn!: (params: {
@@ -329,7 +329,7 @@ export default class PcrTestView extends Vue {
         if (this.$v.$invalid) {
             return;
         }
-        this.clearError();
+        this.clearErrors();
         const shortCodeFirst =
             this.pcrTest.testKitCode.length > 0
                 ? this.pcrTest.testKitCode.split("-")[0]


### PR DESCRIPTION
# Fixes [AB#11609](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11609) and Implements [AB#13537](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13537)

## Description

- clears the "too many requests" warning and error alerts when navigating to new page [AB#13537](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13537)
- clears the generic error alert when navigating to new page [AB#11609](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/11609)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
