### PR TITLE
Add SupportService unit tests for AB#13985

### DIFF
--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.Admin.Server.Controllers
         [Route("Users")]
         public IActionResult GetSupportUsers([FromQuery] UserQueryType queryType, [FromQuery] string queryString)
         {
-            return new JsonResult(this.supportService.GetSupportUsers(queryType, queryString));
+            return new JsonResult(this.supportService.GetUsers(queryType, queryString));
         }
 
         /// <summary>

--- a/Apps/AdminWebClient/src/Server/Controllers/SupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/SupportController.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.Admin.Controllers
         [Route("Users")]
         public IActionResult GetSupportUsers([FromQuery] UserQueryType queryType, [FromQuery] string queryString)
         {
-            return new JsonResult(this.supportService.GetSupportUsers(queryType, queryString));
+            return new JsonResult(this.supportService.GetUsers(queryType, queryString));
         }
 
         /// <summary>

--- a/Apps/Common/src/Services/ISupportService.cs
+++ b/Apps/Common/src/Services/ISupportService.cs
@@ -32,11 +32,11 @@ namespace HealthGateway.Common.Services
         RequestResult<IEnumerable<MessagingVerificationModel>> GetMessageVerifications(string hdid);
 
         /// <summary>
-        /// Retrieves a list of support users matching the query.
+        /// Retrieves a list of users matching the query.
         /// </summary>
         /// <param name="queryType">The type of query to perform.</param>
         /// <param name="queryString">The value to query on.</param>
-        /// <returns>A list of support users matching the query.</returns>
-        RequestResult<IEnumerable<SupportUser>> GetSupportUsers(UserQueryType queryType, string queryString);
+        /// <returns>A list of users matching the query.</returns>
+        RequestResult<IEnumerable<SupportUser>> GetUsers(UserQueryType queryType, string queryString);
     }
 }

