### PR TITLE
Webclient server side updates for year of birth

### DIFF
--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-    using System.Text.Json;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
@@ -31,8 +30,8 @@ namespace HealthGateway.Database.Delegates
     [ExcludeFromCodeCoverage]
     public class DBProfileDelegate : IUserProfileDelegate
     {
-        private readonly ILogger logger;
         private readonly GatewayDbContext dbContext;
+        private readonly ILogger logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DBProfileDelegate"/> class.
@@ -81,6 +80,7 @@ namespace HealthGateway.Database.Delegates
                 result.Payload.TermsOfServiceId = profile.TermsOfServiceId;
                 result.Payload.UpdatedBy = profile.UpdatedBy;
                 result.Payload.Version = profile.Version;
+                result.Payload.YearOfBirth = profile.YearOfBirth;
                 result.Status = DBStatusCode.Deferred;
 
                 if (commit)

--- a/Apps/Database/src/Migrations/20221005233413_AddYearOfBirthToUserProfile.cs
+++ b/Apps/Database/src/Migrations/20221005233413_AddYearOfBirthToUserProfile.cs
@@ -58,8 +58,8 @@ BEGIN
                old.""YearOfBirth"", old.""LastLoginDateTime"", old.""CreatedBy"", old.""CreatedDateTime"", old.""UpdatedBy"", old.""UpdatedDateTime"", old.""SMSNumber"");
         RETURN old;
     ELSEIF(TG_OP = 'UPDATE') THEN
-        INSERT INTO {schema}.""UserProfileHistory""(""UserProfileHistoryId"", ""Operation"", ""OperationDateTime"", ""EncryptionKey"",
-                    ""UserProfileId"", ""AcceptedTermsOfService"", ""TermsOfServiceId"", ""Email"", ""ClosedDateTime"", ""IdentityManagementId"",
+        INSERT INTO {schema}.""UserProfileHistory""(""UserProfileHistoryId"", ""Operation"", ""OperationDateTime"",
+                    ""UserProfileId"", ""AcceptedTermsOfService"", ""TermsOfServiceId"", ""Email"", ""ClosedDateTime"", ""IdentityManagementId"", ""EncryptionKey"",
                     ""YearOfBirth"", ""LastLoginDateTime"", ""CreatedBy"", ""CreatedDateTime"", ""UpdatedBy"", ""UpdatedDateTime"", ""SMSNumber"")
 		VALUES(uuid_generate_v4(), TG_OP || '_LOGIN', now(),
                old.""UserProfileId"", null, old.""TermsOfServiceId"", old.""Email"", old.""ClosedDateTime"", old.""IdentityManagementId"", old.""EncryptionKey"",

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -123,12 +123,12 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Read)]
-        public RequestResult<UserProfileModel> GetUserProfile(string hdid)
+        public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid)
         {
             ClaimsPrincipal? user = this.httpContextAccessor.HttpContext?.User;
             DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(user);
 
-            RequestResult<UserProfileModel> result = this.userProfileService.GetUserProfile(hdid, jwtAuthTime);
+            RequestResult<UserProfileModel> result = await this.userProfileService.GetUserProfile(hdid, jwtAuthTime).ConfigureAwait(true);
             this.AddUserPreferences(result.ResourcePayload);
 
             return result;

--- a/Apps/GatewayApi/src/Services/IUserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileService.cs
@@ -32,8 +32,8 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
         /// <param name="jwtAuthTime">The date of last jwt authorization time.</param>
-        /// <returns>The wrappeed user profile.</returns>
-        RequestResult<UserProfileModel> GetUserProfile(string hdid, DateTime jwtAuthTime);
+        /// <returns>The wrapped user profile.</returns>
+        Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, DateTime jwtAuthTime);
 
         /// <summary>
         /// Saves the user profile to the database.
@@ -85,7 +85,7 @@ namespace HealthGateway.GatewayApi.Services
         /// Gets the user preference model.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
-        /// <returns>The wrappeed user reference.</returns>
+        /// <returns>The wrapped user reference.</returns>
         RequestResult<Dictionary<string, UserPreferenceModel>> GetUserPreferences(string hdid);
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace HealthGateway.GatewayApi.Services
         Task<PrimitiveRequestResult<bool>> ValidateMinimumAge(string hdid);
 
         /// <summary>
