### PR TITLE
Add clinical document controller, model, and service interface AB#13793

### DIFF
--- a/Apps/ClinicalDocument/src/Controllers/ClinicalDocumentController.cs
+++ b/Apps/ClinicalDocument/src/Controllers/ClinicalDocumentController.cs
@@ -1,0 +1,105 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.ClinicalDocument.Controllers
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading.Tasks;
+    using HealthGateway.ClinicalDocument.Models;
+    using HealthGateway.ClinicalDocument.Services;
+    using HealthGateway.Common.AccessManagement.Authorization.Policy;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Filters;
+    using HealthGateway.Common.Models.PHSA;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// The clinical document controller.
+    /// </summary>
+    [Authorize]
+    [ApiVersion("1.0")]
+    [Route("[controller]")]
+    [ApiController]
+    [TypeFilter(typeof(AvailabilityFilter))]
+    [ExcludeFromCodeCoverage]
+    public class ClinicalDocumentController : ControllerBase
+    {
+        private readonly ILogger<ClinicalDocumentController> logger;
+        private readonly IClinicalDocumentService clinicalDocumentService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ClinicalDocumentController"/> class.
+        /// </summary>
+        /// <param name="logger">Injected logger.</param>
+        /// <param name="clinicalDocumentService">Injected service.</param>
+        public ClinicalDocumentController(ILogger<ClinicalDocumentController> logger, IClinicalDocumentService clinicalDocumentService)
+        {
+            this.logger = logger;
+            this.clinicalDocumentService = clinicalDocumentService;
+        }
+
+        /// <summary>
+        /// Gets the collection of clinical document records associated with the given HDID.
+        /// </summary>
+        /// <param name="hdid">The subject's HDID.</param>
+        /// <returns>The collection of clinical document records.</returns>
+        /// <response code="200">Returns the collection of clinical document records.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        /// <response code="503">The service is unavailable for use.</response>
+        [HttpGet]
+        [Produces("application/json")]
+        [Route("{hdid}")]
+        [Authorize(Policy = LaboratoryPolicy.Read)]
+        public async Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecords([FromQuery] string hdid)
+        {
+            this.logger.LogDebug("Getting clinical document records for HDID: {Hdid}", hdid);
+            RequestResult<IEnumerable<ClinicalDocumentRecord>> result = await this.clinicalDocumentService.GetRecordsAsync(hdid).ConfigureAwait(true);
+            this.logger.LogDebug("Finished getting clinical document records for HDID: {Hdid}", hdid);
+            return result;
+        }
+
+        /// <summary>
+        /// Gets a specific clinical document file associated with the given HDID and file ID.
+        /// </summary>
+        /// <param name="hdid">The subject's HDID.</param>
+        /// <param name="fileId">The ID of the file to fetch.</param>
+        /// <returns>The specified clinical document file.</returns>
+        /// <response code="200">Returns the specified clinical document file.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        /// <response code="503">The service is unavailable for use.</response>
+        [HttpGet]
+        [Produces("application/json")]
+        [Route("{hdid}/file/{fileId}")]
+        [Authorize(Policy = LaboratoryPolicy.Read)]
+        public async Task<RequestResult<EncodedMedia>> GetFile(string hdid, string fileId)
+        {
+            this.logger.LogDebug("Getting clinical document file for Hdid: {Hdid} with file ID: {FileId}", hdid, fileId);
+            RequestResult<EncodedMedia> result = await this.clinicalDocumentService.GetFileAsync(hdid, fileId).ConfigureAwait(true);
+            this.logger.LogDebug("Finished getting clinical document file for Hdid: {Hdid} with file ID: {FileId}", hdid, fileId);
+            return result;
+        }
+    }
+}

--- a/Apps/ClinicalDocument/src/Models/ClinicalDocumentRecord.cs
+++ b/Apps/ClinicalDocument/src/Models/ClinicalDocumentRecord.cs
@@ -1,0 +1,68 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.ClinicalDocument.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Represents a clinical document record.
+    /// </summary>
+    public class ClinicalDocumentRecord
+    {
+        /// <summary>
+        /// Gets or sets the ID.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public string Id { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the file ID.
+        /// </summary>
+        [JsonPropertyName("fileId")]
+        public string FileId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the facility name.
+        /// </summary>
+        [JsonPropertyName("facilityName")]
+        public string FacilityName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the discipline.
+        /// </summary>
+        [JsonPropertyName("discipline")]
+        public string Discipline { get; set; }
+
+        /// <summary>
+        /// Gets or sets the service date.
+        /// </summary>
+        [JsonPropertyName("serviceDate")]
+        public DateTime ServiceDate { get; set; }
+    }
+}

--- a/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
@@ -15,24 +15,41 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.ClinicalDocument.Services
 {
+    using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Threading.Tasks;
+    using HealthGateway.ClinicalDocument.Models;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models.PHSA;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
     public class ClinicalDocumentService : IClinicalDocumentService
     {
-        private readonly ILogger logger;
+        private readonly ILogger<ClinicalDocumentService> logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClinicalDocumentService"/> class.
         /// </summary>
-        /// <param name="logger">Injected Logger Provider.</param>
-        public ClinicalDocumentService(
-            ILogger<ClinicalDocumentService> logger)
+        /// <param name="logger">Injected logger.</param>
+        public ClinicalDocumentService(ILogger<ClinicalDocumentService> logger)
         {
             this.logger = logger;
         }
 
         private static ActivitySource Source { get; } = new(nameof(ClinicalDocumentService));
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecordsAsync(string hdid)
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<EncodedMedia>> GetFileAsync(string hdid, string fileId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/Apps/ClinicalDocument/src/Services/IClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/IClinicalDocumentService.cs
@@ -15,12 +15,30 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.ClinicalDocument.Services
 {
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.ClinicalDocument.Models;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models.PHSA;
+
     /// <summary>
-    /// The Clinical Document data service.
+    /// The clinical document data service.
     /// </summary>
-#pragma warning disable CA1040
     public interface IClinicalDocumentService
-#pragma warning restore CA1040
     {
+        /// <summary>
+        /// Gets the collection of clinical document records associated with the given HDID.
+        /// </summary>
+        /// <param name="hdid">The subject's HDID.</param>
+        /// <returns>The collection of clinical document records.</returns>
+        Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecordsAsync(string hdid);
+
+        /// <summary>
+        /// Gets a specific clinical document file associated with the given HDID and file ID.
+        /// </summary>
+        /// <param name="hdid">The subject's HDID.</param>
+        /// <param name="fileId">The ID of the file to fetch.</param>
+        /// <returns>The specified clinical document file.</returns>
+        Task<RequestResult<EncodedMedia>> GetFileAsync(string hdid, string fileId);
     }
 }


### PR DESCRIPTION
# Implements [AB#13793](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13793)

## Description

Creates a new controller and model for clinical documents and updates the service interface with method definitions to support the controller.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
