### PR TITLE
Initial restructure of Cache

### DIFF
--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -43,8 +43,8 @@ namespace HealthGateway.Common.AccessManagement.Authentication
 
         private readonly ILogger<IAuthenticationDelegate> logger;
         private readonly IHttpClientService httpClientService;
-        private readonly IConfiguration? configuration;
-        private readonly ICacheProvider? cacheProvider;
+        private readonly IConfiguration configuration;
+        private readonly ICacheProvider cacheProvider;
         private readonly int tokenCacheMinutes;
         private readonly IHttpContextAccessor? httpContextAccessor;
         private readonly ClientCredentialsTokenRequest tokenRequest;
@@ -61,8 +61,8 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         public AuthenticationDelegate(
             ILogger<IAuthenticationDelegate> logger,
             IHttpClientService httpClientService,
-            IConfiguration? configuration,
-            ICacheProvider? cacheProvider,
+            IConfiguration configuration,
+            ICacheProvider cacheProvider,
             IHttpContextAccessor? httpContextAccessor)
         {
             this.logger = logger;
@@ -71,7 +71,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
             this.cacheProvider = cacheProvider;
             this.httpContextAccessor = httpContextAccessor;
 
-            IConfigurationSection? configSection = configuration?.GetSection(CacheConfigSectionName);
+            IConfigurationSection? configSection = configuration.GetSection(CacheConfigSectionName);
             this.tokenCacheMinutes = configSection?.GetValue("TokenCacheExpireMinutes", 0) ?? 0;
             (this.tokenUri, this.tokenRequest) = this.GetConfiguration(DefaultAuthConfigSectionName);
         }
@@ -136,7 +136,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
             JwtModel? jwtModel = null;
             if (cacheEnabled && this.tokenCacheMinutes > 0)
             {
-                jwtModel = this.cacheProvider?.GetItem<JwtModel>(cacheKey);
+                jwtModel = this.cacheProvider.GetItem<JwtModel>(cacheKey);
             }
 
             if (jwtModel != null)
