### PR TITLE
Refactored CloseUserProfile to use Authtentication Delegate for AB#13909

### DIFF
--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         /// <param name="cacheProvider">The injected cache provider.</param>
         /// <param name="httpContextAccessor">The Http Context accessor.</param>
         public AuthenticationDelegate(
-            ILogger<IAuthenticationDelegate> logger,
+            ILogger<AuthenticationDelegate> logger,
             IHttpClientService httpClientService,
             IConfiguration configuration,
             ICacheProvider cacheProvider,

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             Uri tokenUri = new("http://testsite");
             Dictionary<string, string> configurationParams = new()
             {
-                {"AuthCache:TokenCacheExpireMinutes", "20"},
+                { "AuthCache:TokenCacheExpireMinutes", "20" },
             };
             IConfiguration configuration = CreateConfiguration(configurationParams);
 

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Net;
     using System.Net.Http;
     using System.Text.Json;
@@ -43,13 +44,13 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
         /// AuthenticateAsUser - Happy Path.
         /// </summary>
         [Fact]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
+        [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
         public void ShouldAuthenticateAsUser()
         {
             Uri tokenUri = new("http://testsite");
             Dictionary<string, string> configurationParams = new()
             {
-                { "AuthCache:TokenCacheExpireMinutes", "20" },
+                {"AuthCache:TokenCacheExpireMinutes", "20"},
             };
             IConfiguration configuration = CreateConfiguration(configurationParams);
 
@@ -64,10 +65,11 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             using IMemoryCache memoryCache = new MemoryCache(new MemoryCacheOptions());
             ICacheProvider cacheProvider = new MemoryCacheProvider(memoryCache);
 
-            string json = @"{ ""access_token"":""token"", ""expires_in"":500, ""refresh_expires_in"":0, ""refresh_token"":""refresh_token"", ""token_type"":""bearer"", ""not-before-policy"":25, ""session_state"":""session_state"", ""scope"":""scope"" }";
+            string json =
+                @"{ ""access_token"":""token"", ""expires_in"":500, ""refresh_expires_in"":0, ""refresh_token"":""refresh_token"", ""token_type"":""bearer"", ""not-before-policy"":25, ""session_state"":""session_state"", ""scope"":""scope"" }";
             JwtModel? expected = JsonSerializer.Deserialize<JwtModel>(json);
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            ILogger<IAuthenticationDelegate> logger = loggerFactory.CreateLogger<IAuthenticationDelegate>();
+            ILogger<AuthenticationDelegate> logger = loggerFactory.CreateLogger<AuthenticationDelegate>();
             Mock<HttpMessageHandler> handlerMock = new();
             using HttpResponseMessage httpResponseMessage = new()
             {
@@ -75,18 +77,18 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
                 Content = new StringContent(json),
             };
             handlerMock
-               .Protected()
-               .Setup<Task<HttpResponseMessage>>(
-                  "SendAsync",
-                  ItExpr.IsAny<HttpRequestMessage>(),
-                  ItExpr.IsAny<CancellationToken>())
-               .ReturnsAsync(httpResponseMessage)
-               .Verifiable();
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponseMessage)
+                .Verifiable();
             Mock<IHttpClientService> mockHttpClientService = new();
             mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
 
             IAuthenticationDelegate authDelegate = new AuthenticationDelegate(logger, mockHttpClientService.Object, configuration, cacheProvider, null);
-            JwtModel actualModel = authDelegate.AuthenticateAsUser(tokenUri, tokenRequest, false);
+            JwtModel actualModel = authDelegate.AuthenticateAsUser(tokenUri, tokenRequest);
             expected.ShouldDeepEqual(actualModel);
 
             (_, bool cached) = authDelegate.AuthenticateUser(tokenUri, tokenRequest, true);
@@ -108,10 +110,11 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
                 ClientId = "CLIENT_ID",
                 ClientSecret = "SOME_SECRET",
             };
-            string json = @"{ ""access_token"":""token"", ""expires_in"":500, ""refresh_expires_in"":0, ""refresh_token"":""refresh_token"", ""token_type"":""bearer"", ""not-before-policy"":25, ""session_state"":""session_state"", ""scope"":""scope"" }";
+            string json =
+                @"{ ""access_token"":""token"", ""expires_in"":500, ""refresh_expires_in"":0, ""refresh_token"":""refresh_token"", ""token_type"":""bearer"", ""not-before-policy"":25, ""session_state"":""session_state"", ""scope"":""scope"" }";
             JwtModel? expected = JsonSerializer.Deserialize<JwtModel>(json);
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            ILogger<IAuthenticationDelegate> logger = loggerFactory.CreateLogger<IAuthenticationDelegate>();
+            ILogger<AuthenticationDelegate> logger = loggerFactory.CreateLogger<AuthenticationDelegate>();
             Mock<HttpMessageHandler> handlerMock = new();
             using HttpResponseMessage httpResponseMessage = new()
             {
@@ -120,13 +123,13 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
             };
 
             handlerMock
-               .Protected()
-               .Setup<Task<HttpResponseMessage>>(
-                  "SendAsync",
-                  ItExpr.IsAny<HttpRequestMessage>(),
-                  ItExpr.IsAny<CancellationToken>())
-               .ReturnsAsync(httpResponseMessage)
-               .Verifiable();
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>())
+                .ReturnsAsync(httpResponseMessage)
+                .Verifiable();
             Mock<IHttpClientService> mockHttpClientService = new();
             mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
             Dictionary<string, string> extraConfig = new();
