### PR TITLE
Fix AB#14129 to use dynamic birthdate

### DIFF
--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -45,7 +45,7 @@ namespace HealthGateway.GatewayApi.Test.Services
         private readonly string mockPHN = "MockPHN";
         private readonly string mockFirstName = "MockFirstName";
         private readonly string mockLastName = "MockLastName";
-        private readonly DateTime mockDateOfBirth = new(2010, 10, 10);
+        private readonly DateTime mockDateOfBirth = DateTime.Now.AddYears(-12).AddDays(1);
         private readonly string mockGender = "Male";
         private readonly string mockHdId = "MockHdId";
         private readonly string mismatchedError = "The information you entered does not match our records. Please try again.";


### PR DESCRIPTION
# Fixes or Implements [AB#14129](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14129)

## Description
Remove the hard-coded date and replace with dynamic one.


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
N/A


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
