### PR TITLE
Create service and controller for broadcasts AB#14071

### DIFF
--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -1,0 +1,80 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Controllers
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// Web API to handle system broadcasts.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/api/[controller]")]
+    [Produces("application/json")]
+    [Authorize(Roles = "AdminUser,AdminReviewer")]
+    public class BroadcastController
+    {
+        private readonly IBroadcastService broadcastService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastController"/> class.
+        /// </summary>
+        /// <param name="broadcastService">The injected broadcast service.</param>
+        public BroadcastController(IBroadcastService broadcastService)
+        {
+            this.broadcastService = broadcastService;
+        }
+
+        /// <summary>
+        /// Creates a broadcast.
+        /// </summary>
+        /// <returns>The created broadcast wrapped in a RequestResult.</returns>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <response code="200">Returns the created broadcast wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpPost]
+        public async Task<RequestResult<Broadcast>> CreateBroadcast(Broadcast broadcast)
+        {
+            return await this.broadcastService.CreateBroadcastAsync(broadcast).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Retrieves all broadcasts.
+        /// </summary>
+        /// <returns>The collection of broadcasts wrapped in a RequestResult.</returns>
+        /// <response code="200">Returns the collection of broadcasts wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        public async Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcasts()
+        {
+            return await this.broadcastService.GetBroadcastsAsync().ConfigureAwait(true);
+        }
+    }
+}

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -20,10 +20,12 @@ namespace HealthGateway.Admin.Server
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Common.AccessManagement.Administration;
     using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.Api;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
+    using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
     using Microsoft.AspNetCore.Builder;
@@ -32,6 +34,7 @@ namespace HealthGateway.Admin.Server
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
+    using Refit;
     using CommunicationService = HealthGateway.Admin.Server.Services.CommunicationService;
     using ICommunicationService = HealthGateway.Admin.Server.Services.ICommunicationService;
 
@@ -94,6 +97,12 @@ namespace HealthGateway.Admin.Server
             services.AddTransient<IAdminUserProfileDelegate, DbAdminUserProfileDelegate>();
             services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
             services.AddTransient<IUserAdminDelegate, KeycloakUserAdminDelegate>();
+
+            // Add API clients
+            PhsaConfigV2 phsaConfig = new();
+            configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfig);
+            services.AddRefitClient<ISystemBroadcastApi>()
+                .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
 
             services.AddAutoMapper(typeof(Program));
 

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -69,6 +69,7 @@ namespace HealthGateway.Admin.Server
             services.AddControllersWithViews();
 
             // Add HG Services
+            services.AddTransient<IBroadcastService, BroadcastService>();
             services.AddTransient<IConfigurationService, ConfigurationService>();
             services.AddTransient<IUserFeedbackService, UserFeedbackService>();
             services.AddTransient<IDashboardService, DashboardService>();

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -41,5 +41,8 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "http://localhost:5005/"
+    },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -43,6 +43,7 @@
         "JobScheduler": "http://localhost:5005/"
     },
     "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -40,5 +40,8 @@
     "ServiceEndpoints": {
         "JobScheduler": "https://dev.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
+    },
     "RedisAuditing": true
 }

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -41,6 +41,7 @@
         "JobScheduler": "https://dev.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
     "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     },
     "RedisAuditing": true

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -39,5 +39,8 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://mock.healthgateway.gov.bc.ca/admin/jobscheduler"
+    },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -41,6 +41,7 @@
         "JobScheduler": "https://mock.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
     "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -36,5 +36,8 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://test.healthgateway.gov.bc.ca/admin/jobscheduler"
+    },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-test.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -38,6 +38,7 @@
         "JobScheduler": "https://test.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
     "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-test.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-test.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -91,6 +91,12 @@
         "JobScheduler": "https://www.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
     "PhsaV2": {
-        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-prod.azurewebsites.net"
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-prod.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-prod.azurewebsites.net",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "delegation",
+        "Scope": "healthdata.read",
+        "TokenCacheEnabled": true
     }
 }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -89,5 +89,8 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://www.healthgateway.gov.bc.ca/admin/jobscheduler"
+    },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-prod.azurewebsites.net"
     }
 }

--- a/Apps/Common/src/Api/ISystemBroadcastApi.cs
+++ b/Apps/Common/src/Api/ISystemBroadcastApi.cs
@@ -29,7 +29,7 @@ namespace HealthGateway.Common.Api
         /// Retrieves broadcasts.
         /// </summary>
         /// <returns>A response containing the collection of broadcasts.</returns>
-        [Get("/api/system-broadcasts")]
+        [Get("/system-broadcasts")]
         Task<IApiResponse<IEnumerable<BroadcastResponse>>> GetBroadcasts();
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace HealthGateway.Common.Api
         /// </summary>
         /// <param name="request">The broadcast to create.</param>
         /// <returns>A response containing the broadcast that was created.</returns>
