### PR TITLE
Create Fluxor store for broadcasts AB#14073

### DIFF
--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -103,6 +103,7 @@ namespace HealthGateway.Admin.Client
         private static void RegisterRefitClients(this WebAssemblyHostBuilder builder)
         {
             RegisterRefitClient<IAnalyticsApi>(builder, "v1/api/CsvExport", true);
+            RegisterRefitClient<IBroadcastsApi>(builder, "v1/api/Broadcast", true);
             RegisterRefitClient<ICommunicationsApi>(builder, "v1/api/Communication", true);
             RegisterRefitClient<IConfigurationApi>(builder, "v1/api/Configuration", false);
             RegisterRefitClient<IDashboardApi>(builder, "v1/api/Dashboard", true);

--- a/Apps/Admin/Client/Services/IBroadcastsApi.cs
+++ b/Apps/Admin/Client/Services/IBroadcastsApi.cs
@@ -1,0 +1,60 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Services
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
+    using Refit;
+
+    /// <summary>
+    /// API for interacting with broadcasts.
+    /// </summary>
+    public interface IBroadcastsApi
+    {
+        /// <summary>
+        /// Adds a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The model to add.</param>
+        /// <returns>The wrapped model.</returns>
+        [Post("/")]
+        Task<ApiResponse<RequestResult<Broadcast>>> Add([Body] Broadcast broadcast);
+
+        /// <summary>
+        /// Gets all broadcasts.
+        /// </summary>
+        /// <returns>The wrapped collection of models.</returns>
+        [Get("/")]
+        Task<ApiResponse<RequestResult<IEnumerable<Broadcast>>>> GetAll();
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The model to update.</param>
+        /// <returns>The wrapped model.</returns>
+        [Put("/")]
+        Task<ApiResponse<RequestResult<Broadcast>>> Update([Body] Broadcast broadcast);
+
+        /// <summary>
+        /// Deletes a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The model to delete.</param>
+        /// <returns>The wrapped model.</returns>
+        [Delete("/")]
+        Task<ApiResponse<RequestResult<Broadcast>>> Delete([Body] Broadcast broadcast);
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
@@ -1,0 +1,228 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.ViewModels;
+
+/// <summary>
+/// Static class that implements all actions for the feature.
+/// </summary>
+[SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Team decision")]
+public static class BroadcastsActions
+{
+    /// <summary>
+    /// The action representing the initiation of an add.
+    /// </summary>
+    public class AddAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddAction"/> class.
+        /// </summary>
+        /// <param name="broadcast">Represents the broadcast model.</param>
+        public AddAction(Broadcast broadcast)
+        {
+            this.Broadcast = broadcast;
+        }
+
+        /// <summary>
+        /// Gets or sets the broadcast.
+        /// </summary>
+        public Broadcast Broadcast { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed add.
+    /// </summary>
+    public class AddFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public AddFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful add.
+    /// </summary>
+    public class AddSuccessAction : BaseSuccessAction<RequestResult<Broadcast>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">Broadcast data.</param>
+        public AddSuccessAction(RequestResult<Broadcast> data)
+            : base(data)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of a load.
+    /// </summary>
+    public class LoadAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadAction"/> class.
+        /// </summary>
+        public LoadAction()
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a failed load.
+    /// </summary>
+    public class LoadFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public LoadFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful load.
+    /// </summary>
+    public class LoadSuccessAction : BaseSuccessAction<RequestResult<IEnumerable<Broadcast>>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadSuccessAction"/> class.
+        /// </summary>
+        /// <param name="requestResultModel">Broadcasts data.</param>
+        public LoadSuccessAction(RequestResult<IEnumerable<Broadcast>> requestResultModel)
+            : base(requestResultModel)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of an update.
+    /// </summary>
+    public class UpdateAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateAction"/> class.
+        /// </summary>
+        /// <param name="broadcast">Represents the broadcast model.</param>
+        public UpdateAction(Broadcast broadcast)
+        {
+            this.Broadcast = broadcast;
+        }
+
+        /// <summary>
+        /// Gets or sets the broadcast.
+        /// </summary>
+        public Broadcast Broadcast { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed update.
+    /// </summary>
+    public class UpdateFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public UpdateFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful update.
+    /// </summary>
+    public class UpdateSuccessAction : BaseSuccessAction<RequestResult<Broadcast>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">Broadcast data.</param>
+        public UpdateSuccessAction(RequestResult<Broadcast> data)
+            : base(data)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of a deletion.
+    /// </summary>
+    public class DeleteAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteAction"/> class.
+        /// </summary>
+        /// <param name="broadcast">Represents the broadcast model.</param>
+        public DeleteAction(Broadcast broadcast)
+        {
+            this.Broadcast = broadcast;
+        }
+
+        /// <summary>
+        /// Gets or sets the broadcast.
+        /// </summary>
+        public Broadcast Broadcast { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed deletion.
+    /// </summary>
+    public class DeleteFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public DeleteFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful deletion.
+    /// </summary>
+    public class DeleteSuccessAction : BaseSuccessAction<RequestResult<Broadcast>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">Broadcast data.</param>
+        public DeleteSuccessAction(RequestResult<Broadcast> data)
+            : base(data)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action that clears the state.
+    /// </summary>
+    public class ResetStateAction
+    {
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
@@ -1,0 +1,147 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fluxor;
+using HealthGateway.Admin.Client.Services;
+using HealthGateway.Admin.Client.Utils;
+using HealthGateway.Common.Data.Constants;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.ViewModels;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using Refit;
+
+/// <summary>
+/// The effects for the feature.
+/// </summary>
+public class BroadcastsEffects
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BroadcastsEffects"/> class.
+    /// </summary>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="api">The injected API.</param>
+    public BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi api)
+    {
+        this.Logger = logger;
+        this.Api = api;
+    }
+
+    [Inject]
+    private ILogger<BroadcastsEffects> Logger { get; set; }
+
+    [Inject]
+    private IBroadcastsApi Api { get; set; }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="action">The triggering action.</param>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod]
+    public async Task HandleAddAction(BroadcastsActions.AddAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Adding broadcast");
+
+        ApiResponse<RequestResult<Broadcast>> response = await this.Api.Add(action.Broadcast).ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcast added successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.AddSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error adding broadcast, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.AddFailAction(error));
+    }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod(typeof(BroadcastsActions.LoadAction))]
+    public async Task HandleLoadAction(IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Loading broadcasts");
+
+        ApiResponse<RequestResult<IEnumerable<Broadcast>>> response = await this.Api.GetAll().ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcasts loaded successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.LoadSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error loading broadcasts, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.LoadFailAction(error));
+    }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="action">The triggering action.</param>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod]
+    public async Task HandleUpdateAction(BroadcastsActions.UpdateAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Updating broadcast");
+
+        ApiResponse<RequestResult<Broadcast>> response = await this.Api.Update(action.Broadcast).ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcast updated successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.UpdateSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error updating broadcast, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.UpdateFailAction(error));
+    }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="action">The triggering action.</param>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod]
+    public async Task HandleDeleteAction(BroadcastsActions.DeleteAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Deleting broadcast");
+
+        ApiResponse<RequestResult<Broadcast>> response = await this.Api.Delete(action.Broadcast).ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcast deleted successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.DeleteSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error deleting broadcast, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.DeleteFailAction(error));
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -1,0 +1,320 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Fluxor;
+using HealthGateway.Common.Data.Models;
+
+/// <summary>
+/// The set of reducers for the feature.
+/// </summary>
+public static class BroadcastsReducers
+{
+    /// <summary>
+    /// The reducer for loading broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.LoadAction))]
+    public static BroadcastsState ReduceLoadAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Load = state.Load with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the load success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The load success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceLoadSuccessAction(BroadcastsState state, BroadcastsActions.LoadSuccessAction action)
+    {
+        return state with
+        {
+            Load = state.Load with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = action.Data.ResourcePayload.ToImmutableDictionary(tag => tag.Id),
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the load fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The load fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceLoadFailAction(BroadcastsState state, BroadcastsActions.LoadFailAction action)
+    {
+        return state with
+        {
+            Load = state.Load with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for adding broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.AddAction))]
+    public static BroadcastsState ReduceAddAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the add success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The add success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceAddSuccessAction(BroadcastsState state, BroadcastsActions.AddSuccessAction action)
+    {
+        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+
+        Broadcast? broadcast = action.Data.ResourcePayload;
+        if (broadcast != null)
+        {
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+        }
+
+        return state with
+        {
+            Add = state.Add with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = data,
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the add fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The add fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceAddFailAction(BroadcastsState state, BroadcastsActions.AddFailAction action)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for updating broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.UpdateAction))]
+    public static BroadcastsState ReduceUpdateAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the update success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The update success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceUpdateSuccessAction(BroadcastsState state, BroadcastsActions.UpdateSuccessAction action)
+    {
+        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+
+        Broadcast? broadcast = action.Data.ResourcePayload;
+        if (broadcast != null)
+        {
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+        }
+
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = data,
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the update fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The update fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceUpdateFailAction(BroadcastsState state, BroadcastsActions.UpdateFailAction action)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for deleting broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.DeleteAction))]
+    public static BroadcastsState ReduceDeleteAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Delete = state.Delete with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the delete success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The delete success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceDeleteSuccessAction(BroadcastsState state, BroadcastsActions.DeleteSuccessAction action)
+    {
+        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+
+        Broadcast? broadcast = action.Data.ResourcePayload;
+        if (broadcast != null)
+        {
+            data = data.Remove(broadcast.Id);
+        }
+
+        return state with
+        {
+            Delete = state.Delete with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = data,
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the delete fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The delete fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceDeleteFailAction(BroadcastsState state, BroadcastsActions.DeleteFailAction action)
+    {
+        return state with
+        {
+            Delete = state.Delete with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the reset state action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The default state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.ResetStateAction))]
+    public static BroadcastsState ReduceResetStateAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Add = new(),
+            Load = new(),
+            Update = new(),
+            Delete = new(),
+            Data = null,
+            Error = null,
+            IsLoading = false,
+        };
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
@@ -1,0 +1,72 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Fluxor;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.ViewModels;
+
+/// <summary>
+/// The state for the feature.
+/// State should be decorated with [FeatureState] for automatic discovery when services. AddFluxor is called.
+/// </summary>
+[FeatureState]
+public record BroadcastsState
+{
+    /// <summary>
+    /// Gets the request state for adds.
+    /// </summary>
+    public BaseRequestState<RequestResult<Broadcast>> Add { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for loads.
+    /// </summary>
+    public BaseRequestState<RequestResult<IEnumerable<Broadcast>>> Load { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for updates.
+    /// </summary>
+    public BaseRequestState<RequestResult<Broadcast>> Update { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for deletions.
+    /// </summary>
+    public BaseRequestState<RequestResult<Broadcast>> Delete { get; init; } = new();
+
+    /// <summary>
+    /// Gets the collection of data.
+    /// </summary>
+    public IImmutableDictionary<Guid, Broadcast>? Data { get; init; }
+
+    /// <summary>
+    /// Gets the request error if available.
+    /// </summary>
+    public RequestError? Error { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a request is loading.
+    /// </summary>
+    public bool IsLoading { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the data has been loaded.
+    /// </summary>
+    public bool Loaded => this.Data != null;
+}

--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Controllers
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.MapProfiles
 {
     using AutoMapper;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.PHSA;
 

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.Common.Services
     using AutoMapper;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Services
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
 

--- a/Apps/CommonData/src/Models/Broadcast.cs
+++ b/Apps/CommonData/src/Models/Broadcast.cs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Models
+namespace HealthGateway.Common.Data.Models
 {
     using System;
     using System.Text.Json.Serialization;


### PR DESCRIPTION
# Implements [AB#14073](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14073)

## Description

- moves Broadcast model to CommonData
- adds Refit interface for broadcasts
- adds store for broadcasts

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

I included the update and delete behaviour since the easiest way to implement the store was to base it on an existing one that has all of that functionality and it seemed a shame to throw it away.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
