### PR TITLE
Add disclaimer to timeline filter for AB #13975

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -1027,7 +1027,7 @@ export default class DependentCardComponent extends Vue {
                             Immunization
                         </div>
                     </template>
-                    <div id="disclaimer">
+                    <div id="dependent-immunization-disclaimer">
                         <b-alert
                             :show="immunizationItems.length != 0"
                             variant="info"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -172,9 +172,7 @@ export default class LinearTimelineComponent extends Vue {
     }
 
     private get isImmunization(): boolean {
-        return this.timelineEntries.some(
-            (x) => x.type === EntryType.Immunization
-        );
+        return this.isFilterApplied(EntryType.Immunization);
     }
 
     private get numberOfPages(): number {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -171,6 +171,15 @@ export default class LinearTimelineComponent extends Vue {
         return filterLoading;
     }
 
+    private get isImmunization(): boolean {
+        const isImmunization = this.timelineEntries.some(
+            (x) => x.type === EntryType.Immunization
+        );
+
+        this.logger.debug(`Is Immunization: ${isImmunization}`);
+        return isImmunization;
+    }
+
     private get numberOfPages(): number {
         let pageCount = 1;
         if (this.timelineEntries.length > this.pageSize) {
@@ -322,6 +331,24 @@ export default class LinearTimelineComponent extends Vue {
                 {{ timelineEntryCount }} records
             </b-col>
         </b-row>
+        <div id="linear-timeline-immunization-disclaimer" class="containter">
+            <b-alert
+                :show="isImmunization"
+                variant="info"
+                class="mt-0 mb-1"
+                data-testid="linear-timeline-immunization-disclaimer-alert"
+            >
+                <span>
+                    You can add or update immunizations by visiting
+                    <a
+                        href="https://www.immunizationrecord.gov.bc.ca"
+                        target="_blank"
+                        rel="noopener"
+                        >immunizationrecord.gov.bc.ca</a
+                    >.
+                </span>
+            </b-alert>
+        </div>
         <div id="timeData" data-testid="linearTimelineData">
             <div
                 v-for="dateGroup in dateGroups"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -172,12 +172,9 @@ export default class LinearTimelineComponent extends Vue {
     }
 
     private get isImmunization(): boolean {
-        const isImmunization = this.timelineEntries.some(
+        return this.timelineEntries.some(
             (x) => x.type === EntryType.Immunization
         );
-
-        this.logger.debug(`Is Immunization: ${isImmunization}`);
-        return isImmunization;
     }
 
     private get numberOfPages(): number {


### PR DESCRIPTION
# Implements [AB#13975](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13975)

## Description

1. Add disclaimer to timeline filter - disclaimer only displays when Immunization filter is selected.
2. Updated div id for dependent immunization.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

**Timeline with Immunization filter:**

<img width="1276" alt="Screen Shot 2022-09-26 at 6 30 19 PM" src="https://user-images.githubusercontent.com/58790456/192411214-f984cb87-27a0-4679-99de-081516c92d19.png">

**Timeline with all filters except Immunization:**

<img width="1277" alt="Screen Shot 2022-09-26 at 6 30 33 PM" src="https://user-images.githubusercontent.com/58790456/192411223-2700f3fc-a720-4ae0-83a8-cba917abf857.png">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