-        [Post("/api/system-broadcasts")]
+        [Post("/system-broadcasts")]
         Task<IApiResponse<BroadcastResponse>> CreateBroadcast([Body] BroadcastRequest request);
 
         /// <summary>
@@ -46,7 +46,7 @@ namespace HealthGateway.Common.Api
         /// <param name="id">The id of the broadcast that is being updated.</param>
         /// <param name="request">The broadcast values to update.</param>
         /// <returns>A response containing the broadcast that was updated.</returns>
-        [Put("/api/system-broadcasts/{id}")]
+        [Put("/system-broadcasts/{id}")]
         Task<IApiResponse<BroadcastResponse>> UpdateBroadcast(string id, [Body] BroadcastRequest request);
 
         /// <summary>
@@ -54,7 +54,7 @@ namespace HealthGateway.Common.Api
         /// </summary>
         /// <param name="id">The id of the broadcast that is being deleted.</param>
         /// <returns>A response indicating success or failure.</returns>
-        [Delete("/api/system-broadcasts/{id}")]
+        [Delete("/system-broadcasts/{id}")]
         Task<IApiResponse> DeleteBroadcast(string id);
     }
 }

--- a/Apps/Common/src/Api/ISystemBroadcastApi.cs
+++ b/Apps/Common/src/Api/ISystemBroadcastApi.cs
@@ -23,12 +23,12 @@ namespace HealthGateway.Common.Api
     /// <summary>
     /// Interface to interact with PHSA System Broadcasts API.
     /// </summary>
-    public interface ISystemBroadcastsApi
+    public interface ISystemBroadcastApi
     {
         /// <summary>
-        /// Retrieves the broadcasts.
+        /// Retrieves broadcasts.
         /// </summary>
-        /// <returns>The collection of Broadcasts.</returns>
+        /// <returns>A response containing the collection of broadcasts.</returns>
         [Get("/api/system-broadcasts")]
         Task<IApiResponse<IEnumerable<BroadcastResponse>>> GetBroadcasts();
 
@@ -36,7 +36,7 @@ namespace HealthGateway.Common.Api
         /// Creates a broadcast.
         /// </summary>
         /// <param name="request">The broadcast to create.</param>
-        /// <returns>The Broadcasts that was created.</returns>
+        /// <returns>A response containing the broadcast that was created.</returns>
         [Post("/api/system-broadcasts")]
         Task<IApiResponse<BroadcastResponse>> CreateBroadcast([Body] BroadcastRequest request);
 
@@ -45,15 +45,15 @@ namespace HealthGateway.Common.Api
         /// </summary>
         /// <param name="id">The id of the broadcast that is being updated.</param>
         /// <param name="request">The broadcast values to update.</param>
-        /// <returns>The Broadcasts that was updated.</returns>
+        /// <returns>A response containing the broadcast that was updated.</returns>
         [Put("/api/system-broadcasts/{id}")]
         Task<IApiResponse<BroadcastResponse>> UpdateBroadcast(string id, [Body] BroadcastRequest request);
 
         /// <summary>
         /// Deletes a broadcast.
         /// </summary>
-        /// <param name="id">The id of the broadcast that is being deleted..</param>
-        /// <returns>The Broadcasts that was created.</returns>
+        /// <param name="id">The id of the broadcast that is being deleted.</param>
+        /// <returns>A response indicating success or failure.</returns>
         [Delete("/api/system-broadcasts/{id}")]
         Task<IApiResponse> DeleteBroadcast(string id);
     }

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.MapProfiles
+{
+    using AutoMapper;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.PHSA;
+
+    /// <summary>
+    /// An AutoMapper profile class which defines mapping between PHSA and front-end models.
+    /// </summary>
+    public class BroadcastProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastProfile"/> class.
+        /// </summary>
+        public BroadcastProfile()
+        {
+            this.CreateMap<BroadcastResponse, Broadcast>();
+            this.CreateMap<Broadcast, BroadcastRequest>();
+        }
+    }
+}

