### PR TITLE
Write db delegate queries for year of birth counts

### DIFF
--- a/Apps/Admin/Server/Services/CsvExportService.cs
+++ b/Apps/Admin/Server/Services/CsvExportService.cs
@@ -35,12 +35,12 @@ namespace HealthGateway.Admin.Server.Services
     {
         private const int PageSize = 100000;
         private const int Page = 0;
-        private readonly INoteDelegate noteDelegate;
-        private readonly IUserProfileDelegate userProfileDelegate;
         private readonly ICommentDelegate commentDelegate;
-        private readonly IRatingDelegate ratingDelegate;
-        private readonly IInactiveUserService inactiveUserService;
         private readonly IFeedbackDelegate feedbackDelegate;
+        private readonly IInactiveUserService inactiveUserService;
+        private readonly INoteDelegate noteDelegate;
+        private readonly IRatingDelegate ratingDelegate;
+        private readonly IUserProfileDelegate userProfileDelegate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CsvExportService"/> class.
@@ -115,18 +115,27 @@ namespace HealthGateway.Admin.Server.Services
             return GetStream<UserFeedback, UserFeedbackCsvMap>(feedback.Payload);
         }
 
+        /// <inheritdoc/>
+        public Stream GetYearOfBirthCounts(DateTime startDate, DateTime endDate)
+        {
+            IDictionary<string, int> yobCounts = this.userProfileDelegate.GetLoggedInUserYearOfBirthCounts(startDate, endDate);
+
+            MemoryStream stream = new();
+            using StreamWriter writer = new(stream);
+            using CsvWriter csv = new(writer, CultureInfo.CurrentCulture);
+            csv.WriteRecords(yobCounts);
+
+            return stream;
+        }
+
         private static Stream GetStream<TModel, TMap>(IEnumerable<TModel> obj)
             where TMap : ClassMap
         {
             MemoryStream stream = new();
-            using (StreamWriter writeFile = new(stream, leaveOpen: true))
-            {
-#pragma warning disable CA2000 // Dispose objects before losing scope
-                CsvWriter csv = new(writeFile, CultureInfo.CurrentCulture, true);
-#pragma warning restore CA2000 // Dispose objects before losing scope
-                csv.Context.RegisterClassMap<TMap>();
-                csv.WriteRecords(obj);
-            }
+            using StreamWriter writeFile = new(stream, leaveOpen: true);
+            using CsvWriter csv = new(writeFile, CultureInfo.CurrentCulture, true);
+            csv.Context.RegisterClassMap<TMap>();
+            csv.WriteRecords(obj);
 
             return stream;
         }

--- a/Apps/Admin/Server/Services/CsvExportService.cs
+++ b/Apps/Admin/Server/Services/CsvExportService.cs
@@ -116,9 +116,15 @@ namespace HealthGateway.Admin.Server.Services
         }
 
         /// <inheritdoc/>
-        public Stream GetYearOfBirthCounts(DateTime startDate, DateTime endDate)
+        public Stream GetYearOfBirthCounts(DateTime startDate, DateTime endDate, int timeOffset)
         {
-            IDictionary<string, int> yobCounts = this.userProfileDelegate.GetLoggedInUserYearOfBirthCounts(startDate, endDate);
+            int offset = timeOffset * -1;
+            TimeSpan timeSpan = new(0, offset, 0);
+            DateTime startDateUtc = startDate.Date.Add(timeSpan);
+            startDateUtc = DateTime.SpecifyKind(startDateUtc, DateTimeKind.Utc);
+            DateTime endDateUtc = endDate.Date.Add(timeSpan).AddDays(1).AddMilliseconds(-1);
+            endDateUtc = DateTime.SpecifyKind(endDateUtc, DateTimeKind.Utc);
+            IDictionary<string, int> yobCounts = this.userProfileDelegate.GetLoggedInUserYearOfBirthCounts(startDateUtc, endDateUtc);
 
             MemoryStream stream = new();
             using StreamWriter writer = new(stream);

--- a/Apps/Admin/Server/Services/ICsvExportService.cs
+++ b/Apps/Admin/Server/Services/ICsvExportService.cs
@@ -69,5 +69,13 @@ namespace HealthGateway.Admin.Server.Services
         /// </summary>
         /// <returns>returns a stream representing a CSV of the User Feedback.</returns>
         Stream GetUserFeedback();
+
+        /// <summary>
+        /// Retrieves stream of logged in user Year of Birth counts over a date range.
+        /// </summary>
+        /// <param name="startDate">The start date of last login of users.</param>
+        /// <param name="endDate">The end date of last login of users.</param>
+        /// <returns>Return the counts of logged in users by Year of Birth.</returns>
+        Stream GetYearOfBirthCounts(DateTime startDate, DateTime endDate);
     }
 }

--- a/Apps/Admin/Server/Services/ICsvExportService.cs
+++ b/Apps/Admin/Server/Services/ICsvExportService.cs
@@ -75,7 +75,8 @@ namespace HealthGateway.Admin.Server.Services
         /// </summary>
         /// <param name="startDate">The start date of last login of users.</param>
         /// <param name="endDate">The end date of last login of users.</param>
+        /// <param name="timeOffset">The clients offset to get to UTC.</param>
         /// <returns>Return the counts of logged in users by Year of Birth.</returns>
