### PR TITLE
Add error handling for downloading reports for AB#13757

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -374,6 +374,18 @@ export default class DependentCardComponent extends Vue {
                         )
                 );
             })
+            .catch((err: ResultError) => {
+                this.logger.error(err.resultMessage);
+                if (err.statusCode === 429) {
+                    this.setTooManyRequestsError({ key: "page" });
+                } else {
+                    this.addError({
+                        errorType: ErrorType.Download,
+                        source: ErrorSourceType.DependentImmunizationReport,
+                        traceId: err.traceId,
+                    });
+                }
+            })
             .finally(() => {
                 this.isReportDownloading = false;
             });

--- a/Apps/WebClient/src/ClientApp/src/constants/errorType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/errorType.ts
@@ -28,4 +28,6 @@ export enum ErrorSourceType {
     TermsOfService = "terms of service",
     TestKit = "test kit",
     QuickLinks = "quick links",
+    DependentImmunizationReport = "Dependent Immunization Report",
+    ExportRecords = "Export Records",
 }


### PR DESCRIPTION
# Implements [AB#13757](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13757)

## Description

1. Add error handling  for [AB#13757](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13757) when downloading reports from dependent immunization tab.
2. Add error handling for [AB#13757](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13757) when downloading reports from export records.
3. Add functional tests for [AB#13894](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13894) to check 'too many requests' and non 'too many requests' error when downloading report from dependent immunization tab.
4. Add functional tests for [AB#13894](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13894) to check 'too many requests' and non 'too many requests' error when downloading report from export records.

<img width="1317" alt="Screen Shot 2022-09-13 at 3 34 00 PM" src="https://user-images.githubusercontent.com/58790456/190022418-ae57bcf9-8dae-4396-b969-72c157ad6508.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
