### PR TITLE
Bug fix for AppErrorView.vue for AB#14023

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/errors/AppErrorView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/AppErrorView.vue
@@ -8,8 +8,7 @@ const options: any = { components: { BAlert } };
 
 @Component(options)
 export default class AppErrorView extends Vue {
-    @Prop({ type: Boolean, default: false })
-    busy = false;
+    @Prop({ default: false }) busy!: boolean;
 }
 </script>
 


### PR DESCRIPTION
# Fixes or Implements [AB#14023](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14023)

## Fix bug in AppErrorView.vue

Fixed functional test failures in errorAlerts.js. Bug introduced in code clean up from change to Volar from Vetur tool. The variable 'busy' was changed to 'busy = false' which caused the message to always be the error variant and not the busy warning when a 429 occurred. Changed to 'busy!: boolean' instead so now the correct message shows.

![Screen Shot 2022-09-27 at 4 05 33 PM](https://user-images.githubusercontent.com/5408101/192653503-675ccd7c-5bf6-4d4d-b3a1-d51a376e9dcb.png)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
