### PR TITLE
Update popovers on lab result timeline cards AB#13528

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -955,6 +955,7 @@ export default class DependentCardComponent extends Vue {
                                         "
                                         triggers="hover focus"
                                         placement="bottomleft"
+                                        boundary="viewport"
                                         data-testid="dependent-covid-test-info-popover"
                                     >
                                         <Covid19LaboratoryTestDescriptionComponent

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
@@ -269,6 +269,7 @@ export default class FilterComponent extends Vue {
                 data-testid="filterContainer"
                 placement="bottom"
                 fallback-placement="clockwise"
+                boundary="viewport"
                 menu-class="z-index-large w-100"
             >
                 <div class="px-1">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -146,11 +146,58 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
             </div>
             <div class="my-2">
                 <div data-testid="reporting-lab-information-text">
-                    <span
-                        ><router-link to="/faq">Find resources</router-link> to
-                        learn about your lab test and what the results
-                        mean.</span
+                    <span>Find resources about your lab tests.</span>
+                    <hg-button
+                        :id="`resources-${index}-${datekey}`"
+                        aria-label="Other Resources"
+                        href="#"
+                        variant="link"
+                        data-testid="other-resources-info-button"
+                        class="shadow-none align-baseline p-0 ml-1"
                     >
+                        <hg-icon icon="info-circle" size="small" />
+                    </hg-button>
+                    <b-popover
+                        :target="`resources-${index}-${datekey}`"
+                        triggers="hover focus"
+                        placement="topright"
+                        boundary="viewport"
+                        data-testid="other-resources-info-popover"
+                    >
+                        <p>
+                            Use these websites to learn about specific types of
+                            lab tests:
+                        </p>
+                        <ul class="mb-0">
+                            <li>
+                                <a
+                                    href="https://www.healthlinkbc.ca/tests-treatments-medications/medical-tests"
+                                    target="_blank"
+                                    rel="noopener"
+                                >
+                                    HealthLink BC
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    href="https://www.mayocliniclabs.com/"
+                                    target="_blank"
+                                    rel="noopener"
+                                >
+                                    Mayo Clinic Laboratories
+                                </a>
+                            </li>
+                            <li>
+                                <a
+                                    href="https://www.mypathologyreport.ca/"
+                                    target="_blank"
+                                    rel="noopener"
+                                >
+                                    For pathology tests (like a biopsy)
+                                </a>
+                            </li>
+                        </ul>
+                    </b-popover>
                 </div>
             </div>
             <b-row class="my-3">
@@ -196,6 +243,42 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                         {{ data.value }}
                     </strong>
                 </template>
+                <template #head(result)="data">
+                    <span>{{ data.label }}</span>
+                    <hg-button
+                        :id="`result-info-${index}-${datekey}`"
+                        aria-label="Other Resources"
+                        href="#"
+                        variant="link"
+                        data-testid="result-info-button"
+                        class="shadow-none align-baseline p-0 ml-1"
+                    >
+                        <hg-icon icon="info-circle" size="small" />
+                    </hg-button>
+                    <b-popover
+                        :target="`result-info-${index}-${datekey}`"
+                        triggers="hover focus"
+                        placement="topright"
+                        boundary="viewport"
+                        data-testid="result-info-popover"
+                    >
+                        <p>
+                            Follow the instructions from your health care
+                            provider. When needed, they can explain what your
+                            results mean. Remember:
+                        </p>
+                        <ul class="mb-0">
+                            <li>
+                                <strong>Ranges</strong> are different between
+                                laboratories
+                            </li>
+                            <li>
+                                <strong>“Out of range”</strong> results may be
+                                <strong>normal</strong> for you
+                            </li>
+                        </ul>
+                    </b-popover>
+                </template>
                 <template #cell(status)="data">
                     <span class="mr-1">{{ data.value }}</span>
                     <hg-button
@@ -214,6 +297,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                         :target="getStatusInfoId(entry.labPdfId, data.index)"
                         triggers="hover focus"
                         :placement="isMobileDetails ? 'bottom' : 'left'"
+                        boundary="viewport"
                         :data-testid="`${getStatusInfoId(
                             entry.labPdfId,
                             data.index

--- a/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
@@ -740,6 +740,7 @@ export default class PcrTestView extends Vue {
                                         :target="'pcr-no-phn-info-button'"
                                         triggers="hover focus"
                                         placement="bottomleft"
+                                        boundary="viewport"
                                         data-testid="pcr-no-phn-info-popover"
                                     >
                                         You can find your personal health number
@@ -1011,6 +1012,7 @@ export default class PcrTestView extends Vue {
                                     target="privacy-statement"
                                     triggers="hover focus"
                                     placement="topright"
+                                    boundary="viewport"
                                 >
                                     Your information is being collected to
                                     provide you with your COVID-19 test result

--- a/Apps/WebClient/src/ClientApp/src/views/PublicCovidTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicCovidTestView.vue
@@ -635,6 +635,7 @@ export default class PublicCovidTestView extends Vue {
                         target="privacy-statement"
                         triggers="hover focus"
                         placement="topright"
+                        boundary="viewport"
                     >
                         Your information is being collected to provide you with
                         your COVID-19 test result under s. 26(c) of the

--- a/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
@@ -604,6 +604,7 @@ export default class PublicVaccineCardView extends Vue {
                         target="privacy-statement"
                         triggers="hover focus"
                         placement="topright"
+                        boundary="viewport"
                     >
                         Your information is being collected to provide you with
                         your COVID-19 vaccination status under s. 26(c) of the

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -58,6 +58,18 @@ describe("Laboratory Orders", () => {
                 cy.get("[data-testid=reporting-lab-information-text]").should(
                     "be.visible"
                 );
+                cy.get("[data-testid=other-resources-info-button]")
+                    .should("be.visible")
+                    .click();
+                cy.get("[data-testid=other-resources-info-popover]").should(
+                    "be.visible"
+                );
+                cy.get("[data-testid=result-info-button]")
+                    .should("be.visible")
+                    .click();
+                cy.get("[data-testid=result-info-popover]").should(
+                    "be.visible"
+                );
 
                 cy.log("Verifying partial status");
                 cy.get("[data-testid=laboratoryResultTable]").within(() => {


### PR DESCRIPTION
# Implements [AB#13528](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13528)

## Description

- updates popovers on lab result timeline cards [AB#13889](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13889)
- updates functional tests for lab result timeline cards [AB#13890](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13890)
- fixes potential popover placement issues

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![localhost-2022-09-14-143236](https://user-images.githubusercontent.com/16570293/190267703-0daa8c30-fe2b-4702-9bf7-4c56a1b6ad43.png)

![localhost-2022-09-14-143253](https://user-images.githubusercontent.com/16570293/190267715-49933e3b-a1d9-4faf-807b-696007bc759a.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