@@ -138,9 +141,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Administration
         private static IConfiguration CreateConfiguration(Dictionary<string, string> configParams)
         {
             return new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: true)
-                .AddJsonFile("appsettings.Development.json", optional: true)
-                .AddJsonFile("appsettings.local.json", optional: true)
+                .AddJsonFile("appsettings.json", true)
+                .AddJsonFile("appsettings.Development.json", true)
+                .AddJsonFile("appsettings.local.json", true)
                 .AddInMemoryCollection(configParams)
                 .Build();
         }

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.GatewayApi.Controllers
     using System.Diagnostics.CodeAnalysis;
     using System.Security.Claims;
     using System.Threading.Tasks;
+    using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Utils;
@@ -40,11 +41,12 @@ namespace HealthGateway.GatewayApi.Controllers
     [ApiController]
     public class UserProfileController : ControllerBase
     {
-        private readonly ILogger logger;
-        private readonly IUserProfileService userProfileService;
+        private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly ILogger logger;
         private readonly IUserEmailService userEmailService;
-        private readonly IUserSMSService userSMSService;
+        private readonly IUserProfileService userProfileService;
+        private readonly IUserSMSService userSmsService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileController"/> class.
@@ -53,19 +55,22 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <param name="userProfileService">The injected user profile service.</param>
         /// <param name="httpContextAccessor">The injected http context accessor provider.</param>
         /// <param name="userEmailService">The injected user email service.</param>
-        /// <param name="userSMSService">The injected user sms service.</param>
+        /// <param name="userSmsService">The injected user sms service.</param>
+        /// <param name="authenticationDelegate">The injected authentication delegate.</param>
         public UserProfileController(
             ILogger<UserProfileController> logger,
             IUserProfileService userProfileService,
             IHttpContextAccessor httpContextAccessor,
             IUserEmailService userEmailService,
-            IUserSMSService userSMSService)
+            IUserSMSService userSmsService,
+            IAuthenticationDelegate authenticationDelegate)
         {
             this.logger = logger;
             this.userProfileService = userProfileService;
             this.httpContextAccessor = httpContextAccessor;
             this.userEmailService = userEmailService;
-            this.userSMSService = userSMSService;
+            this.userSmsService = userSmsService;
+            this.authenticationDelegate = authenticationDelegate;
         }
 
         /// <summary>
