### PR TITLE
Fixed bug in delegate and updated delegate unit tests for AB#14169.

### DIFF
--- a/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
+++ b/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.Encounter.Delegates
             RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> requestResult = new()
             {
                 ResultStatus = ResultType.Error,
-                PageSize = 0,
+                PageSize = int.Parse(this.phsaConfig.FetchSize, CultureInfo.InvariantCulture),
                 ResourcePayload = new PhsaResult<IEnumerable<HospitalVisit>>
                 {
                     Result = Enumerable.Empty<HospitalVisit>(),
@@ -105,7 +105,7 @@ namespace HealthGateway.Encounter.Delegates
                 };
             }
 
-            this.logger.LogDebug("Finished getting Immunizations");
+            this.logger.LogDebug("Finished getting hospital visits for hdid: {Hdid}", hdid);
             return requestResult;
         }
 
@@ -124,7 +124,6 @@ namespace HealthGateway.Encounter.Delegates
                     case HttpStatusCode.NoContent:
                         requestResult.ResultStatus = ResultType.Success;
                         requestResult.TotalResultCount = 0;
-                        requestResult.PageSize = int.Parse(this.phsaConfig.FetchSize, CultureInfo.InvariantCulture);
                         break;
                     case HttpStatusCode.Forbidden:
                         requestResult.ResultError = new()


### PR DESCRIPTION
# Implements [AB#14169](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14169)

## Description

Updated delegate to properly initialize PageSize in RequestResult object
Updated delegate unit tests to assert PageSize and TotalResultsCount
Updated typo in logging message in delegate

Unit tests:

<img width="1329" alt="Screen Shot 2022-10-22 at 11 21 13 AM" src="https://user-images.githubusercontent.com/58790456/197356999-a2193435-2af4-4f07-926d-a51f8913b4d1.png">

Swagger:

<img width="1673" alt="Screen Shot 2022-10-22 at 11 20 13 AM" src="https://user-images.githubusercontent.com/58790456/197357002-fdf90085-1319-4c6f-aea3-3f44e9881bdf.png">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