@@ -153,7 +153,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
                     if (cacheEnabled && this.tokenCacheMinutes > 0)
                     {
                         this.logger.LogDebug("Attempting to store Access token in cache");
-                        this.cacheProvider?.AddItem(cacheKey, jwtModel, TimeSpan.FromMinutes(this.tokenCacheMinutes));
+                        this.cacheProvider.AddItem(cacheKey, jwtModel, TimeSpan.FromMinutes(this.tokenCacheMinutes));
                     }
                     else
                     {
@@ -182,7 +182,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
 
         private (Uri TokenUri, ClientCredentialsTokenRequest TokenRequest) GetConfiguration(string sectionName)
         {
-            IConfigurationSection? configSection = this.configuration?.GetSection(sectionName);
+            IConfigurationSection? configSection = this.configuration.GetSection(sectionName);
             Uri configUri = configSection.GetValue<Uri>(@"TokenUri");
             ClientCredentialsTokenRequest configTokenRequest = new();
             configSection.Bind(configTokenRequest); // Client ID, Client Secret, Audience, Username, Password

--- a/Apps/Common/src/CacheProviders/ICacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/ICacheProvider.cs
@@ -1,0 +1,44 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.CacheProviders
+{
+    using System;
+
+    /// <summary>
+    /// Provides a mechanism to store string or JSON data in a Cache.
+    /// </summary>
+    public interface ICacheProvider
+    {
+        /// <summary>
+        /// Retrieves an item from the cache if available.
+        /// </summary>
+        /// <param name="key">The key to lookup.</param>
+        /// <typeparam name="T">The return class type.</typeparam>
+        /// <returns>The cache item serialized as T.</returns>
+        T? GetItem<T>(string key)
+            where T : class;
+
+        /// <summary>
+        /// Adds an item to the cache.
+        /// </summary>
+        /// <param name="key">The cache key.</param>
+        /// <param name="value">The cache value.</param>
+        /// <param name="expiry">The expiry timespan of the cache item.</param>
+        /// <typeparam name="T">The class type to cache.</typeparam>
+        void AddItem<T>(string key, T value, TimeSpan expiry)
+            where T : class;
+    }
+}

--- a/Apps/Common/src/CacheProviders/MemoryCacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/MemoryCacheProvider.cs
@@ -1,0 +1,56 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.CacheProviders
+{
+    using System;
+    using Microsoft.Extensions.Caching.Memory;
+
+    /// <summary>
+    /// Provides a cache Provider for InMemory Cache.
+    /// </summary>
+    public class MemoryCacheProvider : ICacheProvider
+    {
+        private readonly IMemoryCache memoryCache;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryCacheProvider"/> class.
+        /// </summary>
+        /// <param name="memoryCache">The injected memory cache.</param>
+        public MemoryCacheProvider(IMemoryCache memoryCache)
+        {
+            this.memoryCache = memoryCache;
+        }
+
+        /// <inheritdoc/>
+        public T? GetItem<T>(string key)
+            where T : class
+        {
+            this.memoryCache.TryGetValue(key, out T? cacheItem);
+            return cacheItem;
+        }
+
+        /// <inheritdoc/>
+        public void AddItem<T>(string key, T value, TimeSpan expiry)
+            where T : class
+        {
+            MemoryCacheEntryOptions cacheEntryOptions = new()
+            {
+                AbsoluteExpirationRelativeToNow = expiry,
+            };
+            this.memoryCache.Set(key, value, cacheEntryOptions);
+        }
+    }
+}

--- a/Apps/Common/src/CacheProviders/RedisCacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/RedisCacheProvider.cs
@@ -1,0 +1,83 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.CacheProviders
+{
+    using System;
+    using System.Text.Json;
+    using Microsoft.Extensions.Logging;
+    using StackExchange.Redis;
+
+    /// <summary>
+    /// Provides a cache Provider for Redis.
+    /// </summary>
+    public class RedisCacheProvider : ICacheProvider
+    {
+        private readonly ILogger<RedisCacheProvider> logger;
+        private readonly IConnectionMultiplexer connectionMultiplexer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RedisCacheProvider"/> class.
+        /// </summary>
+        /// <param name="logger">The injected logger.</param>
+        /// <param name="connectionMultiplexer">The injected connection multiplexer.</param>
+        public RedisCacheProvider(ILogger<RedisCacheProvider> logger, IConnectionMultiplexer connectionMultiplexer)
+        {
+            this.logger = logger;
+            this.connectionMultiplexer = connectionMultiplexer;
+        }
+
+        /// <inheritdoc/>
+        public T? GetItem<T>(string key)
+            where T : class
+        {
+            T? cacheItem = null;
+            string? cacheJson = this.GetItem(key);
+            if (cacheJson != null)
+            {
+                cacheItem = JsonSerializer.Deserialize<T>(cacheJson);
+            }
+
+            return cacheItem;
+        }
+
+        /// <inheritdoc/>
+        public void AddItem<T>(string key, T value, TimeSpan expiry)
+            where T : class
+        {
+            this.Add(key, JsonSerializer.Serialize(value), expiry);
+        }
+
+        private void Add(string key, string value, TimeSpan expiry)
+        {
+            this.connectionMultiplexer.GetDatabase().StringSet(key, value, expiry, flags: CommandFlags.FireAndForget);
+        }
+
+        private string? GetItem(string key)
+        {
+            string? cacheStr = null;
+            try
+            {
+                cacheStr = this.connectionMultiplexer.GetDatabase().StringGet(key);
+            }
+            catch (RedisTimeoutException e)
+            {
+                this.logger.LogInformation($"Unable to retrieve cache key {key}\n{e}");
+            }
+
+            return cacheStr;
+        }
+    }
+}

--- a/Apps/Common/src/Common.csproj
+++ b/Apps/Common/src/Common.csproj
@@ -25,6 +25,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SpaServices.Extensions" Version="6.0.8" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.3.2" />
     <PackageReference Include="Npgsql.OpenTelemetry" Version="6.0.6" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.48" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.HealthChecks" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="6.0.8" />

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
     using DeepEqual.Syntax;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authentication.Models;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Services;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Configuration;
@@ -61,6 +62,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             };
 
             using IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
+            ICacheProvider cacheProvider = new MemoryCacheProvider(memoryCache);
 
             string json = @"{ ""access_token"":""token"", ""expires_in"":500, ""refresh_expires_in"":0, ""refresh_token"":""refresh_token"", ""token_type"":""bearer"", ""not-before-policy"":25, ""session_state"":""session_state"", ""scope"":""scope"" }";
             JwtModel? expected = JsonSerializer.Deserialize<JwtModel>(json);
@@ -83,7 +85,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             Mock<IHttpClientService> mockHttpClientService = new();
             mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
 
-            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, configuration, memoryCache, null);
+            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, configuration, cacheProvider, null);
             JwtModel actualModel = authDelegate.AuthenticateAsUser(tokenUri, tokenRequest, false);
             expected.ShouldDeepEqual(actualModel);
 

