### PR TITLE
Fix issues with failing closed profile functional test AB#14123 AB#14124

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -268,22 +268,7 @@ export const actions: UserActions = {
             patientService
                 .getPatientData(context.state.user.hdid)
                 .then((result) => {
-                    if (result.resultStatus === ResultType.Error) {
-                        if (result.resultError?.statusCode === 429) {
-                            logger.debug(
-                                "Patient retrieval failed because of too many requests"
-                            );
-                            context.commit(
-                                "setAppError",
-                                AppErrorType.TooManyRequests,
-                                { root: true }
-                            );
-                        } else {
-                            logger.debug("Patient retrieval failed");
-                            context.commit("setPatientRetrievalFailed");
-                        }
-                        resolve();
-                    } else {
+                    if (result.resultStatus === ResultType.Success) {
                         context.commit(
                             "setPatientData",
                             result.resourcePayload
@@ -320,6 +305,21 @@ export const actions: UserActions = {
                                 }
                                 resolve();
                             });
+                    } else {
+                        if (result.resultError?.statusCode === 429) {
+                            logger.debug(
+                                "Patient retrieval failed because of too many requests"
+                            );
+                            context.commit(
+                                "setAppError",
+                                AppErrorType.TooManyRequests,
+                                { root: true }
+                            );
+                        } else {
+                            logger.debug("Patient retrieval failed");
+                            context.commit("setPatientRetrievalFailed");
+                        }
+                        resolve();
                     }
                 })
                 .catch((error: ResultError) => {

--- a/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
@@ -59,6 +59,6 @@ describe("Registration Page", () => {
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak
         );
-        cy.url().should("include", "/registration");
+        cy.url().should("include", "/patientRetrievalError");
     });
 });


### PR DESCRIPTION
# Fixes [AB#14123](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14123) and [AB#14124](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14124)

## Description

- fixes closed profile functional test to expect to land on the new patient retrieval error page [AB#14123](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14123)
- treats "ActionRequired" responses from patient as unsuccessful [AB#14124](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14124)
    - this fixes closed profiles not being caught by the patient retrieval error detection (because they return with a status of ActionRequired instead of Error)

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
