### PR TITLE
Update Kong tooling for clinical documents AB#13796

### DIFF
--- a/Tools/Kong/generate.sh
+++ b/Tools/Kong/generate.sh
@@ -10,7 +10,7 @@ EOF
 
   source "hg-$environment.env"
 
-  services=('encounter' 'gatewayapi' 'immunization' 'laboratory' 'medication' 'patient')
+  services=('clinicaldocument' 'encounter' 'gatewayapi' 'immunization' 'laboratory' 'medication' 'patient')
   
   for service in "${services[@]}"; do
     export SERVICE=$service

--- a/Tools/Kong/network-policies.yaml
+++ b/Tools/Kong/network-policies.yaml
@@ -1,6 +1,26 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
+  name: allow-kong-to-clinicaldocument
+spec:
+  podSelector:
+    matchLabels:
+      app: clinicaldocument
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              environment: test
+              name: 264e6f
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              environment: prod
+              name: 264e6f
+---
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
   name: allow-kong-to-encounter
 spec:
   podSelector:


### PR DESCRIPTION
# Implements [AB#13796](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13796)

## Description

- updates the generate script to create a Kong config for clinical documents
- updates the network policies to allow Kong to access the clinicaldocumentservice in OpenShift
    - will need to be applied to the OpenShift environments after the new service has been deployed (tracked in [AB#13899](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13899))

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