-        /// Updates the user profile and sets the acceepted terms of service to the supplied value.
+        /// Updates the user profile and sets the accepted terms of service to the supplied value.
         /// </summary>
         /// <param name="hdid">The users hdid.</param>
         /// <param name="termsOfServiceId">The terms of service id accepted.</param>

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -49,11 +49,12 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         /// <summary>
         /// GetUserProfile - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetUserProfile()
+        public async Task ShouldGetUserProfile()
         {
             RequestResult<UserProfileModel> expected = this.GetUserProfileExpectedRequestResultMock(ResultType.Success);
-            RequestResult<UserProfileModel> actualResult = this.GetUserProfile(expected, new Dictionary<string, UserPreferenceModel>());
+            RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected, new Dictionary<string, UserPreferenceModel>()).ConfigureAwait(true);
 
             expected.ShouldDeepEqual(actualResult);
         }
@@ -61,12 +62,12 @@ namespace HealthGateway.GatewayApi.Test.Controllers
         /// <summary>
         /// GetUserProfile - With Empty User Preferences.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetUserProfileWithoutUserPreference()
+        public async Task ShouldGetUserProfileWithoutUserPreference()
         {
             RequestResult<UserProfileModel> expected = this.GetUserProfileExpectedRequestResultMock(ResultType.Success);
-
-            RequestResult<UserProfileModel> actualResult = this.GetUserProfile(expected, null);
+            RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected, null).ConfigureAwait(true);
 
             Assert.NotNull(actualResult);
             Assert.Equal(ResultType.Success, actualResult?.ResultStatus);
@@ -577,7 +578,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             };
         }
 
