### PR TITLE
Clean up table sorting on Admin site AB#14009

### DIFF
--- a/Apps/Admin/Client/Components/CommunicationsTable.razor
+++ b/Apps/Admin/Client/Components/CommunicationsTable.razor
@@ -1,6 +1,13 @@
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<MudTable Class="mt-3" Items="@Rows" Loading="@IsLoading" Breakpoint="@Breakpoint.Md" HorizontalScrollbar="true" Striped="true" Dense="true">
+<MudTable Class="mt-3"
+          Items="@Rows"
+          Loading="@IsLoading"
+          AllowUnsorted="false"
+          Breakpoint="@Breakpoint.Md"
+          HorizontalScrollbar="true"
+          Striped="true"
+          Dense="true">
     <ColGroup>
         <MudHidden Breakpoint="@Breakpoint.MdAndDown">
             <col />
@@ -22,12 +29,13 @@
             </MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel SortBy="new Func<CommunicationRow, object>(x => x.EffectiveDate)" InitialDirection="SortDirection.Descending">
+            <MudTableSortLabel SortBy="new Func<CommunicationRow, object>(x => x.EffectiveDate)"
+                               InitialDirection="@SortDirection.Descending">
                 Effective On
             </MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel SortBy="new Func<CommunicationRow, object>(x => x.ExpiryDate)" InitialDirection="SortDirection.Descending">
+            <MudTableSortLabel SortBy="new Func<CommunicationRow, object>(x => x.ExpiryDate)">
                 Expires On
             </MudTableSortLabel>
         </MudTh>

--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -143,7 +143,15 @@ else
         <MudText Class="mt-3" Typo="Typo.subtitle1">
             <strong>Daily Data</strong>
         </MudText>
-        <MudTable Class="mt-3" Loading="@(RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading)" data-testid="daily-data-table" Items="@TableData" HorizontalScrollbar="true" Striped="true" Dense="true" RowsPerPage="25">
+        <MudTable Class="mt-3"
+                  Loading="@(RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading)"
+                  Items="@TableData"
+                  AllowUnsorted="false"
+                  HorizontalScrollbar="true"
+                  Striped="true"
+                  Dense="true"
+                  RowsPerPage="25"
+                  data-testid="daily-data-table">
             <HeaderContent>
                 <MudTh>
                     <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.DailyDateTime)"
@@ -152,20 +160,17 @@ else
                     </MudTableSortLabel>
                 </MudTh>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalRegisteredUsers)"
-                                       InitialDirection="@SortDirection.Descending">
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalRegisteredUsers)">
                         Registered
                     </MudTableSortLabel>
                 </MudTh>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalLoggedInUsers)"
-                                       InitialDirection="@SortDirection.Descending">
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalLoggedInUsers)">
                         Logged In
                     </MudTableSortLabel>
                 </MudTh>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalDependents)"
-                                       InitialDirection="@SortDirection.Descending">
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalDependents)">
                         Dependents
                     </MudTableSortLabel>
                 </MudTh>
@@ -177,7 +182,7 @@ else
                 <MudTd data-testid="daily-data-dependents" DataLabel="Dependents">@context.TotalDependents</MudTd>
             </RowTemplate>
             <PagerContent>
-                <MudTablePager PageSizeOptions="new int[]{10, 25, 50, 100, 200}" />
+                <MudTablePager PageSizeOptions="new[]{10, 25, 50, 100, 200}" />
             </PagerContent>
         </MudTable>
     </MudItem>

--- a/Apps/Admin/Client/Pages/DashboardPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor.cs
@@ -227,8 +227,7 @@ public partial class DashboardPage : FluxorComponent
                         TotalRegisteredUsers = grp.Sum(s => s.TotalRegisteredUsers),
                         TotalDependents = grp.Sum(d => d.TotalDependents),
                         TotalLoggedInUsers = grp.Sum(l => l.TotalLoggedInUsers),
-                    })
-                .OrderByDescending(grp => grp.DailyDateTime);
+                    });
         }
     }
 