--- a/Apps/Common/src/Services/SupportService.cs
+++ b/Apps/Common/src/Services/SupportService.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.Common.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<IEnumerable<SupportUser>> GetSupportUsers(UserQueryType queryType, string queryString)
+        public RequestResult<IEnumerable<SupportUser>> GetUsers(UserQueryType queryType, string queryString)
         {
             RequestResult<IEnumerable<SupportUser>> result = new()
             {
@@ -98,7 +98,7 @@ namespace HealthGateway.Common.Services
                     break;
             }
 
-            if (result.ResultError != null)
+            if (result.ResultError != null && result.ResultError.ActionCode != null && result.ResultError.ActionCode.Equals(ActionType.Warning))
             {
                 result.ResultStatus = ResultType.ActionRequired;
             }

--- a/Apps/Common/test/unit/CommonTests.csproj
+++ b/Apps/Common/test/unit/CommonTests.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="XunitXml.TestLogger" Version="3.0.70" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Admin\Server\Admin.Server.csproj" />
     <ProjectReference Include="..\..\src\Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Common/test/unit/Services/SupportServiceTests.cs
+++ b/Apps/Common/test/unit/Services/SupportServiceTests.cs
@@ -1,0 +1,329 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using AutoMapper;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.Models.ErrorHandling;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using HealthGateway.CommonTests.Utils;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using Moq;
+    using Xunit;
+    using UserQueryType = HealthGateway.Common.Data.Constants.UserQueryType;
+
+    /// <summary>
+    /// SupportService's Unit Tests.
+    /// </summary>
+    public class SupportServiceTests
+    {
+        private const string Hdid = "DEV4FPEGCXG2NB5K2USBL52S66SC3GOUHWRP3GTXR2BTY5HEC4YA";
+        private const string Phn = "9735361219";
+        private const string SmsNumber = "2501234567";
+        private const string Email = "fakeemail@healthgateway.gov.bc.ca";
+        private const string ClientRegistryWarning = "Client Registry Warning";
+        private const string ClientRegistryError = "Client Registry Error";
+        private const string ProfileNotFound = $"Unable to find user profile for hdid: {Hdid}";
+        private const string PatientResponseCode = $"500|{ClientRegistryWarning}";
+
+        /// <summary>
+        /// Gets Users by Hdid.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersByHdid()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.Success), GetUserProfile(DBStatusCode.Read));
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Hdid, Hdid);
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Single(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Users by Phn.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersByPhn()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.Success), GetUserProfile(DBStatusCode.Read));
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Phn, Phn);
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Single(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Users by Email.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersByEmail()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.Success), GetUserProfile(DBStatusCode.Read), GetUserProfiles());
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Email, Email);
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Single(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Users by SMS.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersBySms()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.Success), GetUserProfile(DBStatusCode.Read), GetUserProfiles());
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Sms, SmsNumber);
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Single(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Users returns Profile Not Found.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersReturnsProfileNotFound()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.Success), GetUserProfile(DBStatusCode.NotFound));
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Hdid, Hdid);
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Equal(ProfileNotFound, actualResult.ResultError?.ResultMessage);
+            Assert.Empty(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Users returns Client Registry Warning.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersByHdidReturnsClientRegistryWarning()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.ActionRequired), GetUserProfile(DBStatusCode.Read));
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Hdid, Hdid);
+
+            // Assert
+            Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
+            Assert.Equal(ClientRegistryWarning, actualResult.ResultError?.ResultMessage);
+            Assert.Single(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Users returns Client Registry Error.
+        /// </summary>
+        [Fact]
+        public void ShouldGetUsersByHdidReturnsClientRegistryError()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetPatient(ResultType.Error));
+
+            // Act
+            RequestResult<IEnumerable<SupportUser>> actualResult = supportService.GetUsers(UserQueryType.Hdid, Hdid);
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Equal(ClientRegistryError, actualResult.ResultError?.ResultMessage);
+            Assert.Empty(actualResult.ResourcePayload);
+        }
+
+        /// <summary>
+        /// Gets Verifications by Hdid.
+        /// </summary>
+        [Fact]
+        public void ShouldGetVerifications()
+        {
+            // Arrange
+            ISupportService supportService = GetSupportService(GetVerifications());
+
+            // Act
+            RequestResult<IEnumerable<MessagingVerificationModel>> actualResult = supportService.GetMessageVerifications(Hdid);
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Equal(2, actualResult.ResourcePayload.Count());
+        }
+
+        private static RequestResult<PatientModel> GetPatient(ResultType resultType)
+        {
+            switch (resultType)
+            {
+                case ResultType.Success:
+                    return new RequestResult<PatientModel>()
+                    {
+                        ResultStatus = ResultType.Success,
+                        ResourcePayload = new()
+                        {
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
+                        },
+                    };
+                case ResultType.ActionRequired:
+                    return new RequestResult<PatientModel>()
+                    {
+                        ResultStatus = ResultType.Success,
+                        ResourcePayload = new()
+                        {
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
+                            ResponseCode = PatientResponseCode,
+                        },
+                        ResultError = GetRequestResultError(ClientRegistryWarning, ActionType.Warning),
+                    };
+                default:
+                    return new RequestResult<PatientModel>()
+                    {
+                        ResultStatus = ResultType.Error,
+                        ResultError = GetRequestResultError(ClientRegistryError, null),
+                    };
+            }
+        }
+
+        private static RequestResultError GetRequestResultError(string resultMessage, ActionType? actionType)
+        {
+            return new RequestResultError()
+            {
+                ActionCode = actionType,
+                ResultMessage = resultMessage,
+            };
+        }
+
+        private static DBResult<UserProfile> GetUserProfile(DBStatusCode statusCode)
+        {
+            switch (statusCode)
+            {
+                case DBStatusCode.NotFound:
+                    return new DBResult<UserProfile>()
+                    {
+                        Status = DBStatusCode.NotFound,
+                    };
+                default:
+                    return new DBResult<UserProfile>()
+                    {
+                        Status = DBStatusCode.Read,
+                        Payload = new UserProfile()
+                        {
+                            HdId = Hdid,
+                            LastLoginDateTime = DateTime.UtcNow,
+                        },
+                    };
+            }
+        }
+
+        private static DBResult<List<UserProfile>> GetUserProfiles()
+        {
+            return new DBResult<List<UserProfile>>()
+            {
+                Status = DBStatusCode.Read,
+                Payload = new List<UserProfile>()
+                {
+                    new UserProfile()
+                    {
+                        HdId = Hdid,
+                        LastLoginDateTime = DateTime.UtcNow,
+                    },
+                },
+            };
+        }
+
+        private static DBResult<IEnumerable<MessagingVerification>> GetVerifications()
+        {
+            return new DBResult<IEnumerable<MessagingVerification>>()
+            {
+                Status = DBStatusCode.Read,
+                Payload = new List<MessagingVerification>()
+                {
+                    new MessagingVerification()
+                    {
+                        Id = Guid.NewGuid(),
+                        Validated = true,
+                        SMSNumber = SmsNumber,
+                    },
+                    new MessagingVerification()
+                    {
+                        Id = Guid.NewGuid(),
+                        Validated = false,
+                        Email = new()
+                        {
+                            To = Email,
+                        },
+                    },
+                },
+            };
+        }
+
+        private static ISupportService GetSupportService(DBResult<IEnumerable<MessagingVerification>> verificationResult)
+        {
+            return GetSupportService(GetPatient(ResultType.Success), null, null, verificationResult);
+        }
+
+        private static ISupportService GetSupportService(
+            RequestResult<PatientModel> patientResult,
+            DBResult<UserProfile>? userProfileResult = null,
+            DBResult<List<UserProfile>>? userProfilesResult = null,
+            DBResult<IEnumerable<MessagingVerification>>? verificationResult = null)
+        {
+            IMapper autoMapper = MapperUtil.InitializeAutoMapper();
+
+            Mock<IMessagingVerificationDelegate> mockMessagingVerificationDelegate = new();
+            mockMessagingVerificationDelegate.Setup(d => d.GetUserMessageVerifications(It.IsAny<string>())).Returns(verificationResult);
+
+            Mock<IPatientService> mockPatientService = new();
+            mockPatientService.Setup(p => p.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false)).ReturnsAsync(patientResult);
+
+            Mock<IUserProfileDelegate> mockUserProfileDelegate = new();
+            mockUserProfileDelegate.Setup(u => u.GetUserProfile(It.IsAny<string>())).Returns(userProfileResult);
+            mockUserProfileDelegate.Setup(u => u.GetUserProfiles(It.IsAny<HealthGateway.Database.Constants.UserQueryType>(), It.IsAny<string>())).Returns(userProfilesResult);
+
+            return new SupportService(
+                mockUserProfileDelegate.Object,
+                mockMessagingVerificationDelegate.Object,
+                mockPatientService.Object,
+                autoMapper);
+        }
+    }
+}

