### PR TITLE
Dependent Federal Proof for AB#13706

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/models/vaccinationRecord.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/vaccinationRecord.ts
@@ -1,0 +1,13 @@
+import CovidVaccineRecord from "./covidVaccineRecord";
+import { ResultError } from "./errors";
+import { LoadStatus } from "./storeOperations";
+
+export default interface VaccinationRecord {
+    hdid: string;
+    record?: CovidVaccineRecord;
+    download: boolean;
+    error?: ResultError;
+    status: LoadStatus;
+    statusMessage: string;
+    resultMessage: string;
+}

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/actions.ts
@@ -312,26 +312,35 @@ export const actions: VaccinationStatusActions = {
 
         return new Promise((resolve, reject) => {
             logger.debug(`Retrieving Vaccination Record`);
-            context.commit("setAuthenticatedVaccineRecordRequested");
+            context.commit("setAuthenticatedVaccineRecordRequested", {
+                hdid: params.hdid,
+            });
             vaccinationStatusService
                 .getAuthenticatedVaccineRecord(params.hdid)
                 .then((result) => {
                     const payload = result.resourcePayload;
                     if (result.resultStatus === ResultType.Success) {
-                        context.commit(
-                            "setAuthenticatedVaccineRecord",
-                            payload
-                        );
+                        logger.info("Vaccination Record loaded");
+                        context.commit("setAuthenticatedVaccineRecord", {
+                            hdid: params.hdid,
+                            vaccinationRecord: payload,
+                        });
                         resolve(payload);
                     } else if (
                         result.resultError?.actionCode === ActionType.Refresh &&
                         !payload.loaded &&
                         payload.retryin > 0
                     ) {
-                        logger.info("Vaccination Record not loaded");
+                        logger.info(
+                            "Vaccination Record not loaded but will try again"
+                        );
                         context.commit(
                             "setAuthenticatedVaccineRecordStatusMessage",
-                            "We're busy but will continue to try to download the Vaccine Record...."
+                            {
+                                hdid: params.hdid,
+                                statusMessage:
+                                    "We're busy but will continue to try to download the Vaccine Record....",
+                            }
                         );
                         setTimeout(() => {
                             logger.info(
@@ -346,7 +355,11 @@ export const actions: VaccinationStatusActions = {
                         }, payload.retryin);
                         resolve(payload);
                     } else {
+                        logger.error(
+                            "Vaccination Record not loaded due to error"
+                        );
                         context.dispatch("handleAuthenticatedPdfError", {
+                            hdid: params.hdid,
                             error: result.resultError,
                             errorType: ErrorType.Retrieve,
                         });
@@ -354,7 +367,11 @@ export const actions: VaccinationStatusActions = {
                     }
                 })
                 .catch((error: ResultError) => {
+                    logger.error(
+                        "Vaccination Record not loaded due to unexpected error"
+                    );
                     context.dispatch("handleAuthenticatedPdfError", {
+                        hdid: params.hdid,
                         error,
                         errorType: ErrorType.Retrieve,
                     });
@@ -364,12 +381,15 @@ export const actions: VaccinationStatusActions = {
     },
     handleAuthenticatedPdfError(
         context,
-        params: { error: ResultError; errorType: ErrorType }
+        params: { hdid: string; error: ResultError; errorType: ErrorType }
     ) {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
         logger.error(`ERROR: ${JSON.stringify(params.error)}`);
-        context.commit("setAuthenticatedVaccineRecordError", params.error);
+        context.commit("setAuthenticatedVaccineRecordError", {
+            hdid: params.hdid,
+            error: params.error,
+        });
 
         if (params.error.statusCode === 429) {
             context.dispatch(
@@ -379,10 +399,10 @@ export const actions: VaccinationStatusActions = {
             );
         } else {
             if (params.error.actionCode === ActionType.Invalid) {
-                context.commit(
-                    "setAuthenticatedVaccineRecordResultMessage",
-                    "No records found"
-                );
+                context.commit("setAuthenticatedVaccineRecordResultMessage", {
+                    hdid: params.hdid,
+                    resultMessage: "No records found",
+                });
             } else {
                 context.dispatch(
                     "errorBanner/addError",
@@ -395,5 +415,11 @@ export const actions: VaccinationStatusActions = {
                 );
             }
         }
+    },
+    stopAuthenticatedVaccineRecordDownload(context, params: { hdid: string }) {
+        context.commit("setAuthenticatedVaccineRecordDownload", {
+            hdid: params.hdid,
+            download: false,
+        });
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/getters.ts
@@ -1,6 +1,7 @@
 import CovidVaccineRecord from "@/models/covidVaccineRecord";
 import { CustomBannerError, ResultError } from "@/models/errors";
 import { LoadStatus } from "@/models/storeOperations";
+import VaccinationRecord from "@/models/vaccinationRecord";
 import VaccinationStatus from "@/models/vaccinationStatus";
 
 import { VaccinationStatusGetters, VaccinationStatusState } from "./types";
@@ -50,29 +51,19 @@ export const getters: VaccinationStatusGetters = {
     authenticatedStatusMessage(state: VaccinationStatusState): string {
         return state.authenticated.statusMessage;
     },
-    authenticatedVaccineRecord(
+    authenticatedVaccineRecords(
         state: VaccinationStatusState
-    ): CovidVaccineRecord | undefined {
-        return state.authenticatedVaccineRecord.vaccinationRecord;
+    ): Map<string, VaccinationRecord> {
+        return state.authenticatedVaccineRecord.vaccinationRecords;
     },
-    authenticatedVaccineRecordIsLoading(
+    authenticatedVaccineRecordStatusChanges(
         state: VaccinationStatusState
-    ): boolean {
-        return state.authenticatedVaccineRecord.status === LoadStatus.REQUESTED;
+    ): number {
+        return state.authenticatedVaccineRecord.statusChanges;
     },
-    authenticatedVaccineRecordError(
-        state: VaccinationStatusState
-    ): ResultError | undefined {
-        return state.authenticatedVaccineRecord.error;
-    },
-    authenticatedVaccineRecordStatusMessage(
+    authenticatedVaccineRecordActiveHdid(
         state: VaccinationStatusState
     ): string {
-        return state.authenticatedVaccineRecord.statusMessage;
-    },
-    authenticatedVaccineRecordResultMessage(
-        state: VaccinationStatusState
-    ): string {
-        return state.authenticatedVaccineRecord.resultMessage;
+        return state.authenticatedVaccineRecord.activeHdid;
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/mutations.ts
@@ -2,6 +2,7 @@ import CovidVaccineRecord from "@/models/covidVaccineRecord";
 import { DateWrapper } from "@/models/dateWrapper";
 import { CustomBannerError, ResultError } from "@/models/errors";
 import { LoadStatus } from "@/models/storeOperations";
+import VaccinationRecord from "@/models/vaccinationRecord";
 import VaccinationStatus from "@/models/vaccinationStatus";
 
 import { VaccinationStatusMutations, VaccinationStatusState } from "./types";
@@ -96,38 +97,97 @@ export const mutations: VaccinationStatusMutations = {
     ) {
         state.authenticated.statusMessage = statusMessage;
     },
-    setAuthenticatedVaccineRecordRequested(state: VaccinationStatusState) {
-        state.authenticatedVaccineRecord.error = undefined;
-        state.authenticatedVaccineRecord.status = LoadStatus.REQUESTED;
-        state.authenticatedVaccineRecord.statusMessage = "";
-        state.authenticatedVaccineRecord.resultMessage = "";
+    setAuthenticatedVaccineRecordRequested(
+        state: VaccinationStatusState,
+        params: { hdid: string }
+    ) {
+        const vaccinationRecord: VaccinationRecord = {
+            hdid: params.hdid,
+            download: true,
+            error: undefined,
+            status: LoadStatus.REQUESTED,
+            statusMessage: "",
+            resultMessage: "",
+        };
+
+        state.authenticatedVaccineRecord.vaccinationRecords.set(
+            params.hdid,
+            vaccinationRecord
+        );
+        state.authenticatedVaccineRecord.activeHdid = params.hdid;
+        state.authenticatedVaccineRecord.statusChanges++;
     },
     setAuthenticatedVaccineRecord(
         state: VaccinationStatusState,
-        vaccineRecord: CovidVaccineRecord
+        params: { hdid: string; vaccinationRecord: CovidVaccineRecord }
     ) {
-        state.authenticatedVaccineRecord.vaccinationRecord = vaccineRecord;
-        state.authenticatedVaccineRecord.status = LoadStatus.LOADED;
-        state.authenticatedVaccineRecord.statusMessage = "";
-        state.authenticatedVaccineRecord.error = undefined;
+        const vaccinationRecord: VaccinationRecord | undefined =
+            state.authenticatedVaccineRecord.vaccinationRecords.get(
+                params.hdid
+            );
+
+        if (vaccinationRecord !== undefined) {
+            vaccinationRecord.record = params.vaccinationRecord;
+            vaccinationRecord.status = LoadStatus.LOADED;
+            vaccinationRecord.statusMessage = "";
+            vaccinationRecord.error = undefined;
+        }
+        state.authenticatedVaccineRecord.statusChanges++;
     },
     setAuthenticatedVaccineRecordError(
         state: VaccinationStatusState,
-        error: ResultError
+        params: { hdid: string; error: ResultError }
     ) {
-        state.authenticatedVaccineRecord.error = error;
-        state.authenticatedVaccineRecord.status = LoadStatus.ERROR;
+        const vaccinationRecord: VaccinationRecord | undefined =
+            state.authenticatedVaccineRecord.vaccinationRecords.get(
+                params.hdid
+            );
+
+        if (vaccinationRecord !== undefined) {
+            vaccinationRecord.error = params.error;
+            vaccinationRecord.status = LoadStatus.ERROR;
+        }
+        state.authenticatedVaccineRecord.statusChanges++;
     },
     setAuthenticatedVaccineRecordStatusMessage(
         state: VaccinationStatusState,
-        statusMessage: string
+        params: { hdid: string; statusMessage: string }
     ) {
-        state.authenticatedVaccineRecord.statusMessage = statusMessage;
+        const vaccinationRecord: VaccinationRecord | undefined =
+            state.authenticatedVaccineRecord.vaccinationRecords.get(
+                params.hdid
+            );
+        if (vaccinationRecord !== undefined) {
+            vaccinationRecord.statusMessage = params.statusMessage;
+        }
+        state.authenticatedVaccineRecord.statusChanges++;
     },
     setAuthenticatedVaccineRecordResultMessage(
         state: VaccinationStatusState,
-        resultMessage: string
+        params: { hdid: string; resultMessage: string }
     ) {
-        state.authenticatedVaccineRecord.resultMessage = resultMessage;
+        const vaccinationRecord: VaccinationRecord | undefined =
+            state.authenticatedVaccineRecord.vaccinationRecords.get(
+                params.hdid
+            );
+
+        if (vaccinationRecord !== undefined) {
+            vaccinationRecord.resultMessage = params.resultMessage;
+        }
+        state.authenticatedVaccineRecord.statusChanges++;
+    },
+    setAuthenticatedVaccineRecordDownload(
+        state: VaccinationStatusState,
+        params: { hdid: string; download: boolean }
+    ) {
+        const vaccinationRecord: VaccinationRecord | undefined =
+            state.authenticatedVaccineRecord.vaccinationRecords.get(
+                params.hdid
+            );
+
+        if (vaccinationRecord !== undefined) {
+            vaccinationRecord.download = params.download;
+        }
+        state.authenticatedVaccineRecord.statusChanges++;
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/types.ts
@@ -11,6 +11,7 @@ import CovidVaccineRecord from "@/models/covidVaccineRecord";
 import { StringISODate } from "@/models/dateWrapper";
 import { CustomBannerError, ResultError } from "@/models/errors";
 import { LoadStatus } from "@/models/storeOperations";
+import VaccinationRecord from "@/models/vaccinationRecord";
 import VaccinationStatus from "@/models/vaccinationStatus";
 import { RootState } from "@/store/types";
 
@@ -34,11 +35,9 @@ export interface VaccinationStatusState {
         statusMessage: string;
     };
     authenticatedVaccineRecord: {
-        vaccinationRecord?: CovidVaccineRecord;
-        error?: ResultError;
-        status: LoadStatus;
-        statusMessage: string;
-        resultMessage: string;
+        activeHdid: string;
+        statusChanges: number;
+        vaccinationRecords: Map<string, VaccinationRecord>;
     };
 }
 
@@ -64,19 +63,13 @@ export interface VaccinationStatusGetters
     authenticatedIsLoading(state: VaccinationStatusState): boolean;
     authenticatedError(state: VaccinationStatusState): ResultError | undefined;
     authenticatedStatusMessage(state: VaccinationStatusState): string;
-    authenticatedVaccineRecord(
+    authenticatedVaccineRecords(
         state: VaccinationStatusState
-    ): CovidVaccineRecord | undefined;
-    authenticatedVaccineRecordIsLoading(state: VaccinationStatusState): boolean;
-    authenticatedVaccineRecordError(
+    ): Map<string, VaccinationRecord>;
+    authenticatedVaccineRecordStatusChanges(
         state: VaccinationStatusState
-    ): ResultError | undefined;
-    authenticatedVaccineRecordStatusMessage(
-        state: VaccinationStatusState
-    ): string;
-    authenticatedVaccineRecordResultMessage(
-        state: VaccinationStatusState
-    ): string;
+    ): number;
+    authenticatedVaccineRecordActiveHdid(state: VaccinationStatusState): string;
 }
 
 type StoreContext = ActionContext<VaccinationStatusState, RootState>;
@@ -124,7 +117,11 @@ export interface VaccinationStatusActions
     ): Promise<CovidVaccineRecord>;
     handleAuthenticatedPdfError(
         context: StoreContext,
-        params: { error: ResultError; errorType: ErrorType }
+        params: { hdid: string; error: ResultError; errorType: ErrorType }
+    ): void;
+    stopAuthenticatedVaccineRecordDownload(
+        context: StoreContext,
+        params: { hdid: string }
     ): void;
 }
 
@@ -169,22 +166,29 @@ export interface VaccinationStatusMutations
         state: VaccinationStatusState,
         statusMessage: string
     ): void;
-    setAuthenticatedVaccineRecordRequested(state: VaccinationStatusState): void;
+    setAuthenticatedVaccineRecordRequested(
+        state: VaccinationStatusState,
+        params: { hdid: string }
+    ): void;
     setAuthenticatedVaccineRecord(
         state: VaccinationStatusState,
-        vaccineRecord: CovidVaccineRecord
+        params: { hdid: string; vaccinationRecord: CovidVaccineRecord }
     ): void;
     setAuthenticatedVaccineRecordError(
         state: VaccinationStatusState,
-        error: ResultError
+        params: { hdid: string; error: ResultError }
     ): void;
     setAuthenticatedVaccineRecordStatusMessage(
         state: VaccinationStatusState,
-        statusMessage: string
+        params: { hdid: string; statusMessage: string }
     ): void;
     setAuthenticatedVaccineRecordResultMessage(
         state: VaccinationStatusState,
-        resultMessage: string
+        params: { hdid: string; resultMessage: string }
+    ): void;
+    setAuthenticatedVaccineRecordDownload(
+        state: VaccinationStatusState,
+        params: { hdid: string; download: boolean }
     ): void;
 }
 

--- a/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/vaccinationStatus.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/vaccinationStatus/vaccinationStatus.ts
@@ -1,4 +1,5 @@
 import { LoadStatus } from "@/models/storeOperations";
+import VaccinationRecord from "@/models/vaccinationRecord";
 
 import { actions } from "./actions";
 import { getters } from "./getters";
@@ -25,11 +26,9 @@ const state: VaccinationStatusState = {
         statusMessage: "",
     },
     authenticatedVaccineRecord: {
-        vaccinationRecord: undefined,
-        error: undefined,
-        status: LoadStatus.NONE,
-        statusMessage: "",
-        resultMessage: "",
+        activeHdid: "",
+        statusChanges: 0,
+        vaccinationRecords: new Map<string, VaccinationRecord>(),
     },
 };
 

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -27,9 +27,11 @@ import type { WebClientConfiguration } from "@/models/configData";
 import CovidVaccineRecord from "@/models/covidVaccineRecord";
 import { DateWrapper } from "@/models/dateWrapper";
 import { QuickLink } from "@/models/quickLink";
+import { LoadStatus } from "@/models/storeOperations";
 import { TimelineFilterBuilder } from "@/models/timelineFilter";
 import User from "@/models/user";
 import { UserPreference } from "@/models/userPreference";
+import VaccinationRecord from "@/models/vaccinationRecord";
 import SnowPlow from "@/utility/snowPlow";
 
 library.add(
@@ -68,6 +70,11 @@ export default class HomeView extends Vue {
         hdid: string;
     }) => Promise<CovidVaccineRecord>;
 
+    @Action("stopAuthenticatedVaccineRecordDownload", {
+        namespace: "vaccinationStatus",
+    })
+    stopAuthenticatedVaccineRecordDownload!: (params: { hdid: string }) => void;
+
     @Action("setFilter", { namespace: "timeline" })
     setFilter!: (filterBuilder: TimelineFilterBuilder) => void;
 
@@ -90,16 +97,6 @@ export default class HomeView extends Vue {
         userPreference: UserPreference;
     }) => Promise<void>;
 
-    @Getter("authenticatedVaccineRecordIsLoading", {
-        namespace: "vaccinationStatus",
-    })
-    isLoadingVaccineRecord!: boolean;
-
-    @Getter("authenticatedVaccineRecordStatusMessage", {
-        namespace: "vaccinationStatus",
-    })
-    vaccineRecordStatusMessage!: string;
-
     @Getter("webClient", { namespace: "config" })
     config!: WebClientConfiguration;
 
@@ -109,13 +106,13 @@ export default class HomeView extends Vue {
         | QuickLink[]
         | undefined;
 
-    @Getter("authenticatedVaccineRecord", { namespace: "vaccinationStatus" })
-    vaccineRecord!: CovidVaccineRecord | undefined;
-
-    @Getter("authenticatedVaccineRecordResultMessage", {
+    @Getter("authenticatedVaccineRecordStatusChanges", {
         namespace: "vaccinationStatus",
     })
-    vaccineRecordResultMessage!: string;
+    vaccineRecordStatusChanges!: number;
+
+    @Getter("authenticatedVaccineRecords", { namespace: "vaccinationStatus" })
+    vaccineRecords!: Map<string, VaccinationRecord>;
 
     @Ref("sensitivedocumentDownloadModal")
     readonly sensitivedocumentDownloadModal!: MessageModalComponent;
@@ -126,12 +123,40 @@ export default class HomeView extends Vue {
     @Ref("addQuickLinkModal")
     readonly addQuickLinkModal!: AddQuickLinkComponent;
 
-    private get isLoading(): boolean {
-        return this.isLoadingVaccineRecord;
+    private get isVaccineRecordDownloading(): boolean {
+        const vaccinationRecord: VaccinationRecord | undefined =
+            this.getVaccinationRecord();
+        if (
+            this.vaccineRecordStatusChanges > 0 &&
+            vaccinationRecord !== undefined
+        ) {
+            return vaccinationRecord.status === LoadStatus.REQUESTED;
+        }
+        return false;
     }
 
-    private get loadingStatusMessage(): string {
-        return this.vaccineRecordStatusMessage;
+    private get vaccineRecordStatusMessage(): string {
+        const vaccinationRecord: VaccinationRecord | undefined =
+            this.getVaccinationRecord();
+        if (
+            this.vaccineRecordStatusChanges > 0 &&
+            vaccinationRecord !== undefined
+        ) {
+            return vaccinationRecord.statusMessage;
+        }
+        return "";
+    }
+
+    private get vaccineRecordResultMessage(): string {
+        const vaccinationRecord: VaccinationRecord | undefined =
+            this.getVaccinationRecord();
+        if (
+            this.vaccineRecordStatusChanges > 0 &&
+            vaccinationRecord !== undefined
+        ) {
+            return vaccinationRecord.resultMessage;
+        }
+        return "";
     }
 
     private get unverifiedEmail(): boolean {
@@ -250,6 +275,10 @@ export default class HomeView extends Vue {
         });
     }
 
+    private getVaccinationRecord(): VaccinationRecord | undefined {
+        return this.vaccineRecords.get(this.user.hdid);
+    }
+
     private handleClickHealthRecords(): void {
         this.trackClickLink("all_records");
         this.clearFilter();
@@ -306,24 +335,40 @@ export default class HomeView extends Vue {
         this.$router.push({ path: "/timeline" });
     }
 
-    @Watch("vaccineRecordResultMessage")
-    private vaccineRecordErrorChanged(): void {
-        if (this.vaccineRecordResultMessage.length > 0) {
+    @Watch("vaccineRecordStatusChanges")
+    private showVaccineRecordResultModal(): void {
+        const vaccinationRecord: VaccinationRecord | undefined =
+            this.getVaccinationRecord();
+        if (
+            vaccinationRecord !== undefined &&
+            vaccinationRecord.resultMessage.length > 0
+        ) {
             this.vaccineRecordResultModal.showModal();
         }
     }
 
-    @Watch("vaccineRecord")
+    @Watch("vaccineRecordStatusChanges")
     private saveVaccinePdf(): void {
-        if (this.vaccineRecord !== undefined) {
-            const mimeType = this.vaccineRecord.document.mediaType;
-            const downloadLink = `data:${mimeType};base64,${this.vaccineRecord.document.data}`;
+        const vaccinationRecord: VaccinationRecord | undefined =
+            this.getVaccinationRecord();
+
+        if (
+            vaccinationRecord !== undefined &&
+            vaccinationRecord.hdid === this.user.hdid &&
+            vaccinationRecord.status === LoadStatus.LOADED &&
+            vaccinationRecord.download
+        ) {
+            const mimeType = vaccinationRecord.record.document.mediaType;
+            const downloadLink = `data:${mimeType};base64,${vaccinationRecord.record.document.data}`;
             fetch(downloadLink).then((res) => {
                 SnowPlow.trackEvent({
                     action: "click_button",
                     text: "FederalPVC",
                 });
                 res.blob().then((blob) => saveAs(blob, "VaccineProof.pdf"));
+            });
+            this.stopAuthenticatedVaccineRecordDownload({
+                hdid: this.user.hdid,
             });
         }
     }
@@ -341,8 +386,8 @@ export default class HomeView extends Vue {
 <template>
     <div>
         <LoadingComponent
-            :is-loading="isLoading"
-            :text="loadingStatusMessage"
+            :is-loading="isVaccineRecordDownloading"
+            :text="vaccineRecordStatusMessage"
         />
         <b-alert
             v-if="unverifiedEmail || unverifiedSMS"


### PR DESCRIPTION
# Implements [AB#13706](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13706)

## Description

Merging feature 13706 to dev:

- Add button to download proof of vaccination under COVID tab under dependent 
- If no federal proof available, display same modal as on home page 
- Same retry logic as home page download 
- Add title "Test results" above test results table 

- Add SnowPlow events: 

Action: Click Button
Event: Dependent Proof

Action: Download Card
Event: Dependent Proof

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

YES.

See merged in PRs for screenshots and videos.

https://github.com/bcgov/healthgateway/pull/4082
https://github.com/bcgov/healthgateway/pull/4060

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
