### PR TITLE
Implement Edit Notification for AB#14077

### DIFF
--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -77,5 +77,22 @@ namespace HealthGateway.Admin.Server.Controllers
         {
             return await this.broadcastService.GetBroadcastsAsync().ConfigureAwait(true);
         }
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The updated broadcast wrapped in a RequestResult.</returns>
+        /// <response code="200">Returns the updated broadcast  wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpPut]
+        public async Task<RequestResult<Broadcast>> UpdateBroadcast(Broadcast broadcast)
+        {
+            return await this.broadcastService.UpdateBroadcastAsync(broadcast).ConfigureAwait(true);
+        }
     }
 }

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -38,5 +38,12 @@ namespace HealthGateway.Common.Services
         /// </summary>
         /// <returns>The collection of broadcasts wrapped in a RequestResult.</returns>
         Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcastsAsync();
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The updated broadcast wrapped in a RequestResult.</returns>
+        Task<RequestResult<Broadcast>> UpdateBroadcastAsync(Broadcast broadcast);
     }
 }

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -1,0 +1,312 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Common.Services;
+    using HealthGateway.CommonTests.Utils;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Refit;
+    using Xunit;
+
+    /// <summary>
+    /// BroadcastService's Unit Tests.
+    /// </summary>
+    public class BroadcastServiceTests
+    {
+        private const string CategoryName = "Test Category Name";
+        private const string UnexpectedErrorMessage = "An unexpected error occurred while processing external call";
+        private const string ThrownExceptionMessage = "Error with HTTP Request";
+
+        /// <summary>
+        /// CreateBroadcast.
+        /// </summary>
+        [Fact]
+        public void ShouldCreateBroadcast()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(new Broadcast()).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(CategoryName, actualResult.ResourcePayload.CategoryName);
+        }
+
+        /// <summary>
+        /// CreateBroadcast returns error.
+        /// </summary>
+        [Fact]
+        public void ShouldCreateBroadcastReturnsError()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(new Broadcast()).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// CreateBroadcast throws exception.
+        /// </summary>
+        [Fact]
+        public void ShouldCreateBroadcastThrowsException()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(new Broadcast()).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - returns one row.
+        /// </summary>
+        [Fact]
+        public void ShouldGetBroadcasts()
+        {
+            // Arrange
+            Guid expectedId = Guid.NewGuid();
+            IBroadcastService service = GetBroadcastService(expectedId, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.ResourcePayload.Count() == 1);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(expectedId, actualResult.ResourcePayload.First().Id);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - returns no rows.
+        /// </summary>
+        [Fact]
+        public void ShouldGetBroadcastsNoRowsReturned()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(!actualResult.ResourcePayload.Any());
+            Assert.True(actualResult.TotalResultCount == 0);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - returns error.
+        /// </summary>
+        [Fact]
+        public void ShouldGetBroadcastsReturnsError()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - throws exception.
+        /// </summary>
+        [Fact]
+        public void ShouldGetBroadcastsThrowsException()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// UpdateBroadcast.
+        /// </summary>
+        [Fact]
+        public void ShouldUpdateBroadcast()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(expectedId, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(expectedId, actualResult.ResourcePayload.Id);
+        }
+
+        /// <summary>
+        /// UpdateBroadcast returns error.
+        /// </summary>
+        [Fact]
+        public void ShouldUpdateBroadcastReturnsError()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// CreateBroadcast throws exception.
+        /// </summary>
+        [Fact]
+        public void ShouldUpdateBroadcastThrowsException()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        private static BroadcastResponse GetApiResponse(Guid? id)
+        {
+            BroadcastResponse response = new()
+            {
+                Id = id ?? Guid.NewGuid(),
+                CategoryName = CategoryName,
+                ModifiedDateUtc = DateTime.UtcNow,
+                CreationDateUtc = DateTime.UtcNow,
+            };
+            return response;
+        }
+
+        private static IBroadcastService GetBroadcastService(Guid? id, HttpStatusCode? statusCode, bool throwException)
+        {
+            Mock<IApiResponse> mockApiDeleteResponse = new();
+            mockApiDeleteResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<IApiResponse<BroadcastResponse>> mockApiUpdateResponse = new();
+            mockApiUpdateResponse.Setup(r => r.Content).Returns(GetApiResponse(id));
+            mockApiUpdateResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<IApiResponse<BroadcastResponse>> mockApiCreateResponse = new();
+            mockApiCreateResponse.Setup(r => r.Content).Returns(GetApiResponse(null));
+            mockApiCreateResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<IApiResponse<IEnumerable<BroadcastResponse>>> mockApiGetResponse = new();
+            List<BroadcastResponse> responses = new();
+            if (id != null)
+            {
+                responses.Add(GetApiResponse(id));
+            }
+
+            mockApiGetResponse.Setup(r => r.Content).Returns(responses);
+            mockApiGetResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<ISystemBroadcastApi> mockSystemBroadcastApi = new();
+
+            if (!throwException)
+            {
+                mockSystemBroadcastApi.Setup(s => s.GetBroadcasts()).ReturnsAsync(mockApiGetResponse.Object);
+                mockSystemBroadcastApi.Setup(s => s.UpdateBroadcast(It.IsAny<string>(), It.IsAny<BroadcastRequest>())).ReturnsAsync(mockApiUpdateResponse.Object);
+                mockSystemBroadcastApi.Setup(s => s.CreateBroadcast(It.IsAny<BroadcastRequest>())).ReturnsAsync(mockApiCreateResponse.Object);
+                mockSystemBroadcastApi.Setup(s => s.DeleteBroadcast(It.IsAny<string>())).ReturnsAsync(mockApiDeleteResponse.Object);
+            }
+            else
+            {
+                mockSystemBroadcastApi.Setup(s => s.GetBroadcasts()).ThrowsAsync(new HttpRequestException(string.Empty));
+                mockSystemBroadcastApi.Setup(s => s.UpdateBroadcast(It.IsAny<string>(), It.IsAny<BroadcastRequest>())).ThrowsAsync(new HttpRequestException(string.Empty));
+                mockSystemBroadcastApi.Setup(s => s.CreateBroadcast(It.IsAny<BroadcastRequest>())).ThrowsAsync(new HttpRequestException(string.Empty));
+                mockSystemBroadcastApi.Setup(s => s.DeleteBroadcast(It.IsAny<string>())).ThrowsAsync(new HttpRequestException(string.Empty));
+            }
+
+            return new BroadcastService(
+                new Mock<ILogger<BroadcastService>>().Object,
+                mockSystemBroadcastApi.Object,
+                MapperUtil.InitializeAutoMapper());
+        }
+    }
+}

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.CommonTests.Services
         /// CreateBroadcast - api returns error.
         /// </summary>
         [Fact]
