### PR TITLE
Add API Endpoint to CSP ConnectSource for AB#13722

### DIFF
--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -25,7 +25,7 @@
         "Patient": "https://hg-test.api.gov.bc.ca/api/patientservice/"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/ https://hg-test.api.gov.bc.ca/",
         "FrameSource": "'self' https://test.oidc.gov.bc.ca/",
         "FrameAncestors": "'self' https://test.oidc.gov.bc.ca/"
     },


### PR DESCRIPTION
# Fixes or Implements [AB#13722](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13722)

## Description
Adds hg-test.api.gov.bc.ca to the CSP ConnectSource.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

No

## Notes

N/A

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
