### PR TITLE
Fix broken Admin functional tests AB#13635

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/analytics.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/analytics.cy.js
@@ -1,3 +1,5 @@
+const timeout = 45000;
+
 function getFileName(name) {
     // yyyy-mm-dd
     const today = new Date().toLocaleDateString("en-CA");
@@ -18,10 +20,9 @@ describe("System Analytics", () => {
 
         cy.intercept("GET", "**/CsvExport/GetRatings").as("getRatings");
 
-        cy.intercept(
-            "GET",
-            "**/CsvExport/GetInactiveUsers?timeOffset=420&inactiveDays=100"
-        ).as("getInactiveUsers");
+        cy.intercept("GET", "**/CsvExport/GetInactiveUsers*").as(
+            "getInactiveUsers"
+        );
 
         cy.login(
             Cypress.env("keycloak_username"),
@@ -36,32 +37,32 @@ describe("System Analytics", () => {
         cy.get("[data-testid=user-profile-download-btn]")
             .should("be.visible")
             .click();
-        cy.wait("@getUserProfiles");
+        cy.wait("@getUserProfiles", { timeout });
         cy.verifyDownload(getFileName("UserProfile"));
 
         cy.get("[data-testid=user-comments-download-btn]")
             .should("be.visible")
             .click();
-        cy.wait("@getComments");
+        cy.wait("@getComments", { timeout });
         cy.verifyDownload(getFileName("Comments"));
 
         cy.get("[data-testid=user-notes-download-btn]")
             .should("be.visible")
             .click();
-        cy.wait("@getNotes");
+        cy.wait("@getNotes", { timeout });
         cy.verifyDownload(getFileName("Notes"));
 
         cy.get("[data-testid=user-ratings-download-btn]")
             .should("be.visible")
             .click();
-        cy.wait("@getRatings");
+        cy.wait("@getRatings", { timeout });
         cy.verifyDownload(getFileName("Ratings"));
 
         cy.get("[data-testid=days-inactive-input]").clear().type(100);
         cy.get("[data-testid=inactive-users-download-btn]")
             .should("be.visible")
             .click();
-        cy.wait("@getInactiveUsers");
+        cy.wait("@getInactiveUsers", { timeout });
         cy.verifyDownload(getFileName("InactiveUsers"));
 
         cy.log("System Analytics stats download test finished.");

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
@@ -7,7 +7,7 @@ describe("Dashboard", () => {
         );
     });
 
-    it("Verify dashboards counts.", () => {
+    it("Verify dashboard counts from seeded data.", () => {
         cy.log("Dashboard test started.");
         cy.get("[data-testid=total-registered-users]").contains(6);
         cy.get("[data-testid=total-dependents]").contains(2);

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
@@ -3,7 +3,7 @@ describe("Dashboard", () => {
         cy.login(
             Cypress.env("keycloak_username"),
             Cypress.env("keycloak_password"),
-            "/"
+            "/dashboard"
         );
     });
 

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
@@ -42,7 +42,7 @@ describe("Support", () => {
         cy.log("Verify support query test started.");
 
         // Search by PHN
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("PHN")
             .click({ force: true });
@@ -51,7 +51,7 @@ describe("Support", () => {
         verifyTableResults("PHN");
 
         // Search by HDID.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("HDID")
             .click({ force: true });
@@ -60,7 +60,7 @@ describe("Support", () => {
         verifyTableResults("HDID");
 
         // Search by SMS.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("SMS")
             .click({ force: true });
@@ -69,7 +69,7 @@ describe("Support", () => {
         verifyTableResults("SMS");
 
         // Search by Email.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("Email")
             .click({ force: true });
@@ -91,7 +91,7 @@ describe("Support", () => {
     it("Verify no results hdid query.", () => {
         cy.log("Verify hdid returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("HDID")
             .click({ force: true });
@@ -112,7 +112,7 @@ describe("Support", () => {
     it("Verify no results sms query.", () => {
         cy.log("Verify sms returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("SMS")
             .click({ force: true });
@@ -128,7 +128,7 @@ describe("Support", () => {
     it("Verify no results email query.", () => {
         cy.log("Verify email returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("Email")
             .click({ force: true });

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard.cy.js
@@ -1,9 +1,10 @@
-// UTC midnight on 2022-07-02, the middle of the year
-const theDay = new Date(Date.UTC(2022, 7 - 1, 2));
+// midnight on 2022-07-02, the middle of the year
+const utcDate = new Date(Date.UTC(2022, 7 - 1, 2));
+const localDate = new Date(2022, 7 - 1, 2);
 
 function getPastDate(daysAgo) {
-    // initialize date to theDay minus a number of days
-    const date = new Date(theDay);
+    // initialize date to utcDate minus a number of days
+    const date = new Date(utcDate);
     date.setDate(date.getDate() - daysAgo);
 
     // the calculated date may be 1 hour off because of Daylight Savings
@@ -17,8 +18,7 @@ function getPastDate(daysAgo) {
 
 describe("Dashboard", () => {
     beforeEach(() => {
-        cy.clock(theDay);
-        cy.log(`"Today" is ${theDay.toISOString()}`);
+        cy.log(`"Today" is ${utcDate.toISOString()}`);
 
         cy.intercept("GET", "**/Dashboard/RegisteredCount*", {
             body: {
@@ -58,8 +58,14 @@ describe("Dashboard", () => {
         cy.login(
             Cypress.env("keycloak_username"),
             Cypress.env("keycloak_password"),
-            "/"
+            "/analytics"
         );
+
+        // changing the date must be done after logging in
+        cy.clock(localDate, ["Date"]);
+
+        // the dashboard page must be loaded (or reloaded) after the date is changed
+        cy.visit("/dashboard");
     });
 
     it("Verify dashboard counts and skeletons.", () => {

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
@@ -234,12 +234,6 @@ describe("Support", () => {
     });
 
     it("Verify invalid phn value.", () => {
-        cy.login(
-            Cypress.env("keycloak_username"),
-            Cypress.env("keycloak_password"),
-            "/support"
-        );
-
         cy.log("Verify invalid phn test started.");
 
         // Search by invalid PHN.
@@ -256,12 +250,6 @@ describe("Support", () => {
     });
 
     it("Verify parameter value missing.", () => {
-        cy.login(
-            Cypress.env("keycloak_username"),
-            Cypress.env("keycloak_password"),
-            "/support"
-        );
-
         cy.log("Verify phn parameter value missing test started.");
 
         cy.get("[data-testid=query-type-select]").click({ force: true });

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
@@ -116,7 +116,7 @@ describe("Support", () => {
         cy.log("Verify support query test started.");
 
         // Search by PHN
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("PHN")
             .click({ force: true });
@@ -125,7 +125,7 @@ describe("Support", () => {
         verifyTableResults("PHN");
 
         // Search by HDID.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("HDID")
             .click({ force: true });
@@ -134,7 +134,7 @@ describe("Support", () => {
         verifyTableResults("HDID");
 
         // Search by SMS.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("SMS")
             .click({ force: true });
@@ -143,7 +143,7 @@ describe("Support", () => {
         verifyTableResults("SMS");
 
         // Search by Email.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("Email")
             .click({ force: true });
@@ -165,7 +165,7 @@ describe("Support", () => {
     it("Verify support no results query errors.", () => {
         cy.log("Verify phn returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("PHN")
             .click({ force: true });
@@ -185,7 +185,7 @@ describe("Support", () => {
 
         cy.log("Verify hdid returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("HDID")
             .click({ force: true });
@@ -204,7 +204,7 @@ describe("Support", () => {
 
         cy.log("Verify sms returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("SMS")
             .click({ force: true });
@@ -219,7 +219,7 @@ describe("Support", () => {
 
         cy.log("Verify email returns no results test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("Email")
             .click({ force: true });
@@ -243,7 +243,7 @@ describe("Support", () => {
         cy.log("Verify invalid phn test started.");
 
         // Search by invalid PHN.
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("PHN")
             .click({ force: true });
@@ -264,7 +264,7 @@ describe("Support", () => {
 
         cy.log("Verify phn parameter value missing test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("PHN")
             .click({ force: true });
@@ -280,7 +280,7 @@ describe("Support", () => {
 
         cy.log("Verify hdid parameter value missing test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("HDID")
             .click({ force: true });
@@ -296,7 +296,7 @@ describe("Support", () => {
 
         cy.log("Verify sms parameter value missing test started.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("SMS")
             .click({ force: true });
@@ -309,7 +309,7 @@ describe("Support", () => {
 
         cy.log("Verify sms parameter value missing test finished.");
 
-        cy.get("[data-testid=query-type-select]").click();
+        cy.get("[data-testid=query-type-select]").click({ force: true });
         cy.get("[data-testid=query-type]")
             .contains("Email")
             .click({ force: true });

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -7,9 +7,6 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-import { AuthMethod } from "./constants";
-import { globalStorage } from "./globalStorage";
-
 require("cy-verify-downloads").addCustomCommand();
 
 function generateRandomString(length) {
@@ -34,89 +31,74 @@ Cypress.Commands.add("logout", () => {
     cy.readConfig().then((config) => logout(config));
 });
 
-Cypress.Commands.add(
-    "login",
-    (username, password, path, authMethod = AuthMethod.Keycloak) => {
-        if (authMethod == AuthMethod.Keycloak) {
-            cy.log("Logging in using Keycloak.");
-            cy.readConfig().then((config) => {
-                logout(config);
+Cypress.Commands.add("login", (username, password, path) => {
+    cy.log("Logging in using Keycloak.");
+    cy.readConfig().then((config) => {
+        logout(config);
 
-                const stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
-                const codeVerifier = generateRandomString(96);
-                const stateStore = {
-                    id: stateId,
-                    created: new Date().getTime(),
-                    request_type: "si:r",
-                    code_verifier: codeVerifier,
-                    redirect_uri: config.openIdConnect.callbacks.Logon,
-                    authority: config.openIdConnect.authority,
-                    client_id: config.openIdConnect.clientId,
-                    response_mode: "query",
-                    scope: config.openIdConnect.scope,
-                    extraTokenParams: {},
+        const stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
+        const codeVerifier = generateRandomString(96);
+        const stateStore = {
+            id: stateId,
+            created: new Date().getTime(),
+            request_type: "si:r",
+            code_verifier: codeVerifier,
+            redirect_uri: config.openIdConnect.callbacks.Logon,
+            authority: config.openIdConnect.authority,
+            client_id: config.openIdConnect.clientId,
+            response_mode: "query",
+            scope: config.openIdConnect.scope,
+            extraTokenParams: {},
+        };
+
+        cy.log("Creating OIDC StateStore in local storage.");
+        cy.log(`State ID:  ${stateId}`);
+        cy.log(`Generated Code Verifier: ${codeVerifier}`);
+        window.sessionStorage.setItem(
+            `oidc.${stateStore.id}`,
+            JSON.stringify(stateStore)
+        );
+
+        cy.log(`Requesting Keycloak Authentication form.`);
+        cy.request({
+            url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
+            followRedirect: false,
+            qs: {
+                scope: config.openIdConnect.scope,
+                response_type: config.openIdConnect.responseType,
+                approval_prompt: "auto",
+                redirect_uri: config.openIdConnect.callbacks.Logon,
+                client_id: config.openIdConnect.clientId,
+                response_mode: "query",
+                state: stateStore.id,
+            },
+        })
+            .then((response) => {
+                cy.log("Posting credentials.");
+                const html = document.createElement("html");
+                html.innerHTML = response.body;
+                const form = html.getElementsByTagName("form")[0];
+                const body = {
+                    username: username,
+                    password: password,
                 };
-
-                cy.log("Creating OIDC StateStore in local storage.");
-                cy.log(`State ID:  ${stateId}`);
-                cy.log(`Generated Code Verifier: ${codeVerifier}`);
-                window.sessionStorage.setItem(
-                    `oidc.${stateStore.id}`,
-                    JSON.stringify(stateStore)
-                );
-
-                const escapedRedirectPath = encodeURI(path);
-                const redirectUri = `${config.openIdConnect.callbacks.Logon}?redirect=${escapedRedirectPath}`;
-
-                cy.log(`Requesting Keycloak Authentication form.`);
-                cy.request({
-                    url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
+                const url = form.action;
+                return cy.request({
+                    method: "POST",
+                    url,
                     followRedirect: false,
-                    qs: {
-                        scope: config.openIdConnect.scope,
-                        response_type: config.openIdConnect.responseType,
-                        approval_prompt: "auto",
-                        redirect_uri: redirectUri,
-                        client_id: config.openIdConnect.clientId,
-                        response_mode: "query",
-                        state: stateStore.id,
-                    },
-                })
-                    .then((response) => {
-                        cy.log("Posting credentials.");
-                        const html = document.createElement("html");
-                        html.innerHTML = response.body;
-                        const form = html.getElementsByTagName("form")[0];
-                        const body = {
-                            username: username,
-                            password: password,
-                        };
-                        const url = form.action;
-                        return cy.request({
-                            method: "POST",
-                            url,
-                            followRedirect: false,
-                            form: true,
-                            body,
-                        });
-                    })
-                    .then(() => {
-                        cy.visit(path, { timeout: 60000 });
+                    form: true,
+                    body,
+                });
+            })
+            .then(() => {
+                cy.visit(path, { timeout: 60000 });
 
-                        // wait for cookies to be set before storing them in Cypress
-                        cy.get("[data-testid=user-account-icon]").should(
-                            "exist"
-                        );
-
-                        // store auth cookies
-                        cy.getCookies().then(
-                            (cookies) => (globalStorage.authCookies = cookies)
-                        );
-                    });
+                // wait for log in to complete
+                cy.get("[data-testid=user-account-icon]").should("exist");
             });
-        }
-    }
-);
+    });
+});
 
 Cypress.Commands.add("readConfig", () => {
     cy.log(`Reading Environment Configuration`);

--- a/Apps/Admin/Tests/Functional/cypress/support/constants.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/constants.js
@@ -1,3 +1,0 @@
-export const AuthMethod = {
-    Keycloak: "Keycloak",
-};

--- a/Apps/Admin/Tests/Functional/cypress/support/globalStorage.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/globalStorage.js
@@ -1,1 +1,0 @@
-export const globalStorage = { authCookies: [] };

--- a/Apps/Admin/Tests/Functional/cypress/support/index.d.ts
+++ b/Apps/Admin/Tests/Functional/cypress/support/index.d.ts
@@ -1,12 +1,7 @@
 declare namespace Cypress {
     interface Chainable {
         logout(): void;
-        login(
-            username: string,
-            password: string,
-            path: string,
-            authMethod?: string
-        ): void;
+        login(username: string, password: string, path: string): void;
         readConfig(): Chainable<any>;
         /**
          * Select an `<option>` with specific text, value, or index within a `<select>`.


### PR DESCRIPTION
# Fixes [AB#13635](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13635)

## Description

- fixes opening dropdowns in support page tests
    - `{ force: true }` is required because MudSelect puts the data-testid attribute on an element that's hidden
- changes dashboard UI tests to use an unchanging date to avoid time zone issues regardless of where the tests are run
    - `cy.clock()` enables precise control over the time the browser thinks it is
    - moves usage of `cy.clock()` after login
- changes an intercept in the analytics tests to be more resilient to time zone issues regardless of where the tests are run
- pre-emptively increases the timeout values for downloading analytics files
- removes additional login commands in support tests
- removes unused parts of login command

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