--- a/Apps/Common/test/unit/CacheProviders/MemoryCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/MemoryCacheProviderTests.cs
@@ -1,0 +1,73 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.CacheProviders
+{
+    using System;
+    using System.Threading;
+    using HealthGateway.Common.CacheProviders;
+    using Microsoft.Extensions.Caching.Memory;
+    using Xunit;
+
+    /// <summary>
+    /// Integration Tests for the MemoryCacheProvider.
+    /// </summary>
+    public class MemoryCacheProviderTests
+    {
+        /// <summary>
+        /// Validates adding items to the cache.
+        /// </summary>
+        [Fact]
+        public void AddItemToCache()
+        {
+            string key = "key";
+            using IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
+            ICacheProvider cacheProvider = new MemoryCacheProvider(memoryCache);
+            cacheProvider.AddItem(key, "value", TimeSpan.FromMilliseconds(500));
+            Assert.True(memoryCache.TryGetValue(key, out _));
+        }
+
+        /// <summary>
+        /// Validates items in the cache expire.
+        /// </summary>
+        [Fact]
+        public void AddItemToCacheExpired()
+        {
+            string key = "key";
+            using IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
+            ICacheProvider cacheProvider = new MemoryCacheProvider(memoryCache);
+            cacheProvider.AddItem(key, "value", TimeSpan.FromMilliseconds(100));
+            Thread.Sleep(101);
+            string? cacheItem = cacheProvider.GetItem<string>(key);
+            Assert.True(cacheItem is null);
+        }
+
+        /// <summary>
+        /// Validates getting items from the cache.
+        /// </summary>
+        [Fact]
+        public void GetItemFromCache()
+        {
+            string key = "key";
+            string value = "value";
+            using IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
+            memoryCache.Set(key, value);
+
+            ICacheProvider cacheProvider = new MemoryCacheProvider(memoryCache);
+            string? cacheItem = cacheProvider.GetItem<string>(key);
+            Assert.True(value == cacheItem);
+        }
+    }
+}

