### PR TITLE
Fix Immunization Recommendations for AB#13912.

### DIFF
--- a/Apps/Common/src/Models/PHSA/Recommendation/RecommendationResponse.cs
+++ b/Apps/Common/src/Models/PHSA/Recommendation/RecommendationResponse.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.Models.PHSA.Recommendation
         /// Gets or sets the Target Disease.
         /// </summary>
         [JsonPropertyName("targetDisease")]
-        public TargetDiseaseResponse TargetDisease { get; set; } = new();
+        public TargetDiseaseResponse? TargetDisease { get; set; }
 
         /// <summary>
         /// Gets or sets the Vaccine Code.

--- a/Apps/Immunization/src/MapUtils/ImmunizationRecommendationMapUtils.cs
+++ b/Apps/Immunization/src/MapUtils/ImmunizationRecommendationMapUtils.cs
@@ -39,11 +39,18 @@ namespace HealthGateway.Immunization.MapUtils
         public static IList<ImmunizationRecommendation> FromPHSAModelList(IEnumerable<ImmunizationRecommendationResponse> models, IMapper autoMapper)
         {
             List<ImmunizationRecommendation> recommendations = new();
-            ImmunizationRecommendationResponse? recommendationSet = models.FirstOrDefault();
-            if (recommendationSet != null)
-            {
-                recommendations.AddRange(recommendationSet.Recommendations.Select(model => FromPHSAModel(recommendationSet.RecommendationId, model, autoMapper)));
-            }
+            models.ToList()
+                .ForEach(
+                    model =>
+                    {
+                        string? vaccineGroup = model.Recommendations.FirstOrDefault(r => r.TargetDisease == null)?.VaccineCode.VaccineCodes.FirstOrDefault()?.Display;
+                        List<string> vaccinations = model.Recommendations.Where(r => r.TargetDisease != null).Select(v => v.VaccineCode.VaccineCodeText).ToList();
+                        string recommendedVaccinations = $"{vaccineGroup} ({string.Join(", ", vaccinations)})";
+
+                        recommendations.AddRange(
+                            model.Recommendations.Select(
+                                recommendation => FromPHSAModel(model.RecommendationId, recommendation, autoMapper, recommendedVaccinations)));
+                    });
 
             return recommendations;
         }
@@ -54,8 +61,9 @@ namespace HealthGateway.Immunization.MapUtils
         /// <param name="recommendationSetId">The recommendation set id of the source system.</param>
         /// <param name="model">The recommendation object to convert.</param>
         /// <param name="autoMapper">The automapper to use.</param>
+        /// <param name="recommendedVaccinations">The recommended vaccinations.</param>
         /// <returns>The newly created ImmunizationEvent object.</returns>
