### PR TITLE
Move BannerListener from GatewayApi to JobScheduler for AB#13736

### DIFF
--- a/Apps/Common/src/Converters/DateTimeConverter.cs
+++ b/Apps/Common/src/Converters/DateTimeConverter.cs
@@ -13,31 +13,27 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Test.Services
+namespace HealthGateway.Common.Converters
 {
+    using System;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
     /// <summary>
-    /// Scenario enum to use for testing purposes.
+    /// Json Converter to put Postgres +00 dates into c# UTC DateTimes.
     /// </summary>
-    public enum Scenario
+    public class DateTimeConverter : JsonConverter<DateTime>
     {
-        /// <summary>
-        /// The communication is Active.
-        /// </summary>
-        Active,
+        /// <inheritdoc/>
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            return reader.GetDateTime().ToUniversalTime();
+        }
 
-        /// <summary>
-        /// The communication is expired.
-        /// </summary>
-        Expired,
-
-        /// <summary>
-        /// The communication should be removed.
-        /// </summary>
-        Deleted,
-
-        /// <summary>
-        /// The communication should be future effective dated.
-        /// </summary>
-        Future,
+        /// <inheritdoc/>
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.ToUniversalTime());
+        }
     }
 }

--- a/Apps/Common/src/Models/BannerChangeEvent.cs
+++ b/Apps/Common/src/Models/BannerChangeEvent.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Models
+namespace HealthGateway.Common.Models
 {
     using HealthGateway.Database.Models;
 

--- a/Apps/Common/src/Services/CommunicationService.cs
+++ b/Apps/Common/src/Services/CommunicationService.cs
@@ -13,18 +13,18 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Services
+namespace HealthGateway.Common.Services
 {
     using System;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.ErrorHandling;
+    using HealthGateway.Common.Models;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
-    using HealthGateway.GatewayApi.Models;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
@@ -154,6 +154,13 @@ namespace HealthGateway.GatewayApi.Services
                     }
                 }
             }
+        }
+
+        /// <inheritdoc/>
+        public void ClearCache()
+        {
+            this.RemoveCommunicationFromCache(CommunicationType.Banner);
+            this.RemoveCommunicationFromCache(CommunicationType.InApp);
         }
 
         private void RemoveCommunicationFromCache(CommunicationType cacheType)

--- a/Apps/Common/src/Services/ICommunicationService.cs
+++ b/Apps/Common/src/Services/ICommunicationService.cs
@@ -13,12 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Services
+namespace HealthGateway.Common.Services
 {
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
     using HealthGateway.Database.Models;
-    using HealthGateway.GatewayApi.Models;
 
     /// <summary>
     /// Service to interact with the Communication Delegate.
@@ -38,5 +38,10 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="changeEvent">The change event that was triggered.</param>
         void ProcessChange(BannerChangeEvent changeEvent);
+
+        /// <summary>
+        /// Removes any items that have been stored in the cache.
+        /// </summary>
+        void ClearCache();
     }
 }

--- a/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
+++ b/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
@@ -13,19 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Test.Services
+namespace HealthGateway.CommonTests.Services
 {
     using System;
     using DeepEqual.Syntax;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using HealthGateway.CommonTests.Utils;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
-    using HealthGateway.GatewayApi.Models;
-    using HealthGateway.GatewayApi.Services;
     using Microsoft.Extensions.Caching.Memory;
     using Microsoft.Extensions.Logging;
     using Moq;

--- a/Apps/Common/test/unit/Utils/Scenario.cs
+++ b/Apps/Common/test/unit/Utils/Scenario.cs
@@ -13,27 +13,31 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Converters
+namespace HealthGateway.CommonTests.Utils
 {
-    using System;
-    using System.Text.Json;
-    using System.Text.Json.Serialization;
-
     /// <summary>
-    /// Json Converter to put Postgres +00 dates into c# UTC DateTimes.
+    /// Scenario enum to use for testing purposes.
     /// </summary>
-    public class DateTimeConverter : JsonConverter<DateTime>
+    public enum Scenario
     {
-        /// <inheritdoc/>
-        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
-        {
-            return reader.GetDateTime().ToUniversalTime();
-        }
+        /// <summary>
+        /// The communication is Active.
+        /// </summary>
+        Active,
 
-        /// <inheritdoc/>
-        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
-        {
-            writer.WriteStringValue(value.ToUniversalTime());
-        }
+        /// <summary>
+        /// The communication is expired.
+        /// </summary>
+        Expired,
+
+        /// <summary>
+        /// The communication should be removed.
+        /// </summary>
+        Deleted,
+
+        /// <summary>
+        /// The communication should be future effective dated.
+        /// </summary>
+        Future,
     }
 }

--- a/Apps/GatewayApi/src/Controllers/CommunicationController.cs
+++ b/Apps/GatewayApi/src/Controllers/CommunicationController.cs
@@ -17,8 +17,8 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Services;
     using HealthGateway.Database.Models;
-    using HealthGateway.GatewayApi.Services;
     using Microsoft.AspNetCore.Mvc;
 
     /// <summary>

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -19,21 +19,17 @@ namespace HealthGateway.GatewayApi
     using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
-    using HealthGateway.Common.AspNetConfiguration.Modules;
-    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.Common.Utils;
     using HealthGateway.Database.Delegates;
-    using HealthGateway.GatewayApi.Listeners;
     using HealthGateway.GatewayApi.Services;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
-    using StackExchange.Redis;
 
     /// <summary>
     /// Configures the application during startup.
@@ -105,8 +101,6 @@ namespace HealthGateway.GatewayApi
             services.AddTransient<IResourceDelegateDelegate, DBResourceDelegateDelegate>();
             services.AddTransient<ICDogsDelegate, CDogsDelegate>();
 
-            // Add Background Services
-            services.AddHostedService<BannerListener>();
             services.Configure<ApiBehaviorOptions>(options => options.SuppressModelStateInvalidFilter = true);
 
             services.AddControllers().AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new DateOnlyJsonConverter()));

