### PR TITLE
Fixed missed Rider Logging Disabled Warnings for AB#14041

### DIFF
--- a/Apps/Directory.Build.props
+++ b/Apps/Directory.Build.props
@@ -4,15 +4,15 @@
         <Nullable>enable</Nullable>
         <LangVersion>10.0</LangVersion>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
-     	<WarningLevel>4</WarningLevel>
+        <WarningLevel>4</WarningLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-      <NoWarn>CA1848,CA2253,CA2254</NoWarn>
+        <NoWarn>CA1848</NoWarn>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0" ExcludeAssets="All" />
+        <PackageReference Include="Microsoft.CodeAnalysis" Version="4.3.0" ExcludeAssets="All"/>
         <PackageReference Include="SonarAnalyzer.CSharp" Version="8.45.0.54064">
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-          <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.354">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.JobScheduler.Listeners
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             this.logger.LogInformation("Banner Listener is starting");
-            stoppingToken.Register(() => this.logger.LogInformation("Banner Listener Shutdown as cancellation requested    "));
+            stoppingToken.Register(() => this.logger.LogInformation("Banner Listener Shutdown as cancellation requested"));
             this.ClearCache();
             int attempts = 0;
             while (!stoppingToken.IsCancellationRequested)
@@ -118,7 +118,7 @@ namespace HealthGateway.JobScheduler.Listeners
 
         private void ReceiveEvent(object sender, NpgsqlNotificationEventArgs e)
         {
-            this.logger.LogDebug($"Banner Event received on channel {Channel}");
+            this.logger.LogDebug("Banner Event received on channel {Channel}", Channel);
             JsonSerializerOptions options = new()
             {
                 PropertyNameCaseInsensitive = true,


### PR DESCRIPTION
# Fixes [AB#14041](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14041)

## Description

- Fixed a Rider missed a Logging Disabled Warning using string interpolation.
- Fixed a logging message with unnecessary white space.
- Removed No Warn from build props.

<img width="1294" alt="Screen Shot 2022-09-30 at 3 35 58 PM" src="https://user-images.githubusercontent.com/58790456/193643034-0161467a-6b3f-435f-a0cd-0ba8a880af11.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