--- a/Apps/Admin/Client/Pages/FeedbackPage.razor
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor
@@ -76,6 +76,7 @@ else
         <MudTable Class="mt-3"
                   Items="@FeedbackRows"
                   Loading="@(FeedbackLoading || FeedbackUpdating)"
+                  AllowUnsorted="false"
                   Breakpoint="@Breakpoint.Md"
                   HorizontalScrollbar="true"
                   Striped="true"
@@ -153,7 +154,7 @@ else
                 </MudTd>
             </RowTemplate>
             <PagerContent>
-                <MudTablePager data-testid="feedback-table-pagination" PageSizeOptions="new int[]{10, 25, 50, 100, 200}" />
+                <MudTablePager data-testid="feedback-table-pagination" PageSizeOptions="new[]{10, 25, 50, 100, 200}" />
             </PagerContent>
         </MudTable>
     </MudForm>

--- a/Apps/Admin/Client/Pages/FeedbackPage.razor.cs
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor.cs
@@ -76,7 +76,6 @@ public partial class FeedbackPage : FluxorComponent
 
     private IEnumerable<FeedbackRow> FeedbackRows => this.Feedback
         .Where(f => this.TagIdFilter.All(t => f.Tags.Any(ft => ft.TagId == t)))
-        .OrderByDescending(f => f.CreatedDateTime)
         .Select(f => new FeedbackRow(f));
 
     private MudChip[] SelectedTagChips { get; set; } = Array.Empty<MudChip>();

--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -44,25 +44,46 @@
 
 @if (MessagingVerificationsLoaded || MessagingVerificationsLoading)
 {
-    <MudTable Class="mt-3" Items="MessagingVerificationRows" Loading="MessagingVerificationsLoading" Breakpoint="Breakpoint.Md" HorizontalScrollbar="true" Striped="true" Dense="true" data-testid="message-verification-table">
+    <MudTable Class="mt-3"
+              Items="MessagingVerificationRows"
+              Loading="MessagingVerificationsLoading"
+              AllowUnsorted="false"
+              Breakpoint="Breakpoint.Md"
+              HorizontalScrollbar="true"
+              Striped="true"
+              Dense="true"
+              data-testid="message-verification-table">
         <HeaderContent>
             <MudTh>
-                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.Hdid)">HDID</MudTableSortLabel>
+                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.Hdid)">
+                    HDID
+                </MudTableSortLabel>
             </MudTh>
             <MudTh>
-                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.PersonalHealthNumber)">PHN</MudTableSortLabel>
+                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.PersonalHealthNumber)">
+                    PHN
+                </MudTableSortLabel>
             </MudTh>
             <MudTh>
-                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.EmailOrSms)">Email or SMS</MudTableSortLabel>
+                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.EmailOrSms)">
+                    Email or SMS
+                </MudTableSortLabel>
             </MudTh>
             <MudTh>
-                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.Verified)">Verified</MudTableSortLabel>
+                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.Verified)">
+                    Verified
+                </MudTableSortLabel>
             </MudTh>
             <MudTh>
-                <MudTableSortLabel InitialDirection="SortDirection.Descending" SortBy="new Func<MessagingVerificationRow, object>(x => x.VerificationDate)">Verification Date</MudTableSortLabel>
+                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.VerificationDate)"
+                                   InitialDirection="@SortDirection.Descending">
+                    Verification Date
+                </MudTableSortLabel>
             </MudTh>
             <MudTh>
-                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.VerificationCode)">Verification Code</MudTableSortLabel>
+                <MudTableSortLabel SortBy="new Func<MessagingVerificationRow, object>(x => x.VerificationCode)">
+                    Verification Code
+                </MudTableSortLabel>
             </MudTh>
         </HeaderContent>
         <RowTemplate>


### PR DESCRIPTION
# Implements AB#14009

## Description

- reduces the number of MudTableSortLabels that have an InitialDirection to one per table since behaviour is undefined otherwise
- removes ordering of table data in the code-behind since simple orderings can be handled by setting InitialDirection
- sets tables to not allow unsorted data, meaning clicking a column header will iterate through 2 sorting states (ascending, descending) instead of 3 (ascending, descending, unsorted)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
