### PR TITLE
Adjust method for displaying loading toast on timeline AB#14152

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -506,8 +506,9 @@ export default class TimelineView extends Vue {
 <template>
     <div>
         <b-toast
+            v-if="!isFullyLoaded"
             id="loading-toast"
-            :visible="!isFullyLoaded"
+            visible
             toaster="b-toaster-top-center"
             variant="info"
             solid


### PR DESCRIPTION
# Fixes [AB#14152](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14152)

## Description

Alters the way the loading toast is toggled on the timeline to prevent it occasionally persisting after the data had been fully loaded.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