-        Stream GetYearOfBirthCounts(DateTime startDate, DateTime endDate);
+        Stream GetYearOfBirthCounts(DateTime startDate, DateTime endDate, int timeOffset);
     }
 }

--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
-    using System.Text.Json;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
@@ -31,8 +30,8 @@ namespace HealthGateway.Database.Delegates
     [ExcludeFromCodeCoverage]
     public class DBProfileDelegate : IUserProfileDelegate
     {
-        private readonly ILogger logger;
         private readonly GatewayDbContext dbContext;
+        private readonly ILogger logger;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DBProfileDelegate"/> class.
@@ -77,7 +76,7 @@ namespace HealthGateway.Database.Delegates
             if (result.Status == DBStatusCode.Read)
             {
                 // Copy certain attributes into the fetched User Profile
-                result.Payload!.Email = profile.Email;
+                result.Payload.Email = profile.Email;
                 result.Payload.TermsOfServiceId = profile.TermsOfServiceId;
                 result.Payload.UpdatedBy = profile.UpdatedBy;
                 result.Payload.Version = profile.Version;
@@ -278,6 +277,24 @@ namespace HealthGateway.Database.Delegates
                 .Take(limit);
             result.Status = DBStatusCode.Read;
             return result;
+        }
+
+        /// <inheritdoc/>
+        public IDictionary<string, int> GetLoggedInUserYearOfBirthCounts(DateTime startDate, DateTime endDate)
+        {
+            Dictionary<string, int> yobCount = this.dbContext.UserProfile
+                .Select(x => new { x.HdId, x.LastLoginDateTime, x.YearOfBirth })
+                .Concat(
+                    this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime, x.YearOfBirth }))
+                .Where(x => x.YearOfBirth != null && x.LastLoginDateTime >= startDate && x.LastLoginDateTime <= endDate)
+                .Select(x => new { x.HdId, lastLoginDate = GatewayDbContext.DateTrunc("days", x.LastLoginDateTime), x.YearOfBirth })
+                .Distinct()
+                .GroupBy(x => x.YearOfBirth)
+                .Select(x => new { yearOfBirth = x.Key, count = x.Count() })
+                .OrderBy(x => x.yearOfBirth)
+                .ToDictionary(x => x.yearOfBirth!, x => x.count);
+
+            return yobCount;
         }
     }
 }

--- a/Apps/Database/src/Delegates/DBProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DBProfileDelegate.cs
@@ -287,14 +287,13 @@ namespace HealthGateway.Database.Delegates
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime, x.YearOfBirth }))
                 .Where(x => x.YearOfBirth != null && x.LastLoginDateTime >= startDate && x.LastLoginDateTime <= endDate)
-                .Select(x => new { x.HdId, lastLoginDate = GatewayDbContext.DateTrunc("days", x.LastLoginDateTime), x.YearOfBirth })
+                .Select(x => new { x.HdId, x.YearOfBirth })
                 .Distinct()
                 .GroupBy(x => x.YearOfBirth)
                 .Select(x => new { yearOfBirth = x.Key, count = x.Count() })
-                .OrderBy(x => x.yearOfBirth)
                 .ToDictionary(x => x.yearOfBirth!, x => x.count);
 
-            return yobCount;
+            return new SortedDictionary<string, int>(yobCount);
         }
     }
 }

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -124,5 +124,13 @@ namespace HealthGateway.Database.Delegates
         /// <param name="limit">The number of rows to return.</param>
         /// <returns>A list of matching UserProfileHistory wrapped in a DBResult.</returns>
         DBResult<IEnumerable<UserProfileHistory>> GetUserProfileHistories(string hdid, int limit);
+
+        /// <summary>
+        /// Returns the list of logged in user Year of Birth counts over a date range.
+        /// </summary>
+        /// <param name="startDate">The start date of last login of users.</param>
+        /// <param name="endDate">The end date of last login of users.</param>
+        /// <returns>The counts of logged in users by Year of Birth.</returns>
+        IDictionary<string, int> GetLoggedInUserYearOfBirthCounts(DateTime startDate, DateTime endDate);
     }
 }

--- a/Apps/Database/src/Models/UserProfile.cs
+++ b/Apps/Database/src/Models/UserProfile.cs
@@ -83,7 +83,7 @@ namespace HealthGateway.Database.Models
         public string? EncryptionKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the users year of birth.
+        /// Gets or sets the user's year of birth.
         /// </summary>
         [MaxLength(4)]
         public string? YearOfBirth { get; set; }

--- a/Apps/Database/src/Models/UserProfileHistory.cs
+++ b/Apps/Database/src/Models/UserProfileHistory.cs
@@ -81,7 +81,7 @@ namespace HealthGateway.Database.Models
         public string? EncryptionKey { get; set; }
 
         /// <summary>
-        /// Gets or sets the users year of birth.
+        /// Gets or sets the user's year of birth.
         /// </summary>
         [MaxLength(4)]
         public string? YearOfBirth { get; set; }


### PR DESCRIPTION
# Fixes or Implements [AB#14066](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14066)

## Description

- added method for year of birth to profile delegate
- updated csv export service with new method to get year of birth counts
- changed GetStream method to implement using statements so no need for #pragma warning disable CA2000

* note this logic still needs to be tested with the upcoming Blazor changes, so pushing it to the feature branch

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
