### PR TITLE
Add Health Visits rolloff warning for AB#13988 (#4173)

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -25,6 +25,10 @@ export default class EncounterTimelineComponent extends Vue {
     private get entryIcon(): string | undefined {
         return entryTypeMap.get(EntryType.Encounter)?.icon;
     }
+
+    private get showEncounterRolloffAlert(): boolean {
+        return this.entry.showRollOffWarning();
+    }
 }
 </script>
 
@@ -62,6 +66,20 @@ export default class EncounterTimelineComponent extends Vue {
                 </div>
                 <div data-testid="encounterClinicName">
                     {{ entry.clinic.name }}
+                </div>
+                <div>
+                    <b-alert
+                        :show="showEncounterRolloffAlert"
+                        variant="warning"
+                        class="no-print mt-3 mb-0"
+                        data-testid="encounterRolloffAlert"
+                    >
+                        <span>
+                            Health visits are shown for the past 6 years only.
+                            You may wish to export and save older records so you
+                            still have them when the calendar year changes.
+                        </span>
+                    </b-alert>
                 </div>
             </b-col>
         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
@@ -1,3 +1,5 @@
+import { Duration } from "luxon";
+
 import { EntryType } from "@/constants/entryType";
 import Clinic from "@/models/clinic";
 import { DateWrapper } from "@/models/dateWrapper";
@@ -39,6 +41,12 @@ export default class EncounterTimelineEntry extends TimelineEntry {
             this.clinic.name;
         text = text.toUpperCase();
         return text.includes(keyword.toUpperCase());
+    }
+
+    public showRollOffWarning(): boolean {
+        const duration = Duration.fromObject({ years: 6 });
+        const warningDate = new DateWrapper().subtract(duration);
+        return this.date.isBeforeOrSame(warningDate);
     }
 }
 

--- a/Testing/functional/tests/cypress/fixtures/EncounterService/encountersrolloff.json
+++ b/Testing/functional/tests/cypress/fixtures/EncounterService/encountersrolloff.json
@@ -1,0 +1,27 @@
+{
+    "resourcePayload": [
+        {
+            "id": "f57bcb39-64ca-0a17-5477-92ea7f084fbf",
+            "encounterDate": "2022-09-25T00:00:00",
+            "specialtyDescription": "FAMILY MEDICINE",
+            "practitionerName": "ILCVAPPOJ CLPXWG",
+            "clinic": {
+                "name": "FRANCIS N WER WERASDF"
+            }
+        },
+        {
+            "id": "72c2d6c0-b370-24e6-0b5c-04e42b6511c8",
+            "encounterDate": "2010-07-14T00:00:00",
+            "specialtyDescription": "LABORATORY MEDICINE",
+            "practitionerName": "TFWBLV GBXIK LRNSOII",
+            "clinic": {
+                "name": "DAVID WRN WER WERASDF"
+            }
+        }
+    ],
+    "totalResultCount": 2,
+    "pageIndex": 1,
+    "pageSize": 2,
+    "resultStatus": 1,
+    "resultError": null
+}

--- a/Testing/functional/tests/cypress/integration/ui/timeline/encounter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/encounter.js
@@ -1,0 +1,30 @@
+const { AuthMethod } = require("../../../support/constants");
+
+describe("MSP Visits Rolloff", () => {
+    before(() => {
+        cy.intercept("GET", "**/Encounter/*", (req) => {
+            req.reply({
+                fixture: "EncounterService/encountersrolloff.json",
+            });
+        });
+        cy.enableModules("Encounter");
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak
+        );
+        cy.checkTimelineHasLoaded();
+    });
+
+    it("Verify rolloff message not visible", () => {
+        let cards = cy.get("[data-testid=timelineCard");
+        cards.first().click();
+        cy.get("[data-testid=encounterRolloffAlert]").should("not.be.visible");
+    });
+
+    it("Verify rolloff message visible", () => {
+        let cards = cy.get("[data-testid=timelineCard");
+        cards.last().click();
+        cy.get("[data-testid=encounterRolloffAlert]").should("be.visible");
+    });
+});


### PR DESCRIPTION
# Fixes or Implements [AB#13344](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13344)

## Description

Updated UI to display message when Health Visits are nearing rolloff.
Added UI Functional tests to validate the message on and off.


## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

## UI Changes

<img width="1083" alt="image" src="https://user-images.githubusercontent.com/51342761/192028667-6ceccb3a-52f1-4c01-9328-9a1b2191d694.png">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