-        public void ShouldCreateBroadcastApiReturnsError()
+        public void CreateBroadcastShouldReturnsError()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
@@ -83,7 +83,7 @@ namespace HealthGateway.CommonTests.Services
         /// CreateBroadcast - api throws exception.
         /// </summary>
         [Fact]
-        public void ShouldCreateBroadcastApiThrowsException()
+        public void CreateBroadcastShouldThrowsException()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, null, true);
@@ -142,7 +142,7 @@ namespace HealthGateway.CommonTests.Services
         /// GetBroadcasts - api returns error.
         /// </summary>
         [Fact]
-        public void ShouldGetBroadcastsApiReturnsError()
+        public void GetBroadcastsShouldReturnsError()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
@@ -161,7 +161,7 @@ namespace HealthGateway.CommonTests.Services
         /// GetBroadcasts - api throws exception.
         /// </summary>
         [Fact]
-        public void ShouldGetBroadcastsApiThrowsException()
+        public void GetBroadcastsShouldThrowsException()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, null, true);
@@ -205,7 +205,7 @@ namespace HealthGateway.CommonTests.Services
         /// UpdateBroadcast -api returns error.
         /// </summary>
         [Fact]
-        public void ShouldUpdateBroadcastApiReturnsError()
+        public void UpdateBroadcastShouldReturnsError()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -230,7 +230,7 @@ namespace HealthGateway.CommonTests.Services
         /// CreateBroadcast -api throws exception.
         /// </summary>
         [Fact]