@@ -166,8 +171,7 @@ namespace HealthGateway.GatewayApi.Controllers
         public RequestResult<UserProfileModel> CloseUserProfile(string hdid)
         {
             // Retrieve the user identity id from the claims
-            ClaimsPrincipal user = this.httpContextAccessor.HttpContext!.User;
-            Guid userId = new(user.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+            Guid userId = new(this.authenticationDelegate.FetchAuthenticatedUserId());
 
             return this.userProfileService.CloseUserProfile(hdid, userId);
         }
@@ -256,7 +260,7 @@ namespace HealthGateway.GatewayApi.Controllers
             HttpContext? httpContext = this.httpContextAccessor.HttpContext;
             if (httpContext != null)
             {
-                PrimitiveRequestResult<bool> result = this.userSMSService.ValidateSMS(hdid, validationCode);
+                PrimitiveRequestResult<bool> result = this.userSmsService.ValidateSMS(hdid, validationCode);
                 if (!result.ResourcePayload)
                 {
                     await Task.Delay(5000).ConfigureAwait(true);
@@ -305,7 +309,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [Authorize(Policy = UserProfilePolicy.Write)]
         public bool UpdateUserSMSNumber(string hdid, [FromBody] string smsNumber)
         {
-            return this.userSMSService.UpdateUserSMS(hdid, smsNumber);
+            return this.userSmsService.UpdateUserSMS(hdid, smsNumber);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
     using System.Security.Claims;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
+    using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Database.Models;
@@ -52,7 +53,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         public void ShouldGetUserProfile()
         {
             RequestResult<UserProfileModel> expected = this.GetUserProfileExpectedRequestResultMock(ResultType.Success);
-            RequestResult<UserProfileModel> actualResult = this.GetUserProfile(expected, new Dictionary<string, UserPreferenceModel>() { });
+            RequestResult<UserProfileModel> actualResult = this.GetUserProfile(expected, new Dictionary<string, UserPreferenceModel>());
 
             expected.ShouldDeepEqual(actualResult);
         }
@@ -109,7 +110,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest).ConfigureAwait(true);
             expected.ShouldDeepEqual(actualResult.Value);
@@ -151,7 +153,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest).ConfigureAwait(true);
             Assert.IsType<BadRequestResult>(actualResult.Result);
@@ -164,7 +167,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         [Fact]
         public async Task ShouldValidateAge()
         {
-            PrimitiveRequestResult<bool> expected = new() { ResultStatus = ResultType.Success, ResourcePayload = true };
+            PrimitiveRequestResult<bool> expected = new() {ResultStatus = ResultType.Success, ResourcePayload = true};
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
@@ -175,7 +178,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object);
+                new Mock<IUserSMSService>().Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             PrimitiveRequestResult<bool> actualResult = await controller.Validate(this.hdid).ConfigureAwait(true);
 
@@ -316,7 +320,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             RequestResult<TermsOfServiceModel> actualResult = service.GetLastTermsOfService();
             expectedResult.ShouldDeepEqual(actualResult);
@@ -337,7 +342,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 new Mock<IUserProfileService>().Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                new Mock<IUserSMSService>().Object);
+                new Mock<IUserSMSService>().Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             bool actualResult = controller.UpdateUserEmail(this.hdid, "emailadd@hgw.ca");
 
@@ -367,7 +373,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 new Mock<IUserProfileService>().Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                new Mock<IUserSMSService>().Object);
+                new Mock<IUserSMSService>().Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             ActionResult<PrimitiveRequestResult<bool>> actualResult = await controller.ValidateEmail(this.hdid, Guid.NewGuid()).ConfigureAwait(true);
             Assert.Equal(ResultType.Success, actualResult.Value?.ResultStatus);
@@ -395,7 +402,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 new Mock<IUserProfileService>().Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                new Mock<IUserSMSService>().Object);
+                new Mock<IUserSMSService>().Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             ActionResult<PrimitiveRequestResult<bool>> actualResult = await controller.ValidateEmail(this.hdid, Guid.NewGuid()).ConfigureAwait(true);
             Assert.Equal(ResultType.Error, actualResult.Value?.ResultStatus);
@@ -416,7 +424,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 new Mock<IUserProfileService>().Object,
                 httpContextAccessorMock.Object,
                 new Mock<IUserEmailService>().Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             bool actualResult = controller.UpdateUserSMSNumber(this.hdid, "250 123 456");
             Assert.True(actualResult);
@@ -443,7 +452,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 new Mock<IUserProfileService>().Object,
                 httpContextAccessorMock.Object,
                 new Mock<IUserEmailService>().Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             ActionResult<PrimitiveRequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSMS(this.hdid, "205 123 4567").ConfigureAwait(true)).Result;
 
@@ -473,7 +483,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 new Mock<IUserProfileService>().Object,
                 httpContextAccessorMock.Object,
                 new Mock<IUserEmailService>().Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             ActionResult<PrimitiveRequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSMS(this.hdid, "205 123 4567").ConfigureAwait(true)).Result;
 
@@ -501,7 +512,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 new Mock<IUserEmailService>().Object,
-                new Mock<IUserSMSService>().Object);
+                new Mock<IUserSMSService>().Object,
+                new Mock<IAuthenticationDelegate>().Object);
 
             RequestResult<UserProfileModel> actualResult = controller.UpdateAcceptedTerms(this.hdid, Guid.Empty);
             expected.ShouldDeepEqual(actualResult);