--- a/Apps/Common/test/unit/Utils/MapperUtil.cs
+++ b/Apps/Common/test/unit/Utils/MapperUtil.cs
@@ -1,0 +1,42 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Utils
+{
+    using AutoMapper;
+    using HealthGateway.Admin.Server.MapProfiles;
+
+    /// <summary>
+    /// Static utility class to provide a fully initialized AutoMapper.
+    /// NOTE: Any newly added profiles will have to be registered.
+    /// </summary>
+    public static class MapperUtil
+    {
+        /// <summary>
+        /// Creates an AutoMapper.
+        /// </summary>
+        /// <returns>A configured AutoMapper.</returns>
+        public static IMapper InitializeAutoMapper()
+        {
+            MapperConfiguration config = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile(new MessagingVerificationModelProfile());
+                cfg.AddProfile(new SupportUserProfile());
+            });
+
+            return config.CreateMapper();
+        }
+    }
+}


### PR DESCRIPTION
# Implements [AB#13985](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13985)

## Description

- Add unit tests for GetUsers and GetVerifications in SupportService
- Renamed SupportService.GetSupportUsers to GetUsers and updated documentation accordingly
- Fixed bug when displaying error message from patient call as it was being associated with a result status of action required instead of just being an error

<img width="1285" alt="Screen Shot 2022-10-13 at 11 00 36 PM" src="https://user-images.githubusercontent.com/58790456/195774610-b4bb1987-c412-460f-b9c1-0b39619b7f39.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
