### PR TITLE
Set default values for banner effective and expiry dates AB#14076

### DIFF
--- a/Apps/Admin/Client/Components/BannerDialog.razor.cs
+++ b/Apps/Admin/Client/Components/BannerDialog.razor.cs
@@ -94,7 +94,16 @@ public partial class BannerDialog : FluxorComponent
 
     private void SetFormValues()
     {
-        if (!this.IsNewBanner)
+        if (this.IsNewBanner)
+        {
+            DateTime now = DateTime.Now;
+            DateTime tomorrow = now.AddDays(1);
+            this.EffectiveDate = now.Date;
+            this.EffectiveTime = now.TimeOfDay;
+            this.ExpiryDate = tomorrow.Date;
+            this.ExpiryTime = tomorrow.TimeOfDay;
+        }
+        else
         {
             this.EffectiveDate = this.Communication.EffectiveDateTime.ToLocalTime().Date;
             this.EffectiveTime = this.Communication.EffectiveDateTime.ToLocalTime().TimeOfDay;


### PR DESCRIPTION
# Implements [AB#14076](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14076)

## Description

Initializes the effective and expiry dates when creating a new banner.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
