### PR TITLE
Remove IMemoryCache from CommunicationService and fixes for AB#13725

### DIFF
--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.Admin.Server
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Database.Delegates;
@@ -64,6 +65,10 @@ namespace HealthGateway.Admin.Server
 
             // Add services to the container.
             services.AddControllersWithViews();
+
+            // Add Services
+            services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
 
             // Add HG Services
             services.AddTransient<IConfigurationService, ConfigurationService>();

--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.Admin
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.Authorization.Admin;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Common.Models.PHSA;
@@ -92,6 +93,9 @@ namespace HealthGateway.Admin
             this.startupConfig.ConfigurePatientAccess(services);
 
             // Add services
+            services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
+
             services.AddTransient<IConfigurationService, ConfigurationService>();
             services.AddTransient<IAuthenticationService, AuthenticationService>();
             services.AddTransient<ISupportService, SupportService>();

--- a/Apps/Common/src/CacheProviders/ICacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/ICacheProvider.cs
@@ -38,7 +38,13 @@ namespace HealthGateway.Common.CacheProviders
         /// <param name="value">The cache value.</param>
         /// <param name="expiry">The expiry timespan of the cache item.</param>
         /// <typeparam name="T">The class type to cache.</typeparam>
-        void AddItem<T>(string key, T value, TimeSpan expiry)
+        void AddItem<T>(string key, T value, TimeSpan? expiry = null)
             where T : class;
+
+        /// <summary>
+        /// Removes an item from the cache.
+        /// </summary>
+        /// <param name="key">The key to remove.</param>
+        void RemoveItem(string key);
     }
 }

--- a/Apps/Common/src/CacheProviders/MemoryCacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/MemoryCacheProvider.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.Common.CacheProviders
         }
 
         /// <inheritdoc/>
-        public void AddItem<T>(string key, T value, TimeSpan expiry)
+        public void AddItem<T>(string key, T value, TimeSpan? expiry = null)
             where T : class
         {
             MemoryCacheEntryOptions cacheEntryOptions = new()
@@ -51,6 +51,12 @@ namespace HealthGateway.Common.CacheProviders
                 AbsoluteExpirationRelativeToNow = expiry,
             };
             this.memoryCache.Set(key, value, cacheEntryOptions);
+        }
+
+        /// <inheritdoc/>
+        public void RemoveItem(string key)
+        {
+            this.memoryCache.Remove(key);
         }
     }
 }

--- a/Apps/Common/src/CacheProviders/RedisCacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/RedisCacheProvider.cs
@@ -54,13 +54,19 @@ namespace HealthGateway.Common.CacheProviders
         }
 
         /// <inheritdoc/>
-        public void AddItem<T>(string key, T value, TimeSpan expiry)
+        public void AddItem<T>(string key, T value, TimeSpan? expiry = null)
             where T : class
         {
             this.Add(key, JsonSerializer.Serialize(value), expiry);
         }
 
-        private void Add(string key, string value, TimeSpan expiry)
+        /// <inheritdoc/>
+        public void RemoveItem(string key)
+        {
+            this.connectionMultiplexer.GetDatabase().KeyDelete(key, flags: CommandFlags.FireAndForget);
+        }
+
+        private void Add(string key, string value, TimeSpan? expiry = null)
         {
             this.connectionMultiplexer.GetDatabase().StringSet(key, value, expiry, flags: CommandFlags.FireAndForget);
         }

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -130,7 +130,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             Mock<IHttpClientService> mockHttpClientService = new();
             mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
             Dictionary<string, string> extraConfig = new();
-            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, CreateConfiguration(extraConfig), null, null);
+            IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, CreateConfiguration(extraConfig), new Mock<ICacheProvider>().Object, null);
             JwtModel actualModel = authDelegate.AuthenticateAsSystem(tokenUri, tokenRequest);
             expected.ShouldDeepEqual(actualModel);
         }

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -32,6 +32,7 @@ namespace HealthGateway.GatewayApi
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using StackExchange.Redis;
 
     /// <summary>
     /// Configures the application during startup.
@@ -72,8 +73,9 @@ namespace HealthGateway.GatewayApi
             this.startupConfig.ConfigureAccessControl(services);
 
             // Add services
-            services.AddMemoryCache();
-            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
+            services.AddSingleton<IConnectionMultiplexer>(x =>
+                ConnectionMultiplexer.Connect(this.configuration.GetValue<string>("RedisConnection")));
+            services.AddSingleton<ICacheProvider, RedisCacheProvider>();
 
             services.AddTransient<IUserProfileService, UserProfileService>();
             services.AddTransient<IUserEmailService, UserEmailService>();

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -73,9 +73,8 @@ namespace HealthGateway.GatewayApi
             this.startupConfig.ConfigureAccessControl(services);
 
             // Add services
-            services.AddSingleton<IConnectionMultiplexer>(x =>
-                ConnectionMultiplexer.Connect(this.configuration.GetValue<string>("RedisConnection")));
-            services.AddSingleton<ICacheProvider, RedisCacheProvider>();
+            services.AddMemoryCache();
+            services.AddSingleton<ICacheProvider, MemoryCacheProvider>();
 
             services.AddTransient<IUserProfileService, UserProfileService>();
             services.AddTransient<IUserEmailService, UserEmailService>();

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -36,5 +36,6 @@
     "CDOGS": {
         "DynamicServiceLookup": "false",
         "BaseEndpoint": "https://dev-hgcdogs.healthgateway.gov.bc.ca"
-    }
+    },
+    "RedisConnection": "localhost:6379,abortConnect=false"
 }

--- a/Tools/Dev/Postgres/docker-compose.yml
+++ b/Tools/Dev/Postgres/docker-compose.yml
@@ -14,6 +14,16 @@ services:
       - ./scripts:/scripts
       - gatewaydb:/var/lib/postgresql/data
       - ./init://docker-entrypoint-initdb.d
+  gatewaycache:
+    container_name: gatewaycache
+    image: redis:6.2
+    ports:
+      - "6379:6379"
+    restart: unless-stopped
+    volumes:
+      - gatewaycache:/data
 volumes:
   gatewaydb:
     name: gatewaydb.local
+  gatewaycache:
+    name: gatewaycache.local


### PR DESCRIPTION
# Fixes or Implements [AB#13725](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13725)

## Description
Removed IMemoryCache direct usage in CommunicationService
Updated DI for the ICacheProvider where needed (Admin, AdminWebClient)
Updated ICacheProvider to allow TimeSpan to be null and cache objects indefinitely

Added the ability to remove/evict a cached item
Added Redis container to Dev/Postgres docker compose to make available to all team.
Added RedisConnection to dev appsettings


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
