### PR TITLE
Display error page if patient data can't be retrieved after login AB#13546

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/app.vue
+++ b/Apps/WebClient/src/ClientApp/src/app.vue
@@ -42,11 +42,13 @@ import FooterComponent from "@/components/navmenu/FooterComponent.vue";
 import HeaderComponent from "@/components/navmenu/HeaderComponent.vue";
 import SidebarComponent from "@/components/navmenu/SidebarComponent.vue";
 import ResourceCentreComponent from "@/components/ResourceCentreComponent.vue";
+import { AppErrorType } from "@/constants/errorType";
 import Process, { EnvironmentType } from "@/constants/process";
 import ScreenWidth from "@/constants/screenWidth";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
+import AppErrorView from "@/views/errors/AppErrorView.vue";
 
 Vue.use(LayoutPlugin);
 Vue.use(NavPlugin);
@@ -88,6 +90,7 @@ const options: any = {
         IdleComponent,
         CommunicationComponent,
         ResourceCentreComponent,
+        AppErrorView,
     },
 };
 
@@ -98,6 +101,9 @@ export default class App extends Vue {
 
     @Action("setIsMobile")
     setIsMobile!: (isMobile: boolean) => void;
+
+    @Getter("appError")
+    appError?: AppErrorType;
 
     @Getter("isMobile")
     isMobile!: boolean;
@@ -193,19 +199,25 @@ export default class App extends Vue {
     }
 
     private get isHeaderVisible(): boolean {
-        return !this.currentPathMatches(
-            this.loginCallbackPath,
-            this.vaccineCardPath,
-            this.covidTestPath
+        return (
+            this.appError === undefined &&
+            !this.currentPathMatches(
+                this.loginCallbackPath,
+                this.vaccineCardPath,
+                this.covidTestPath
+            )
         );
     }
 
     private get isFooterVisible(): boolean {
-        return !this.currentPathMatches(
-            this.loginCallbackPath,
-            this.registrationPath,
-            this.vaccineCardPath,
-            this.covidTestPath
+        return (
+            this.appError === undefined &&
+            !this.currentPathMatches(
+                this.loginCallbackPath,
+                this.registrationPath,
+                this.vaccineCardPath,
+                this.covidTestPath
+            )
         );
     }
 
@@ -255,7 +267,9 @@ export default class App extends Vue {
         </div>
 
         <NavHeader v-if="isHeaderVisible" class="d-print-none" />
-        <b-row>
+
+        <AppErrorView v-if="appError !== undefined" />
+        <b-row v-else>
             <NavSidebar
                 v-if="isSidebarVisible"
                 class="d-print-none sticky-top vh-100"

--- a/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
@@ -160,7 +160,7 @@ export default class ErrorCardComponent extends Vue {
                         <p
                             v-for="(error, index) in errorDetails"
                             :key="index"
-                            class="break-word"
+                            class="text-break"
                             :data-testid="'error-details-span-' + (index + 1)"
                         >
                             {{ error }}
@@ -182,9 +182,5 @@ export default class ErrorCardComponent extends Vue {
 .collapsed > .when-opened,
 :not(.collapsed) > .when-closed {
     display: none;
-}
-
-.break-word {
-    word-wrap: break-word;
 }
 </style>

--- a/Apps/WebClient/src/ClientApp/src/components/PageErrorComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/PageErrorComponent.vue
@@ -2,20 +2,22 @@
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
 
-import { PageError } from "@/models/errors";
-
 @Component
 export default class PageErrorComponent extends Vue {
-    @Prop(PageError) error!: PageError;
+    @Prop({ required: true })
+    title!: string;
+
+    @Prop({ required: false })
+    subtitle?: string;
 }
 </script>
 
 <template>
     <div class="d-flex justify-content-center">
         <div class="px-3 py-5">
-            <h1>{{ error.code }}</h1>
-            <h2>{{ error.name }}</h2>
-            <p>{{ error.message }}</p>
+            <h1>{{ title }}</h1>
+            <h2 v-if="subtitle">{{ subtitle }}</h2>
+            <slot />
         </div>
     </div>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -8,7 +8,7 @@ import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import UserPreferenceType from "@/constants/userPreferenceType";
 import type { WebClientConfiguration } from "@/models/configData";
-import { BannerError, instanceOfResultError } from "@/models/errors";
+import { BannerError, isTooManyRequestsError } from "@/models/errors";
 import { QuickLink } from "@/models/quickLink";
 import User from "@/models/user";
 import { UserPreference } from "@/models/userPreference";
@@ -209,7 +209,7 @@ export default class AddQuickLinkComponent extends Vue {
             await this.$nextTick();
             this.hideModal();
         } catch (error) {
-            if (instanceOfResultError(error) && error.statusCode === 429) {
+            if (isTooManyRequestsError(error)) {
                 this.setTooManyRequestsError({ key: "addQuickLinkModal" });
             } else {
                 this.bannerError = ErrorTranslator.toBannerError(

--- a/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/VerifySMSComponent.vue
@@ -9,7 +9,7 @@ import TooManyRequestsComponent from "@/components/TooManyRequestsComponent.vue"
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper } from "@/models/dateWrapper";
-import { instanceOfResultError, ResultError } from "@/models/errors";
+import { isTooManyRequestsError, ResultError } from "@/models/errors";
 import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
@@ -178,7 +178,7 @@ export default class VerifySMSComponent extends Vue {
                 setTimeout(() => (this.smsVerificationSent = false), 5000)
             )
             .catch((error) => {
-                if (instanceOfResultError(error) && error.statusCode === 429) {
+                if (isTooManyRequestsError(error)) {
                     this.setTooManyRequestsWarning({ key: "page" });
                 } else {
                     this.addError({

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/HeaderComponent.vue
@@ -61,6 +61,9 @@ export default class HeaderComponent extends Vue {
     @Getter("oidcUserInfo", { namespace: "user" })
     oidcUserInfo!: OidcUserInfo | undefined;
 
+    @Getter("patientRetrievalFailed", { namespace: "user" })
+    patientRetrievalFailed!: boolean;
+
     @Ref("ratingComponent")
     readonly ratingComponent!: RatingComponent;
 
@@ -115,6 +118,14 @@ export default class HeaderComponent extends Vue {
 
     private get isLogInButtonShown(): boolean {
         return !this.oidcIsAuthenticated && !this.isOffline && !this.isPcrTest;
+    }
+
+    private get isProfileLinkAvailable(): boolean {
+        return (
+            this.isLoggedInMenuShown &&
+            this.isValidIdentityProvider &&
+            !this.patientRetrievalFailed
+        );
     }
 
     private onScroll(): void {
@@ -253,7 +264,7 @@ export default class HeaderComponent extends Vue {
                         <b-dropdown-divider />
                     </span>
                     <b-dropdown-item
-                        v-if="isValidIdentityProvider"
+                        v-if="isProfileLinkAvailable"
                         id="menuBtnProfile"
                         data-testid="profileBtn"
                         to="/profile"

--- a/Apps/WebClient/src/ClientApp/src/constants/errorType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/errorType.ts
@@ -1,3 +1,8 @@
+export const enum AppErrorType {
+    General,
+    TooManyRequests,
+}
+
 export const enum ErrorType {
     Create,
     Retrieve,

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -36,6 +36,8 @@ import HgIconComponent from "@/components/shared/HgIconComponent.vue";
 import PageTitleComponent from "@/components/shared/PageTitleComponent.vue";
 import StatusLabelComponent from "@/components/shared/StatusLabelComponent.vue";
 
+import { AppErrorType } from "@/constants/errorType";
+
 import { isTooManyRequestsError } from "@/models/errors";
 import User from "@/models/user";
 import {
@@ -70,7 +72,6 @@ import {
     IUserRatingService,
     IVaccinationStatusService,
 } from "@/services/interfaces";
-import { AppErrorType } from "./constants/errorType";
 
 Vue.component("BBadge", BBadge);
 Vue.component("BBreadcrumb", BBreadcrumb);

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -214,7 +214,7 @@ configService
 
                 if (user.hdid && isValidIdentityProvider) {
                     try {
-                        await store.dispatch("user/checkRegistration");
+                        await store.dispatch("user/retrieveProfile");
                     } catch (error) {
                         let busy = false;
                         if (

--- a/Apps/WebClient/src/ClientApp/src/models/errors.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/errors.ts
@@ -17,18 +17,6 @@ export interface HttpError {
     statusCode?: number;
 }
 
-export class PageError {
-    public code: string;
-    public name: string;
-    public message: string;
-
-    constructor(code: string, name: string, message: string) {
-        this.code = code;
-        this.name = name;
-        this.message = message;
-    }
-}
-
 export interface ResultError {
     // The error code associated to the request
     errorCode: string;

--- a/Apps/WebClient/src/ClientApp/src/models/errors.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/errors.ts
@@ -38,3 +38,8 @@ export function instanceOfResultError(object: any): object is ResultError {
         "resultMessage" in object
     );
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isTooManyRequestsError(object: any): boolean {
+    return instanceOfResultError(object) && object.statusCode === 429;
+}

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -279,7 +279,6 @@ const routes = [
         meta: {
             validStates: [
                 UserState.unauthenticated,
-                UserState.invalidIdentityProvider,
                 UserState.registered,
                 UserState.notRegistered,
                 UserState.pendingDeletion,

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -43,6 +43,10 @@ const IdirLoggedInView = () =>
     import(
         /* webpackChunkName: "idirLoggedIn" */ "@/views/errors/IdirLoggedInView.vue"
     );
+const PatientRetrievalErrorView = () =>
+    import(
+        /* webpackChunkName: "patientRetrievalError" */ "@/views/errors/PatientRetrievalErrorView.vue"
+    );
 const LoginCallbackView = () =>
     import(
         /* webpackChunkName: "loginCallback" */ "@/views/LoginCallbackView.vue"
@@ -85,13 +89,14 @@ const PcrTestView = () =>
     import(/* webpackChunkName: "pcrTest" */ "@/views/PcrTestView.vue");
 
 export enum UserState {
-    unauthenticated = "unauthenticated",
-    notRegistered = "notRegistered",
-    registered = "registered",
-    pendingDeletion = "pendingDeletion",
-    invalidIdentityProvider = "invalidIdentityProvider",
     offline = "offline",
+    unauthenticated = "unauthenticated",
+    invalidIdentityProvider = "invalidIdentityProvider",
+    noPatientData = "noPatientData",
+    notRegistered = "notRegistered",
+    pendingDeletion = "pendingDeletion",
     acceptTermsOfService = "acceptTermsOfService",
+    registered = "registered",
 }
 
 function calculateUserState(): UserState {
@@ -103,6 +108,8 @@ function calculateUserState(): UserState {
     const isAuthenticated: boolean = store.getters["auth/oidcIsAuthenticated"];
     const isValidIdentityProvider: boolean =
         store.getters["auth/isValidIdentityProvider"];
+    const patientRetrievalFailed: boolean =
+        store.getters["user/patientRetrievalFailed"];
     const isRegistered: boolean = store.getters["user/userIsRegistered"];
     const userIsActive: boolean = store.getters["user/userIsActive"];
     const hasTermsOfServiceUpdated: boolean =
@@ -114,6 +121,8 @@ function calculateUserState(): UserState {
         return UserState.unauthenticated;
     } else if (!isValidIdentityProvider) {
         return UserState.invalidIdentityProvider;
+    } else if (patientRetrievalFailed) {
+        return UserState.noPatientData;
     } else if (!isRegistered) {
         return UserState.notRegistered;
     } else if (!userIsActive) {
@@ -142,15 +151,16 @@ function getAvailableModules(): string[] {
     return availableModules;
 }
 
+const ACCEPT_TERMS_OF_SERVICE_PATH = "/acceptTermsOfService";
 const HOME_PATH = "/home";
 const IDIR_LOGGED_IN_PATH = "/idirLoggedIn";
 const LOGIN_PATH = "/login";
+const PATIENT_RETRIEVAL_ERROR_PATH = "/patientRetrievalError";
 const PROFILE_PATH = "/profile";
 const REGISTRATION_PATH = "/registration";
 const ROOT_PATH = "/";
 const TIMELINE_PATH = "/timeline";
 const UNAUTHORIZED_PATH = "/unauthorized";
-const ACCEPT_TERMS_OF_SERVICE_PATH = "/acceptTermsOfService";
 
 const routes = [
     {
@@ -160,6 +170,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.offline,
             ],
@@ -240,6 +251,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -282,6 +294,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -295,6 +308,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -307,6 +321,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -319,6 +334,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -331,6 +347,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
+                UserState.noPatientData,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -366,6 +383,11 @@ const routes = [
         path: IDIR_LOGGED_IN_PATH,
         component: IdirLoggedInView,
         meta: { validStates: [UserState.invalidIdentityProvider] },
+    },
+    {
+        path: PATIENT_RETRIEVAL_ERROR_PATH,
+        component: PatientRetrievalErrorView,
+        meta: { validStates: [UserState.noPatientData] },
     },
     {
         path: UNAUTHORIZED_PATH,
@@ -455,6 +477,8 @@ function getDefaultPath(
             return REGISTRATION_PATH;
         case UserState.invalidIdentityProvider:
             return IDIR_LOGGED_IN_PATH;
+        case UserState.noPatientData:
+            return PATIENT_RETRIEVAL_ERROR_PATH;
         case UserState.unauthenticated:
             return hasRequiredModules ? LOGIN_PATH : UNAUTHORIZED_PATH;
         case UserState.acceptTermsOfService:

--- a/Apps/WebClient/src/ClientApp/src/store/modules/auth/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/auth/actions.ts
@@ -63,7 +63,7 @@ export const actions: AuthActions = {
             throw err;
         }
     },
-    signOut(): void {
+    signOut(context): void {
         const authService = container.get<IAuthenticationService>(
             SERVICE_IDENTIFIER.AuthenticationService
         );
@@ -72,7 +72,7 @@ export const actions: AuthActions = {
             clearTimeout(refreshTimeout);
             refreshTimeout = undefined;
         }
-
+        context.commit("user/clearUserData", null, { root: true });
         authService.signOut();
     },
     async refreshToken(context): Promise<void> {

--- a/Apps/WebClient/src/ClientApp/src/store/modules/auth/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/auth/types.ts
@@ -33,7 +33,7 @@ export interface AuthActions extends ActionTree<AuthState, RootState> {
         context: StoreContext,
         params: { idpHint: string; redirectPath: string }
     ): Promise<void>;
-    signOut(): void;
+    signOut(context: StoreContext): void;
     refreshToken(context: StoreContext): Promise<void>;
     clearStorage(context: StoreContext): void;
     handleSuccessfulAuthentication(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/navbar/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/navbar/getters.ts
@@ -53,8 +53,16 @@ export const getters: NavbarGetters = {
         const isValid: boolean = rootGetters["auth/isValidIdentityProvider"];
         const isRegistered: boolean = rootGetters["user/userIsRegistered"];
         const isActive: boolean = rootGetters["user/userIsActive"];
+        const patientRetrievalFailed: boolean =
+            rootGetters["user/patientRetrievalFailed"];
+
         return (
-            !isOffline && isAuthenticated && isValid && isRegistered && isActive
+            !isOffline &&
+            isAuthenticated &&
+            isValid &&
+            isRegistered &&
+            isActive &&
+            !patientRetrievalFailed
         );
     },
 };

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -48,7 +48,7 @@ export const actions: UserActions = {
                 })
         );
     },
-    checkRegistration(context): Promise<boolean> {
+    retrieveProfile(context): Promise<void> {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         const userProfileService = container.get<IUserProfileService>(
             SERVICE_IDENTIFIER.UserProfileService
@@ -62,7 +62,7 @@ export const actions: UserActions = {
                         `User Profile: ${JSON.stringify(userProfile)}`
                     );
                     context.commit("setProfileUserData", userProfile);
-                    resolve(userProfile.acceptedTermsOfService);
+                    resolve();
                 })
                 .catch((error) => {
                     context.commit("userError");

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -1,4 +1,8 @@
-import { ErrorSourceType, ErrorType } from "@/constants/errorType";
+import {
+    AppErrorType,
+    ErrorSourceType,
+    ErrorType,
+} from "@/constants/errorType";
 import { ResultType } from "@/constants/resulttype";
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { DateWrapper } from "@/models/dateWrapper";
@@ -250,49 +254,90 @@ export const actions: UserActions = {
                 })
         );
     },
-    retrievePatientData(context): Promise<void> {
+    retrieveEssentialData(context): Promise<void> {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         const patientService = container.get<IPatientService>(
             SERVICE_IDENTIFIER.PatientService
         );
+        const userProfileService = container.get<IUserProfileService>(
+            SERVICE_IDENTIFIER.UserProfileService
+        );
 
-        return new Promise((resolve, reject) => {
-            if (context.getters.patientData.hdid !== undefined) {
-                logger.debug(`Patient data found stored, not querying!`);
-                resolve();
-            } else {
-                context.commit("setRequested");
-                patientService
-                    .getPatientData(context.state.user.hdid)
-                    .then((result) => {
-                        if (result.resultStatus === ResultType.Error) {
-                            context.dispatch("handleError", {
-                                error: result.resultError,
-                                errorType: ErrorType.Retrieve,
-                            });
-                            reject(result.resultError);
-                        } else {
+        return new Promise((resolve) => {
+            context.commit("setRequested");
+            patientService
+                .getPatientData(context.state.user.hdid)
+                .then((result) => {
+                    if (result.resultStatus === ResultType.Error) {
+                        if (result.resultError?.statusCode === 429) {
                             logger.debug(
-                                `retrievePatientData User Profile: ${JSON.stringify(
-                                    result
-                                )}`
+                                "Patient retrieval failed because of too many requests"
                             );
                             context.commit(
-                                "setPatientData",
-                                result.resourcePayload
+                                "setAppError",
+                                AppErrorType.TooManyRequests,
+                                { root: true }
                             );
-                            resolve();
+                        } else {
+                            logger.debug("Patient retrieval failed");
+                            context.commit("setPatientRetrievalFailed");
                         }
-                    })
-                    .catch((error: ResultError) => {
-                        context.dispatch("handleError", {
-                            error,
-                            errorType: ErrorType.Retrieve,
-                            source: ErrorSourceType.Patient,
-                        });
-                        reject(error);
-                    });
-            }
+                        resolve();
+                    } else {
+                        context.commit(
+                            "setPatientData",
+                            result.resourcePayload
+                        );
+
+                        userProfileService
+                            .getProfile(context.state.user.hdid)
+                            .then((userProfile) => {
+                                context.commit(
+                                    "setProfileUserData",
+                                    userProfile
+                                );
+                                resolve();
+                            })
+                            .catch((error: ResultError) => {
+                                if (error.statusCode === 429) {
+                                    logger.debug(
+                                        "User profile retrieval failed because of too many requests"
+                                    );
+                                    context.commit(
+                                        "setAppError",
+                                        AppErrorType.TooManyRequests,
+                                        { root: true }
+                                    );
+                                } else {
+                                    logger.debug(
+                                        "User profile retrieval failed"
+                                    );
+                                    context.commit(
+                                        "setAppError",
+                                        AppErrorType.General,
+                                        { root: true }
+                                    );
+                                }
+                                resolve();
+                            });
+                    }
+                })
+                .catch((error: ResultError) => {
+                    if (error.statusCode === 429) {
+                        logger.debug(
+                            "Patient retrieval failed because of too many requests"
+                        );
+                        context.commit(
+                            "setAppError",
+                            AppErrorType.TooManyRequests,
+                            { root: true }
+                        );
+                    } else {
+                        logger.debug("Patient retrieval failed");
+                        context.commit("setPatientRetrievalFailed");
+                    }
+                    resolve();
+                });
         });
     },
     handleError(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/getters.ts
@@ -47,6 +47,9 @@ export const getters: UserGetters = {
     patientData(state: UserState): PatientData {
         return state.patientData;
     },
+    patientRetrievalFailed(state: UserState): boolean {
+        return state.patientRetrievalFailed;
+    },
     isLoading(state: UserState): boolean {
         return state.status === LoadStatus.REQUESTED;
     },

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/mutations.ts
@@ -140,12 +140,19 @@ export const mutations: UserMutation = {
             state.status = LoadStatus.PARTIALLY_LOADED;
         }
     },
+    setPatientRetrievalFailed(state: UserState) {
+        state.patientRetrievalFailed = true;
+    },
     clearUserData(state: UserState) {
         state.user = new User();
         state.oidcUserInfo = undefined;
+        state.patientData = new PatientData();
+        state.patientRetrievalFailed = false;
+        state.smsResendDateTime = undefined;
+        state.seenTutorialComment = false;
         state.error = false;
-        state.statusMessage = "success";
-        state.status = LoadStatus.LOADED;
+        state.statusMessage = "";
+        state.status = LoadStatus.NONE;
     },
     userError(state: UserState, errorMessage: string) {
         state.error = true;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/types.ts
@@ -49,7 +49,7 @@ export interface UserActions extends ActionTree<UserState, RootState> {
         context: StoreContext,
         params: { request: CreateUserRequest }
     ): Promise<void>;
-    checkRegistration(context: StoreContext): Promise<boolean>;
+    retrieveProfile(context: StoreContext): Promise<void>;
     updateUserEmail(
         context: StoreContext,
         params: { emailAddress: string }

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/types.ts
@@ -22,6 +22,7 @@ export interface UserState {
     user: User;
     oidcUserInfo?: OidcUserInfo;
     patientData: PatientData;
+    patientRetrievalFailed: boolean;
     smsResendDateTime?: DateWrapper;
     seenTutorialComment: boolean;
     statusMessage: string;
@@ -40,6 +41,7 @@ export interface UserGetters extends GetterTree<UserState, RootState> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     quickLinks(state: UserState, getters: any): QuickLink[] | undefined;
     patientData(state: UserState): PatientData;
+    patientRetrievalFailed(state: UserState): boolean;
     isLoading(state: UserState): boolean;
 }
 
@@ -72,7 +74,7 @@ export interface UserActions extends ActionTree<UserState, RootState> {
     ): Promise<RequestResult<boolean>>;
     closeUserAccount(context: StoreContext): Promise<void>;
     recoverUserAccount(context: StoreContext): Promise<void>;
-    retrievePatientData(context: StoreContext): Promise<void>;
+    retrieveEssentialData(context: StoreContext): Promise<void>;
     setSeenTutorialComment(
         context: StoreContext,
         params: { value: boolean }
@@ -90,6 +92,7 @@ export interface UserMutation extends MutationTree<UserState> {
     setSMSResendDateTime(state: UserState, dateTime: DateWrapper): void;
     setUserPreference(state: UserState, userPreference: UserPreference): void;
     setPatientData(state: UserState, patientData: PatientData): void;
+    setPatientRetrievalFailed(state: UserState): void;
     clearUserData(state: UserState): void;
     setSeenTutorialComment(state: UserState, value: boolean): void;
     userError(state: UserState, errorMessage: string): void;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/user.ts
@@ -8,10 +8,11 @@ import { mutations } from "./mutations";
 import { UserModule, UserState } from "./types";
 
 const state: UserState = {
-    statusMessage: "",
     user: new User(),
     patientData: new PatientData(),
+    patientRetrievalFailed: false,
     seenTutorialComment: false,
+    statusMessage: "",
     error: false,
     status: LoadStatus.NONE,
 };

--- a/Apps/WebClient/src/ClientApp/src/store/options.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/options.ts
@@ -1,6 +1,8 @@
 import { injectable } from "inversify";
 import { ActionContext } from "vuex";
 
+import { AppErrorType } from "@/constants/errorType";
+
 import { auth } from "./modules/auth/auth";
 import { clinicalDocument } from "./modules/clinicalDocument/clinicalDocument";
 import { comment } from "./modules/comment/comment";
@@ -21,10 +23,17 @@ import { GatewayStoreOptions, RootState } from "./types";
 @injectable()
 export class StoreOptions implements GatewayStoreOptions {
     state = {
-        version: "1.0.0",
+        appError: undefined,
         isMobile: false,
+        version: "1.0.0",
     };
     actions = {
+        setAppError(
+            context: ActionContext<RootState, RootState>,
+            appError: AppErrorType
+        ): void {
+            context.commit("setAppError", appError);
+        },
         setIsMobile(
             context: ActionContext<RootState, RootState>,
             isMobile: boolean
@@ -33,9 +42,14 @@ export class StoreOptions implements GatewayStoreOptions {
         },
     };
     getters = {
+        appError: (state: RootState): AppErrorType | undefined =>
+            state.appError,
         isMobile: (state: RootState): boolean => state.isMobile,
     };
     mutations = {
+        setAppError(state: RootState, appError: AppErrorType): void {
+            state.appError = appError;
+        },
         setIsMobile(state: RootState, isMobile: boolean): void {
             state.isMobile = isMobile;
         },

--- a/Apps/WebClient/src/ClientApp/src/store/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/types.ts
@@ -1,5 +1,7 @@
 import { ActionContext, StoreOptions } from "vuex";
 
+import { AppErrorType } from "@/constants/errorType";
+
 import { AuthModule } from "./modules/auth/types";
 import { ClinicalDocumentModule } from "./modules/clinicalDocument/types";
 import { CommentModule } from "./modules/comment/types";
@@ -17,21 +19,28 @@ import { UserModule } from "./modules/user/types";
 import { VaccinationStatusModule } from "./modules/vaccinationStatus/types";
 
 export interface RootState {
-    version: string;
+    appError?: AppErrorType;
     isMobile: boolean;
+    version: string;
 }
 
 export interface GatewayStoreOptions extends StoreOptions<RootState> {
     actions: {
+        setAppError(
+            context: ActionContext<RootState, RootState>,
+            appError: AppErrorType
+        ): void;
         setIsMobile(
             context: ActionContext<RootState, RootState>,
             isMobile: boolean
         ): void;
     };
     getters: {
+        appError: (state: RootState) => AppErrorType | undefined;
         isMobile: (state: RootState) => boolean;
     };
     mutations: {
+        setAppError(state: RootState, appError: AppErrorType): void;
         setIsMobile(state: RootState, isMobile: boolean): void;
     };
     modules: {

--- a/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
@@ -72,9 +72,6 @@ export default class LandingView extends Vue {
     @Getter("isSidebarAvailable", { namespace: "navbar" })
     isSidebarAvailable!: boolean;
 
-    @Getter("userIsRegistered", { namespace: "user" })
-    userIsRegistered!: boolean;
-
     private get isVaccinationBannerEnabled(): boolean {
         return false;
     }

--- a/Apps/WebClient/src/ClientApp/src/views/LoginCallbackView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LoginCallbackView.vue
@@ -19,6 +19,9 @@ export default class LoginCallbackView extends Vue {
     @Action("clearStorage", { namespace: "auth" })
     clearStorage!: () => void;
 
+    @Action("retrieveEssentialData", { namespace: "user" })
+    retrieveEssentialData!: () => Promise<void>;
+
     @Action("retrieveProfile", { namespace: "user" })
     retrieveProfile!: () => Promise<void>;
 
@@ -42,10 +45,10 @@ export default class LoginCallbackView extends Vue {
             await this.signIn({ redirectPath: this.redirectPath });
             this.logger.debug(`signIn for user: ${JSON.stringify(this.user)}`);
 
-            // If the idp is valid, check the registration status and continue the route.
-            // Otherwise the router will handle the path.
+            // If the identity provider is valid, the essential user data can be retrieved.
+            // If the identity provider is invalid, the router will redirect to the appropriate error page.
             if (this.isValidIdentityProvider) {
-                await this.retrieveProfile();
+                await this.retrieveEssentialData();
             }
 
             this.$router

--- a/Apps/WebClient/src/ClientApp/src/views/LoginCallbackView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LoginCallbackView.vue
@@ -19,8 +19,8 @@ export default class LoginCallbackView extends Vue {
     @Action("clearStorage", { namespace: "auth" })
     clearStorage!: () => void;
 
-    @Action("checkRegistration", { namespace: "user" })
-    checkRegistration!: () => Promise<boolean>;
+    @Action("retrieveProfile", { namespace: "user" })
+    retrieveProfile!: () => Promise<void>;
 
     @Getter("user", { namespace: "user" })
     user!: User;
@@ -45,7 +45,7 @@ export default class LoginCallbackView extends Vue {
             // If the idp is valid, check the registration status and continue the route.
             // Otherwise the router will handle the path.
             if (this.isValidIdentityProvider) {
-                await this.checkRegistration();
+                await this.retrieveProfile();
             }
 
             this.$router

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -82,9 +82,6 @@ export default class ProfileView extends Vue {
     @Action("updateSMSResendDateTime", { namespace: "user" })
     updateSMSResendDateTime!: ({ dateTime }: { dateTime: DateWrapper }) => void;
 
-    @Action("retrievePatientData", { namespace: "user" })
-    retrievePatientData!: () => Promise<void>;
-
     @Getter("oidcIsAuthenticated", { namespace: "auth" })
     oidcIsAuthenticated!: boolean;
 
@@ -257,13 +254,10 @@ export default class ProfileView extends Vue {
         );
 
         this.isLoading = true;
-        let patientPromise = this.retrievePatientData();
-        let userProfilePromise = this.userProfileService.getProfile(
-            this.user.hdid
-        );
 
-        Promise.all([userProfilePromise, patientPromise])
-            .then(([userProfile]) => {
+        this.userProfileService
+            .getProfile(this.user.hdid)
+            .then((userProfile) => {
                 if (userProfile) {
                     // Load user profile
                     this.logger.verbose(

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -22,7 +22,7 @@ import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper } from "@/models/dateWrapper";
-import { instanceOfResultError, ResultError } from "@/models/errors";
+import { isTooManyRequestsError, ResultError } from "@/models/errors";
 import PatientData, { Address } from "@/models/patientData";
 import User, { OidcUserInfo } from "@/models/user";
 import UserProfile from "@/models/userProfile";
@@ -281,7 +281,7 @@ export default class ProfileView extends Vue {
                 this.logger.error(
                     `Error loading profile: ${error.resultMessage}`
                 );
-                if (instanceOfResultError(error) && error.statusCode === 429) {
+                if (isTooManyRequestsError(error)) {
                     this.setTooManyRequestsError({ key: "page" });
                 } else {
                     this.addError({
@@ -408,7 +408,7 @@ export default class ProfileView extends Vue {
                 this.smsVerified = this.user.verifiedSMS;
             })
             .catch((error) => {
-                if (instanceOfResultError(error) && error.statusCode === 429) {
+                if (isTooManyRequestsError(error)) {
                     this.setTooManyRequestsWarning({ key: "page" });
                 } else {
                     this.addError({
@@ -434,10 +434,7 @@ export default class ProfileView extends Vue {
                 this.$v.$reset();
                 this.showCheckEmailAlert = !this.isEmptyEmail;
                 this.retrieveProfile().catch((error) => {
-                    if (
-                        instanceOfResultError(error) &&
-                        error.statusCode === 429
-                    ) {
+                    if (isTooManyRequestsError(error)) {
                         this.setTooManyRequestsWarning({ key: "page" });
                     } else {
                         this.addError({
@@ -489,10 +486,7 @@ export default class ProfileView extends Vue {
                 this.$v.$reset();
 
                 this.retrieveProfile().catch((error) => {
-                    if (
-                        instanceOfResultError(error) &&
-                        error.statusCode === 429
-                    ) {
+                    if (isTooManyRequestsError(error)) {
                         this.setTooManyRequestsWarning({ key: "page" });
                     } else {
                         this.addError({
@@ -504,7 +498,7 @@ export default class ProfileView extends Vue {
                 });
             })
             .catch((error) => {
-                if (instanceOfResultError(error) && error.statusCode === 429) {
+                if (isTooManyRequestsError(error)) {
                     this.setTooManyRequestsError({ key: "page" });
                 } else {
                     this.addError({

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -70,8 +70,8 @@ export default class ProfileView extends Vue {
         emailAddress: string;
     }) => Promise<void>;
 
-    @Action("checkRegistration", { namespace: "user" })
-    checkRegistration!: () => Promise<boolean>;
+    @Action("retrieveProfile", { namespace: "user" })
+    retrieveProfile!: () => Promise<void>;
 
     @Action("closeUserAccount", { namespace: "user" })
     closeUserAccount!: () => Promise<void>;
@@ -409,7 +409,7 @@ export default class ProfileView extends Vue {
     }
 
     private onVerifySMSSubmit(): void {
-        this.checkRegistration()
+        this.retrieveProfile()
             .then(() => {
                 this.smsVerified = this.user.verifiedSMS;
             })
@@ -439,7 +439,7 @@ export default class ProfileView extends Vue {
                 this.tempEmail = "";
                 this.$v.$reset();
                 this.showCheckEmailAlert = !this.isEmptyEmail;
-                this.checkRegistration().catch((error) => {
+                this.retrieveProfile().catch((error) => {
                     if (
                         instanceOfResultError(error) &&
                         error.statusCode === 429
@@ -494,7 +494,7 @@ export default class ProfileView extends Vue {
                 }
                 this.$v.$reset();
 
-                this.checkRegistration().catch((error) => {
+                this.retrieveProfile().catch((error) => {
                     if (
                         instanceOfResultError(error) &&
                         error.statusCode === 429

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -58,9 +58,6 @@ export default class RegistrationView extends Vue {
     @Action("setTooManyRequestsWarning", { namespace: "errorBanner" })
     setTooManyRequestsWarning!: (params: { key: string }) => void;
 
-    @Action("checkRegistration", { namespace: "user" })
-    checkRegistration!: () => Promise<boolean>;
-
     @Action("createProfile", { namespace: "user" })
     createProfile!: (params: { request: CreateUserRequest }) => Promise<void>;
 

--- a/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
@@ -93,9 +93,6 @@ export default class ReportsView extends Vue {
         traceId: string | undefined;
     }) => void;
 
-    @Action("retrievePatientData", { namespace: "user" })
-    retrievePatientData!: () => Promise<void>;
-
     @Action("setTooManyRequestsError", { namespace: "errorBanner" })
     setTooManyRequestsError!: (params: { key: string }) => void;
 
@@ -188,7 +185,6 @@ export default class ReportsView extends Vue {
 
     private created(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-        this.retrievePatientData();
 
         if (this.config.modules["Medication"]) {
             this.reportTypeOptions.push({

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -91,9 +91,6 @@ export default class TimelineView extends Vue {
     @Getter("webClient", { namespace: "config" })
     config!: WebClientConfiguration;
 
-    @Action("retrievePatientData", { namespace: "user" })
-    retrievePatientData!: () => Promise<void>;
-
     @Action("retrieve", { namespace: "immunization" })
     retrieveImmunizations!: (params: { hdid: string }) => Promise<void>;
 
@@ -422,7 +419,6 @@ export default class TimelineView extends Vue {
 
     private fetchTimelineData(): void {
         Promise.all([
-            this.retrievePatientData(),
             this.retrieveMedications({ hdid: this.user.hdid }),
             this.retrieveMedicationRequests({ hdid: this.user.hdid }),
             this.retrieveImmunizations({ hdid: this.user.hdid }),

--- a/Apps/WebClient/src/ClientApp/src/views/errors/AppErrorView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/AppErrorView.vue
@@ -22,7 +22,8 @@ export default class AppErrorView extends Vue {
             Please try again later.
         </b-alert>
         <b-alert v-else show variant="danger" data-testid="app-error">
-            Unable to load application.
+            Unable to load application. Please try refreshing the page or come
+            back later.
         </b-alert>
     </div>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/AppErrorView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/AppErrorView.vue
@@ -1,23 +1,35 @@
 <script lang="ts">
 import { BAlert } from "bootstrap-vue";
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component } from "vue-property-decorator";
+import { Getter } from "vuex-class";
+
+import { AppErrorType } from "@/constants/errorType";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = { components: { BAlert } };
 
 @Component(options)
 export default class AppErrorView extends Vue {
-    @Prop({ default: false }) busy!: boolean;
+    @Getter("appError")
+    appError?: AppErrorType;
+
+    private get isTooManyRequests(): boolean {
+        return this.appError === AppErrorType.TooManyRequests;
+    }
 }
 </script>
 
 <template>
     <div
-        id="app-root"
-        class="d-flex align-items-center justify-content-center h-100 p-3 p-md-4"
+        class="flex-grow-1 d-flex align-items-center justify-content-center p-3 p-md-4"
     >
-        <b-alert v-if="busy" show variant="warning" data-testid="app-warning">
+        <b-alert
+            v-if="isTooManyRequests"
+            show
+            variant="warning"
+            data-testid="app-warning"
+        >
             We are unable to complete all actions because the site is too busy.
             Please try again later.
         </b-alert>
@@ -27,8 +39,3 @@ export default class AppErrorView extends Vue {
         </b-alert>
     </div>
 </template>
-<style lang="scss" scoped>
-#app-root {
-    min-height: 100vh;
-}
-</style>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/IdirLoggedInView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/IdirLoggedInView.vue
@@ -3,7 +3,6 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 
 import PageErrorComponent from "@/components/PageErrorComponent.vue";
-import { PageError } from "@/models/errors";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
@@ -13,15 +12,14 @@ const options: any = {
 };
 
 @Component(options)
-export default class IdirLoggedInView extends Vue {
-    public errorDescription = new PageError(
-        "403",
-        "IDIR Login",
-        "You've logged in with your IDIR. Please log out and use your BC Services Card."
-    );
-}
+export default class IdirLoggedInView extends Vue {}
 </script>
 
 <template>
-    <PageErrorComponent :error="errorDescription" />
+    <PageErrorComponent title="403" subtitle="IDIR Login">
+        <p>
+            You’ve logged in with your IDIR. Please log out and use your BC
+            Services Card.
+        </p>
+    </PageErrorComponent>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/NotFoundView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/NotFoundView.vue
@@ -3,7 +3,6 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 
 import PageErrorComponent from "@/components/PageErrorComponent.vue";
-import { PageError } from "@/models/errors";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
@@ -13,15 +12,11 @@ const options: any = {
 };
 
 @Component(options)
-export default class NotFoundView extends Vue {
-    public errorDescription = new PageError(
-        "404",
-        "Page Not Found",
-        "The page you were looking for does not exist."
-    );
-}
+export default class NotFoundView extends Vue {}
 </script>
 
 <template>
-    <PageErrorComponent :error="errorDescription" />
+    <PageErrorComponent title="404" subtitle="Page Not Found">
+        <p>The page you were looking for does not exist.</p>
+    </PageErrorComponent>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/PatientRetrievalErrorView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/PatientRetrievalErrorView.vue
@@ -1,0 +1,25 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+
+import PageErrorComponent from "@/components/PageErrorComponent.vue";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const options: any = {
+    components: {
+        PageErrorComponent,
+    },
+};
+
+@Component(options)
+export default class PatientRetrievalErrorView extends Vue {}
+</script>
+
+<template>
+    <PageErrorComponent title="Error retrieving user information">
+        <p>
+            There may be an issue in our Client Registry. Please contact
+            <strong>HealthGateway@gov.bc.ca</strong>
+        </p>
+    </PageErrorComponent>
+</template>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/UnauthorizedView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/UnauthorizedView.vue
@@ -3,7 +3,6 @@ import Vue from "vue";
 import { Component } from "vue-property-decorator";
 
 import PageErrorComponent from "@/components/PageErrorComponent.vue";
-import { PageError } from "@/models/errors";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
@@ -13,15 +12,11 @@ const options: any = {
 };
 
 @Component(options)
-export default class UnauthorizedView extends Vue {
-    public errorDescription = new PageError(
-        "401",
-        "Unauthorized",
-        "You do not have permission to view this page."
-    );
-}
+export default class UnauthorizedView extends Vue {}
 </script>
 
 <template>
-    <PageErrorComponent :error="errorDescription" />
+    <PageErrorComponent title="401" subtitle="Unauthorized">
+        <p>You do not have permission to view this page.</p>
+    </PageErrorComponent>
 </template>


### PR DESCRIPTION
# Fixes [AB#13546](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13546)

## Description

Updates WebClient to retrieve both the user profile and patient data, now grouped together in the action "retrieveEssentialData", after logging in or after opening the site in the browser while authenticated.  Failures to retrieve this data result in several possible errors being shown as described in the task description.

The existing AppErrorView that was previously only available when first loading the application is now controlled by the store, allowing it to be used after login, and a new page and route has been added for the scenario when patient data cannot be retrieved successfully.

- removes unused references to store
- renames "user/checkRegistration" action to "user/retrieveProfile"
- updates text on app error page
- removes old calls to retrieve patient data
- improves versatility of PageErrorComponent
- adds isTooManyRequestsError function
- refactors error handling for logging in and refreshing
- fixes access to PCR test kit registration page with invalid login provider
- fixes long error messages not wrapping

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screenshot 2022-10-06 185429](https://user-images.githubusercontent.com/16570293/194453683-87484e00-76e5-4e35-a705-02e950089037.png)

## Notes

- functional tests should be run to ensure there are no breaking changes
- functional tests may need to be updated to ensure all failure conditions described in the task are covered

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
