### PR TITLE
Add missing import for TooManyRequestsComponent AB#13751

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -3,6 +3,7 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
+import TooManyRequestsComponent from "@/components/TooManyRequestsComponent.vue";
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import UserPreferenceType from "@/constants/userPreferenceType";
@@ -23,7 +24,9 @@ interface QuickLinkFilter {
 }
 
 @Component({
-    components: {},
+    components: {
+        TooManyRequestsComponent,
+    },
 })
 export default class AddQuickLinkComponent extends Vue {
     @Action("setTooManyRequestsError", { namespace: "errorBanner" })


### PR DESCRIPTION
# Fixes [AB#13751](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13751)

## Description

Fixes the 429 error not appearing on the Add Quick Links modal.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