--- a/Apps/Common/test/unit/CacheProviders/RedisCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/RedisCacheProviderTests.cs
@@ -1,0 +1,122 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.CacheProviders
+{
+    using System;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DotNet.Testcontainers.Builders;
+    using DotNet.Testcontainers.Configurations;
+    using DotNet.Testcontainers.Containers;
+    using HealthGateway.Common.CacheProviders;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using StackExchange.Redis;
+    using Xunit;
+
+    /// <summary>
+    /// Integration Tests for the RedisCacheProvider.
+    /// </summary>
+    public class RedisCacheProviderTests : IAsyncLifetime
+    {
+        private readonly RedisTestcontainer redisContainer = new TestcontainersBuilder<RedisTestcontainer>()
+            .WithDatabase(new RedisTestcontainerConfiguration("redis:latest"))
+            .Build();
+
+        private IConnectionMultiplexer? connectionMultiplexer;
+
+        /// <summary>
+        /// Validates adding items to the cache.
+        /// </summary>
+        [Fact]
+        public void AddItemToCache()
+        {
+            Mock<ILogger<RedisCacheProvider>> mockLogger = new();
+            ICacheProvider cacheProvider = new RedisCacheProvider(mockLogger.Object, this.connectionMultiplexer);
+
+            string key = "key";
+            cacheProvider.AddItem(key, "value", TimeSpan.FromMilliseconds(5000));
+
+            Assert.True(this.connectionMultiplexer.GetDatabase().KeyExists(key));
+        }
+
+        /// <summary>
+        /// Validates items in the cache expire.
+        /// </summary>
+        [Fact]
+        public void AddItemToCacheExpired()
+        {
+            Mock<ILogger<RedisCacheProvider>> mockLogger = new();
+            ICacheProvider cacheProvider = new RedisCacheProvider(mockLogger.Object, this.connectionMultiplexer);
+
+            string key = "key";
+            cacheProvider.AddItem(key, "value", TimeSpan.FromMilliseconds(100));
+            Thread.Sleep(101);
+
+            Assert.False(this.connectionMultiplexer.GetDatabase().KeyExists(key));
+        }
+
+        /// <summary>
+        /// Validates getting items from the cache.
+        /// </summary>
+        [Fact]
+        public void GetItemFromCache()
+        {
+            string key = "key";
+            string value = "value";
+            this.connectionMultiplexer!.GetDatabase().StringSet(key, JsonSerializer.Serialize(value));
+
+            Mock<ILogger<RedisCacheProvider>> mockLogger = new();
+            ICacheProvider cacheProvider = new RedisCacheProvider(mockLogger.Object, this.connectionMultiplexer);
+            string? cacheItem = cacheProvider.GetItem<string>(key);
+
+            Assert.True(value == cacheItem);
+        }
+
+        /// <summary>
+        /// Ensures that null is returned when the cache is not available.
+        /// </summary>
+        [Fact]
+        public void GetBadConnection()
+        {
+            Mock<ILogger<RedisCacheProvider>> mockLogger = new();
+            ConnectionMultiplexer broken = ConnectionMultiplexer.Connect("localhost:9999,abortConnect=false");
+            ICacheProvider cacheProvider = new RedisCacheProvider(mockLogger.Object, broken);
+            string? result = cacheProvider.GetItem<string>("NOTFOUND");
+            Assert.Null(result);
+        }
+
+        /// <summary>
+        /// performs initialization for the test as per IAsyncLifetime.
+        /// </summary>
+        /// <returns>A task representing nothing.</returns>
+        public async Task InitializeAsync()
+        {
+            await this.redisContainer.StartAsync().ConfigureAwait(true);
+            this.connectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(this.redisContainer.ConnectionString).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Disposes resources for the test as per IAsyncLifetime.
+        /// </summary>
+        /// <returns>A task representing nothing.</returns>
+        public async Task DisposeAsync()
+        {
+            await this.redisContainer.DisposeAsync().ConfigureAwait(true);
+        }
+    }
+}

--- a/Apps/Common/test/unit/CommonTests.csproj
+++ b/Apps/Common/test/unit/CommonTests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="6.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="Testcontainers" Version="2.1.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.GatewayApi
     using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Common.Services;
@@ -72,6 +73,8 @@ namespace HealthGateway.GatewayApi
 
             // Add services
             services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
+
             services.AddTransient<IUserProfileService, UserProfileService>();
             services.AddTransient<IUserEmailService, UserEmailService>();
             services.AddTransient<IEmailQueueService, EmailQueueService>();

--- a/Apps/Immunization/src/Startup.cs
+++ b/Apps/Immunization/src/Startup.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Immunization
     using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Immunization.Api;
@@ -66,6 +67,8 @@ namespace HealthGateway.Immunization
 
             // Add Services
             services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
+
             services.AddTransient<IImmunizationService, ImmunizationService>();
             services.AddTransient<IVaccineStatusService, VaccineStatusService>();
 

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.JobScheduler
     using HealthGateway.Common.AccessManagement.Administration;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Common.FileDownload;
     using HealthGateway.Common.Jobs;
@@ -88,6 +89,10 @@ namespace HealthGateway.JobScheduler
                             policy.RequireAssertion(ctx => ctx.User.HasClaim(userRoleClaimType, requiredUserRole));
                         });
                 });
+
+            // Add Services
+            services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
 
             // Add Delegates and services for jobs
             services.AddTransient<IFileDownloadService, FileDownloadService>();

--- a/Apps/Laboratory/src/Startup.cs
+++ b/Apps/Laboratory/src/Startup.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Laboratory
     using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Laboratory.Delegates;
     using HealthGateway.Laboratory.Factories;
     using HealthGateway.Laboratory.Models;
@@ -63,6 +64,8 @@ namespace HealthGateway.Laboratory
             this.startupConfig.ConfigureAccessControl(services);
 
             // Add services
+            services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
             services.AddSingleton<ILaboratoryDelegateFactory, LaboratoryDelegateFactory>();
             services.AddTransient<ILaboratoryService, LaboratoryService>();
             services.AddTransient<ILabTestKitService, LabTestKitService>();

--- a/Apps/Medication/src/Startup.cs
+++ b/Apps/Medication/src/Startup.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Medication
     using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Medication.Delegates;
@@ -78,6 +79,8 @@ namespace HealthGateway.Medication
 
             // Add services
             services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
+
             services.AddTransient<IMedicationService, RestMedicationService>();
             services.AddTransient<IMedicationStatementService, RestMedicationStatementService>();
             services.AddTransient<IMedicationRequestService, MedicationRequestService>();


### PR DESCRIPTION
# Fixes or Implements [AB#13720](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13720)

## Description
Creates a generic cache mechanism that will replace all of the one off implementations of MemoryCache and the DB GenericCache once Redis is deployed.

Initial implementation and usage in AuthenticationDelegate.

Provides integration tests for both of the CacheProviders implemented.


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