--- a/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
@@ -18,11 +18,9 @@ namespace HealthGateway.GatewayApi.Test.Controllers
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Database.Constants;
+    using HealthGateway.Common.Services;
     using HealthGateway.Database.Models;
     using HealthGateway.GatewayApi.Controllers;
-    using HealthGateway.GatewayApi.Services;
-    using Microsoft.AspNetCore.Mvc;
     using Moq;
     using Xunit;
 

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.GatewayApi.Listeners
+namespace HealthGateway.JobScheduler.Listeners
 {
     using System;
     using System.Data;
@@ -22,10 +22,10 @@ namespace HealthGateway.GatewayApi.Listeners
     using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Converters;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
     using HealthGateway.Database.Context;
-    using HealthGateway.GatewayApi.Converters;
-    using HealthGateway.GatewayApi.Models;
-    using HealthGateway.GatewayApi.Services;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
@@ -66,8 +66,9 @@ namespace HealthGateway.GatewayApi.Listeners
         [SuppressMessage("Security", "CA2100:Review SQL queries for security vulnerabilities", Justification = "Abstract class property")]
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            this.logger.LogInformation("DBChangeListener is starting");
-            stoppingToken.Register(() => this.logger.LogInformation("DBChangeListener Shutdown as cancellation requested    "));
+            this.logger.LogInformation("Banner Listener is starting");
+            stoppingToken.Register(() => this.logger.LogInformation("Banner Listener Shutdown as cancellation requested    "));
+            this.ClearCache();
             int attempts = 0;
             while (!stoppingToken.IsCancellationRequested)
             {
@@ -103,8 +104,16 @@ namespace HealthGateway.GatewayApi.Listeners
                     }
                 }
 
-                this.logger.LogWarning($"DBChangeListener on {Channel} exiting...");
+                this.logger.LogWarning($"Banner Listener on {Channel} exiting...");
             }
+        }
+
+        private void ClearCache()
+        {
+            using IServiceScope scope = this.services.CreateScope();
+            ICommunicationService cs = scope.ServiceProvider.GetRequiredService<ICommunicationService>();
+            this.logger.LogInformation("Clearing Banner and InApp Cache");
+            cs.ClearCache();
         }
 
         private void ReceiveEvent(object sender, NpgsqlNotificationEventArgs e)

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -30,6 +30,7 @@ namespace HealthGateway.JobScheduler
     using HealthGateway.Database.Delegates;
     using HealthGateway.DrugMaintainer;
     using Healthgateway.JobScheduler.Jobs;
+    using HealthGateway.JobScheduler.Listeners;
     using Healthgateway.JobScheduler.Utils;
     using Microsoft.AspNetCore.Authentication.OpenIdConnect;
     using Microsoft.AspNetCore.Builder;
@@ -106,6 +107,7 @@ namespace HealthGateway.JobScheduler
             services.AddTransient<IResourceDelegateDelegate, DBResourceDelegateDelegate>();
             services.AddTransient<IEventLogDelegate, DBEventLogDelegate>();
             services.AddTransient<IFeedbackDelegate, DBFeedbackDelegate>();
+            services.AddTransient<ICommunicationService, CommunicationService>();
 
             // Add injection for KeyCloak User Admin
             services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
@@ -123,6 +125,9 @@ namespace HealthGateway.JobScheduler
 
             // Add processing server as IHostedService
             services.AddHangfireServer();
+
+            // Add Background Services
+            services.AddHostedService<BannerListener>();
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixes or Implements [AB#13736](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13736)

## Description
Moves the Banner Listener to JobScheduler
Updated the Banner Listener to clear the cache on restart
Moves ICommunicationService and implementation to Common

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
No


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