-        public void ShouldUpdateBroadcastApiThrowsException()
+        public void UpdateBroadcastShouldThrowsException()
         {
             Guid expectedId = Guid.NewGuid();
 

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -61,10 +61,10 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// CreateBroadcast returns error.
+        /// CreateBroadcast - api returns error.
         /// </summary>
         [Fact]
-        public void ShouldCreateBroadcastReturnsError()
+        public void ShouldCreateBroadcastApiReturnsError()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
@@ -80,10 +80,10 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// CreateBroadcast throws exception.
+        /// CreateBroadcast - api throws exception.
         /// </summary>
         [Fact]
-        public void ShouldCreateBroadcastThrowsException()
+        public void ShouldCreateBroadcastApiThrowsException()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, null, true);
@@ -99,7 +99,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// GetBroadcasts - returns one row.
+        /// GetBroadcasts - api returns one row.
         /// </summary>
         [Fact]
         public void ShouldGetBroadcasts()
@@ -139,10 +139,10 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// GetBroadcasts - returns error.
+        /// GetBroadcasts - api returns error.
         /// </summary>
         [Fact]
-        public void ShouldGetBroadcastsReturnsError()
+        public void ShouldGetBroadcastsApiReturnsError()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
@@ -158,10 +158,10 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// GetBroadcasts - throws exception.
+        /// GetBroadcasts - api throws exception.
         /// </summary>
         [Fact]
-        public void ShouldGetBroadcastsThrowsException()
+        public void ShouldGetBroadcastsApiThrowsException()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, null, true);
@@ -202,10 +202,10 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// UpdateBroadcast returns error.
+        /// UpdateBroadcast -api returns error.
         /// </summary>
         [Fact]
-        public void ShouldUpdateBroadcastReturnsError()
+        public void ShouldUpdateBroadcastApiReturnsError()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -227,10 +227,10 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// CreateBroadcast throws exception.
+        /// CreateBroadcast -api throws exception.
         /// </summary>
         [Fact]
-        public void ShouldUpdateBroadcastThrowsException()
+        public void ShouldUpdateBroadcastApiThrowsException()
         {
             Guid expectedId = Guid.NewGuid();
 

--- a/Apps/Common/test/unit/Utils/MapperUtil.cs
+++ b/Apps/Common/test/unit/Utils/MapperUtil.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.CommonTests.Utils
 {
     using AutoMapper;
     using HealthGateway.Admin.Server.MapProfiles;
+    using HealthGateway.Common.MapProfiles;
 
     /// <summary>
     /// Static utility class to provide a fully initialized AutoMapper.
@@ -30,11 +31,13 @@ namespace HealthGateway.CommonTests.Utils
         /// <returns>A configured AutoMapper.</returns>
         public static IMapper InitializeAutoMapper()
         {
-            MapperConfiguration config = new MapperConfiguration(cfg =>
-            {
-                cfg.AddProfile(new MessagingVerificationModelProfile());
-                cfg.AddProfile(new SupportUserProfile());
-            });
+            MapperConfiguration config = new(
+                cfg =>
+                {
+                    cfg.AddProfile(new MessagingVerificationModelProfile());
+                    cfg.AddProfile(new SupportUserProfile());
+                    cfg.AddProfile(new BroadcastProfile());
+                });
 
             return config.CreateMapper();
         }


### PR DESCRIPTION
# Fixes or Implements [AB#14077](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14077)

## Description

- Implemented edit notification - PUT method for Broadcast
- Add unit tests for create, get and update broadcast for [AB#14075](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14075) and [AB#14080](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14080)
- Rider reformatted MapperUtil.cs file

**PUT Broadcast**

<img width="1084" alt="Screenshot 2022-10-27 at 11 23 19 AM" src="https://user-images.githubusercontent.com/58790456/198368922-27f387fe-82be-4401-90ea-1d432de60f16.png">


**Unit Tests:**

<img width="1292" alt="Screenshot 2022-10-27 at 11 18 39 AM" src="https://user-images.githubusercontent.com/58790456/198368157-28f08007-ff30-4a7c-9393-9bff676aee81.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
