### PR TITLE
Fix immunization recommendation sorting for AB#13945

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -645,9 +645,9 @@ export default class DependentCardComponent extends Vue {
 
         this.recommendations.sort((a, b) => {
             const firstDateEmpty =
-                a.diseaseDueDate === null || a.diseaseDueDate === undefined;
+                a.agentDueDate === null || a.agentDueDate === undefined;
             const secondDateEmpty =
-                b.diseaseDueDate === null || b.diseaseDueDate === undefined;
+                b.agentDueDate === null || b.agentDueDate === undefined;
 
             if (firstDateEmpty && secondDateEmpty) {
                 return 0;
@@ -661,15 +661,15 @@ export default class DependentCardComponent extends Vue {
                 return -1;
             }
 
-            const firstDate = new DateWrapper(a.diseaseDueDate);
-            const secondDate = new DateWrapper(b.diseaseDueDate);
+            const firstDate = new DateWrapper(a.agentDueDate);
+            const secondDate = new DateWrapper(b.agentDueDate);
 
             if (firstDate.isBefore(secondDate)) {
-                return -1;
+                return 1;
             }
 
             if (firstDate.isAfter(secondDate)) {
-                return 1;
+                return -1;
             }
 
             return 0;

--- a/Testing/functional/tests/cypress/fixtures/ImmunizationService/dependentImmunization.json
+++ b/Testing/functional/tests/cypress/fixtures/ImmunizationService/dependentImmunization.json
@@ -3,6 +3,48 @@
         "loadState": {
             "refreshInProgress": false
         },
+        "immunizations": [
+            {
+                "id": "27edc2b5-4257-4291-ccff-08da85ecee53",
+                "dateOfImmunization": "2022-01-07T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": "Burnaby",
+                "targetedDisease": "COVID19",
+                "immunization": {
+                    "name": "COVID-19 mRNA",
+                    "immunizationAgents": [
+                        {
+                            "code": "1119349007",
+                            "name": "COVID-19 mRNA",
+                            "lotNumber": null,
+                            "productName": "Pfizer Pediatric 10mcg COMIRNATY"
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "e7d297ae-27b9-456b-cd00-08da85ecee53",
+                "dateOfImmunization": "2021-04-01T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Human Papillomavirus-HPV2",
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AG080",
+                            "name": "HPV-2",
+                            "lotNumber": null,
+                            "productName": "Cervarix"
+                        }
+                    ]
+                },
+                "forecast": null
+            }
+        ],
         "recommendations": [
             {
                 "recommendationSetId": "50001020_168682388",
@@ -35,7 +77,7 @@
                 "diseaseEligibleDate": null,
                 "diseaseDueDate": null,
                 "agentEligibleDate": "2011-08-20T00:00:00",
-                "agentDueDate": "2011-08-20T00:00:00",
+                "agentDueDate": null,
                 "status": "Overdue",
                 "recommendedVaccinations": "Men-C-C (Meningococcal-C Conjugate)",
                 "targetDiseases": [],
@@ -50,48 +92,356 @@
                         }
                     ]
                 }
-            }
-        ],
-        "immunizations": [
+            },
             {
-                "id": "3209587_54397520",
-                "name": "COVID-19",
-                "dateOfImmunization": "2013-09-20T00:00:00",
-                "status": "Completed",
-                "valid": true,
-                "targetedDisease": "Covid",
-                "providerOrClinic": "Island Health",
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "36653000",
+                        "name": "Rubella"
+                    }
+                ],
                 "immunization": {
-                    "name": "Mocked Name",
+                    "name": "Rubella",
                     "immunizationAgents": [
                         {
-                            "code": "414003004",
-                            "name": "DTaP-IPV",
-                            "lotNumber": "123456",
-                            "productName": "COVID"
-                        },
-                        {
-                            "code": "777003004",
-                            "name": "Agent 1",
-                            "lotNumber": "1234567789",
-                            "productName": "COVID 2"
+                            "code": "120998006",
+                            "name": "Rubella",
+                            "lotNumber": "",
+                            "productName": ""
                         }
                     ]
-                },
-                "forecast": {
-                    "recomendationId": "",
-                    "createDate": "0001-01-01T00:00:00",
-                    "status": "Eligible",
-                    "displayName": "Covid-191",
-                    "eligibleDate": "0001-01-01T00:00:00",
-                    "dueDate": "2021-01-31T00:00:00-08:00"
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "36989005",
+                        "name": "Mumps"
+                    }
+                ],
+                "immunization": {
+                    "name": "Mumps",
+                    "immunizationAgents": [
+                        {
+                            "code": "121087003",
+                            "name": "Mumps",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "14189004",
+                        "name": "Measles"
+                    }
+                ],
+                "immunization": {
+                    "name": "Measles",
+                    "immunizationAgents": [
+                        {
+                            "code": "121030007",
+                            "name": "Measles",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2014-08-20T00:00:00",
+                "diseaseDueDate": "2014-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "38907003",
+                        "name": "Varicella"
+                    }
+                ],
+                "immunization": {
+                    "name": "Chickenpox (Varicella)",
+                    "immunizationAgents": [
+                        {
+                            "code": "121005009",
+                            "name": "Varicella",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2014-08-20T00:00:00",
+                "agentDueDate": "2014-08-20T00:00:00",
+                "status": "Overdue",
+                "recommendedVaccinations": "MMRV (Rubella, Mumps, Measles, Chickenpox (Varicella))",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "419550004",
+                            "name": "MMRV",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682389",
+                "diseaseEligibleDate": "2021-04-20T00:00:00",
+                "diseaseDueDate": "2021-04-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Due",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "66071002",
+                        "name": "Hepatitis B"
+                    }
+                ],
+                "immunization": {
+                    "name": "Hepatitis B",
+                    "immunizationAgents": [
+                        {
+                            "code": "303233001",
+                            "name": "HB",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682389",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2021-04-20T00:00:00",
+                "agentDueDate": "2021-04-20T00:00:00",
+                "status": "Due",
+                "recommendedVaccinations": "HB (Hepatitis B)",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "SCT_AG0004",
+                            "name": "HB",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "76902006",
+                        "name": "Tetanus"
+                    }
+                ],
+                "immunization": {
+                    "name": "Tetanus",
+                    "immunizationAgents": [
+                        {
+                            "code": "412375000",
+                            "name": "Tetanus",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "398102009",
+                        "name": "Poliomyelitis"
+                    }
+                ],
+                "immunization": {
+                    "name": "Polio",
+                    "immunizationAgents": [
+                        {
+                            "code": "125688000",
+                            "name": "Polio",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "27836007",
+                        "name": "Pertussis"
+                    }
+                ],
+                "immunization": {
+                    "name": "Pertussis",
+                    "immunizationAgents": [
+                        {
+                            "code": "SCT_AN0012",
+                            "name": "Pertussis",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "397428000",
+                        "name": "Diphtheria"
+                    }
+                ],
+                "immunization": {
+                    "name": "Diphtheria",
+                    "immunizationAgents": [
+                        {
+                            "code": "SCT_AN0061",
+                            "name": "Diphtheria-d",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2017-08-20T00:00:00",
+                "agentDueDate": "2017-08-20T00:00:00",
+                "status": "Overdue",
+                "recommendedVaccinations": "Tdap-IPV (Tetanus, Polio, Pertussis, Diphtheria)",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AG066",
+                            "name": "Tdap-IPV",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682391",
+                "diseaseEligibleDate": "2021-08-29T00:00:00",
+                "diseaseDueDate": "2021-10-01T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "240532009",
+                        "name": "Human papillomavirus infection"
+                    }
+                ],
+                "immunization": {
+                    "name": "Human Papillomavirus-HPV9",
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AN032",
+                            "name": "HPV-9",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682391",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2021-08-29T00:00:00",
+                "agentDueDate": "2021-10-01T00:00:00",
+                "status": "Overdue",
+                "recommendedVaccinations": "HPV-9 (Human Papillomavirus-HPV9)",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AG082",
+                            "name": "HPV-9",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
                 }
             }
         ]
     },
-    "totalResultCount": 9,
-    "pageIndex": 0,
-    "pageSize": 25,
+    "totalResultCount": 1,
+    "pageIndex": null,
+    "pageSize": 0,
     "resultStatus": 1,
     "resultError": null
 }

--- a/Testing/functional/tests/cypress/fixtures/Report/immunizationUnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/immunizationUnSorted.json
@@ -67,20 +67,46 @@
         ],
         "recommendations": [
             {
-                "recommendationSetId": "5513119_138378891",
-                "disseaseEligibleDate": "2020-12-30T00:00:00",
-                "diseaseDueDate": "2021-02-02T00:00:00",
+                "recommendationSetId": "50001020_168682389",
+                "diseaseEligibleDate": "2021-04-20T00:00:00",
+                "diseaseDueDate": "2021-04-20T00:00:00",
                 "agentEligibleDate": null,
                 "agentDueDate": null,
-                "status": "Eligible",
-                "recommendedVaccinations": "COVID-19 mRNA ()",
+                "status": "Due",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "66071002",
+                        "name": "Hepatitis B"
+                    }
+                ],
+                "immunization": {
+                    "name": "Hepatitis B",
+                    "immunizationAgents": [
+                        {
+                            "code": "303233001",
+                            "name": "HB",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682389",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2021-04-20T00:00:00",
+                "agentDueDate": null,
+                "status": "Due",
+                "recommendedVaccinations": "HB (Hepatitis B)",
                 "targetDiseases": [],
                 "immunization": {
                     "name": null,
                     "immunizationAgents": [
                         {
-                            "code": "1119349007",
-                            "name": "COVID-19 mRNA",
+                            "code": "SCT_AG0004",
+                            "name": "HB",
                             "lotNumber": "",
                             "productName": ""
                         }
@@ -88,25 +114,25 @@
                 }
             },
             {
-                "recommendationSetId": "5513119_138378891",
-                "disseaseEligibleDate": "2020-12-30T00:00:00",
-                "diseaseDueDate": "2021-02-02T00:00:00",
+                "recommendationSetId": "50001020_168682388",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
                 "agentEligibleDate": null,
                 "agentDueDate": null,
-                "status": "Eligible",
+                "status": "Overdue",
                 "recommendedVaccinations": "",
                 "targetDiseases": [
                     {
-                        "code": "186747009",
-                        "name": "Coronavirus infection"
+                        "code": "BCY_DIS163",
+                        "name": "Meningococcal disease (invasive)"
                     }
                 ],
                 "immunization": {
-                    "name": null,
+                    "name": "Meningococcal-C Conjugate",
                     "immunizationAgents": [
                         {
-                            "code": "840536004",
-                            "name": "COVID-19 mRNA",
+                            "code": "SCT_AN0010",
+                            "name": "Men-C-C",
                             "lotNumber": "",
                             "productName": ""
                         }
@@ -114,46 +140,20 @@
                 }
             },
             {
-                "recommendationSetId": "5513119_138378894",
-                "disseaseEligibleDate": "2020-11-30T00:00:00",
-                "diseaseDueDate": "2021-04-02T00:00:00",
-                "agentEligibleDate": "2020-11-30T00:00:00",
-                "agentDueDate": "2022-11-30T00:00:00",
-                "status": "Eligible",
-                "recommendedVaccinations": "",
-                "targetDiseases": [
-                    {
-                        "code": "240532009",
-                        "name": "Human papillomavirus infection"
-                    }
-                ],
-                "immunization": {
-                    "name": "Human Papillomavirus-HPV9",
-                    "immunizationAgents": [
-                        {
-                            "code": "BCYSCT_AN032",
-                            "name": "HPV-9",
-                            "lotNumber": "",
-                            "productName": ""
-                        }
-                    ]
-                }
-            },
-            {
-                "recommendationSetId": "5513119_138378894",
-                "disseaseEligibleDate": "2020-11-30T00:00:00",
-                "diseaseDueDate": "2021-04-02T00:00:00",
-                "agentEligibleDate": "2020-11-30T00:00:00",
-                "agentDueDate": "2022-11-30T00:00:00",
-                "status": "Eligible",
-                "recommendedVaccinations": "HPV-9 (Human Papillomavirus-HPV9)",
+                "recommendationSetId": "50001020_168682388",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2011-08-20T00:00:00",
+                "agentDueDate": "2011-08-20T00:00:00",
+                "status": "Overdue",
+                "recommendedVaccinations": "Men-C-C (Meningococcal-C Conjugate)",
                 "targetDiseases": [],
                 "immunization": {
                     "name": null,
                     "immunizationAgents": [
                         {
-                            "code": "BCYSCT_AG082",
-                            "name": "HPV-9",
+                            "code": "359068008",
+                            "name": "Men-C-C",
                             "lotNumber": "",
                             "productName": ""
                         }
@@ -161,12 +161,215 @@
                 }
             },
             {
-                "recommendationSetId": "5513119_138378894",
-                "disseaseEligibleDate": "2020-11-30T00:00:00",
-                "diseaseDueDate": "2021-06-02T00:00:00",
-                "agentEligibleDate": "2020-11-30T00:00:00",
-                "agentDueDate": "2020-11-30T00:00:00",
-                "status": "Eligible",
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "36653000",
+                        "name": "Rubella"
+                    }
+                ],
+                "immunization": {
+                    "name": "Rubella",
+                    "immunizationAgents": [
+                        {
+                            "code": "120998006",
+                            "name": "Rubella",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "36989005",
+                        "name": "Mumps"
+                    }
+                ],
+                "immunization": {
+                    "name": "Mumps",
+                    "immunizationAgents": [
+                        {
+                            "code": "121087003",
+                            "name": "Mumps",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2011-08-20T00:00:00",
+                "diseaseDueDate": "2011-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "14189004",
+                        "name": "Measles"
+                    }
+                ],
+                "immunization": {
+                    "name": "Measles",
+                    "immunizationAgents": [
+                        {
+                            "code": "121030007",
+                            "name": "Measles",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": "2014-08-20T00:00:00",
+                "diseaseDueDate": "2014-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "38907003",
+                        "name": "Varicella"
+                    }
+                ],
+                "immunization": {
+                    "name": "Chickenpox (Varicella)",
+                    "immunizationAgents": [
+                        {
+                            "code": "121005009",
+                            "name": "Varicella",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682386",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2014-08-20T00:00:00",
+                "agentDueDate": "2014-08-20T00:00:00",
+                "status": "Overdue",
+                "recommendedVaccinations": "MMRV (Rubella, Mumps, Measles, Chickenpox (Varicella))",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "419550004",
+                            "name": "MMRV",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "76902006",
+                        "name": "Tetanus"
+                    }
+                ],
+                "immunization": {
+                    "name": "Tetanus",
+                    "immunizationAgents": [
+                        {
+                            "code": "412375000",
+                            "name": "Tetanus",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "398102009",
+                        "name": "Poliomyelitis"
+                    }
+                ],
+                "immunization": {
+                    "name": "Polio",
+                    "immunizationAgents": [
+                        {
+                            "code": "125688000",
+                            "name": "Polio",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "27836007",
+                        "name": "Pertussis"
+                    }
+                ],
+                "immunization": {
+                    "name": "Pertussis",
+                    "immunizationAgents": [
+                        {
+                            "code": "SCT_AN0012",
+                            "name": "Pertussis",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": "2017-08-20T00:00:00",
+                "diseaseDueDate": "2017-08-20T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
                 "recommendedVaccinations": "",
                 "targetDiseases": [
                     {
@@ -187,12 +390,12 @@
                 }
             },
             {
-                "recommendationSetId": "5513119_138378894",
-                "disseaseEligibleDate": "2020-11-30T00:00:00",
-                "diseaseDueDate": "2021-06-02T00:00:00",
-                "agentEligibleDate": "2020-11-30T00:00:00",
-                "agentDueDate": "2020-11-30T00:00:00",
-                "status": "Eligible",
+                "recommendationSetId": "50001020_168682387",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2017-08-20T00:00:00",
+                "agentDueDate": "2017-08-20T00:00:00",
+                "status": "Overdue",
                 "recommendedVaccinations": "Tdap-IPV (Tetanus, Polio, Pertussis, Diphtheria)",
                 "targetDiseases": [],
                 "immunization": {
@@ -206,12 +409,59 @@
                         }
                     ]
                 }
+            },
+            {
+                "recommendationSetId": "50001020_168682391",
+                "diseaseEligibleDate": "2021-08-29T00:00:00",
+                "diseaseDueDate": "2021-10-01T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "recommendedVaccinations": "",
+                "targetDiseases": [
+                    {
+                        "code": "240532009",
+                        "name": "Human papillomavirus infection"
+                    }
+                ],
+                "immunization": {
+                    "name": "Human Papillomavirus-HPV9",
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AN032",
+                            "name": "HPV-9",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "50001020_168682391",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2021-08-29T00:00:00",
+                "agentDueDate": "2021-10-01T00:00:00",
+                "status": "Overdue",
+                "recommendedVaccinations": "HPV-9 (Human Papillomavirus-HPV9)",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AG082",
+                            "name": "HPV-9",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
             }
         ]
     },
-    "totalResultCount": 3,
-    "pageIndex": 0,
-    "pageSize": 25,
+    "totalResultCount": 1,
+    "pageIndex": null,
+    "pageSize": 0,
     "resultStatus": 1,
     "resultError": null
 }

--- a/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
@@ -1,6 +1,10 @@
 const { AuthMethod } = require("../../../support/constants");
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 
+function getDueDate(value) {
+    return new Date(value && value.trim().length !== 0 ? value.trim() : 0);
+}
+
 describe("Reports - Medication", () => {
     beforeEach(() => {
         cy.enableModules([
@@ -51,33 +55,56 @@ describe("Reports - Medication", () => {
             });
     });
 
-    it("Validate Medication Request Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/MedicationRequest/${HDID}`, {
-            fixture: "Report/medicationRequestUnSorted.json",
+    it("Validate Immunization Report with Unsorted Data", () => {
+        cy.intercept("GET", `**/Immunization?hdid=${HDID}`, {
+            fixture: "Report/immunizationUnSorted.json",
         });
-        cy.get("[data-testid=reportType]").select("Special Authority Requests");
+        cy.get("[data-testid=reportType]").select("Immunizations");
 
         cy.get("[data-testid=reportSample]").should("be.visible");
 
-        cy.get("[data-testid=medicationRequestDateItem]")
+        cy.get("[data-testid=immunizationDateItem]")
             .first()
             .then(($dateItem) => {
                 // Column date in the 1st row in the table
                 const firstDate = new Date($dateItem.text().trim());
-                cy.get("[data-testid=medicationRequestDateItem]")
+                cy.get("[data-testid=immunizationDateItem]")
                     .eq(1)
                     .then(($dateItem) => {
                         // Column date in the 2nd row in the table
                         const secondDate = new Date($dateItem.text().trim());
                         expect(firstDate).to.be.gte(secondDate);
                         // Column date in the last row in the table
-                        cy.get("[data-testid=medicationRequestDateItem]")
+                        cy.get("[data-testid=immunizationDateItem]")
                             .eq(2)
                             .then(($dateItem) => {
                                 // Column date in the last row in the table
                                 const lastDate = new Date(
                                     $dateItem.text().trim()
                                 );
+                                expect(firstDate).to.be.gte(lastDate);
+                                expect(secondDate).to.be.gte(lastDate);
+                            });
+                    });
+            });
+
+        cy.get("[data-testid=recommendationDateItem]")
+            .first()
+            .then(($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = getDueDate($dateItem.text());
+                cy.get("[data-testid=recommendationDateItem]")
+                    .eq(1)
+                    .then(($dateItem) => {
+                        // Column date in the 2nd row in the table
+                        const secondDate = getDueDate($dateItem.text());
+                        expect(firstDate).to.be.gte(secondDate);
+                        // Column date in the last row in the table
+                        cy.get("[data-testid=recommendationDateItem]")
+                            .eq(4)
+                            .then(($dateItem) => {
+                                // Column date in the last row in the table
+                                const lastDate = getDueDate($dateItem.text());
                                 expect(firstDate).to.be.gte(lastDate);
                                 expect(secondDate).to.be.gte(lastDate);
                             });

--- a/Testing/functional/tests/cypress/integration/ui/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/dependents.js
@@ -4,6 +4,10 @@ const sensitiveDocMessage =
     " The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off. ";
 const validHdid = "645645767756756767";
 
+function getDueDate(value) {
+    return new Date(value && value.trim().length !== 0 ? value.trim() : 0);
+}
+
 describe("COVID-19", () => {
     beforeEach(() => {
         cy.intercept("GET", "**/Laboratory/Covid19Orders*", {
@@ -209,40 +213,51 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
         );
     });
 
-    it("Immunization - History - Tab - Configuration Enabled", () => {
+    it("Immunization - History - Tab - Verify sort and download", () => {
         cy.intercept("GET", "**/Immunization?hdid=*", {
             fixture: "ImmunizationService/dependentImmunization.json",
         });
 
         cy.log("Validating Immunization Tab - configuration enabled");
 
-        cy.get("[data-testid=immunization-tab-title-" + dependentHdid + "]")
+        cy.get(`[data-testid=immunization-tab-title-${dependentHdid}]`)
             .parent()
             .click();
 
         // History tab
         cy.log("Validating History Tab");
+        cy.get(`[data-testid=immunization-tab-div-${dependentHdid}]`).within(
+            () => {
+                cy.contains("a", "History").click();
+            }
+        );
         cy.get(
-            "[data-testid=immunization-tab-div-" + dependentHdid + "]"
-        ).within(() => {
-            cy.contains("a", "History").click();
-        });
-        cy.get(
-            "[data-testid=immunization-history-table-" + dependentHdid + "]"
+            `[data-testid=immunization-history-table-${dependentHdid}]`
         ).should("be.visible");
+
+        // Verify history table has been sorted by due date descending
+        cy.get(
+            `[data-testid=history-immunization-date-${dependentHdid}-0]`
+        ).then(($dateItem) => {
+            // Column date in the 1st row in the table
+            const firstDate = new Date($dateItem.text().trim());
+            cy.get(
+                `[data-testid=history-immunization-date-${dependentHdid}-1]`
+            ).then(($dateItem) => {
+                // Column date in the 2nd row in the table
+                const secondDate = new Date($dateItem.text().trim());
+                expect(firstDate).to.be.gte(secondDate);
+            });
+        });
 
         // Click download dropdown under History tab
         cy.get(
-            "[data-testid=download-immunization-history-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-btn-${dependentHdid}]`
         ).click();
 
         // Click PDF
         cy.get(
-            "[data-testid=download-immunization-history-report-pdf-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-pdf-btn-${dependentHdid}]`
         ).click();
 
         // Confirmation modal
@@ -256,16 +271,12 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
 
         // Click download dropdown
         cy.get(
-            "[data-testid=download-immunization-history-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-btn-${dependentHdid}]`
         ).click();
 
         // Click CSV
         cy.get(
-            "[data-testid=download-immunization-history-report-csv-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-csv-btn-${dependentHdid}]`
         ).click();
 
         // Confirmation modal
@@ -279,16 +290,12 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
 
         // Click download dropdown
         cy.get(
-            "[data-testid=download-immunization-history-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-btn-${dependentHdid}]`
         ).click();
 
         // Click XLSX
         cy.get(
-            "[data-testid=download-immunization-history-report-xlsx-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-xlsx-btn-${dependentHdid}]`
         ).click();
 
         // Confirmation modal
@@ -301,30 +308,51 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
         });
     });
 
-    it("Immunization - Forecast - Tab - Configuration Enabled", () => {
+    it("Immunization - Forecast - Tab - Verify sort and download", () => {
         cy.intercept("GET", "**/Immunization?hdid=*", {
             fixture: "ImmunizationService/dependentImmunization.json",
         });
 
         cy.log("Validating Immunization Tab - configuration enabled");
 
-        cy.get("[data-testid=immunization-tab-title-" + dependentHdid + "]")
+        cy.get(`[data-testid=immunization-tab-title-${dependentHdid}]`)
             .parent()
             .click();
 
         // Click download dropdown under Forecasts tab
         cy.log("Validating Forecasts Tab");
         cy.get(
-            "[data-testid=download-immunization-forecast-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-btn-${dependentHdid}]`
         ).click({ force: true });
+
+        // Verify forecast table has been sorted by due date descending
+
+        cy.get(`[data-testid=forecast-due-date-${dependentHdid}-0]`).then(
+            ($dateItem) => {
+                // Column date in the 1st row in the table
+                const firstDate = getDueDate($dateItem.text());
+                cy.get(
+                    `[data-testid=forecast-due-date-${dependentHdid}-1]`
+                ).then(($dateItem) => {
+                    // Column date in the 2nd row in the table
+                    const secondDate = getDueDate($dateItem.text());
+                    expect(firstDate).to.be.gte(secondDate);
+                    // Column date in the last row in the table
+                    cy.get(
+                        `[data-testid=forecast-due-date-${dependentHdid}-4]`
+                    ).then(($dateItem) => {
+                        // Column date in the last row in the table
+                        const lastDate = getDueDate($dateItem.text());
+                        expect(firstDate).to.be.gte(lastDate);
+                        expect(secondDate).to.be.gte(lastDate);
+                    });
+                });
+            }
+        );
 
         // Click PDF
         cy.get(
-            "[data-testid=download-immunization-forecast-report-pdf-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-pdf-btn-${dependentHdid}]`
         ).click({ force: true });
 
         // Confirmation modal
@@ -338,16 +366,12 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
 
         // Click download dropdown
         cy.get(
-            "[data-testid=download-immunization-forecast-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-btn-${dependentHdid}]`
         ).click({ force: true });
 
         // Click CSV
         cy.get(
-            "[data-testid=download-immunization-forecast-report-csv-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-csv-btn-${dependentHdid}]`
         ).click({ force: true });
 
         // Confirmation modal
@@ -361,16 +385,12 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
 
         // Click download dropdown
         cy.get(
-            "[data-testid=download-immunization-forecast-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-btn-${dependentHdid}]`
         ).click({ force: true });
 
         // Click XLSX
         cy.get(
-            "[data-testid=download-immunization-forecast-report-xlsx-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-xlsx-btn-${dependentHdid}]`
         ).click({ force: true });
 
         // Confirmation modal
@@ -390,33 +410,25 @@ describe("Dependents - Immuniazation Tab - Enabled", () => {
 
         cy.log("Validating Immunization Tab - No Data Found");
 
-        cy.get("[data-testid=immunization-tab-title-" + dependentHdid + "]")
+        cy.get(`[data-testid=immunization-tab-title-${dependentHdid}]`)
             .parent()
             .click();
         cy.get(
-            "[data-testid=immunization-history-no-rows-found-" +
-                dependentHdid +
-                "]"
+            `[data-testid=immunization-history-no-rows-found-${dependentHdid}]`
         ).should("be.visible");
         cy.get(
-            "[data-testid=download-immunization-history-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-history-report-btn-${dependentHdid}]`
         ).should("not.exist");
+        cy.get(`[data-testid=immunization-tab-div-${dependentHdid}]`).within(
+            () => {
+                cy.contains("a", "Forecasts").click();
+            }
+        );
         cy.get(
-            "[data-testid=immunization-tab-div-" + dependentHdid + "]"
-        ).within(() => {
-            cy.contains("a", "Forecasts").click();
-        });
-        cy.get(
-            "[data-testid=immunization-forecast-no-rows-found-" +
-                dependentHdid +
-                "]"
+            `[data-testid=immunization-forecast-no-rows-found-${dependentHdid}]`
         ).should("be.visible");
         cy.get(
-            "[data-testid=download-immunization-forecast-report-btn-" +
-                dependentHdid +
-                "]"
+            `[data-testid=download-immunization-forecast-report-btn-${dependentHdid}]`
         ).should("not.exist");
     });
 });


### PR DESCRIPTION
# Fixes [AB#13945](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13945)

## Description

Fix sorting for dependent immunization forecast tab - descending due date
Fix functional test for export records report for immunization.
Add functional tests for sorting on dependent immunization history and forecast

**Dependent Immunization**

<img width="2553" alt="Screen Shot 2022-09-19 at 3 20 29 PM" src="https://user-images.githubusercontent.com/58790456/191132349-d6aa0a00-0ad4-42c7-8079-d9dad109645e.png">

**Export Records Immunization**

<img width="2540" alt="Screen Shot 2022-09-19 at 3 24 45 PM" src="https://user-images.githubusercontent.com/58790456/191132386-0750afae-4594-4694-8550-2fb25efeeb7a.png">

**Dependent Functional Test**

<img width="1501" alt="Screen Shot 2022-09-19 at 3 28 21 PM" src="https://user-images.githubusercontent.com/58790456/191132455-aa5da61d-a263-49f1-8b14-6187a846407b.png">

**Export Records Immunization Functional Test**

<img width="1493" alt="Screen Shot 2022-09-19 at 3 26 26 PM" src="https://user-images.githubusercontent.com/58790456/191132413-d8f7d3b9-9b59-4255-a341-776feae50cc9.png">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No back logic to sort by due date has been fixed for Dependent Immunization.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
