### PR TITLE
Add Health Visits rolloff warning for AB#13988

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -73,7 +73,6 @@ export default class EncounterTimelineComponent extends Vue {
                         variant="warning"
                         class="no-print mt-3 mb-0"
                         data-testid="encounterRolloffAlert"
-                        @dismissed="showCheckEmailAlert = false"
                     >
                         <span>
                             Health visits are shown for the past 6 years only.

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -25,6 +25,10 @@ export default class EncounterTimelineComponent extends Vue {
     private get entryIcon(): string | undefined {
         return entryTypeMap.get(EntryType.Encounter)?.icon;
     }
+
+    private get showEncounterRolloffAlert(): boolean {
+        return this.entry.showRollOffWarning();
+    }
 }
 </script>
 
@@ -62,6 +66,21 @@ export default class EncounterTimelineComponent extends Vue {
                 </div>
                 <div data-testid="encounterClinicName">
                     {{ entry.clinic.name }}
+                </div>
+                <div>
+                    <b-alert
+                        :show="showEncounterRolloffAlert"
+                        variant="warning"
+                        class="no-print mt-3 mb-0"
+                        data-testid="encounterRolloffAlert"
+                        @dismissed="showCheckEmailAlert = false"
+                    >
+                        <span>
+                            Health visits are shown for the past 6 years only.
+                            You may wish to export and save older records so you
+                            still have them when the calendar year changes.
+                        </span>
+                    </b-alert>
                 </div>
             </b-col>
         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
@@ -1,3 +1,5 @@
+import { Duration } from "luxon";
+
 import { EntryType } from "@/constants/entryType";
 import Clinic from "@/models/clinic";
 import { DateWrapper } from "@/models/dateWrapper";
@@ -39,6 +41,12 @@ export default class EncounterTimelineEntry extends TimelineEntry {
             this.clinic.name;
         text = text.toUpperCase();
         return text.includes(keyword.toUpperCase());
+    }
+
+    public showRollOffWarning(): boolean {
+        const duration = Duration.fromObject({ years: 6 });
+        const warningDate = new DateWrapper().subtract(duration);
+        return this.date.isBeforeOrSame(warningDate);
     }
 }
 


### PR DESCRIPTION
# Fixes or Implements [AB#13988](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13988)

## Description

Added the new warning if Health Visits are >= 6 years old.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/51342761/192028667-6ceccb3a-52f1-4c01-9328-9a1b2191d694.png">


## Notes

Functional Tests to be updated in later task.


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
