### PR TITLE
Create clinical document service and refit API for AB#13792

### DIFF
--- a/Apps/ClinicalDocument/src/Api/IClinicalDocumentsApi.cs
+++ b/Apps/ClinicalDocument/src/Api/IClinicalDocumentsApi.cs
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.ClinicalDocument.Api
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.ClinicalDocument.Models;
+    using Refit;
+
+    /// <summary>
+    /// Interface to interact with PHSA Clinical Documents API.
+    /// </summary>
+    public interface IClinicalDocumentsApi
+    {
+        /// <summary>
+        /// Retrieves clinical document records by patient identifier.
+        /// </summary>
+        /// <param name="pid">The pid to get clinical document records.</param>
+        /// <returns>The clinical document records for the patient identifier.</returns>
+        [Get("/patient/{pid}/health-data")]
+        Task<IApiResponse<IEnumerable<ClinicalDocumentRecord>>> GetClinicalDocumentRecordsByPid(string pid);
+    }
+}

--- a/Apps/ClinicalDocument/src/Models/ClinicalDocumentRecord.cs
+++ b/Apps/ClinicalDocument/src/Models/ClinicalDocumentRecord.cs
@@ -26,13 +26,13 @@ namespace HealthGateway.ClinicalDocument.Models
         /// <summary>
         /// Gets or sets the ID.
         /// </summary>
-        [JsonPropertyName("id")]
+        [JsonPropertyName("healthDataId")]
         public string Id { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the file ID.
         /// </summary>
-        [JsonPropertyName("fileId")]
+        [JsonPropertyName("healthDataFileId")]
         public string FileId { get; set; } = string.Empty;
 
         /// <summary>

--- a/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
@@ -17,29 +17,39 @@ namespace HealthGateway.ClinicalDocument.Services
 {
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Threading.Tasks;
+    using HealthGateway.ClinicalDocument.Api;
     using HealthGateway.ClinicalDocument.Models;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using Microsoft.Extensions.Logging;
+    using Refit;
 
     /// <inheritdoc/>
     public class ClinicalDocumentService : IClinicalDocumentService
     {
         private readonly ILogger<ClinicalDocumentService> logger;
         private readonly IPersonalAccountsService personalAccountsService;
+        private readonly IClinicalDocumentsApi clinicalDocumentsApi;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ClinicalDocumentService"/> class.
         /// </summary>
         /// <param name="logger">Injected logger.</param>
         /// <param name="personalAccountsService">The injected personal accounts service.</param>
-        public ClinicalDocumentService(ILogger<ClinicalDocumentService> logger, IPersonalAccountsService personalAccountsService)
+        /// <param name="clinicalDocumentsApi">The injected clinical documents api.</param>
+        public ClinicalDocumentService(
+            ILogger<ClinicalDocumentService> logger,
+            IPersonalAccountsService personalAccountsService,
+            IClinicalDocumentsApi clinicalDocumentsApi)
         {
             this.logger = logger;
             this.personalAccountsService = personalAccountsService;
+            this.clinicalDocumentsApi = clinicalDocumentsApi;
         }
 
         private static ActivitySource Source { get; } = new(nameof(ClinicalDocumentService));
@@ -57,6 +67,23 @@ namespace HealthGateway.ClinicalDocument.Services
             if (response.ResultStatus == ResultType.Success)
             {
                 this.logger.LogDebug("PID Fetched: {Pid}", response.ResourcePayload?.PatientIdentity?.Pid);
+                IApiResponse<IEnumerable<ClinicalDocumentRecord>> apiResponse =
+                    await this.clinicalDocumentsApi.GetClinicalDocumentRecordsByPid(response.ResourcePayload?.PatientIdentity?.Pid.ToString()).ConfigureAwait(true);
+                if (apiResponse.IsSuccessStatusCode)
+                {
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = apiResponse.Content;
+                    requestResult.TotalResultCount = apiResponse.Content.Count();
+                }
+                else
+                {
+                    this.logger.LogCritical("API Exception {Error}", apiResponse.Error?.ToString());
+                    requestResult.ResultError = new()
+                    {
+                        ResultMessage = $"API Exception {apiResponse.Error}",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                }
             }
             else
             {


### PR DESCRIPTION
# Fixes or Implements [AB#13792](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13792)

## Description

- Update clinical doc service to retrieve records
- create clinical document API with refit method to get records
- add backend model 

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
