### PR TITLE
Updated admin webclient front end for client registry task handling

### DIFF
--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -38,7 +38,7 @@
     </MudGrid>
 </MudForm>
 
-<HgBannerFeedback Severity="@Severity.Normal" IsEnabled="HasWarning" TResetAction="MessageVerificationActions.ResetStateAction">
+<HgBannerFeedback Severity="@Severity.Info" IsEnabled="HasWarning" TResetAction="MessageVerificationActions.ResetStateAction">
     @MessageVerificationState.Value.WarningMessage
 </HgBannerFeedback>
 

--- a/Apps/AdminWebClient/src/ClientApp/src/components/core/BannerFeedback.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/components/core/BannerFeedback.vue
@@ -42,6 +42,9 @@ export default class BannerFeedbackComponent extends Vue {
             case FeedbackType.Warning: {
                 return "warning";
             }
+            case FeedbackType.Info: {
+                return "info";
+            }
             default: {
                 return "NONE";
             }

--- a/Apps/AdminWebClient/src/ClientApp/src/components/core/BannerFeedback.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/components/core/BannerFeedback.vue
@@ -2,7 +2,7 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 
-import { ResultType } from "@/constants/resulttype";
+import { FeedbackType } from "@/constants/feedbacktype";
 import { SnackbarPosition } from "@/constants/snackbarPosition";
 import type BannerFeedback from "@/models/bannerFeedback";
 
@@ -33,13 +33,13 @@ export default class BannerFeedbackComponent extends Vue {
 
     private get vuetifyType(): string {
         switch (this.feedback.type) {
-            case ResultType.Success: {
+            case FeedbackType.Success: {
                 return "success";
             }
-            case ResultType.Error: {
+            case FeedbackType.Error: {
                 return "error";
             }
-            case ResultType.Warning: {
+            case FeedbackType.Warning: {
                 return "warning";
             }
             default: {

--- a/Apps/AdminWebClient/src/ClientApp/src/constants/feedbacktype.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/constants/feedbacktype.ts
@@ -1,0 +1,6 @@
+export const enum FeedbackType {
+    Error = 0,
+    Success = 1,
+    Warning = 2,
+    NONE = -1,
+}

--- a/Apps/AdminWebClient/src/ClientApp/src/constants/feedbacktype.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/constants/feedbacktype.ts
@@ -2,5 +2,6 @@ export const enum FeedbackType {
     Error = 0,
     Success = 1,
     Warning = 2,
+    Info = 3,
     NONE = -1,
 }

--- a/Apps/AdminWebClient/src/ClientApp/src/constants/resulttype.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/constants/resulttype.ts
@@ -1,6 +1,5 @@
 export const enum ResultType {
     Error = 0,
     Success = 1,
-    Warning = 2,
-    NONE = -1,
+    ActionRequired = 2,
 }

--- a/Apps/AdminWebClient/src/ClientApp/src/models/bannerFeedback.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/bannerFeedback.ts
@@ -1,7 +1,7 @@
-import { ResultType } from "@/constants/resulttype";
+import { FeedbackType } from "@/constants/feedbacktype";
 
 export default interface BannerFeedback {
-    type: ResultType;
+    type: FeedbackType;
     title: string;
     message: string;
 }

--- a/Apps/AdminWebClient/src/ClientApp/src/models/patientData.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/models/patientData.ts
@@ -9,4 +9,5 @@ export default interface PatientData {
     birthdate: StringISODate;
     physicalAddress: Address | null;
     postalAddress: Address | null;
+    responseCode: string;
 }

--- a/Apps/AdminWebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/services/interfaces.ts
@@ -8,6 +8,7 @@ import CovidTreatmentAssessmentDetails from "@/models/covidTreatmentAssessmentDe
 import CovidTreatmentAssessmentRequest from "@/models/covidTreatmentAssessmentRequest";
 import ExternalConfiguration from "@/models/externalConfiguration";
 import MessageVerification from "@/models/messageVerification";
+import RequestResult from "@/models/requestResult";
 import { QueryType } from "@/models/userQuery";
 
 export interface IConfigService {
@@ -28,7 +29,7 @@ export interface ISupportService {
     getMessageVerifications(
         type: QueryType,
         query: string
-    ): Promise<MessageVerification[]>;
+    ): Promise<RequestResult<MessageVerification[]>>;
 }
 
 export interface ICovidSupportService {

--- a/Apps/AdminWebClient/src/ClientApp/src/services/restSupportService.ts
+++ b/Apps/AdminWebClient/src/ClientApp/src/services/restSupportService.ts
@@ -1,10 +1,10 @@
 import { injectable } from "inversify";
 
+import { ResultType } from "@/constants/resulttype";
 import MessageVerification from "@/models/messageVerification";
 import RequestResult from "@/models/requestResult";
 import { QueryType } from "@/models/userQuery";
 import { IHttpDelegate, ISupportService } from "@/services/interfaces";
-import RequestResultUtil from "@/utility/requestResultUtil";
 
 @injectable()
 export class RestSupportService implements ISupportService {
@@ -18,18 +18,21 @@ export class RestSupportService implements ISupportService {
     public getMessageVerifications(
         type: QueryType,
         query: string
-    ): Promise<MessageVerification[]> {
+    ): Promise<RequestResult<MessageVerification[]>> {
         return new Promise((resolve, reject) => {
             this.http
                 .get<RequestResult<MessageVerification[]>>(
                     `${this.BASE_URI}/Users?queryType=${type}&queryString=${query}`
                 )
                 .then((requestResult) => {
-                    return RequestResultUtil.handleResult(
-                        requestResult,
-                        resolve,
-                        reject
-                    );
+                    if (
+                        requestResult.resultStatus === ResultType.Success ||
+                        requestResult.resultStatus === ResultType.ActionRequired
+                    ) {
+                        resolve(requestResult);
+                    } else {
+                        reject(requestResult.resultError);
+                    }
                 })
                 .catch((err) => {
                     console.log(err);

--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -16,8 +16,8 @@ import LoadingComponent from "@/components/core/Loading.vue";
 import CovidTreatmentAssessmentComponent from "@/components/covidTreatmentAssessment/CovidTreatmentAssessment.vue";
 import { Countries } from "@/constants/countries";
 import { Feature } from "@/constants/feature";
+import { FeedbackType } from "@/constants/feedbacktype";
 import { Provinces } from "@/constants/provinces";
-import { ResultType } from "@/constants/resulttype";
 import { SnackbarPosition } from "@/constants/snackbarPosition";
 import type Address from "@/models/address";
 import type BannerFeedback from "@/models/bannerFeedback";
@@ -82,7 +82,7 @@ export default class CovidCardView extends Vue {
     private covidSupportService!: ICovidSupportService;
 
     private bannerFeedback: BannerFeedback = {
-        type: ResultType.NONE,
+        type: FeedbackType.NONE,
         title: "",
         message: "",
     };
@@ -165,7 +165,7 @@ export default class CovidCardView extends Vue {
         const phnDigits = this.phn.replace(/[^0-9]/g, "");
         if (!PHNValidator.IsValid(phnDigits)) {
             this.showBannerFeedback({
-                type: ResultType.Error,
+                type: FeedbackType.Error,
                 title: "Validation error",
                 message: "Invalid PHN",
             });
@@ -217,11 +217,20 @@ export default class CovidCardView extends Vue {
                         return firstDate.isAfter(secondDate) ? -1 : 0;
                     });
                 }
+                if (this.searchResult.patient.responseCode) {
+                    const message =
+                        this.searchResult.patient.responseCode.split("|")[1];
+                    this.showBannerFeedback({
+                        type: FeedbackType.Success,
+                        title: "Info",
+                        message: message,
+                    });
+                }
             })
             .catch(() => {
                 this.searchResult = null;
                 this.showBannerFeedback({
-                    type: ResultType.Error,
+                    type: FeedbackType.Error,
                     title: "Search Error",
                     message: "Unknown error searching patient data",
                 });
@@ -308,13 +317,13 @@ export default class CovidCardView extends Vue {
                         if (mailResult) {
                             this.searchResult = null;
                             this.showBannerFeedback({
-                                type: ResultType.Success,
+                                type: FeedbackType.Success,
                                 title: "Success",
                                 message: "BC Vaccine Card mailed successfully.",
                             });
                         } else {
                             this.showBannerFeedback({
-                                type: ResultType.Error,
+                                type: FeedbackType.Error,
                                 title: "Error",
                                 message:
                                     "Something went wrong when mailing the card, please try again later.",
@@ -323,7 +332,7 @@ export default class CovidCardView extends Vue {
                     })
                     .catch(() => {
                         this.showBannerFeedback({
-                            type: ResultType.Error,
+                            type: FeedbackType.Error,
                             title: "Mail Error",
                             message: "Unknown error mailing report",
                         });
@@ -359,7 +368,7 @@ export default class CovidCardView extends Vue {
             })
             .catch(() => {
                 this.showBannerFeedback({
-                    type: ResultType.Error,
+                    type: FeedbackType.Error,
                     title: "Download Error",
                     message: "Unknown error downloading report",
                 });
@@ -404,7 +413,7 @@ export default class CovidCardView extends Vue {
         this.getCovidTreatmentAssessmentDetails()
             .then(() => {
                 this.showBannerFeedback({
-                    type: ResultType.Success,
+                    type: FeedbackType.Success,
                     title: "Success",
                     message:
                         "COVID-19 treatment assessment submitted successfully.",
@@ -412,7 +421,7 @@ export default class CovidCardView extends Vue {
             })
             .catch(() => {
                 this.showBannerFeedback({
-                    type: ResultType.Warning,
+                    type: FeedbackType.Warning,
                     title: "Warning",
                     message:
                         "COVID-19 treatment assessment submitted successfully, but updated assessment history could not be retrieved.",
@@ -425,7 +434,7 @@ export default class CovidCardView extends Vue {
 
     private covidTreatmentAssessmentSubmissionFailed(): void {
         this.showBannerFeedback({
-            type: ResultType.Error,
+            type: FeedbackType.Error,
             title: "Error",
             message: "Unable to submit COVID-19 treatment assessment.",
         });

--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -221,7 +221,7 @@ export default class CovidCardView extends Vue {
                     const message =
                         this.searchResult.patient.responseCode.split("|")[1];
                     this.showBannerFeedback({
-                        type: FeedbackType.Success,
+                        type: FeedbackType.Info,
                         title: "Info",
                         message: message,
                     });

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -3,7 +3,7 @@ import { Component, Prop, Vue } from "vue-property-decorator";
 
 import BannerFeedbackComponent from "@/components/core/BannerFeedback.vue";
 import LoadingComponent from "@/components/core/Loading.vue";
-import { ResultType } from "@/constants/resulttype";
+import { FeedbackType } from "@/constants/feedbacktype";
 import BannerFeedback from "@/models/bannerFeedback";
 import { DateWrapper, StringISODateTime } from "@/models/dateWrapper";
 import MessageVerification, { Email } from "@/models/messageVerification";
@@ -34,7 +34,7 @@ export default class SupportView extends Vue {
     private isLoading = false;
     private showFeedback = false;
     private bannerFeedback: BannerFeedback = {
-        type: ResultType.NONE,
+        type: FeedbackType.NONE,
         title: "",
         message: "",
     };
@@ -157,7 +157,7 @@ export default class SupportView extends Vue {
                 this.emailList = [];
                 this.showFeedback = true;
                 this.bannerFeedback = {
-                    type: ResultType.Error,
+                    type: FeedbackType.Error,
                     title: "Validation error",
                     message: "Invalid PHN",
                 };
@@ -169,12 +169,21 @@ export default class SupportView extends Vue {
         this.supportService
             .getMessageVerifications(this.selectedQueryType, searchText)
             .then((result) => {
-                this.emailList = result;
+                this.emailList = result.resourcePayload;
+                if (result.resultError) {
+                    debugger;
+                    this.showFeedback = true;
+                    this.bannerFeedback = {
+                        type: FeedbackType.Success,
+                        title: "Info",
+                        message: result.resultError.resultMessage,
+                    };
+                }
             })
             .catch((err) => {
                 this.showFeedback = true;
                 this.bannerFeedback = {
-                    type: ResultType.Error,
+                    type: FeedbackType.Error,
                     title: "Error:" + err.errorCode,
                     message: "Message: " + err.resultMessage,
                 };

--- a/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/Support.vue
@@ -171,10 +171,9 @@ export default class SupportView extends Vue {
             .then((result) => {
                 this.emailList = result.resourcePayload;
                 if (result.resultError) {
-                    debugger;
                     this.showFeedback = true;
                     this.bannerFeedback = {
-                        type: FeedbackType.Success,
+                        type: FeedbackType.Info,
                         title: "Info",
                         message: result.resultError.resultMessage,
                     };


### PR DESCRIPTION
# Fixes or Implements [AB#13786](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13786)

## Description

Updated admin webclient front end for client registry task handling.
Minor change to info level message on Blazor support page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

For the admin webclient the only feedback types are success, error or warning so I set it to 'success' and made the title "Info":
![Screen Shot 2022-09-01 at 4 33 32 PM](https://user-images.githubusercontent.com/5408101/188030107-5bfbf209-f8c6-4542-84f2-dce4a9a886cc.png)

The Vaccine Card message shows up at the bottom:
![Screen Shot 2022-09-01 at 4 33 10 PM](https://user-images.githubusercontent.com/5408101/188030098-0b489745-6310-43ae-8fa3-bd0fcba59f64.png)

I also made the minor change on the Blazor admin so that the it is an Info message:
![Screen Shot 2022-09-01 at 4 35 53 PM](https://user-images.githubusercontent.com/5408101/188030185-b7fc04ac-ecd1-4921-8648-04ce26de750e.png)

## Notes

I did a refactoring so that the resulttype in the front end matches the back end and replaced the front end version with a feedbacktype that is specifically for the front end code to use instead.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