@@ -511,8 +523,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         {
             IHeaderDictionary headerDictionary = new HeaderDictionary
             {
-                { "Authorization", token },
-                { "referer", "http://localhost/" },
+                {"Authorization", token},
+                {"referer", "http://localhost/"},
             };
             Mock<HttpRequest> httpRequestMock = new();
             httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
@@ -535,10 +547,11 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             httpContextAccessorMock.Setup(s => s.HttpContext).Returns(httpContextMock.Object);
             Mock<IAuthenticationService> authenticationMock = new();
             AuthenticateResult authResult = AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, JwtBearerDefaults.AuthenticationScheme));
-            authResult.Properties.StoreTokens(new[]
-            {
-                new AuthenticationToken { Name = "access_token", Value = token },
-            });
+            authResult.Properties.StoreTokens(
+                new[]
+                {
+                    new AuthenticationToken {Name = "access_token", Value = token},
+                });
             authenticationMock
                 .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))
                 .ReturnsAsync(authResult);
@@ -574,7 +587,10 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             Mock<IUserProfileService> userProfileServiceMock = new();
             userProfileServiceMock.Setup(s => s.GetUserProfile(this.hdid, It.IsAny<DateTime>())).Returns(expected);
             userProfileServiceMock.Setup(s => s.GetActiveTermsOfService()).Returns(new RequestResult<TermsOfServiceModel>());
-            userProfileServiceMock.Setup(s => s.GetUserPreferences(this.hdid)).Returns(new RequestResult<Dictionary<string, UserPreferenceModel>>() { ResourcePayload = userPreferencePayloadMock });
+            userProfileServiceMock.Setup(s => s.GetUserPreferences(this.hdid))
+                .Returns(
+                    new RequestResult<Dictionary<string, UserPreferenceModel>>
+                        {ResourcePayload = userPreferencePayloadMock});
 
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSMSService> smsServiceMock = new();
@@ -584,7 +600,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
             return service.GetUserProfile(this.hdid);
         }
 
@@ -610,7 +627,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
             return service.UpdateUserPreference(this.hdid, userPref);
         }
 
@@ -636,7 +654,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
-                smsServiceMock.Object);
+                smsServiceMock.Object,
+                new Mock<IAuthenticationDelegate>().Object);
             return service.CreateUserPreference(this.hdid, userPref);
         }
     }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -167,7 +167,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         [Fact]
         public async Task ShouldValidateAge()
         {
-            PrimitiveRequestResult<bool> expected = new() {ResultStatus = ResultType.Success, ResourcePayload = true};
+            PrimitiveRequestResult<bool> expected = new() { ResultStatus = ResultType.Success, ResourcePayload = true };
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
@@ -523,8 +523,8 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         {
             IHeaderDictionary headerDictionary = new HeaderDictionary
             {
-                {"Authorization", token},
-                {"referer", "http://localhost/"},
+                { "Authorization", token },
+                { "referer", "http://localhost/" },
             };
             Mock<HttpRequest> httpRequestMock = new();
             httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
@@ -550,7 +550,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             authResult.Properties.StoreTokens(
                 new[]
                 {
-                    new AuthenticationToken {Name = "access_token", Value = token},
+                    new AuthenticationToken { Name = "access_token", Value = token },
                 });
             authenticationMock
                 .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))
@@ -590,7 +590,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             userProfileServiceMock.Setup(s => s.GetUserPreferences(this.hdid))
                 .Returns(
                     new RequestResult<Dictionary<string, UserPreferenceModel>>
-                        {ResourcePayload = userPreferencePayloadMock});
+                        { ResourcePayload = userPreferencePayloadMock });
 
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSMSService> smsServiceMock = new();


### PR DESCRIPTION
# Implements [AB#13909](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13909)

## Description

1. Refactored CloseUserProfile to use AuthenticationDelegate in UserProfileController
2. Fixed variable naming convention warning in UserProfileController
3. Updated UserProfileController unit tests
4. Updated Logger creation warning in Authentication Unit tests
5. Rider auto formatted Authentication Delegate unit tests

<img width="2471" alt="Screen Shot 2022-09-12 at 2 15 37 PM" src="https://user-images.githubusercontent.com/58790456/189761446-1e95c51d-e0ad-440d-9b18-572076af97b0.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
