### PR TITLE
Fix warning wrongly changed to error for AB#14035

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -499,7 +499,7 @@ export default class ProfileView extends Vue {
                         instanceOfResultError(error) &&
                         error.statusCode === 429
                     ) {
-                        this.setTooManyRequestsError({ key: "page" });
+                        this.setTooManyRequestsWarning({ key: "page" });
                     } else {
                         this.addError({
                             errorType: ErrorType.Retrieve,


### PR DESCRIPTION
# Fixes or Implements [AB#14035](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14035)

## Description

Fix warning wrongly changed to error in update SMS in ProfileView.vue.  Needs to be a warning in this case since it is a retrieve for check registration.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