--- a/Apps/Common/src/Models/Broadcast.cs
+++ b/Apps/Common/src/Models/Broadcast.cs
@@ -1,4 +1,19 @@
-﻿namespace HealthGateway.Common.Models
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Models
 {
     using System;
     using System.Text.Json.Serialization;

--- a/Apps/Common/src/Models/Broadcast.cs
+++ b/Apps/Common/src/Models/Broadcast.cs
@@ -1,0 +1,59 @@
+﻿namespace HealthGateway.Common.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Model representing a broadcast.
+    /// </summary>
+    public class Broadcast
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category name.
+        /// </summary>
+        [JsonPropertyName("categoryName")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text.
+        /// </summary>
+        [JsonPropertyName("displayText")]
+        public string? DisplayText { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this broadcast system is enabled.
+        /// </summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action url.
+        /// </summary>
+        [JsonPropertyName("actionUrl")]
+        public Uri? ActionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action text.
+        /// </summary>
+        [JsonPropertyName("actionText")]
+        public string? ActionText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scheduled datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("scheduledDateUtc")]
+        public DateTime ScheduledDateUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("expirationDateUtc")]
+        public DateTime? ExpirationDateUtc { get; set; }
+    }
+}

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -1,0 +1,147 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Services
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.ErrorHandling;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.PHSA;
+    using Microsoft.Extensions.Logging;
+    using Refit;
+
+    /// <inheritdoc/>
+    public class BroadcastService : IBroadcastService
+    {
+        private readonly ILogger logger;
+        private readonly IMapper autoMapper;
+        private readonly ISystemBroadcastApi systemBroadcastApi;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastService"/> class.
+        /// </summary>
+        /// <param name="logger">The injected logger.</param>
+        /// <param name="systemBroadcastApi">The injected API for interacting with system broadcasts.</param>
+        /// <param name="autoMapper">The injected automapper provider.</param>
+        public BroadcastService(ILogger logger, ISystemBroadcastApi systemBroadcastApi, IMapper autoMapper)
+        {
+            this.logger = logger;
+            this.systemBroadcastApi = systemBroadcastApi;
+            this.autoMapper = autoMapper;
+        }
+
+        private static ActivitySource Source { get; } = new(nameof(BroadcastService));
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<Broadcast>> CreateBroadcastAsync(Broadcast broadcast)
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Creating broadcast");
+
+            RequestResult<Broadcast> requestResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+
+            try
+            {
+                BroadcastRequest broadcastRequest = this.autoMapper.Map<BroadcastRequest>(broadcast);
+                IApiResponse<BroadcastResponse> response = await this.systemBroadcastApi.CreateBroadcast(broadcastRequest).ConfigureAwait(true);
+
+                if (response.StatusCode == HttpStatusCode.OK && response.Error is null && response.Content is not null)
+                {
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = this.autoMapper.Map<Broadcast>(response.Content);
+                    requestResult.TotalResultCount = 1;
+                }
+                else
+                {
+                    this.logger.LogError("Broadcast request returned unsuccessful response");
+                    requestResult.ResultError = new()
+                    {
+                        ResultMessage = "An unexpected error occurred while processing external call",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}", e.ToString());
+                requestResult.ResultError = new()
+                {
+                    ResultMessage = "Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            this.logger.LogDebug("Finished creating broadcast");
+            return requestResult;
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcastsAsync()
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Retrieving broadcasts");
+
+            RequestResult<IEnumerable<Broadcast>> requestResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+
+            try
+            {
+                IApiResponse<IEnumerable<BroadcastResponse>> response = await this.systemBroadcastApi.GetBroadcasts().ConfigureAwait(true);
+
+                if (response.StatusCode == HttpStatusCode.OK && response.Error is null && response.Content is not null)
+                {
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = this.autoMapper.Map<List<Broadcast>>(response.Content);
+                    requestResult.TotalResultCount = requestResult.ResourcePayload.Count();
+                }
+                else
+                {
+                    this.logger.LogError("Broadcast request returned unsuccessful response");
+                    requestResult.ResultError = new()
+                    {
+                        ResultMessage = "An unexpected error occurred while processing external call",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}", e.ToString());
+                requestResult.ResultError = new()
+                {
+                    ResultMessage = "Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            this.logger.LogDebug("Finished retrieving broadcasts");
+            return requestResult;
+        }
+    }
+}

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -44,7 +44,7 @@ namespace HealthGateway.Common.Services
         /// <param name="logger">The injected logger.</param>
         /// <param name="systemBroadcastApi">The injected API for interacting with system broadcasts.</param>
         /// <param name="autoMapper">The injected automapper provider.</param>
-        public BroadcastService(ILogger logger, ISystemBroadcastApi systemBroadcastApi, IMapper autoMapper)
+        public BroadcastService(ILogger<BroadcastService> logger, ISystemBroadcastApi systemBroadcastApi, IMapper autoMapper)
         {
             this.logger = logger;
             this.systemBroadcastApi = systemBroadcastApi;

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -1,4 +1,19 @@
-﻿namespace HealthGateway.Common.Services
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Services
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -1,0 +1,26 @@
+﻿namespace HealthGateway.Common.Services
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
+
+    /// <summary>
+    /// Service to interact with broadcasts.
+    /// </summary>
+    public interface IBroadcastService
+    {
+        /// <summary>
+        /// Creates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The created broadcast wrapped in a RequestResult.</returns>
+        Task<RequestResult<Broadcast>> CreateBroadcastAsync(Broadcast broadcast);
+
+        /// <summary>
+        /// Retrieves all broadcasts.
+        /// </summary>
+        /// <returns>The collection of broadcasts wrapped in a RequestResult.</returns>
+        Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcastsAsync();
+    }
+}


### PR DESCRIPTION
# Implements [AB#14071](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14071)

## Description

Adds a new service and controller, front-end model, and mapper profile for system broadcasts (notifications).

- fixes paths for PHSA endpoints
- enables token swap for calls to ISystemBroadcastApi

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