-        private static ImmunizationRecommendation FromPHSAModel(string recommendationSetId, RecommendationResponse model, IMapper autoMapper)
+        private static ImmunizationRecommendation FromPHSAModel(string recommendationSetId, RecommendationResponse model, IMapper autoMapper, string recommendedVaccinations)
         {
             DateCriterion? diseaseEligible = model.DateCriterions.FirstOrDefault(x => x.DateCriterionCode.Text == "Forecast by Disease Eligible Date");
             DateCriterion? diseaseDue = model.DateCriterions.FirstOrDefault(x => x.DateCriterionCode.Text == "Forecast by Disease Due Date");
@@ -65,6 +73,7 @@ namespace HealthGateway.Immunization.MapUtils
             IList<TargetDisease> targetDiseases = model.TargetDisease != null ? autoMapper.Map<IList<TargetDisease>>(model.TargetDisease.TargetDiseaseCodes) : new List<TargetDisease>();
             return new ImmunizationRecommendation(targetDiseases)
             {
+                RecommendedVaccinations = model.TargetDisease == null ? recommendedVaccinations : string.Empty,
                 RecommendationSetId = recommendationSetId,
                 DiseaseEligibleDate = diseaseEligible != null ? DateTime.Parse(diseaseEligible.Value, CultureInfo.CurrentCulture) : null,
                 DiseaseDueDate = diseaseDue != null ? DateTime.Parse(diseaseDue.Value, CultureInfo.CurrentCulture) : null,

--- a/Apps/Immunization/src/Models/ImmunizationRecommendation.cs
+++ b/Apps/Immunization/src/Models/ImmunizationRecommendation.cs
@@ -72,6 +72,12 @@ namespace HealthGateway.Immunization.Models
         public string Status { get; set; } = string.Empty;
 
         /// <summary>
+        /// Gets or sets the Recommended Vaccinations.
+        /// </summary>
+        [JsonPropertyName("recommendedVaccinations")]
+        public string RecommendedVaccinations { get; set; } = string.Empty;
+
+        /// <summary>
         /// Gets the Target Diseases.
         /// </summary>
         [JsonPropertyName("targetDiseases")]

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
@@ -38,16 +39,16 @@ namespace HealthGateway.ImmunizationTests.Services.Test
     /// <summary>
     /// ImmunizationService's Unit Tests.
     /// </summary>
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1506:Avoid excessive class coupling", Justification = "Unit Test")]
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out", Justification = "Ignore broken tests")]
+    [SuppressMessage("Design", "CA1506:Avoid excessive class coupling", Justification = "Unit Test")]
+    [SuppressMessage("Major Code Smell", "S125:Sections of code should not be commented out", Justification = "Ignore broken tests")]
     public class ImmunizationServiceTests
     {
-        private readonly string recomendationSetId = "set-recomendation-id";
-        private readonly string diseaseEligibleDateString = "2021-02-02";
-        private readonly string diseaseName = "Human papillomavirus infection";
-        private readonly string vaccineName = "Human Papillomavirus-HPV9 Vaccine";
         private readonly string antigenName = "HPV-9";
         private readonly IMapper autoMapper = MapperUtil.InitializeAutoMapper();
+        private readonly string diseaseEligibleDateString = "2021-02-02";
+        private readonly string diseaseName = "Human papillomavirus infection";
+        private readonly string recomendationSetId = "set-recomendation-id";
+        private readonly string vaccineName = "Human Papillomavirus-HPV9 Vaccine";
 
         /// <summary>
         /// GetImmunizations - Happy Path.
@@ -59,13 +60,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = new()
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new PhsaResult<ImmunizationResponse>()
+                ResourcePayload = new PhsaResult<ImmunizationResponse>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = false, },
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = false },
                     Result = new ImmunizationResponse(
                         new List<ImmunizationViewResponse>
                         {
-                            new ImmunizationViewResponse()
+                            new()
                             {
                                 Id = Guid.NewGuid(),
                                 Name = "MockImmunization",
@@ -109,10 +111,11 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             RequestResult<PhsaResult<ImmunizationViewResponse>> delegateResult = new()
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new PhsaResult<ImmunizationViewResponse>()
+                ResourcePayload = new PhsaResult<ImmunizationViewResponse>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = false, },
-                    Result = new ImmunizationViewResponse()
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = false },
+                    Result = new ImmunizationViewResponse
                     {
                         Id = Guid.NewGuid(),
                         Name = "MockImmunization",
@@ -146,7 +149,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// GetImmunizations - Happy Path (With Recommendations).
         /// </summary>
         [Fact]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
+        [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
         public void ShouldGetRecommendation()
         {
             ImmunizationRecommendationResponse immzRecommendationResponse = this.GetImmzRecommendationResponse();
@@ -198,7 +201,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = new()
             {
                 ResultStatus = ResultType.Error,
-                ResultError = new RequestResultError()
+                ResultError = new RequestResultError
                 {
                     ResultMessage = "Mock Error",
                     ErrorCode = "MOCK_BAD_ERROR",
@@ -581,12 +584,12 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
         private static RequestResult<PhsaResult<ImmunizationResponse>> GetPHSAResult(ImmunizationRecommendationResponse immzRecommendationResponse)
         {
-            return new RequestResult<PhsaResult<ImmunizationResponse>>()
+            return new RequestResult<PhsaResult<ImmunizationResponse>>
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new PhsaResult<ImmunizationResponse>()
+                ResourcePayload = new PhsaResult<ImmunizationResponse>
                 {
-                    LoadState = new() { RefreshInProgress = false, },
+                    LoadState = new() { RefreshInProgress = false },
                     Result = new(
                         new List<ImmunizationViewResponse>(),
                         new List<ImmunizationRecommendationResponse>
@@ -663,30 +666,38 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             RecommendationResponse recommendationResponse = new();
             recommendationResponse.ForecastStatus.ForecastStatusText = "Eligible";
-            recommendationResponse.TargetDisease.TargetDiseaseCodes.Add(new SystemCode()
+            recommendationResponse.TargetDisease = new()
             {
-                Code = "240532009",
-                CommonType = "DiseaseCode",
-                Display = this.diseaseName,
-                System = "https://ehealthbc.ca/NamingSystem/ca-bc-panorama-immunization-disease-code",
-            });
-            recommendationResponse.VaccineCode.VaccineCodeText = this.vaccineName;
-            recommendationResponse.VaccineCode.VaccineCodes.Add(new SystemCode()
-            {
-                Code = "BCYSCT_AN032",
-                CommonType = "AntiGenCode",
-                Display = this.antigenName,
-                System = "https://ehealthbc.ca/NamingSystem/ca-bc-panorama-immunization-antigen-code",
-            });
-
-            recommendationResponse.DateCriterions.Add(new DateCriterion()
-            {
-                DateCriterionCode = new DateCriterionCode()
+                TargetDiseaseCodes =
                 {
-                    Text = "Forecast by Disease Eligible Date",
+                    new SystemCode
+                    {
+                        Code = "240532009",
+                        CommonType = "DiseaseCode",
+                        Display = this.diseaseName,
+                        System = "https://ehealthbc.ca/NamingSystem/ca-bc-panorama-immunization-disease-code",
+                    },
                 },
-                Value = this.diseaseEligibleDateString,
-            });
+            };
+            recommendationResponse.VaccineCode.VaccineCodeText = this.vaccineName;
+            recommendationResponse.VaccineCode.VaccineCodes.Add(
+                new SystemCode
+                {
+                    Code = "BCYSCT_AN032",
+                    CommonType = "AntiGenCode",
+                    Display = this.antigenName,
+                    System = "https://ehealthbc.ca/NamingSystem/ca-bc-panorama-immunization-antigen-code",
+                });
+
+            recommendationResponse.DateCriterions.Add(
+                new DateCriterion
+                {
+                    DateCriterionCode = new DateCriterionCode
+                    {
+                        Text = "Forecast by Disease Eligible Date",
+                    },
+                    Value = this.diseaseEligibleDateString,
+                });
 
             immzRecommendationResponse.Recommendations.Add(recommendationResponse);
             return immzRecommendationResponse;

--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -271,11 +271,11 @@ export default class DependentCardComponent extends Vue {
 
     private get recommendationItems(): RecommendationRow[] {
         return this.recommendations.map<RecommendationRow>((x) => ({
-            immunization: x.targetDiseases.find((y) => y.name)?.name ?? "",
+            immunization: x.recommendedVaccinations,
             due_date:
-                x.diseaseDueDate === undefined || x.diseaseDueDate === null
+                x.agentDueDate === undefined || x.agentDueDate === null
                     ? ""
-                    : DateWrapper.format(x.diseaseDueDate),
+                    : DateWrapper.format(x.agentDueDate),
             status: x.status || "",
         }));
     }
@@ -639,8 +639,8 @@ export default class DependentCardComponent extends Vue {
     }
 
     private setRecommendations(recommendations: Recommendation[]): void {
-        this.recommendations = recommendations.filter((x) =>
-            x.targetDiseases.some((y) => y.name)
+        this.recommendations = recommendations.filter(
+            (x) => x.recommendedVaccinations
         );
 
         this.recommendations.sort((a, b) => {

--- a/Apps/WebClient/src/ClientApp/src/components/report/ImmunizationHistoryReportComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/ImmunizationHistoryReportComponent.vue
@@ -104,8 +104,8 @@ export default class ImmunizationHistoryReportComponent extends Vue {
     }
 
     private get visibleRecomendations(): Recommendation[] {
-        let records = this.patientRecommendations.filter((x) =>
-            x.targetDiseases.some((y) => y.name)
+        let records = this.patientRecommendations.filter(
+            (x) => x.recommendedVaccinations
         );
 
         records.sort((a, b) => {
@@ -144,12 +144,15 @@ export default class ImmunizationHistoryReportComponent extends Vue {
     }
 
     private get recomendationItems(): RecomendationRow[] {
+        this.logger.debug(
+            "Recoomendations: " + JSON.stringify(this.visibleRecomendations)
+        );
         return this.visibleRecomendations.map<RecomendationRow>((x) => ({
-            immunization: x.targetDiseases.find((y) => y.name)?.name ?? "",
+            immunization: x.recommendedVaccinations,
             due_date:
-                x.diseaseDueDate === undefined || x.diseaseDueDate === null
+                x.agentDueDate === undefined || x.agentDueDate === null
                     ? ""
-                    : DateWrapper.format(x.diseaseDueDate),
+                    : DateWrapper.format(x.agentDueDate),
             status: x.status || "",
         }));
     }

--- a/Apps/WebClient/src/ClientApp/src/models/immunizationModel.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/immunizationModel.ts
@@ -28,6 +28,7 @@ export interface ImmunizationEvent {
 }
 
 export interface Recommendation {
+    recommendedVaccinations: string;
     recommendationSetId: string;
     diseaseEligibleDate?: StringISODate;
     diseaseDueDate?: StringISODate;


### PR DESCRIPTION
# Fixes [AB#13912](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13912)

## Description

Also fixes [AB#13935](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13935)

1. Changed ImmunizationRecommendationMapUtils to process all recommendation sets being returned from PHSA. Before only group/parent and vaccination row were being returned - 2 rows.  Now 2 rows times x number recommendation sets will be returned in the API call.
2. Added a 'recommendedVaccination' attribute to response. This will contain the vaccination group followed by vaccinations in brackets.
3. These changes affect dependent immunization forecast and export records for immunization
4. Updated unit tests

**Dependent Immunization:**

<img width="1279" alt="Screen Shot 2022-09-16 at 11 47 18 AM" src="https://user-images.githubusercontent.com/58790456/190712675-bf5877c6-1926-4f10-9256-8f41f94bf483.png">

<img width="1734" alt="Screen Shot 2022-09-16 at 11 49 28 AM" src="https://user-images.githubusercontent.com/58790456/190712759-95d51afa-85c4-4379-9ebf-02a9828945e9.png">

**Export Records Immunization**

<img width="2532" alt="Screen Shot 2022-09-16 at 11 47 59 AM" src="https://user-images.githubusercontent.com/58790456/190712721-fe68e28c-8c81-4dba-a401-11e32093ebad.png">

<img width="1406" alt="Screen Shot 2022-09-16 at 11 49 13 AM" src="https://user-images.githubusercontent.com/58790456/190712841-9e450dc0-674d-4f81-8d19-181b3530b174.png">

**Unit Tests**

<img width="1286" alt="Screen Shot 2022-09-16 at 12 34 22 PM" src="https://user-images.githubusercontent.com/58790456/190716903-d2a1c427-e821-48ee-9346-60149cfd9d4d.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
