### PR TITLE
Update JobScheduler return link and remove old conifg for AB#13651

### DIFF
--- a/Apps/JobScheduler/src/appsettings.Development.json
+++ b/Apps/JobScheduler/src/appsettings.Development.json
@@ -17,6 +17,9 @@
         "Enabled": "false"
     },
     "Host": "http://localhost:5000",
+    "JobScheduler": {
+        "AdminHome": "http://localhost:5027"
+    },
     "Smtp": {
         "Host": "mail.shaw.ca",
         "Port": 25
@@ -34,9 +37,5 @@
     "NotificationSettings": {
         "Enabled": true,
         "Endpoint": "https://phsahealthgatewayapi-dev.azurewebsites.net/api/v1/Settings/Notification"
-    },
-    "AcaPy": {
-        "agentApiUrl": "http://localhost:8024/",
-        "agentApiKey": "agent-api-key-dev"
     }
 }

--- a/Apps/JobScheduler/src/appsettings.hgdev.json
+++ b/Apps/JobScheduler/src/appsettings.hgdev.json
@@ -8,6 +8,9 @@
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f"
     },
     "Host": "https://dev.healthgateway.gov.bc.ca",
+    "JobScheduler": {
+        "AdminHome": "https://dev-admin.healthgateway.gov.bc.ca"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "ClientSecret": "****",
@@ -20,9 +23,5 @@
     "NotificationSettings": {
         "Enabled": true,
         "Endpoint": "https://phsahealthgatewayapi-dev.azurewebsites.net/api/v1/Settings/Notification"
-    },
-    "AcaPy": {
-        "agentApiUrl": "https://health-gateway-agent-admin-dev.apps.silver.devops.gov.bc.ca/",
-        "agentApiKey": "***"
     }
 }

--- a/Apps/JobScheduler/src/appsettings.hgmock.json
+++ b/Apps/JobScheduler/src/appsettings.hgmock.json
@@ -8,6 +8,9 @@
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f"
     },
     "Host": "https://mock.healthgateway.gov.bc.ca",
+    "JobScheduler": {
+        "AdminHome": "https://mock-admin.healthgateway.gov.bc.ca"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "ClientSecret": "****",
@@ -20,9 +23,5 @@
     "NotificationSettings": {
         "Enabled": true,
         "Endpoint": "https://mock.healthgateway.gov.bc.ca/api/mockservice/v1/api/phsa/notificationSettings"
-    },
-    "AcaPy": {
-        "agentApiUrl": "https://health-gateway-agent-admin-dev.apps.silver.devops.gov.bc.ca/",
-        "agentApiKey": "***"
     }
 }

--- a/Apps/JobScheduler/src/appsettings.hgpoc.json
+++ b/Apps/JobScheduler/src/appsettings.hgpoc.json
@@ -8,6 +8,9 @@
         "Authority": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f"
     },
     "Host": "https://poc.healthgateway.gov.bc.ca",
+    "JobScheduler": {
+        "AdminHome": "https://poc-admin.healthgateway.gov.bc.ca"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "ClientSecret": "****",

--- a/Apps/JobScheduler/src/appsettings.hgtest.json
+++ b/Apps/JobScheduler/src/appsettings.hgtest.json
@@ -8,6 +8,9 @@
         "Authority": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f"
     },
     "Host": "https://test.healthgateway.gov.bc.ca",
+    "JobScheduler": {
+        "AdminHome": "https://test-admin.healthgateway.gov.bc.ca"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "ClientSecret": "****",
@@ -20,9 +23,5 @@
     "NotificationSettings": {
         "Enabled": true,
         "Endpoint": "https://phsahealthgatewayapi-test.azurewebsites.net/api/v1/Settings/Notification"
-    },
-    "AcaPy": {
-        "agentApiUrl": "https://health-gateway-agent-admin-test.apps.silver.devops.gov.bc.ca/",
-        "agentApiKey": "***"
     }
 }

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -31,7 +31,7 @@
     "DashboardTitle": "HealthGateway JobScheduler Dashboard",
     "Host": "https://healthgateway.gov.bc.ca",
     "JobScheduler": {
-        "AdminHome": "/admin"
+        "AdminHome": "https://admin.healthgateway.gov.bc.ca"
     },
     "Smtp": {
         "Host": "apps.smtp.gov.bc.ca",
@@ -175,12 +175,6 @@
         "Immediate": "false",
         "Delay": 60,
         "DeleteMaxRows": 4000
-    },
-    "AcaPy": {
-        "agentApiUrl": "***",
-        "agentApiKey": "***",
-        "schemaName": "Immunization",
-        "schemaVersion": "1.0"
     },
     "AdminFeedback": {
         "AdminEmail": "healthgateway@gov.bc.ca"


### PR DESCRIPTION
# Fixes or Implements [AB#13651](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13651)

## Description
Update the return link for Job Scheduler to Blazor Admin (formerly WebAdmin)
Remove old AcaPy configuration


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
