### PR TITLE
Fix appearance of feedback instructions on small devices AB#13827

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/FeedbackComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/FeedbackComponent.vue
@@ -328,10 +328,6 @@ export default class FeedbackComponent extends Vue {
     border: 0px;
 }
 
-.description-container {
-    height: 70px;
-}
-
 .submit-button-container {
     height: 36px;
     overflow: hidden;


### PR DESCRIPTION
# Fixes [AB#13827](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13827)

## Description

Removes the height limit on the feedback instructions to prevent them being cut off when wrapping at small screen widths.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://user-images.githubusercontent.com/16570293/188024620-9aeb9f13-d523-4aea-8e7f-6253ec3f9f1b.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
