### PR TITLE
Change invalid dose functional tests to use fixtures for AB#13956

### DIFF
--- a/Testing/functional/tests/cypress.json
+++ b/Testing/functional/tests/cypress.json
@@ -23,7 +23,7 @@
         "keycloak.accountclosure.username": "AccountClosure",
         "keycloak.healthgateway12.username": "healthgateway12",
         "keycloak.hlthgw401.username": "hlthgw401",
-        "keycloak.invaliddoses.username": "hthgtwy20",
+        "keycloak.hthgtwy20.username": "hthgtwy20",
         "keycloak.laboratory.queued.username": "hthgtwy09",
         "keycloak.notfound.username": "hthgtwy03",
         "keycloak.protected.username": "protected",

--- a/Testing/functional/tests/cypress/fixtures/ImmunizationService/immunizationInvalidDoses.json
+++ b/Testing/functional/tests/cypress/fixtures/ImmunizationService/immunizationInvalidDoses.json
@@ -1,0 +1,168 @@
+{
+    "resourcePayload": {
+        "loadState": {
+            "refreshInProgress": false
+        },
+        "immunizations": [
+            {
+                "id": "f7b51d01-16a3-4616-6865-08d99fe36b9e",
+                "dateOfImmunization": "1988-08-08T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Anthrax",
+                    "immunizationAgents": [
+                        {
+                            "code": "333521006",
+                            "name": "Anthrax",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "55e4be9f-33ad-4b52-6866-08d99fe36b9e",
+                "dateOfImmunization": "2000-01-01T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Hepatitis A, Hepatitis B",
+                    "immunizationAgents": [
+                        {
+                            "code": "333702001",
+                            "name": "HAHB",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "e9cc77a4-18ac-458d-6867-08d99fe36b9e",
+                "dateOfImmunization": "2010-10-10T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "NOTSET",
+                "immunization": {
+                    "name": "Chickenpox (Varicella)",
+                    "immunizationAgents": [
+                        {
+                            "code": "412530002",
+                            "name": "Varicella",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "4cf4bebe-c151-4e90-6868-08d99fe36b9e",
+                "dateOfImmunization": "2021-03-30T00:00:00",
+                "status": "Completed",
+                "valid": false,
+                "providerOrClinic": null,
+                "targetedDisease": "COVID19",
+                "immunization": {
+                    "name": "COVID-19",
+                    "immunizationAgents": [
+                        {
+                            "code": "28531000087107",
+                            "name": "COVID-19",
+                            "lotNumber": null,
+                            "productName": null
+                        }
+                    ]
+                },
+                "forecast": null
+            },
+            {
+                "id": "5231285a-ba80-4edc-6869-08d99fe36b9e",
+                "dateOfImmunization": "2021-07-14T00:00:00",
+                "status": "Completed",
+                "valid": true,
+                "providerOrClinic": null,
+                "targetedDisease": "COVID19",
+                "immunization": {
+                    "name": "COVID-19 Non-replicating Viral Vector",
+                    "immunizationAgents": [
+                        {
+                            "code": "29061000087103",
+                            "name": "COVID-19 Non-replicating Viral Vector",
+                            "lotNumber": "4120Z003RN",
+                            "productName": "COVISHIELD"
+                        }
+                    ]
+                },
+                "forecast": {
+                    "recommendationId": "5588012_145363549",
+                    "createDate": "2021-08-18T00:00:00",
+                    "status": "Overdue",
+                    "displayName": "COVID-19 Non-replicating Viral Vector",
+                    "eligibleDate": "2021-08-11T00:00:00",
+                    "dueDate": "2021-08-11T00:00:00"
+                }
+            }
+        ],
+        "recommendations": [
+            {
+                "recommendationSetId": "5588012_145363549",
+                "diseaseEligibleDate": null,
+                "diseaseDueDate": null,
+                "agentEligibleDate": "2021-08-11T00:00:00",
+                "agentDueDate": "2021-08-11T00:00:00",
+                "status": "Overdue",
+                "targetDiseases": [],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "29061000087103",
+                            "name": "COVID-19 Non-replicating Viral Vector",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            },
+            {
+                "recommendationSetId": "5588012_145363549",
+                "diseaseEligibleDate": "2021-08-11T00:00:00",
+                "diseaseDueDate": "2021-08-11T00:00:00",
+                "agentEligibleDate": null,
+                "agentDueDate": null,
+                "status": "Overdue",
+                "targetDiseases": [
+                    {
+                        "code": "186747009",
+                        "name": "Coronavirus infection"
+                    }
+                ],
+                "immunization": {
+                    "name": null,
+                    "immunizationAgents": [
+                        {
+                            "code": "BCYSCT_AN035",
+                            "name": "COVID-19 Non-replicating Viral Vector",
+                            "lotNumber": "",
+                            "productName": ""
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "totalResultCount": 1,
+    "pageIndex": null,
+    "pageSize": 0,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/integration/e2e/report/report.js
+++ b/Testing/functional/tests/cypress/integration/e2e/report/report.js
@@ -229,7 +229,7 @@ describe("Reports - Notes", () => {
         cy.setupDownloads();
         cy.enableModules(["Note"]);
         cy.login(
-            Cypress.env("keycloak.invaliddoses.username"),
+            Cypress.env("keycloak.hthgtwy20.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
             "/reports"

--- a/Testing/functional/tests/cypress/integration/e2e/services/webClient/note.js
+++ b/Testing/functional/tests/cypress/integration/e2e/services/webClient/note.js
@@ -5,7 +5,7 @@ describe("WebClient Note Service", () => {
     beforeEach(() => {
         cy.readConfig().as("config");
         cy.getTokens(
-            Cypress.env("keycloak.invaliddoses.username"),
+            Cypress.env("keycloak.hthgtwy20.username"),
             Cypress.env("keycloak.password")
         ).as("tokens");
     });
@@ -59,8 +59,8 @@ describe("WebClient Note Service", () => {
                 }).should((response) => {
                     expect(response.status).to.eq(200);
                     expect(response.body).to.not.be.null;
-                    expect(response.body.resourcePayload).to.be.an("array").that.is
-                        .not.empty;
+                    expect(response.body.resourcePayload).to.be.an("array").that
+                        .is.not.empty;
                     expect(response.body.totalResultCount).to.eq(3);
                     expect(response.body.resultStatus).to.eq(1);
                     expect(response.body.resultError).to.eq(null);

--- a/Testing/functional/tests/cypress/integration/ui/report/immunizationInvalidDoses.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/immunizationInvalidDoses.js
@@ -1,24 +1,24 @@
 const { AuthMethod } = require("../../../support/constants");
 
-const validDoseDate1 = "2021-Jul-14";
-const invalidDoseDate1 = "2021-Mar-30";
-
 describe("Export Reports - Immunizations - Invalid Doses", () => {
     beforeEach(() => {
-        cy.enableModules("Immunization");
-    });
-
-    it("Immunization Report - Partially Vaccinated 1 Valid Dose and 1 Invalid Dose - Keycloak user", () => {
+        cy.intercept("GET", "**/Immunization?*", {
+            fixture: "ImmunizationService/immunizationInvalidDoses.json",
+        });
+        cy.enableModules(["Immunization"]);
         cy.login(
-            Cypress.env("keycloak.invaliddoses.username"),
+            Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
             "/reports"
         );
+    });
+
+    it("Immunization Report - Partially Vaccinated 1 Valid Dose and 1 Invalid Dose - Keycloak user", () => {
+        const validDoseDate1 = "2021-Jul-14";
+        const invalidDoseDate1 = "2021-Mar-30";
 
         cy.get("[data-testid=reportType]").select("Immunizations");
-
-        cy.get("[data-testid=timelineLoading]").should("be.visible");
 
         cy.get("[data-testid=immunizationDateItem]", { timeout: 60000 })
             .contains(validDoseDate1)

--- a/Testing/functional/tests/cypress/integration/ui/timeline/immunizationInvalidDoses.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/immunizationInvalidDoses.js
@@ -2,9 +2,12 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Timeline - Immunization - Invalid Doses", () => {
     beforeEach(() => {
-        cy.enableModules("Immunization");
+        cy.intercept("GET", "**/Immunization?*", {
+            fixture: "ImmunizationService/immunizationInvalidDoses.json",
+        });
+        cy.enableModules(["Immunization"]);
         cy.login(
-            Cypress.env("keycloak.invaliddoses.username"),
+            Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
             "/timeline"


### PR DESCRIPTION
# Fixes [AB#13956](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13956)

## Description

Change report and timeline invalid dose functional tests to use fixtures instead
Refactor no longer valid keycloak invaliddoses username to something more appropriate
Fixed formatting on note.js

**Report - Invalid doses:**

<img width="1480" alt="Screen Shot 2022-09-21 at 4 41 47 PM" src="https://user-images.githubusercontent.com/58790456/191630139-10a1c463-7f99-4635-baa8-a424f2915dfe.png">

**Timeline - Invalid Doses:**

<img width="1422" alt="Screen Shot 2022-09-21 at 5 01 46 PM" src="https://user-images.githubusercontent.com/58790456/191630421-be87eecd-c752-4bfa-a409-edd80b6321a9.png">

**Note:**

<img width="1530" alt="Screen Shot 2022-09-21 at 4 48 58 PM" src="https://user-images.githubusercontent.com/58790456/191630149-48fe3843-b3bb-487f-ba7b-ab2073444753.png">

**Report:**

<img width="1484" alt="Screen Shot 2022-09-21 at 4 47 40 PM" src="https://user-images.githubusercontent.com/58790456/191630145-68d69853-a8f1-4ce0-bd77-bbf8d8438fc8.png">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
