### PR TITLE
Finalize Kong settings AB#13088

### DIFF
--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -17,12 +17,12 @@
         "Modules": {}
     },
     "ServiceEndpoints": {
-        "GatewayApi": "https://test.healthgateway.gov.bc.ca/api/gatewayapiservice/",
-        "Immunization": "https://test.healthgateway.gov.bc.ca/api/immunizationservice/",
-        "Patient": "https://test.healthgateway.gov.bc.ca/api/patientservice/",
-        "Medication": "https://test.healthgateway.gov.bc.ca/api/medicationservice/",
-        "Laboratory": "https://test.healthgateway.gov.bc.ca/api/laboratoryservice/",
-        "Encounter": "https://test.healthgateway.gov.bc.ca/api/encounterservice/"
+        "Encounter": "https://hg-test.api.gov.bc.ca/api/encounterservice/",
+        "GatewayApi": "https://hg-test.api.gov.bc.ca/api/gatewayapiservice/",
+        "Immunization": "https://hg-test.api.gov.bc.ca/api/immunizationservice/",
+        "Laboratory": "https://hg-test.api.gov.bc.ca/api/laboratoryservice/",
+        "Medication": "https://hg-test.api.gov.bc.ca/api/medicationservice/",
+        "Patient": "https://hg-test.api.gov.bc.ca/api/patientservice/"
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/",

--- a/Tools/Kong/routes-gatewayapi.tmpl
+++ b/Tools/Kong/routes-gatewayapi.tmpl
@@ -8,6 +8,17 @@
           - /api/gatewayapiservice/UserProfile/termsofservice
         strip_path: false
         plugins:
+          - name: rate-limiting
+            tags: [ns.$KONG_NAMESPACE]
+            enabled: true
+            config:
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: ip
+              minute: $IP_RATE_LIMIT
+            protocols:
+              - http
+              - https
           - name: rate-limiting_902
             tags: [ns.$KONG_NAMESPACE]
             enabled: true

--- a/Tools/Kong/routes-immunization.tmpl
+++ b/Tools/Kong/routes-immunization.tmpl
@@ -10,6 +10,17 @@
           - /api/immunizationservice/PublicVaccineStatus
         strip_path: false
         plugins:
+          - name: rate-limiting
+            tags: [ns.$KONG_NAMESPACE]
+            enabled: true
+            config:
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: ip
+              minute: $IP_RATE_LIMIT
+            protocols:
+              - http
+              - https
           - name: rate-limiting_902
             tags: [ns.$KONG_NAMESPACE]
             enabled: true

--- a/Tools/Kong/routes-laboratory.tmpl
+++ b/Tools/Kong/routes-laboratory.tmpl
@@ -10,6 +10,17 @@
           - /api/laboratoryservice/PublicLaboratory
         strip_path: false
         plugins:
+          - name: rate-limiting
+            tags: [ns.$KONG_NAMESPACE]
+            enabled: true
+            config:
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: ip
+              minute: $IP_RATE_LIMIT
+            protocols:
+              - http
+              - https
           - name: rate-limiting_902
             tags: [ns.$KONG_NAMESPACE]
             enabled: true

--- a/Tools/Kong/routes-medication.tmpl
+++ b/Tools/Kong/routes-medication.tmpl
@@ -7,6 +7,17 @@
           - /api/medicationservice/Medication/
         strip_path: false
         plugins:
+          - name: rate-limiting
+            tags: [ns.$KONG_NAMESPACE]
+            enabled: true
+            config:
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: ip
+              minute: $IP_RATE_LIMIT
+            protocols:
+              - http
+              - https
           - name: rate-limiting_902
             tags: [ns.$KONG_NAMESPACE]
             enabled: true


### PR DESCRIPTION
# Implements AB#13088

## Description

- configures TEST environment to use Kong AB#13520
- adds IP-based rate-limiting when credential-based rate-limiting is unavailable AB#13521

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
