### PR TITLE
Display error alerts for "too many requests" AB#13055

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -93,6 +93,12 @@ export default class DependentCardComponent extends Vue {
         traceId: string | undefined;
     }) => void;
 
+    @Action("setTooManyRequestsError", { namespace: "errorBanner" })
+    setTooManyRequestsError!: (params: { key: string }) => void;
+
+    @Action("setTooManyRequestsWarning", { namespace: "errorBanner" })
+    setTooManyRequestsWarning!: (params: { key: string }) => void;
+
     @Ref("sensitiveDocumentDownloadModal")
     readonly sensitiveDocumentDownloadModal!: MessageModalComponent;
 
@@ -214,13 +220,17 @@ export default class DependentCardComponent extends Vue {
         this.dependentService
             .removeDependent(this.user.hdid, this.dependent)
             .then(() => this.needsUpdate())
-            .catch((err: ResultError) =>
-                this.addError({
-                    errorType: ErrorType.Delete,
-                    source: ErrorSourceType.Dependent,
-                    traceId: err.traceId,
-                })
-            )
+            .catch((err: ResultError) => {
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsError({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Delete,
+                        source: ErrorSourceType.Dependent,
+                        traceId: err.traceId,
+                    });
+                }
+            })
             .finally(() => {
                 this.isLoading = false;
             });
@@ -250,11 +260,15 @@ export default class DependentCardComponent extends Vue {
             })
             .catch((err: ResultError) => {
                 this.logger.error(err.resultMessage);
-                this.addError({
-                    errorType: ErrorType.Download,
-                    source: ErrorSourceType.Covid19LaboratoryReport,
-                    traceId: err.traceId,
-                });
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsError({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Download,
+                        source: ErrorSourceType.Covid19LaboratoryReport,
+                        traceId: err.traceId,
+                    });
+                }
             })
             .finally(() => {
                 this.isGeneratingReport = false;
@@ -357,11 +371,15 @@ export default class DependentCardComponent extends Vue {
             })
             .catch((err: ResultError) => {
                 this.logger.error(err.resultMessage);
-                this.addError({
-                    errorType: ErrorType.Retrieve,
-                    source: ErrorSourceType.Covid19Laboratory,
-                    traceId: err.traceId,
-                });
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsWarning({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Retrieve,
+                        source: ErrorSourceType.Covid19Laboratory,
+                        traceId: err.traceId,
+                    });
+                }
                 this.isLoading = false;
             });
     }
@@ -419,11 +437,15 @@ export default class DependentCardComponent extends Vue {
             })
             .catch((err: ResultError) => {
                 this.logger.error(err.resultMessage);
-                this.addError({
-                    errorType: ErrorType.Retrieve,
-                    source: ErrorSourceType.Immunization,
-                    traceId: err.traceId,
-                });
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsWarning({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Retrieve,
+                        source: ErrorSourceType.Immunization,
+                        traceId: err.traceId,
+                    });
+                }
                 this.isLoading = false;
             });
     }

--- a/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
@@ -35,6 +35,9 @@ export default class NewDependentComponent extends Vue {
     @Getter("webClient", { namespace: "config" })
     webClientConfig!: WebClientConfiguration;
 
+    @Action("setTooManyRequestsError", { namespace: "errorBanner" })
+    setTooManyRequestsError!: (params: { key: string }) => void;
+
     private dependentService!: IDependentService;
     private isVisible = false;
     private isLoading = true;
@@ -134,7 +137,11 @@ export default class NewDependentComponent extends Vue {
                 this.handleSubmit();
             })
             .catch((err: ResultError) => {
-                this.errorMessage = err.resultMessage;
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsError({ key: "addDependentModal" });
+                } else {
+                    this.errorMessage = err.resultMessage;
+                }
             });
     }
 

--- a/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
@@ -8,6 +8,7 @@ import { Getter } from "vuex-class";
 
 import DatePickerComponent from "@/components/DatePickerComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";
+import TooManyRequestsComponent from "@/components/TooManyRequestsComponent.vue";
 import AddDependentRequest from "@/models/addDependentRequest";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper } from "@/models/dateWrapper";