-        private RequestResult<UserProfileModel> GetUserProfile(
+        private async Task<RequestResult<UserProfileModel>> GetUserProfile(
             RequestResult<UserProfileModel> expected,
             Dictionary<string, UserPreferenceModel>? userPreferencePayloadMock)
         {
@@ -585,7 +586,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.GetUserProfile(this.hdid, It.IsAny<DateTime>())).Returns(expected);
+            userProfileServiceMock.Setup(s => s.GetUserProfile(this.hdid, It.IsAny<DateTime>())).Returns(Task.FromResult(expected));
             userProfileServiceMock.Setup(s => s.GetActiveTermsOfService()).Returns(new RequestResult<TermsOfServiceModel>());
             userProfileServiceMock.Setup(s => s.GetUserPreferences(this.hdid))
                 .Returns(
@@ -602,7 +603,7 @@ namespace HealthGateway.GatewayApi.Test.Controllers
                 emailServiceMock.Object,
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
-            return service.GetUserProfile(this.hdid);
+            return await service.GetUserProfile(this.hdid).ConfigureAwait(true);
         }
 
         private ActionResult<RequestResult<UserPreferenceModel>> UpdateUserPreference(UserPreferenceModel? userPref)

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -37,9 +37,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
     /// </summary>
     public class UserProfileServiceMock : Mock<IUserProfileService>
     {
+        private readonly string userProfileHistoryRecordLimitKey = "UserProfileHistoryRecordLimit";
         private readonly UserProfileService userProfileService;
         private readonly string webClientConfigSection = "WebClient";
-        private readonly string userProfileHistoryRecordLimitKey = "UserProfileHistoryRecordLimit";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
@@ -50,15 +50,25 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="userProfileDbResult">user profile from DbResult.</param>
         /// <param name="readResult">read result.</param>
         /// <param name="termsOfService">terms of service.</param>
+        /// <param name="patientModel">patient model.</param>
         /// <param name="configuration">configuration.</param>
         /// <param name="userProfileHistoryDbResult">user profile history from DbResult.</param>
-        public UserProfileServiceMock(string hdId, DBStatusCode dbResultStatus, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, DBResult<IEnumerable<UserPreference>> readResult, LegalAgreement termsOfService, IConfiguration configuration, DBResult<IEnumerable<UserProfileHistory>> userProfileHistoryDbResult)
+        public UserProfileServiceMock(
+            string hdId,
+            DBStatusCode dbResultStatus,
+            UserProfile userProfileData,
+            DBResult<UserProfile> userProfileDbResult,
+            DBResult<IEnumerable<UserPreference>> readResult,
+            LegalAgreement termsOfService,
+            PatientModel patientModel,
+            IConfiguration configuration,
+            DBResult<IEnumerable<UserProfileHistory>> userProfileHistoryDbResult)
         {
             int limit = configuration.GetSection(this.webClientConfigSection).GetValue(this.userProfileHistoryRecordLimitKey, 2);
 
             this.userProfileService = new UserProfileService(
                 new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
+                new PatientServiceMock(hdId, patientModel).Object,
                 new Mock<IUserEmailService>().Object,
                 new Mock<IUserSMSService>().Object,
                 new Mock<IEmailQueueService>().Object,
@@ -79,13 +89,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="message">message.</param>
         /// <param name="userProfileData">user profile data.</param>
         /// <param name="userProfileDbResult">user profile from DbResult.</param>
-        /// <param name="registrationStatus">registration status.</param>
+        /// <param name="hdid">hdid.</param>
         /// <param name="configuration">configuration.</param>
-        public UserProfileServiceMock(string message, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, string registrationStatus, IConfiguration configuration)
+        /// <param name="patientModel">patient model.</param>
+        public UserProfileServiceMock(string message, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, string hdid, IConfiguration configuration, PatientModel patientModel)
         {
             this.userProfileService = new UserProfileService(
                 new Mock<ILogger<UserProfileService>>().Object,
-                new Mock<IPatientService>().Object,
+                new PatientServiceMock(hdid, patientModel).Object,
                 new Mock<IUserEmailService>().Object,
                 new Mock<IUserSMSService>().Object,
                 new Mock<IEmailQueueService>().Object,
@@ -136,7 +147,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="termsOfService">terms of service.</param>
         /// <param name="configuration">configuration.</param>
         /// <param name="commit">commit.</param>
-        public UserProfileServiceMock(string hdId, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, DBResult<IEnumerable<UserPreference>> readResult, MessagingVerification messagingVerification, LegalAgreement termsOfService, IConfiguration configuration, bool commit = true)
+        public UserProfileServiceMock(
+            string hdId,
+            UserProfile userProfileData,
+            DBResult<UserProfile> userProfileDbResult,
+            DBResult<IEnumerable<UserPreference>> readResult,
+            MessagingVerification messagingVerification,
+            LegalAgreement termsOfService,
+            IConfiguration configuration,
+            bool commit = true)
         {
             this.userProfileService = new UserProfileService(
                 new Mock<ILogger<UserProfileService>>().Object,
@@ -190,7 +209,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="configuration">configuration.</param>
         /// <param name="shouldEmailCommit">should email commit.</param>
         /// <param name="shouldProfileCommit">should profile commit.</param>
-        public UserProfileServiceMock(string hdId, UserProfile userProfileData, DBResult<UserProfile> userProfileDbResult, IHeaderDictionary headerDictionary, IConfiguration configuration, bool shouldEmailCommit, bool shouldProfileCommit = true)
+        public UserProfileServiceMock(
+            string hdId,
+            UserProfile userProfileData,
+            DBResult<UserProfile> userProfileDbResult,
+            IHeaderDictionary headerDictionary,
+            IConfiguration configuration,
+            bool shouldEmailCommit,
+            bool shouldProfileCommit = true)
         {
             this.userProfileService = new UserProfileService(
                 new Mock<ILogger<UserProfileService>>().Object,
@@ -223,7 +249,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
             DBResult<LegalAgreement> tosDbResult = new()
             {
                 Status = DBStatusCode.Read,
-                Payload = new LegalAgreement()
+                Payload = new LegalAgreement
                 {
                     Id = Guid.Empty,
                     CreatedBy = "MockData",


### PR DESCRIPTION
# Fixes or Implements [AB#14067](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14067)

## Description

Webclient server side updates 
- add year of birth to user profile on create
- add/update year of birth to user profile on get when logging in
- updated service methods to handle async from Patient Service call
- updated controller method to handle async
- update unit tests for async calls
- fixed mistake in db migration script

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
