### PR TITLE
Add functional tests for immunization record card and alert AB#13977

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -174,8 +174,11 @@ export default class LinearTimelineComponent extends Vue {
         return filterLoading;
     }
 
-    private get isImmunization(): boolean {
-        return this.isFilterApplied(EntryType.Immunization);
+    private get isOnlyImmunizationSelected(): boolean {
+        return (
+            this.filter.entryTypes.size === 1 &&
+            this.filter.entryTypes.has(EntryType.Immunization)
+        );
     }
 
     private get numberOfPages(): number {
@@ -293,20 +296,11 @@ export default class LinearTimelineComponent extends Vue {
         return entryTypeMap.get(entryType)?.component ?? "";
     }
 
-    private isFilterApplied(entryType: EntryType): boolean {
-        const entryTypes = Array.from(this.filter.entryTypes);
-        const filterApplied = !!entryTypes.includes(entryType);
-        this.logger.debug(
-            `Timeline filter entry type: ${entryType} applied: ${filterApplied}`
-        );
-        return filterApplied;
-    }
-
     private isSelectedFilterModuleLoading(
         entryType: EntryType,
         loading: boolean
     ): boolean {
-        const filterApplied = this.isFilterApplied(entryType);
+        const filterApplied = this.filter.entryTypes.has(entryType);
         const isLoading = filterApplied && loading;
         this.logger.debug(
             `Timeline filter entry type: ${entryType} applied: ${filterApplied} - filter loading: ${loading} and filter isLoading: ${isLoading}`
@@ -329,9 +323,13 @@ export default class LinearTimelineComponent extends Vue {
                 {{ timelineEntryCount }} records
             </b-col>
         </b-row>
-        <div id="linear-timeline-immunization-disclaimer" class="containter">
+        <div
+            v-show="isOnlyImmunizationSelected"
+            id="linear-timeline-immunization-disclaimer"
+            class="pb-2"
+        >
             <b-alert
-                :show="isImmunization"
+                show
                 variant="info"
                 class="mt-0 mb-1"
                 data-testid="linear-timeline-immunization-disclaimer-alert"

--- a/Testing/functional/tests/cypress/integration/e2e/user/immunizationRecordQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/immunizationRecordQuickLink.js
@@ -1,0 +1,67 @@
+const { AuthMethod } = require("../../../support/constants");
+
+const homePath = "/home";
+
+const addQuickLinkButtonSelector = "[data-testid=add-quick-link-button]";
+const addQuickLinkSubmitButtonSelector = "[data-testid=add-quick-link-btn]";
+const quickLinkMenuButtonSelector = "[data-testid=quick-link-menu-button]";
+const quickLinkRemoveButtonSelector = "[data-testid=remove-quick-link-button]";
+const immunizationRecordQuickLinkCardSelector =
+    "[data-testid=immunization-record-card]";
+const immunizationRecordFilterSelector =
+    "[data-testid=immunization-record-filter]";
+
+describe("Immunization Record Quick Link", () => {
+    it("Remove and Add Immunization Record Quick Link", () => {
+        cy.enableModules([]);
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homePath
+        );
+
+        cy.log("Verifying immunization record card is present");
+        cy.get(immunizationRecordQuickLinkCardSelector).should(
+            "be.visible",
+            "be.enabled"
+        );
+
+        cy.log("Removing immunization record card");
+        cy.get(immunizationRecordQuickLinkCardSelector).within(() => {
+            cy.get(quickLinkMenuButtonSelector)
+                .should("be.visible")
+                .parent("a")
+                .should("be.visible", "be.enabled")
+                .click();
+            cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        });
+
+        cy.log("Verifying immunization record card no longer exists");
+        cy.get(immunizationRecordQuickLinkCardSelector).should("not.exist");
+
+        cy.log("Adding immunization record card");
+        cy.get(addQuickLinkButtonSelector)
+            .should("be.visible")
+            .should("be.enabled")
+            .click();
+        cy.get(immunizationRecordFilterSelector)
+            .should("exist")
+            .check({ force: true });
+        cy.get(addQuickLinkSubmitButtonSelector)
+            .should("be.visible")
+            .should("be.enabled")
+            .click();
+
+        cy.log("Verifying add quick link button is disabled");
+        cy.get(addQuickLinkButtonSelector)
+            .should("be.visible")
+            .should("not.be.enabled");
+
+        cy.log("Verifying immunization record card is present");
+        cy.get(immunizationRecordQuickLinkCardSelector).should(
+            "be.visible",
+            "be.enabled"
+        );
+    });
+});

--- a/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
@@ -39,11 +39,6 @@ describe("Vaccine Card Quick Link", () => {
         cy.log("Verifying vaccine card quick link no longer exists");
         cy.get(vaccineCardQuickLinkCardSelector).should("not.exist");
 
-        cy.log("Verifying add quick link button has been re-enabled");
-        cy.get(addQuickLinkButtonSelector)
-            .should("be.visible")
-            .should("be.enabled");
-
         cy.log("Adding vaccine card quick link");
         cy.get(addQuickLinkButtonSelector)
             .should("be.visible")

--- a/Testing/functional/tests/cypress/integration/ui/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/home.js
@@ -13,6 +13,7 @@ describe("Authenticated User - Home Page", () => {
         );
 
         cy.get("[data-testid=bc-vaccine-card-card]").should("be.visible");
+        cy.get("[data-testid=immunization-record-card]").should("be.visible");
         cy.get("[data-testid=health-records-card]").should("be.visible");
     });
 
@@ -29,7 +30,7 @@ describe("Authenticated User - Home Page", () => {
         cy.get("[data-testid=proof-vaccination-card-btn]").should("be.visible");
     });
 
-    it("Home - Link to Covid19 page", () => {
+    it("Home - Link to COVID-19 page", () => {
         cy.enableModules(["VaccinationStatus"]);
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -65,4 +65,26 @@ describe("Filters", () => {
             unfilteredRecordsMessage
         );
     });
+
+    it("Verify immunization record alert appears when only immunization is selected", () => {
+        cy.get(
+            "[data-testid=linear-timeline-immunization-disclaimer-alert]"
+        ).should("not.be.visible");
+
+        cy.get("[data-testid=filterDropdown]").click();
+        cy.get("[data-testid=Immunization-filter]").click({ force: true });
+        cy.get("[data-testid=btnFilterApply]").click();
+
+        cy.get(
+            "[data-testid=linear-timeline-immunization-disclaimer-alert]"
+        ).should("be.visible");
+
+        cy.get("[data-testid=filterDropdown]").click();
+        cy.get("[data-testid=Encounter-filter]").click({ force: true });
+        cy.get("[data-testid=btnFilterApply]").click();
+
+        cy.get(
+            "[data-testid=linear-timeline-immunization-disclaimer-alert]"
+        ).should("not.be.visible");
+    });
 });


### PR DESCRIPTION
# Implements [AB#13977](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13977)

## Description

- adds functional test for immunization record card on home page
- adds functional test for immunization record alert on timeline page
- fixes immunization record alert on timeline page appearing when more than just immunization is selected

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![localhost-2022-09-28-115415](https://user-images.githubusercontent.com/16570293/192865473-9973a8f1-2eb0-4bcf-9ea0-9aad05c5d598.png) ![localhost-2022-09-28-115429](https://user-images.githubusercontent.com/16570293/192865476-d54f38dd-7582-4bfd-9f36-9b50b40142d9.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
