### PR TITLE
Resolve auth handler calling downstream when token swap fails

### DIFF
--- a/Apps/Common/src/Utils/Phsa/AuthHeaderHandler.cs
+++ b/Apps/Common/src/Utils/Phsa/AuthHeaderHandler.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.Utils.Phsa
             }
             else
             {
-                this.logger.LogError($"Error while retrieving PHSA Token {phsaTokenResponse.ResultError?.ResultMessage}");
+                this.logger.LogError("Error while retrieving PHSA Token {ErrorMessage}", phsaTokenResponse.ResultError?.ResultMessage);
                 throw new HttpRequestException(phsaTokenResponse.ResultError?.ResultMessage);
             }
         }

--- a/Apps/Common/src/Utils/Phsa/AuthHeaderHandler.cs
+++ b/Apps/Common/src/Utils/Phsa/AuthHeaderHandler.cs
@@ -53,13 +53,13 @@ namespace HealthGateway.Common.Utils.Phsa
                 this.logger.LogTrace($"Fetched Token for hdid");
                 string? token = phsaTokenResponse.ResourcePayload?.AccessToken;
                 request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
             }
             else
             {
-                this.logger.LogError($"Error while retrieving PHSA Token {phsaTokenResponse.ResultError}");
+                this.logger.LogError($"Error while retrieving PHSA Token {phsaTokenResponse.ResultError?.ResultMessage}");
+                throw new HttpRequestException(phsaTokenResponse.ResultError?.ResultMessage);
             }
-
-            return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#13954](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13954)

## Description
Fixed the bug when the token swap fails but we continue to call PHSA endpoints.

Unit Tests validated

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
