### PR TITLE
Added 429 too many requests error handling to Notes

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/TooManyRequestsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/TooManyRequestsComponent.vue
@@ -33,8 +33,8 @@ export default class TooManyRequestsComponent extends Vue {
             class="no-print"
             :show="showWarning"
         >
-            We are unable to get your health records because the site is too
-            busy. Please try again later.
+            We are unable to complete all actions because the site is too busy.
+            Please try again later.
         </b-alert>
         <b-alert
             data-testid="too-many-requests-error"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/NoteTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/NoteTimelineComponent.vue
@@ -59,13 +59,15 @@ export default class NoteTimelineComponent extends Vue {
                 hdid: this.user.hdid,
                 note: this.entry.toModel(),
             })
-                .catch((err: ResultError) =>
-                    this.addError({
-                        errorType: ErrorType.Delete,
-                        source: ErrorSourceType.Note,
-                        traceId: err.traceId,
-                    })
-                )
+                .catch((err: ResultError) => {
+                    if (err.statusCode !== 429) {
+                        this.addError({
+                            errorType: ErrorType.Delete,
+                            source: ErrorSourceType.Note,
+                            traceId: err.traceId,
+                        });
+                    }
+                })
                 .finally(() => {
                     this.isSaving = false;
                 });

--- a/Apps/WebClient/src/ClientApp/src/store/modules/note/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/note/actions.ts
@@ -137,11 +137,25 @@ export const actions: NoteActions = {
         context.commit("noteError", params.error);
 
         if (params.error.statusCode === 429) {
-            let action = "errorBanner/setTooManyRequestsError";
             if (params.errorType === ErrorType.Retrieve) {
-                action = "errorBanner/setTooManyRequestsWarning";
+                context.dispatch(
+                    "errorBanner/setTooManyRequestsWarning",
+                    { key: "page" },
+                    { root: true }
+                );
+            } else if (params.errorType === ErrorType.Delete) {
+                context.dispatch(
+                    "errorBanner/setTooManyRequestsError",
+                    { key: "page" },
+                    { root: true }
+                );
+            } else {
+                context.dispatch(
+                    "errorBanner/setTooManyRequestsError",
+                    { key: "noteEditModal" },
+                    { root: true }
+                );
             }
-            context.dispatch(action, { key: "page" }, { root: true });
         } else {
             context.dispatch(
                 "errorBanner/addError",

--- a/Testing/functional/tests/cypress/fixtures/NoteService/notes-test-note.json
+++ b/Testing/functional/tests/cypress/fixtures/NoteService/notes-test-note.json
@@ -1,0 +1,15 @@
+{
+    "resourcePayload": [
+        {
+            "hdId": "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A",
+            "title": "Test",
+            "text": "Test note",
+            "journalDate": "2022-08-18"
+        }
+    ],
+    "totalResultCount": 1,
+    "pageIndex": 0,
+    "pageSize": 500,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
@@ -342,7 +342,7 @@ describe("User Profile", () => {
     });
 });
 
-describe("Dependents - Too Many Requests Error", () => {
+describe("Dependents", () => {
     const validDependent = {
         firstName: "Sam ", // Add end space to ensure field is trimmed
         lastName: "Testfive ", // Add end space to ensure field is trimmed
@@ -376,7 +376,7 @@ describe("Dependents - Too Many Requests Error", () => {
         );
     });
 
-    it("Delete Dependent", () => {
+    it("Delete Dependent: Too Many Requests Error", () => {
         cy.intercept("DELETE", "**/UserProfile/*/Dependent/*", {
             statusCode: 429,
         });
@@ -391,7 +391,7 @@ describe("Dependents - Too Many Requests Error", () => {
         cy.get("[data-testid=too-many-requests-error]").should("be.visible");
     });
 
-    it("Add Dependent Modal", () => {
+    it("Add Dependent: Too Many Requests Error", () => {
         cy.intercept("POST", "**/UserProfile/*/Dependent", {
             statusCode: 429,
         });
@@ -419,7 +419,7 @@ describe("Dependents - Too Many Requests Error", () => {
 });
 
 describe("Comments", () => {
-    it("Validate Add: Too Many Requests Error", () => {
+    it("Add Comment: Too Many Requests Error", () => {
         cy.intercept("POST", "**/UserProfile/*/Comment", {
             statusCode: 429,
         });
@@ -436,6 +436,77 @@ describe("Comments", () => {
         // Add comment
         cy.get("[data-testid=addCommentTextArea]").first().type(testComment);
         cy.get("[data-testid=postCommentBtn]").first().click();
+
+        // Verify
+        cy.get("[data-testid=too-many-requests-error]").should("be.visible");
+    });
+});
+
+describe("Notes", () => {
+    it("Add Note: Too Many Requests Error", () => {
+        cy.intercept("POST", "**/Note/*", {
+            statusCode: 429,
+        });
+        cy.enableModules("Note");
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak
+        );
+
+        cy.get("[data-testid=addNoteBtn]").click();
+        cy.get("[data-testid=noteTitleInput]").type("Note Title!");
+        cy.get("[data-testid=noteDateInput] input")
+            .focus()
+            .clear()
+            .type("1950-Jan-01");
+        cy.get("[data-testid=noteTextInput]").type("Test");
+        cy.get("[data-testid=saveNoteBtn]").click();
+
+        // Verify
+        cy.get("[data-testid=too-many-requests-error]").should("be.visible");
+    });
+
+    it("Edit Note: Too Many Requests Error", () => {
+        cy.intercept("GET", "**/Note/*", {
+            fixture: "NoteService/notes-test-note.json",
+        });
+        cy.intercept("PUT", "**/Note/*", {
+            statusCode: 429,
+        });
+        cy.enableModules("Note");
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak
+        );
+
+        cy.log("Editing Note.");
+        cy.get("[data-testid=noteMenuBtn]").first().click();
+        cy.get("[data-testid=editNoteMenuBtn]").first().click();
+        cy.get("[data-testid=noteTitleInput]").clear().type("Test Edit");
+        cy.get("[data-testid=saveNoteBtn]").click();
+
+        // Verify
+        cy.get("[data-testid=too-many-requests-error]").should("be.visible");
+    });
+
+    it("Delete Note: Too Many Requests Error", () => {
+        cy.intercept("GET", "**/Note/*", {
+            fixture: "NoteService/notes-test-note.json",
+        });
+        cy.intercept("DELETE", "**/Note/*", {
+            statusCode: 429,
+        });
+        cy.enableModules("Note");
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak
+        );
+
+        cy.get("[data-testid=noteMenuBtn]").last().click();
+        cy.get("[data-testid=deleteNoteMenuBtn]").last().click();
 
         // Verify
         cy.get("[data-testid=too-many-requests-error]").should("be.visible");


### PR DESCRIPTION
# Fixes [AB#13652](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13652) and Implements [AB#13653](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13653)

## Description

- Bug fix for Notes 429 errors - added too many requests error handling to the NoteEditComponent modal.
- added new 429 functional tests for Notes.
- Implemented change to verbiage for the TooManyRequestsComponent on retrieval warnings.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

![Screen Shot 2022-08-18 at 2 51 44 PM](https://user-images.githubusercontent.com/5408101/185501610-f81e9825-9b74-4d4e-872c-c84d92d65b90.png)

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
