### PR TITLE
Added delete to broadcast service and controller, updated unit tests

### DIFF
--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -95,12 +95,12 @@ namespace HealthGateway.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Deletes the Broadcast that is passed to the controller.
+        /// Deletes a broadcast.
         /// </summary>
-        /// <param name="broadcast">The broadcast object to delete.</param>
-        /// <returns>The broadcast object delete wrapped in a Request result.</returns>
-        /// <response code="200">Returns the communication json of the deleted object wrapped in a request result.</response>
-        /// <response code="401">the client must authenticate itself to get the requested response.</response>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The deleted broadcast wrapped in a RequestResult.</returns>
+        /// <response code="200">Returns the deleted broadcast wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
         /// The client does not have access rights to the content; that is, it is unauthorized, so the server
         /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.

--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Admin.Server.Controllers
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -93,6 +92,23 @@ namespace HealthGateway.Admin.Server.Controllers
         public async Task<RequestResult<Broadcast>> UpdateBroadcast(Broadcast broadcast)
         {
             return await this.broadcastService.UpdateBroadcastAsync(broadcast).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Deletes the Broadcast that is passed to the controller.
+        /// </summary>
+        /// <param name="broadcast">The broadcast object to delete.</param>
+        /// <returns>The broadcast object delete wrapped in a Request result.</returns>
+        /// <response code="200">Returns the communication json of the deleted object wrapped in a request result.</response>
+        /// <response code="401">the client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpDelete]
+        public async Task<RequestResult<Broadcast>> DeleteBroadcast(Broadcast broadcast)
+        {
+            return await this.broadcastService.DeleteBroadcastAsync(broadcast).ConfigureAwait(true);
         }
     }
 }

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -208,7 +208,8 @@ namespace HealthGateway.Common.Services
                 if (response.StatusCode == HttpStatusCode.OK && response.Error is null)
                 {
                     requestResult.ResultStatus = ResultType.Success;
-                    requestResult.ResultError = null;
+                    requestResult.ResourcePayload = broadcast;
+                    requestResult.TotalResultCount = 1;
                 }
                 else
                 {

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Common.Services
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
 
     /// <summary>
     /// Service to interact with broadcasts.
@@ -45,5 +44,12 @@ namespace HealthGateway.Common.Services
         /// <param name="broadcast">The broadcast model.</param>
         /// <returns>The updated broadcast wrapped in a RequestResult.</returns>
         Task<RequestResult<Broadcast>> UpdateBroadcastAsync(Broadcast broadcast);
+
+        /// <summary>
+        /// Deletes a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast to delete.</param>
+        /// <returns>The deleted broadcast wrapped in a RequestResult.</returns>
+        Task<RequestResult<Broadcast>> DeleteBroadcastAsync(Broadcast broadcast);
     }
 }

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -202,7 +202,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// UpdateBroadcast -api returns error.
+        /// UpdateBroadcast - api returns error.
         /// </summary>
         [Fact]
         public void UpdateBroadcastShouldReturnsError()
@@ -227,7 +227,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// CreateBroadcast -api throws exception.
+        /// CreateBroadcast - api throws exception.
         /// </summary>
         [Fact]
         public void UpdateBroadcastShouldThrowsException()
@@ -275,7 +275,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// DeleteBroadcast -api returns error.
+        /// DeleteBroadcast - api returns error.
         /// </summary>
         [Fact]
         public void DeleteBroadcastShouldReturnError()
@@ -300,7 +300,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// DeleteBroadcast -api throws exception.
+        /// DeleteBroadcast - api throws exception.
         /// </summary>
         [Fact]
         public void DeleteBroadcastShouldThrowException()

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -251,6 +251,79 @@ namespace HealthGateway.CommonTests.Services
             Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
         }
 
+        /// <summary>
+        /// DeleteBroadcast.
+        /// </summary>
+        [Fact]
+        public void ShouldDeleteBroadcast()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(expectedId, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResultError);
+        }
+
+        /// <summary>
+        /// DeleteBroadcast -api returns error.
+        /// </summary>
+        [Fact]
+        public void DeleteBroadcastShouldReturnError()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// DeleteBroadcast -api throws exception.
+        /// </summary>
+        [Fact]
+        public void DeleteBroadcastShouldThrowException()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
         private static BroadcastResponse GetApiResponse(Guid? id)
         {
             BroadcastResponse response = new()

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -271,7 +271,9 @@ namespace HealthGateway.CommonTests.Services
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            Assert.Null(actualResult.ResultError);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(expectedId, actualResult.ResourcePayload.Id);
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixes or Implements [AB#14082](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14082) and [AB#14085](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14085)

## Description

Delete Notifications in Admin 
-update notification service and controller ([AB#14082](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14082))
-update unit tests ([AB#14085](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14085))

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

![Screen Shot 2022-10-27 at 1 33 05 PM](https://user-images.githubusercontent.com/5408101/198393451-0bc11af2-f59b-4d2c-a12b-0cae861070ca.png)

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
