### PR TITLE
Update AccessTokenService to use sub as identifier for AB#13884

### DIFF
--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -40,13 +40,13 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         public const string DefaultAuthConfigSectionName = "ClientAuthentication";
 
         private const string CacheConfigSectionName = "AuthCache";
+        private readonly ICacheProvider cacheProvider;
+        private readonly IConfiguration configuration;
+        private readonly IHttpClientService httpClientService;
+        private readonly IHttpContextAccessor? httpContextAccessor;
 
         private readonly ILogger<IAuthenticationDelegate> logger;
-        private readonly IHttpClientService httpClientService;
-        private readonly IConfiguration configuration;
-        private readonly ICacheProvider cacheProvider;
         private readonly int tokenCacheMinutes;
-        private readonly IHttpContextAccessor? httpContextAccessor;
         private readonly ClientCredentialsTokenRequest tokenRequest;
         private readonly Uri tokenUri;
 
@@ -184,6 +184,13 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         {
             ClaimsPrincipal? user = this.httpContextAccessor?.HttpContext?.User;
             return user?.FindFirst("hdid")?.Value;
+        }
+
+        /// <inheritdoc/>
+        public string? FetchAuthenticatedUserIdentifier()
+        {
+            ClaimsPrincipal? user = this.httpContextAccessor?.HttpContext?.User;
+            return user?.FindFirst(ClaimTypes.NameIdentifier)!.Value;
         }
 
         private (Uri TokenUri, ClientCredentialsTokenRequest TokenRequest) GetConfiguration(string sectionName)

--- a/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
@@ -85,5 +85,11 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         /// </summary>
         /// <returns>The users HDID.</returns>
         string? FetchAuthenticatedUserHdid();
+
+        /// <summary>
+        /// Fetches the identifier for the authenticated user from the http context.
+        /// </summary>
+        /// <returns>The user's identifier.</returns>
+        string? FetchAuthenticatedUserIdentifier();
     }
 }

--- a/Apps/Common/src/Services/AccessTokenService.cs
+++ b/Apps/Common/src/Services/AccessTokenService.cs
@@ -72,9 +72,9 @@ namespace HealthGateway.Common.Services
         public async Task<RequestResult<TokenSwapResponse>> GetPhsaAccessToken()
         {
             using Activity? activity = Source.StartActivity();
-            string? identifier = this.authenticationDelegate.FetchAuthenticatedUserIdentifier();
+            string? userId = this.authenticationDelegate.FetchAuthenticatedUserIdentifier();
             RequestResult<TokenSwapResponse> requestResult = new();
-            string cacheKey = $"{TokenSwapCacheDomain}:Identifier:{identifier}";
+            string cacheKey = $"{TokenSwapCacheDomain}:{userId}";
             TokenSwapResponse? cachedAccessToken = this.GetFromCache(cacheKey);
 
             if (cachedAccessToken == null)
@@ -83,7 +83,7 @@ namespace HealthGateway.Common.Services
 
                 if (accessToken != null)
                 {
-                    requestResult = await this.SwapToken(identifier, accessToken).ConfigureAwait(true);
+                    requestResult = await this.SwapToken(userId, accessToken).ConfigureAwait(true);
                 }
                 else
                 {


### PR DESCRIPTION
# Implements [AB#13884](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13884)

## Description

1. Updated AccessTokenService to use sub identifier instead of hdid when using cache for access token.
2. Also centralized 'cache key' creation to one spot instead of having the key created in multiple locations, which could result in an error if not all keys were updated if a change was required.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
