### PR TITLE
Add  broadcast refit implemenation plus models for AB#13886

### DIFF
--- a/Apps/Common/src/Api/ISystemBroadcastsApi.cs
+++ b/Apps/Common/src/Api/ISystemBroadcastsApi.cs
@@ -1,0 +1,60 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Api
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Models.PHSA;
+    using Refit;
+
+    /// <summary>
+    /// Interface to interact with PHSA System Broadcasts API.
+    /// </summary>
+    public interface ISystemBroadcastsApi
+    {
+        /// <summary>
+        /// Retrieves the broadcasts.
+        /// </summary>
+        /// <returns>The collection of Broadcasts.</returns>
+        [Get("/api/system-broadcasts")]
+        Task<IApiResponse<IEnumerable<BroadcastResponse>>> GetBroadcasts();
+
+        /// <summary>
+        /// Creates a broadcast.
+        /// </summary>
+        /// <param name="request">The broadcast to create.</param>
+        /// <returns>The Broadcasts that was created.</returns>
+        [Post("/api/system-broadcasts")]
+        Task<IApiResponse<BroadcastResponse>> CreateBroadcast([Body] BroadcastRequest request);
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="id">The id of the broadcast that is being updated.</param>
+        /// <param name="request">The broadcast values to update.</param>
+        /// <returns>The Broadcasts that was updated.</returns>
+        [Put("/api/system-broadcasts/{id}")]
+        Task<IApiResponse<BroadcastResponse>> UpdateBroadcast(string id, [Body] BroadcastRequest request);
+
+        /// <summary>
+        /// Deletes a broadcast.
+        /// </summary>
+        /// <param name="id">The id of the broadcast that is being deleted..</param>
+        /// <returns>The Broadcasts that was created.</returns>
+        [Delete("/api/system-broadcasts/{id}")]
+        Task<IApiResponse> DeleteBroadcast(string id);
+    }
+}

--- a/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
@@ -1,0 +1,68 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Models.PHSA
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Model representing a PHSA Broadcast Request.
+    /// </summary>
+    public class BroadcastRequest
+    {
+        /// <summary>
+        /// Gets or sets the category name.
+        /// </summary>
+        [JsonPropertyName("categoryName")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text.
+        /// </summary>
+        [JsonPropertyName("displayText")]
+        public string? DisplayText { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this broadcast system is enabled.
+        /// </summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action text.
+        /// </summary>
+        [JsonPropertyName("actionText")]
+        public string? ActionText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action url.
+        /// </summary>
+        [JsonPropertyName("actionUrl")]
+        public string? ActionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scheduled datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("scheduledDateUtc")]
+        public DateTime ScheduledDateUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("expirationDateUtc")]
+        public DateTime? ExpirationDateUtc { get; set; }
+    }
+}

--- a/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.Common.Models.PHSA
         /// Gets or sets the action url.
         /// </summary>
         [JsonPropertyName("actionUrl")]
-        public string? ActionUrl { get; set; }
+        public Uri? ActionUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the scheduled datetime in UTC.

--- a/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.Common.Models.PHSA
         /// Gets or sets the action url.
         /// </summary>
         [JsonPropertyName("actionUrl")]
-        public string? ActionUrl { get; set; }
+        public Uri? ActionUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the action text.

--- a/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
@@ -1,0 +1,98 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Models.PHSA
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Model representing a PHSA Broadcast Response.
+    /// </summary>
+    public class BroadcastResponse
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category name.
+        /// </summary>
+        [JsonPropertyName("categoryName")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text.
+        /// </summary>
+        [JsonPropertyName("displayText")]
+        public string? DisplayText { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this broadcast system is enabled.
+        /// </summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action url.
+        /// </summary>
+        [JsonPropertyName("actionUrl")]
+        public string? ActionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action text.
+        /// </summary>
+        [JsonPropertyName("actionText")]
+        public string? ActionText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scheduled datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("scheduledDateUtc")]
+        public DateTime ScheduledDateUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("expirationDateUtc")]
+        public DateTime? ExpirationDateUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the created by.
+        /// </summary>
+        [JsonPropertyName("createdBy")]
+        public string? CreatedBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the last modified by.
+        /// </summary>
+        [JsonPropertyName("lastModifiedBy")]
+        public string? LastModifiedBy { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creation datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("creationDateUtc")]
+        public DateTime CreationDateUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the modified datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("modifiedDateUtc")]
+        public DateTime? ModifiedDateUtc { get; set; }
+    }
+}

--- a/Apps/Common/src/Models/PHSA/PhsaConfigV2.cs
+++ b/Apps/Common/src/Models/PHSA/PhsaConfigV2.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Common.Models.PHSA
 {
     using System;
-    using System.Collections.Generic;
 
     /// <summary>
     /// Model object representing form parameter values when posting for an access token.
@@ -37,6 +36,11 @@ namespace HealthGateway.Common.Models.PHSA
         /// Gets or sets the phsa base endpoint for data.
         /// </summary>
         public Uri BaseUrl { get; set; } = null!;
+
+        /// <summary>
+        /// Gets or sets the phsa base endpoint for admin data.
+        /// </summary>
+        public Uri AdminBaseUrl { get; set; } = null!;
 
         /// <summary>
         /// Gets or sets the client id of the token being used to swap.


### PR DESCRIPTION
# Implements [AB#13886](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13886)

## Description

1. Implemented Refit for PHSA Broadcast endpoints - https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net/swagger/index.html
2. Created associated request and response models for Refit calls

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
