### PR TITLE
Add Kong IP rate-limiting to swagger routes AB#13955

### DIFF
--- a/Tools/Kong/config.tmpl
+++ b/Tools/Kong/config.tmpl
@@ -95,6 +95,17 @@
           - $BASE_PATH/swagger
         strip_path: false
         plugins:
+          - name: rate-limiting
+            tags: [ns.$KONG_NAMESPACE]
+            enabled: true
+            config:
+              fault_tolerant: true
+              hide_client_headers: false
+              limit_by: ip
+              minute: $IP_RATE_LIMIT
+            protocols:
+              - http
+              - https
           - name: rate-limiting_902
             tags: [ns.$KONG_NAMESPACE]
             enabled: true


### PR DESCRIPTION
# Fixes [AB#13955](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13955)

## Description

- updates Kong configuration for swagger routes with rate-limiting based on IP address

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
