### PR TITLE
Change when to display table title as per close out review for AB#13862

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -859,7 +859,7 @@ export default class DependentCardComponent extends Vue {
                             Download Proof of Vaccination
                         </hg-button>
                     </div>
-                    <div v-if="!isLoading && testRows.length != 0" class="m-2">
+                    <div v-if="!isLoading" class="m-2">
                         <h4>COVID-19 Test Results</h4>
                     </div>
                     <template #title>


### PR DESCRIPTION
# Fixes [AB#13862](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13862)

## Description

The title for COVID-19 Test Results should be displayed even if there are no COVID test results. 

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

<img width="2546" alt="Screen Shot 2022-09-06 at 10 39 22 AM" src="https://user-images.githubusercontent.com/58790456/188708880-db7d4402-c6b8-4ed7-b4a2-ef6909391350.png">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
