### PR TITLE
Use OrderBy before Take/Skip for predictable results AB#13790

### DIFF
--- a/Apps/Database/src/Delegates/DBEmailDelegate.cs
+++ b/Apps/Database/src/Delegates/DBEmailDelegate.cs
@@ -173,6 +173,7 @@ namespace HealthGateway.Database.Delegates
                     email => email.EmailStatusCode == EmailStatus.Processed &&
                              email.CreatedDateTime <= GatewayDbContext.DateTrunc("days", DateTime.UtcNow.AddDays(daysAgo * -1)))
                 .Where(email => !this.dbContext.MessagingVerification.Any(msgVerification => msgVerification.EmailId == email.Id))
+                .OrderBy(email => email.CreatedDateTime)
                 .Select(email => new Email { Id = email.Id, Version = email.Version })
                 .Take(maxRows)
                 .ToList();

--- a/Apps/Database/src/Delegates/DBResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/DBResourceDelegateDelegate.cs
@@ -83,7 +83,8 @@ namespace HealthGateway.Database.Delegates
             this.logger.LogTrace($"Getting resource delegates from DB... {delegateId}");
             DBResult<IEnumerable<ResourceDelegate>> result = DBDelegateHelper.GetPagedDBResult(
                 this.dbContext.ResourceDelegate
-                    .Where(resourceDelegate => resourceDelegate.ProfileHdid == delegateId),
+                    .Where(resourceDelegate => resourceDelegate.ProfileHdid == delegateId)
+                    .OrderBy(resourceDelegate => resourceDelegate.CreatedDateTime),
                 page,
                 pageSize);
             this.logger.LogTrace($"Finished getting resource delegates from DB... {JsonSerializer.Serialize(result)}");


### PR DESCRIPTION
# Fixes [AB#13790](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13790)

## Description

Resolves an Entity Framework warning that using Take() or Skip() on unordered queries may lead to unpredictable results.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