@@ -27,6 +28,7 @@ const validPersonalHealthNumber = (value: string) => {
     components: {
         LoadingComponent,
         DatePickerComponent,
+        TooManyRequestsComponent,
     },
 })
 export default class NewDependentComponent extends Vue {
@@ -177,6 +179,7 @@ export default class NewDependentComponent extends Vue {
         header-text-variant="light"
         centered
     >
+        <TooManyRequestsComponent location="addDependentModal" />
         <b-alert
             data-testid="dependentErrorBanner"
             variant="danger"

--- a/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
@@ -4,7 +4,7 @@ import Vue from "vue";
 import { Component, Emit } from "vue-property-decorator";
 import { minLength, required, sameAs } from "vuelidate/lib/validators";
 import { Validation } from "vuelidate/vuelidate";
-import { Getter } from "vuex-class";
+import { Action, Getter } from "vuex-class";
 
 import DatePickerComponent from "@/components/DatePickerComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";

--- a/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
@@ -5,6 +5,7 @@ import { Component, Emit, Prop, Watch } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
 import LoadingComponent from "@/components/LoadingComponent.vue";
+import TooManyRequestsComponent from "@/components/TooManyRequestsComponent.vue";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";

--- a/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
@@ -16,7 +16,8 @@ import { ILogger, IUserProfileService } from "@/services/interfaces";
 @Component({
     components: {
         LoadingComponent,
-        countdown: VueCountdown,
+        VueCountdown,
+        TooManyRequestsComponent,
     },
 })
 export default class VerifySMSComponent extends Vue {
@@ -213,6 +214,7 @@ export default class VerifySMSComponent extends Vue {
         <b-row>
             <b-col>
                 <form>
+                    <TooManyRequestsComponent location="verifySmsModal" />
                     <b-row v-if="error">
                         <b-col class="text-center">
                             An unexpected error has occurred. Please try
@@ -280,7 +282,7 @@ export default class VerifySMSComponent extends Vue {
                     </hg-button>
                 </b-col>
                 <b-col v-if="!allowRetry">
-                    <countdown :time="getTimeout()">
+                    <VueCountdown :time="getTimeout()">
                         <template slot-scope="props"
                             >Your code has been sent. You can resend after
                             <span data-testid="countdownText"
@@ -290,7 +292,7 @@ export default class VerifySMSComponent extends Vue {
                                 {{ props.seconds }}s</span
                             ></template
                         >
-                    </countdown>
+                    </VueCountdown>
                 </b-col>
                 <b-col v-if="tooManyRetries">
                     <hg-button

--- a/Apps/WebClient/src/ClientApp/src/services/restUserNoteService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserNoteService.ts
@@ -66,8 +66,6 @@ export class RestUserNoteService implements IUserNoteService {
         });
     }
 
-    NOT_IMPLENTED = "Method not implemented.";
-
     public createNote(
         hdid: string,
         note: UserNote

--- a/Apps/WebClient/src/ClientApp/src/store/modules/comment/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/comment/actions.ts
@@ -128,19 +128,12 @@ export const actions: CommentActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("commentError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
-            context.dispatch(
-                "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
-            );
+        if (params.error.statusCode === 429) {
+            let action = "errorBanner/setTooManyRequestsError";
+            if (params.errorType === ErrorType.Retrieve) {
+                action = "errorBanner/setTooManyRequestsWarning";
+            }
+            context.dispatch(action, { key: "page" }, { root: true });
         } else {
             context.dispatch(
                 "errorBanner/addError",

--- a/Apps/WebClient/src/ClientApp/src/store/modules/encounter/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/encounter/actions.ts
@@ -74,18 +74,11 @@ export const actions: EncounterActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("encounterError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/immunization/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/immunization/actions.ts
@@ -72,18 +72,11 @@ export const actions: ImmunizationActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("immunizationError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
@@ -219,18 +219,11 @@ export const actions: LaboratoryActions = {
                 break;
         }
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(
@@ -323,18 +316,11 @@ export const actions: LaboratoryActions = {
 
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "publicCovidTest",
-                },
-                {
-                    root: true,
-                }
+                { key: "publicCovidTest" },
+                { root: true }
             );
 
             context.commit("setPublicCovidTestResponseResultError", undefined);

--- a/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/request/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/request/actions.ts
@@ -80,18 +80,11 @@ export const actions: MedicationRequestActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("medicationRequestError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/statement/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/statement/actions.ts
@@ -87,18 +87,11 @@ export const actions: MedicationStatementActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("medicationStatementError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/note/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/note/actions.ts
@@ -136,19 +136,12 @@ export const actions: NoteActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("noteError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
-            context.dispatch(
-                "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
-            );
+        if (params.error.statusCode === 429) {
+            let action = "errorBanner/setTooManyRequestsError";
+            if (params.errorType === ErrorType.Retrieve) {
+                action = "errorBanner/setTooManyRequestsWarning";
+            }
+            context.dispatch(action, { key: "page" }, { root: true });
         } else {
             context.dispatch(
                 "errorBanner/addError",

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -278,18 +278,11 @@ export const actions: UserActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("userError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 "errorBanner/setTooManyRequestsWarning",
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -1,5 +1,3 @@
-import { Commit } from "vuex";
-
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { ResultType } from "@/constants/resulttype";
 import UserPreferenceType from "@/constants/userPreferenceType";
@@ -18,15 +16,9 @@ import { QuickLinkUtil } from "@/utility/quickLinkUtil";
 
 import { UserActions } from "./types";
 
-function handleError(commit: Commit, error: Error): void {
-    const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-
-    logger.error(`UserProfile ERROR: ${error}`);
-    commit("userError");
-}
-
 export const actions: UserActions = {
     checkRegistration(context): Promise<boolean> {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         const userProfileService = container.get<IUserProfileService>(
             SERVICE_IDENTIFIER.UserProfileService
         );
@@ -35,9 +27,6 @@ export const actions: UserActions = {
             userProfileService
                 .getProfile(context.state.user.hdid)
                 .then((userProfile) => {
-                    const logger = container.get<ILogger>(
-                        SERVICE_IDENTIFIER.Logger
-                    );
                     logger.verbose(
                         `User Profile: ${JSON.stringify(userProfile)}`
                     );
@@ -45,7 +34,7 @@ export const actions: UserActions = {
                     resolve(userProfile.acceptedTermsOfService);
                 })
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );
@@ -54,10 +43,10 @@ export const actions: UserActions = {
         context,
         params: { termsOfServiceId: string }
     ): Promise<void> {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         const userProfileService = container.get<IUserProfileService>(
             SERVICE_IDENTIFIER.UserProfileService
         );
-        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
         return new Promise((resolve, reject) =>
             userProfileService
@@ -75,7 +64,7 @@ export const actions: UserActions = {
                     resolve();
                 })
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );
@@ -90,7 +79,7 @@ export const actions: UserActions = {
                 .updateEmail(context.state.user.hdid, params.emailAddress)
                 .then(() => resolve())
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );
@@ -102,10 +91,10 @@ export const actions: UserActions = {
         context,
         params: { userPreference: UserPreference }
     ): Promise<void> {
-        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         const userProfileService = container.get<IUserProfileService>(
             SERVICE_IDENTIFIER.UserProfileService
         );
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
         return new Promise((resolve, reject) =>
             userProfileService
@@ -123,7 +112,7 @@ export const actions: UserActions = {
                     resolve();
                 })
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );
@@ -153,7 +142,7 @@ export const actions: UserActions = {
                     resolve();
                 })
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );
@@ -197,12 +186,13 @@ export const actions: UserActions = {
                     resolve();
                 })
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );
     },
     recoverUserAccount(context): Promise<void> {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         const userProfileService = container.get<IUserProfileService>(
             SERVICE_IDENTIFIER.UserProfileService
         );
@@ -211,9 +201,6 @@ export const actions: UserActions = {
             userProfileService
                 .recoverAccount(context.state.user.hdid)
                 .then((userProfile) => {
-                    const logger = container.get<ILogger>(
-                        SERVICE_IDENTIFIER.Logger
-                    );
                     logger.debug(
                         `recoverUserAccount User Profile: ${JSON.stringify(
                             userProfile
@@ -223,7 +210,7 @@ export const actions: UserActions = {
                     resolve();
                 })
                 .catch((error) => {
-                    handleError(context.commit, error);
+                    context.commit("userError");
                     reject(error);
                 })
         );

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
@@ -86,18 +86,11 @@ export const actions: VaccinationStatusActions = {
 
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 setTooManyRequestsWarning,
-                {
-                    key: "publicVaccineCard",
-                },
-                {
-                    root: true,
-                }
+                { key: "publicVaccineCard" },
+                { root: true }
             );
 
             context.commit("publicVaccinationStatusError", undefined);
@@ -190,18 +183,11 @@ export const actions: VaccinationStatusActions = {
 
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 setTooManyRequestsWarning,
-                {
-                    key: "vaccineCardComponent",
-                },
-                {
-                    root: true,
-                }
+                { key: "vaccineCardComponent" },
+                { root: true }
             );
 
             context.commit("setPublicVaccineRecordError", undefined);
@@ -294,18 +280,11 @@ export const actions: VaccinationStatusActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("authenticatedVaccinationStatusError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 setTooManyRequestsWarning,
-                {
-                    key: "page",
-                },
-                {
-                    root: true,
-                }
+                { key: "page" },
+                { root: true }
             );
         } else {
             context.dispatch(
@@ -392,18 +371,11 @@ export const actions: VaccinationStatusActions = {
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
         context.commit("setAuthenticatedVaccineRecordError", params.error);
 
-        if (
-            params.errorType === ErrorType.Retrieve &&
-            params.error.statusCode === 429
-        ) {
+        if (params.error.statusCode === 429) {
             context.dispatch(
                 setTooManyRequestsWarning,
-                {
-                    key: "vaccineCardComponent",
-                },
-                {
-                    root: true,
-                }
+                { key: "vaccineCardComponent" },
+                { root: true }
             );
         } else {
             if (params.error.actionCode === ActionType.Invalid) {

--- a/Apps/WebClient/src/ClientApp/src/views/AcceptTermsOfServiceView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/AcceptTermsOfServiceView.vue
@@ -26,9 +26,6 @@ library.add(faExclamationTriangle);
     },
 })
 export default class AcceptTermsOfServiceView extends Vue {
-    @Action("checkRegistration", { namespace: "user" })
-    checkRegistration!: () => Promise<boolean>;
-
     @Action("updateAcceptedTerms", { namespace: "user" })
     updateAcceptedTerms!: (params: {
         termsOfServiceId: string;

--- a/Apps/WebClient/src/ClientApp/src/views/DependentsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentsView.vue
@@ -46,6 +46,9 @@ export default class DependentsView extends Vue {
         traceId: string | undefined;
     }) => void;
 
+    @Action("setTooManyRequestsWarning", { namespace: "errorBanner" })
+    setTooManyRequestsWarning!: (params: { key: string }) => void;
+
     private logger!: ILogger;
     private dependentService!: IDependentService;
 
@@ -79,11 +82,15 @@ export default class DependentsView extends Vue {
             .then((results) => this.setDependents(results))
             .catch((error: ResultError) => {
                 this.logger.error(error.resultMessage);
-                this.addError({
-                    errorType: ErrorType.Retrieve,
-                    source: ErrorSourceType.Dependent,
-                    traceId: error.traceId,
-                });
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsWarning({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Retrieve,
+                        source: ErrorSourceType.Dependent,
+                        traceId: error.traceId,
+                    });
+                }
             })
             .finally(() => {
                 this.isLoading = false;

--- a/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
@@ -65,6 +65,9 @@ export default class PcrTestView extends Vue {
         traceId: string | undefined;
     }) => void;
 
+    @Action("setTooManyRequestsError", { namespace: "errorBanner" })
+    setTooManyRequestsError!: (params: { key: string }) => void;
+
     @Action("clearErrors", { namespace: "errorBanner" })
     clearErrors!: () => void;
 
@@ -418,7 +421,9 @@ export default class PcrTestView extends Vue {
 
     private handleError(err: ResultError, domain: string): void {
         this.logger.error(`${domain} Error: ${err}`);
-        if (err.actionCode == ActionType.Processed) {
+        if (err.statusCode === 429) {
+            this.setTooManyRequestsError({ key: "page" });
+        } else if (err.actionCode == ActionType.Processed) {
             this.errorMessage = err.resultMessage;
         } else {
             this.addCustomError({

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -333,7 +333,7 @@ export default class RegistrationView extends Vue {
             </div>
             <div v-else>
                 <b-form
-                    v-if="isValid === true"
+                    v-if="isValidAge === true"
                     ref="registrationForm"
                     @submit.prevent="onSubmit"
                 >
@@ -498,7 +498,7 @@ export default class RegistrationView extends Vue {
                         </b-col>
                     </b-row>
                 </b-form>
-                <div v-else-if="isValid === false">
+                <div v-else-if="isValidAge === false">
                     <h1>Minimum age required for registration</h1>
                     <p data-testid="minimumAgeErrorText">
                         You must be <strong>{{ minimumAge }}</strong> years of

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -45,6 +45,12 @@ export default class RegistrationView extends Vue {
         traceId: string | undefined;
     }) => void;
 
+    @Action("setTooManyRequestsError", { namespace: "errorBanner" })
+    setTooManyRequestsError!: (params: { key: string }) => void;
+
+    @Action("setTooManyRequestsWarning", { namespace: "errorBanner" })
+    setTooManyRequestsWarning!: (params: { key: string }) => void;
+
     @Action("checkRegistration", { namespace: "user" })
     checkRegistration!: () => Promise<boolean>;
 
@@ -73,7 +79,7 @@ export default class RegistrationView extends Vue {
     private errorMessage = "";
 
     private logger!: ILogger;
-    private isValidAge = false;
+    private isValidAge?: boolean;
     private minimumAge!: number;
 
     private termsOfService?: TermsOfService;
@@ -142,15 +148,19 @@ export default class RegistrationView extends Vue {
             .then((isValid) => {
                 this.isValidAge = isValid;
             })
-            .catch(() => {
-                this.clientRegistryError = true;
-                this.addCustomError({
-                    title:
-                        "Unable to validate " +
-                        ErrorSourceType.User.toLowerCase(),
-                    source: ErrorSourceType.User,
-                    traceId: undefined,
-                });
+            .catch((err: ResultError) => {
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsError({ key: "page" });
+                } else {
+                    this.clientRegistryError = true;
+                    this.addCustomError({
+                        title:
+                            "Unable to validate " +
+                            ErrorSourceType.User.toLowerCase(),
+                        source: ErrorSourceType.User,
+                        traceId: undefined,
+                    });
+                }
             })
             .finally(() => {
                 this.loadingUserData = false;
@@ -189,13 +199,17 @@ export default class RegistrationView extends Vue {
                 );
                 this.termsOfService = result;
             })
-            .catch((err) => {
+            .catch((err: ResultError) => {
                 this.logger.error(err);
-                this.addError({
-                    errorType: ErrorType.Retrieve,
-                    source: ErrorSourceType.TermsOfService,
-                    traceId: undefined,
-                });
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsWarning({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Retrieve,
+                        source: ErrorSourceType.TermsOfService,
+                        traceId: undefined,
+                    });
+                }
             })
             .finally(() => {
                 this.loadingTermsOfService = false;
@@ -239,13 +253,17 @@ export default class RegistrationView extends Vue {
                 );
                 this.redirect();
             })
-            .catch((err: ResultError) =>
-                this.addError({
-                    errorType: ErrorType.Create,
-                    source: ErrorSourceType.Profile,
-                    traceId: err.traceId,
-                })
-            )
+            .catch((err: ResultError) => {
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsError({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Create,
+                        source: ErrorSourceType.Profile,
+                        traceId: err.traceId,
+                    });
+                }
+            })
             .finally(() => {
                 this.loadingTermsOfService = false;
             });
@@ -315,7 +333,7 @@ export default class RegistrationView extends Vue {
             </div>
             <div v-else>
                 <b-form
-                    v-if="isValidAge"
+                    v-if="isValid === true"
                     ref="registrationForm"
                     @submit.prevent="onSubmit"
                 >
@@ -480,14 +498,14 @@ export default class RegistrationView extends Vue {
                         </b-col>
                     </b-row>
                 </b-form>
-                <div v-else-if="!clientRegistryError">
+                <div v-else-if="isValid === false">
                     <h1>Minimum age required for registration</h1>
                     <p data-testid="minimumAgeErrorText">
                         You must be <strong>{{ minimumAge }}</strong> years of
                         age or older to use this application
                     </p>
                 </div>
-                <div v-else>
+                <div v-else-if="clientRegistryError">
                     <h1>Error retrieving user information</h1>
                     <p data-testid="clientRegistryErrorText">
                         There may be an issue in our Client Registry. Please

--- a/Apps/WebClient/src/ClientApp/src/views/TermsOfServiceView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TermsOfServiceView.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
+import { Action } from "vuex-class";
 
 import HtmlTextAreaComponent from "@/components/HtmlTextAreaComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";


### PR DESCRIPTION
# Implements AB#13055

## Description

- populates store with too many requests errors AB#13501
    - also populates store with too many requests warnings for a couple retrievals we missed
- displays alerts on modals for too many requests AB#13500
- cleans up some handleError actions in the store
- cleans up some actions in the user store that were using a handleError function instead of the action
- removes some unused code in AcceptTermsOfServiceView.vue and restUserNoteService.ts

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
