### PR TITLE
Add home page card for immunization record website AB#13976

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -100,6 +100,14 @@ export default class AddQuickLinkComponent extends Vue {
         );
     }
 
+    private get showImmunizationRecord(): boolean {
+        const preference =
+            this.user.preferences[
+                UserPreferenceType.HideImmunizationRecordQuickLink
+            ];
+        return preference?.value === "true";
+    }
+
     private created(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
     }
@@ -172,6 +180,24 @@ export default class AddQuickLinkComponent extends Vue {
                         this.selectedQuickLinks =
                             this.selectedQuickLinks.filter(
                                 (link) => link !== "bc-vaccine-card"
+                            );
+                    })
+                );
+            }
+
+            if (this.selectedQuickLinks.includes("immunization-record")) {
+                const preference = {
+                    ...this.user.preferences[
+                        UserPreferenceType.HideImmunizationRecordQuickLink
+                    ],
+                    value: "false",
+                };
+
+                promises.push(
+                    this.setUserPreference({ preference }).then(() => {
+                        this.selectedQuickLinks =
+                            this.selectedQuickLinks.filter(
+                                (link) => link !== "immunization-record"
                             );
                     })
                 );
@@ -266,6 +292,20 @@ export default class AddQuickLinkComponent extends Vue {
                         value="bc-vaccine-card"
                     >
                         BC Vaccine Card
+                    </b-form-checkbox>
+                </b-col>
+            </b-row>
+            <b-row v-if="showImmunizationRecord">
+                <b-col cols="8" align-self="start">
+                    <b-form-checkbox
+                        id="immunization-record-filter"
+                        :key="checkboxComponentKey"
+                        v-model="selectedQuickLinks"
+                        data-testid="immunization-record-filter"
+                        name="immunization-record-filter"
+                        value="immunization-record"
+                    >
+                        Add Vaccines
                     </b-form-checkbox>
                 </b-col>
             </b-row>

--- a/Apps/WebClient/src/ClientApp/src/constants/userPreferenceType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/userPreferenceType.ts
@@ -7,4 +7,6 @@ export default abstract class UserPreferenceType {
     public static TutorialComment = "tutorialComment";
     public static QuickLinks = "quickLinks";
     public static HideVaccineCardQuickLink = "hideVaccineCardQuickLink";
+    public static HideImmunizationRecordQuickLink =
+        "hideImmunizationRecordQuickLink";
 }

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/mutations.ts
@@ -29,7 +29,6 @@ export const mutations: UserMutation = {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
         if (userProfile) {
-            // If there are no preferences, set the default states for tutorial popovers
             PreferenceUtil.setDefaultValue(
                 userProfile.preferences,
                 UserPreferenceType.TutorialNote,
@@ -59,6 +58,16 @@ export const mutations: UserMutation = {
                 userProfile.preferences,
                 UserPreferenceType.TutorialComment,
                 "true"
+            );
+            PreferenceUtil.setDefaultValue(
+                userProfile.preferences,
+                UserPreferenceType.HideVaccineCardQuickLink,
+                "false"
+            );
+            PreferenceUtil.setDefaultValue(
+                userProfile.preferences,
+                UserPreferenceType.HideImmunizationRecordQuickLink,
+                "false"
             );
         }
 

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -527,7 +527,7 @@ export default class HomeView extends Vue {
             <b-col class="p-3">
                 <hg-card-button
                     title="Health Records"
-                    data-testid="health-records-card-btn"
+                    data-testid="health-records-card"
                     @click="handleClickHealthRecords()"
                 >
                     <template #icon>
@@ -566,7 +566,7 @@ export default class HomeView extends Vue {
             <b-col v-if="showVaccineCardButton" class="p-3">
                 <hg-card-button
                     title="BC Vaccine Card"
-                    data-testid="bc-vaccine-card-btn"
+                    data-testid="bc-vaccine-card-card"
                     @click="handleClickVaccineCard()"
                 >
                     <template #icon>

--- a/Testing/functional/tests/cypress/integration/e2e/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/home.js
@@ -24,7 +24,7 @@ describe("Home Page", () => {
 
     it("Home - Health Records Card link to Timeline", () => {
         cy.contains("[data-testid=card-button-title]", "Health Records")
-            .parents("[data-testid=health-records-card-btn]")
+            .parents("[data-testid=health-records-card]")
             .should("be.visible", "be.enabled")
             .click();
 

--- a/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
@@ -6,7 +6,7 @@ const addQuickLinkButtonSelector = "[data-testid=add-quick-link-button]";
 const addQuickLinkSubmitButtonSelector = "[data-testid=add-quick-link-btn]";
 const quickLinkMenuButtonSelector = "[data-testid=quick-link-menu-button]";
 const quickLinkRemoveButtonSelector = "[data-testid=remove-quick-link-button]";
-const vaccineCardQuickLinkCardSelector = "[data-testid=bc-vaccine-card-btn]";
+const vaccineCardQuickLinkCardSelector = "[data-testid=bc-vaccine-card-card]";
 const vaccineCardAddQuickLinkCheckboxSelector =
     "[data-testid=bc-vaccine-card-filter]";
 

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -225,7 +225,7 @@ function testHideVaccineCardQuickLinkError(statusCode = serverErrorStatusCode) {
         "/home"
     );
 
-    cy.get("[data-testid=bc-vaccine-card-btn]").within(() => {
+    cy.get("[data-testid=bc-vaccine-card-card]").within(() => {
         cy.get("[data-testid=quick-link-menu-button]")
             .should("be.visible")
             .parent("a")

--- a/Testing/functional/tests/cypress/integration/ui/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/home.js
@@ -12,8 +12,8 @@ describe("Authenticated User - Home Page", () => {
             homeUrl
         );
 
-        cy.get("[data-testid=bc-vaccine-card-btn]").should("be.visible");
-        cy.get("[data-testid=health-records-card-btn]").should("be.visible");
+        cy.get("[data-testid=bc-vaccine-card-card]").should("be.visible");
+        cy.get("[data-testid=health-records-card]").should("be.visible");
     });
 
     it("Home - Federal Card button enabled", () => {
@@ -38,7 +38,7 @@ describe("Authenticated User - Home Page", () => {
             homeUrl
         );
 
-        cy.get("[data-testid=bc-vaccine-card-btn]")
+        cy.get("[data-testid=bc-vaccine-card-card]")
             .should("be.visible")
             .click();
 
@@ -53,7 +53,7 @@ describe("Authenticated User - Home Page", () => {
             homeUrl
         );
 
-        cy.get("[data-testid=health-records-card-btn]")
+        cy.get("[data-testid=health-records-card]")
             .should("be.visible")
             .click();
 


### PR DESCRIPTION
# Implements [AB#13976](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13976)

## Description

- adds new card to the home page for accessing the immunization record website
- updates data-testids for similar cards for consistency

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2022-09-27-185338](https://user-images.githubusercontent.com/16570293/192674130-683f2bfe-474a-49fe-bfba-c34c0b51c135.png)

![localhost-2022-09-27-185419](https://user-images.githubusercontent.com/16570293/192674142-433f29be-223c-4515-b23f-4c3972bf7c74.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
