### PR TITLE
Removed no longer applicable test for AB#13857

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
@@ -14,17 +14,6 @@ describe("Registration Page", () => {
         cy.get("[data-testid=minimumAgeErrorText]").should("be.visible");
     });
 
-    it("Client Registration error", () => {
-        cy.enableModules("Medication");
-        cy.login(
-            Cypress.env("keycloak.healthgateway12.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
-        );
-        cy.location("pathname").should("eq", registrationPath);
-        cy.get("[data-testid=clientRegistryErrorText]").should("be.visible");
-    });
-
     it("No sidebar or footer", () => {
         cy.enableModules("Medication");
         cy.login(


### PR DESCRIPTION
# Fixes AB#135857

## Description

Due to recent code changes 'Client Registration error' test is no longer applicable. This error is no longer being caught and returned.

<img width="1180" alt="Screen Shot 2022-09-06 at 12 15 40 PM" src="https://user-images.githubusercontent.com/58790456/188720591-6b67bd26-a5a5-4927-9d58-c7836ec77a14.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
