### PR TITLE
Update UI for broadcasts AB#14072

### DIFF
--- a/Apps/Admin/Client/Components/BroadcastDialog.razor
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor
@@ -1,0 +1,185 @@
+@using HealthGateway.Admin.Client.Store.Broadcasts
+@using HealthGateway.Common.Data.Utils
+@using HealthGateway.Common.Data.Models
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudDialog>
+    <DialogContent>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasAddError"
+            TResetAction="@BroadcastsActions.AddAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasUpdateError"
+            TResetAction="@BroadcastsActions.UpdateAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <MudForm @ref="Form" data-testid="broadcast-dialog-modal-text">
+            <MudGrid Spacing="0">
+                <MudItem xs="6">
+                    <MudDatePicker
+                        @ref="@EffectiveDatePicker"
+                        @bind-Date="@EffectiveDate"
+                        Label="Effective Date"
+                        Required="@true"
+                        PickerVariant="@PickerVariant.Dialog"
+                        Culture="@DateFormatter.CanadianCulture"
+                        AutoClose="@true"
+                        DisableToolbar="@true"
+                        Variant="@Variant.Filled"
+                        Margin="@Margin.Dense"
+                        Class="mt-3 mr-3"
+                        data-testid="effective-date-pkr">
+                        <PickerActions>
+                            <MudButton Class="mr-auto align-self-start"
+                                       OnClick="@(() => EffectiveDatePicker.Clear())">
+                                Clear
+                            </MudButton>
+                        </PickerActions>
+                    </MudDatePicker>
+                </MudItem>
+                <MudItem xs="6">
+                    <div class="mt-3">
+                        <MudTimePicker
+                            @ref="@EffectiveTimePicker"
+                            @bind-Time="@EffectiveTime"
+                            Label="Effective Time"
+                            Required="@true"
+                            PickerVariant="@PickerVariant.Dialog"
+                            AmPm="@true"
+                            TimeFormat="h:mm tt"
+                            Variant="@Variant.Filled"
+                            Margin="@Margin.Dense"
+                            data-testid="effective-time-pkr">
+                            <PickerActions>
+                                <MudButton Class="mr-auto align-self-start"
+                                           OnClick="@(() => EffectiveTimePicker.Clear())">
+                                    Clear
+                                </MudButton>
+                                <MudButton OnClick="@(() => EffectiveTimePicker.Close(false))">
+                                    Cancel
+                                </MudButton>
+                                <MudButton Color="@Color.Primary"
+                                           OnClick="@(() => EffectiveTimePicker.Close())">
+                                    Ok
+                                </MudButton>
+                            </PickerActions>
+                        </MudTimePicker>
+                    </div>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudDatePicker
+                        @ref="@ExpiryDatePicker"
+                        @bind-Date="@ExpiryDate"
+                        Label="Expiry Date"
+                        PickerVariant="@PickerVariant.Dialog"
+                        Culture="@DateFormatter.CanadianCulture"
+                        AutoClose="@true"
+                        DisableToolbar="@true"
+                        Variant="@Variant.Filled"
+                        Margin="@Margin.Dense"
+                        Class="mt-3 mr-3"
+                        data-testid="expiry-date-pkr">
+                        <PickerActions>
+                            <MudButton Class="mr-auto align-self-start"
+                                       OnClick="@(() => ExpiryDatePicker.Clear())">
+                                Clear
+                            </MudButton>
+                        </PickerActions>
+                    </MudDatePicker>
+                </MudItem>
+                <MudItem xs="6">
+                    <div class="mt-3">
+                        <MudTimePicker
+                            @ref="@ExpiryTimePicker"
+                            @bind-Time="@ExpiryTime"
+                            Label="Expiry Time"
+                            PickerVariant="@PickerVariant.Dialog"
+                            AmPm="@true"
+                            TimeFormat="h:mm tt"
+                            Variant="@Variant.Filled"
+                            Margin="@Margin.Dense"
+                            data-testid="expiry-time-pkr">
+                            <PickerActions>
+                                <MudButton Class="mr-auto align-self-start"
+                                           OnClick="@(() => ExpiryTimePicker.Clear())">
+                                    Clear
+                                </MudButton>
+                                <MudButton OnClick="@(() => ExpiryTimePicker.Close(false))">
+                                    Cancel
+                                </MudButton>
+                                <MudButton Color="@Color.Primary"
+                                           OnClick="@(() => ExpiryTimePicker.Close())">
+                                    Ok
+                                </MudButton>
+                            </PickerActions>
+                        </MudTimePicker>
+                    </div>
+                </MudItem>
+                <MudItem xs="6">
+                    <HgTextField
+                        Label="Subject"
+                        @bind-Value="@Broadcast.CategoryName"
+                        T="@string"
+                        Required="@true"
+                        RightMargin="@Breakpoint.Always"
+                        data-testid="subject-input" />
+                </MudItem>
+                <MudItem xs="6">
+                    <HgSelect
+                        Label="Status"
+                        @bind-Value="@Broadcast.Enabled"
+                        T="@bool"
+                        Required="@true"
+                        ToStringFunc="@BroadcastUtility.FormatEnabled"
+                        data-testid="publish-selector">
+                        <MudSelectItem Value="false" />
+                        <MudSelectItem Value="true" />
+                    </HgSelect>
+                </MudItem>
+                <MudItem xs="12" sm="4">
+                    <HgSelect
+                        Label="Action Type"
+                        Value="@Broadcast.ActionType"
+                        ValueChanged="@ActionTypeChanged"
+                        T="BroadcastActionType"
+                        Required="@true"
+                        RightMargin="@Breakpoint.Sm"
+                        data-testid="action-type-select">
+                        @foreach (BroadcastActionType actionType in ActionTypes)
+                        {
+                            <MudSelectItem Value="@actionType" data-testid="action-type">
+                                @BroadcastUtility.FormatActionType(actionType)
+                            </MudSelectItem>
+                        }
+                    </HgSelect>
+                </MudItem>
+                <MudItem xs="12" sm="8">
+                    <HgTextField
+                        @ref="@ActionUrlTextField"
+                        Label="Action URL"
+                        @bind-Value="@ActionUrlString"
+                        T="@string"
+                        Disabled="@(Broadcast.ActionType == BroadcastActionType.None)"
+                        Validation="@(ValidateActionUrl)"
+                        data-testid="action-url-input" />
+                </MudItem>
+                <MudItem xs="12">
+                    <HgTextField
+                        Label="Content"
+                        @bind-Value="@Broadcast.DisplayText"
+                        T="@string"
+                        Lines="@(2)"
+                        data-testid="content-input" />
+                </MudItem>
+            </MudGrid>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <HgButton Color="@Color.Primary" Variant="@Variant.Text" OnClick="@HandleClickCancel" data-testid="cancel-btn">Cancel</HgButton>
+        <HgButton Color="@Color.Primary" OnClick="@HandleClickSaveAsync" data-testid="save-btn">Save</HgButton>
+    </DialogActions>
+</MudDialog>

--- a/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
@@ -1,0 +1,183 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fluxor;
+using Fluxor.Blazor.Web.Components;
+using HealthGateway.Admin.Client.Store.Broadcasts;
+using HealthGateway.Common.Data.Models;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+/// <summary>
+/// Backing logic for the BroadcastDialog component.
+/// If the Save button is pressed, the dialog's Result will have the Data property populated with a bool value of true.
+/// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
+/// </summary>
+public partial class BroadcastDialog : FluxorComponent
+{
+    /// <summary>
+    /// Gets or sets the broadcast model corresponding to the broadcast that is being edited.
+    /// </summary>
+    [Parameter]
+    public Broadcast Broadcast { get; set; } = default!;
+
+    private static List<BroadcastActionType> ActionTypes => new()
+    {
+        BroadcastActionType.None,
+        BroadcastActionType.InternalLink,
+        BroadcastActionType.ExternalLink,
+    };
+
+    private Func<string, string?> ValidateActionUrl =>
+        urlString =>
+        {
+            switch (this.Broadcast.ActionType)
+            {
+                case BroadcastActionType.InternalLink:
+                case BroadcastActionType.ExternalLink:
+                    return urlString.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? null : "URL is invalid";
+                case BroadcastActionType.None:
+                default:
+                    return urlString.Length == 0 ? null : "Selected Action Type does not support Action URL";
+            }
+        };
+
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; } = default!;
+
+    [Inject]
+    private IDispatcher Dispatcher { get; set; } = default!;
+
+    [Inject]
+    private IActionSubscriber ActionSubscriber { get; set; } = default!;
+
+    [Inject]
+    private IState<BroadcastsState> BroadcastsState { get; set; } = default!;
+
+    private bool IsNewBroadcast => this.Broadcast.Id == Guid.Empty;
+
+    private bool HasAddError => this.BroadcastsState.Value.Add.Error != null && this.BroadcastsState.Value.Add.Error.Message.Length > 0;
+
+    private bool HasUpdateError => this.BroadcastsState.Value.Update.Error != null && this.BroadcastsState.Value.Update.Error.Message.Length > 0;
+
+    private string? ErrorMessage => this.HasAddError ? this.BroadcastsState.Value.Add.Error?.Message : this.BroadcastsState.Value.Update.Error?.Message;
+
+    private MudForm Form { get; set; } = default!;
+
+    private HgTextField<string> ActionUrlTextField { get; set; } = default!;
+
+    private MudDatePicker EffectiveDatePicker { get; set; } = default!;
+
+    private MudTimePicker EffectiveTimePicker { get; set; } = default!;
+
+    private MudDatePicker ExpiryDatePicker { get; set; } = default!;
+
+    private MudTimePicker ExpiryTimePicker { get; set; } = default!;
+
+    private DateTime? EffectiveDate { get; set; }
+
+    private TimeSpan? EffectiveTime { get; set; }
+
+    private DateTime? ExpiryDate { get; set; }
+
+    private TimeSpan? ExpiryTime { get; set; }
+
+    private string ActionUrlString { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        this.ActionSubscriber.SubscribeToAction<BroadcastsActions.AddSuccessAction>(this, _ => this.MudDialog.Close(true));
+        this.ActionSubscriber.SubscribeToAction<BroadcastsActions.UpdateSuccessAction>(this, _ => this.MudDialog.Close(true));
+        this.SetFormValues();
+    }
+
+    private void SetFormValues()
+    {
+        if (this.IsNewBroadcast)
+        {
+            DateTime now = DateTime.Now;
+            DateTime tomorrow = now.AddDays(1);
+            this.EffectiveDate = now.Date;
+            this.EffectiveTime = now.TimeOfDay;
+            this.ExpiryDate = tomorrow.Date;
+            this.ExpiryTime = tomorrow.TimeOfDay;
+        }
+        else
+        {
+            this.EffectiveDate = this.Broadcast.ScheduledDateUtc.ToLocalTime().Date;
+            this.EffectiveTime = this.Broadcast.ScheduledDateUtc.ToLocalTime().TimeOfDay;
+            this.ExpiryDate = this.Broadcast.ExpirationDateUtc?.ToLocalTime().Date;
+            this.ExpiryTime = this.Broadcast.ExpirationDateUtc?.ToLocalTime().TimeOfDay;
+        }
+    }
+
+    private void RetrieveFormValues()
+    {
+        this.Broadcast.ScheduledDateUtc = (this.EffectiveDate!.Value + this.EffectiveTime!.Value).ToUniversalTime();
+        this.Broadcast.ExpirationDateUtc = this.ExpiryDate == null || this.ExpiryTime == null
+            ? null
+            : (this.ExpiryDate.Value + this.ExpiryTime.Value).ToUniversalTime();
+
+        if (this.ActionUrlString.Length > 0 && Uri.TryCreate(this.ActionUrlString, UriKind.Absolute, out Uri? result))
+        {
+            this.Broadcast.ActionUrl = result;
+        }
+        else
+        {
+            this.Broadcast.ActionUrl = null;
+        }
+    }
+
+    private void HandleClickCancel()
+    {
+        this.MudDialog.Cancel();
+    }
+
+    private async Task HandleClickSaveAsync()
+    {
+        await this.Form.Validate().ConfigureAwait(true);
+        if (this.Form.IsValid)
+        {
+            this.RetrieveFormValues();
+
+            if (this.IsNewBroadcast)
+            {
+                this.Dispatcher.Dispatch(new BroadcastsActions.AddAction(this.Broadcast));
+            }
+            else
+            {
+                this.Dispatcher.Dispatch(new BroadcastsActions.UpdateAction(this.Broadcast));
+            }
+        }
+    }
+
+    private void ActionTypeChanged(BroadcastActionType type)
+    {
+        this.Broadcast.ActionType = type;
+        if (type == BroadcastActionType.None)
+        {
+            this.ActionUrlString = string.Empty;
+        }
+
+        this.ActionUrlTextField.MudComponent.ResetValidation();
+    }
+}

--- a/Apps/Admin/Client/Components/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/BroadcastsTable.razor
@@ -1,0 +1,105 @@
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudTable Class="mt-3"
+          Items="@Rows"
+          Loading="@IsLoading"
+          AllowUnsorted="false"
+          Breakpoint="@Breakpoint.Md"
+          HorizontalScrollbar="true"
+          Striped="true"
+          Dense="true">
+    <ColGroup>
+        <MudHidden Breakpoint="@Breakpoint.MdAndDown">
+            <col />
+            <col style="width: 200px;" />
+            <col style="width: 200px;" />
+            <col style="width: 150px;" />
+            <col style="width: 200px;" />
+        </MudHidden>
+    </ColGroup>
+    <HeaderContent>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.Subject)">
+                Subject
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.EffectiveDate)"
+                               InitialDirection="@SortDirection.Descending">
+                Effective On
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.ExpiryDate)">
+                Expires On
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.ActionType)">
+                Action Type
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh Style="text-align:right">
+            Actions
+        </MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd data-testid="broadcast-table-subject" DataLabel="Subject">@context.Subject</MudTd>
+        <MudTd data-testid="broadcast-table-effective-date" DataLabel="Effective On">@context.EffectiveDate</MudTd>
+        <MudTd data-testid="broadcast-table-expiry-date" DataLabel="Expires On">@context.ExpiryDate</MudTd>
+        <MudTd data-testid="broadcast-table-action-type" DataLabel="Action Type">@context.ActionType</MudTd>
+        <MudTd DataLabel="Actions" Style="text-align:right">
+            <div>
+                <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">
+                    <MudIconButton OnClick="@(() => ToggleExpandRow(context.Id))"
+                                   Icon="@(context.IsExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                   Color="@Color.Primary"
+                                   data-testid="broadcast-table-expand-btn" />
+                </MudTooltip>
+                <MudTooltip Text="Edit">
+                    <MudIconButton OnClick="@(async () => await EditBroadcastAsync(context.Id))"
+                                   Icon="@Icons.Material.Filled.Edit"
+                                   Color="@Color.Primary"
+                                   data-testid="broadcast-table-edit-btn" />
+                </MudTooltip>
+                <MudTooltip Text="Delete">
+                    <MudIconButton OnClick="@(() => DeleteBroadcast(context.Id))"
+                                   Icon="@Icons.Material.Filled.Delete"
+                                   Color="@Color.Primary"
+                                   data-testid="broadcast-table-delete-btn" />
+                </MudTooltip>
+            </div>
+        </MudTd>
+    </RowTemplate>
+    <ChildRowContent>
+        @if (context.IsExpanded)
+        {
+            <MudTr>
+                <MudTd data-testid="broadcast-table-expanded-text" colspan="5" Style="text-align:center">
+                    <div class="ma-3">@context.Text</div>
+                </MudTd>
+            </MudTr>
+        }
+    </ChildRowContent>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudMessageBox @ref="DeleteConfirmation" Title="Delete Broadcast">
+    <MessageContent>
+        <span data-testid="confirm-delete-message">
+            Are you sure you want to delete this?
+        </span>
+    </MessageContent>
+    <YesButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteForever" data-testid="confirm-delete-btn">
+            Delete
+        </MudButton>
+    </YesButton>
+    <CancelButton>
+        <MudButton data-testid="confirm-cancel-btn">
+            Cancel
+        </MudButton>
+    </CancelButton>
+</MudMessageBox>

--- a/Apps/Admin/Client/Components/BroadcastsTable.razor.cs
+++ b/Apps/Admin/Client/Components/BroadcastsTable.razor.cs
@@ -1,0 +1,119 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Fluxor;
+    using Fluxor.Blazor.Web.Components;
+    using HealthGateway.Admin.Client.Models;
+    using HealthGateway.Admin.Client.Store.Broadcasts;
+    using HealthGateway.Admin.Client.Utils;
+    using HealthGateway.Common.Data.Utils;
+    using Microsoft.AspNetCore.Components;
+    using MudBlazor;
+
+    /// <summary>
+    /// Backing logic for the BroadcastsTable component.
+    /// </summary>
+    public partial class BroadcastsTable : FluxorComponent
+    {
+        /// <summary>
+        /// Gets or sets the data with which to populate the table.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public IEnumerable<ExtendedBroadcast> Data { get; set; } = Enumerable.Empty<ExtendedBroadcast>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether data is loading.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public bool IsLoading { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the event callback that will be triggered when the button is clicked.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public EventCallback<ExtendedBroadcast> OnEditCallback { get; set; }
+
+        [Inject]
+        private IDispatcher Dispatcher { get; set; } = default!;
+
+        private MudMessageBox DeleteConfirmation { get; set; } = default!;
+
+        private IEnumerable<BroadcastRow> Rows => this.Data.Select(c => new BroadcastRow(c));
+
+        private void ToggleExpandRow(Guid id)
+        {
+            this.Dispatcher.Dispatch(new BroadcastsActions.ToggleIsExpandedAction(id));
+        }
+
+        private async Task EditBroadcastAsync(Guid id)
+        {
+            ExtendedBroadcast? broadcast = this.Data.FirstOrDefault(c => c.Id == id);
+            if (broadcast != null)
+            {
+                await this.OnEditCallback.InvokeAsync(broadcast).ConfigureAwait(true);
+            }
+        }
+
+        private async Task DeleteBroadcast(Guid id)
+        {
+            bool? delete = await this.DeleteConfirmation.Show().ConfigureAwait(true);
+            if (delete is true)
+            {
+                ExtendedBroadcast? broadcast = this.Data.FirstOrDefault(c => c.Id == id);
+                if (broadcast != null)
+                {
+                    this.Dispatcher.Dispatch(new BroadcastsActions.DeleteAction(broadcast));
+                }
+            }
+        }
+
+        private sealed record BroadcastRow
+        {
+            public BroadcastRow(ExtendedBroadcast model)
+            {
+                this.Id = model.Id;
+                this.Subject = model.CategoryName ?? "-";
+                this.EffectiveDate = DateFormatter.ToShortDateAndTime(model.ScheduledDateUtc.ToLocalTime());
+                this.ExpiryDate = model.ExpirationDateUtc == null ? "-" : DateFormatter.ToShortDateAndTime(model.ExpirationDateUtc.Value.ToLocalTime());
+                this.ActionType = BroadcastUtility.FormatActionType(model.ActionType);
+                this.Text = model.DisplayText;
+                this.IsExpanded = model.IsExpanded;
+            }
+
+            public Guid Id { get; }
+
+            public string Subject { get; }
+
+            public string EffectiveDate { get; }
+
+            public string ExpiryDate { get; }
+
+            public string ActionType { get; }
+
+            public string Text { get; }
+
+            public bool IsExpanded { get; set; }
+        }
+    }
+}

--- a/Apps/Admin/Client/Components/CommunicationDialog.razor
+++ b/Apps/Admin/Client/Components/CommunicationDialog.razor
@@ -8,7 +8,7 @@
         <HgBannerFeedback Severity="@Severity.Error" IsEnabled="@(HasAddError || HasUpdateError)" TResetAction="@CommunicationsActions.ResetStateAction">
             @ErrorMessage
         </HgBannerFeedback>
-        <MudForm @ref="Form" data-testid="banner-dialog-modal-text">
+        <MudForm @ref="Form" data-testid="communication-dialog-modal-text">
             <MudGrid Spacing="0">
                 <MudItem xs="6">
                     <MudDatePicker @ref="@EffectiveDatePicker"

--- a/Apps/Admin/Client/Components/CommunicationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/CommunicationDialog.razor.cs
@@ -27,14 +27,14 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
 /// <summary>
-/// Backing logic for the BannerDialog component.
+/// Backing logic for the CommunicationDialog component.
 /// If the Save button is pressed, the dialog's Result will have the Data property populated with a bool value of true.
 /// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
 /// </summary>
-public partial class BannerDialog : FluxorComponent
+public partial class CommunicationDialog : FluxorComponent
 {
     /// <summary>
-    /// Gets or sets the communication model corresponding to the banner that is being edited.
+    /// Gets or sets the communication model corresponding to the communication that is being edited.
     /// </summary>
     [Parameter]
     public Communication Communication { get; set; } = default!;
@@ -53,7 +53,7 @@ public partial class BannerDialog : FluxorComponent
     [Inject]
     private IState<CommunicationsState> CommunicationsState { get; set; } = default!;
 
-    private bool IsNewBanner => this.Communication.Id == Guid.Empty;
+    private bool IsNewCommunication => this.Communication.Id == Guid.Empty;
 
     private bool HasAddError => this.CommunicationsState.Value.Add.Error != null && this.CommunicationsState.Value.Add.Error.Message.Length > 0;
 
@@ -94,7 +94,7 @@ public partial class BannerDialog : FluxorComponent
 
     private void SetFormValues()
     {
-        if (this.IsNewBanner)
+        if (this.IsNewCommunication)
         {
             DateTime now = DateTime.Now;
             DateTime tomorrow = now.AddDays(1);
@@ -132,7 +132,7 @@ public partial class BannerDialog : FluxorComponent
         {
             await this.RetrieveFormValuesAsync().ConfigureAwait(true);
 
-            if (this.IsNewBanner)
+            if (this.IsNewCommunication)
             {
                 this.Dispatcher.Dispatch(new CommunicationsActions.AddAction(this.Communication));
             }

--- a/Apps/Admin/Client/Components/HgBannerFeedback.razor
+++ b/Apps/Admin/Client/Components/HgBannerFeedback.razor
@@ -3,11 +3,13 @@
 
 @if (IsEnabled && !IsHidden)
 {
-    <MudAlert Variant="Variant.Text"
-              Severity="@Severity"
-              ShowCloseIcon="true"
-              CloseIconClicked="@Close"
-              data-testid="@DataTestId">
+    <MudAlert
+        Class="@Class"
+        Variant="Variant.Text"
+        Severity="@Severity"
+        ShowCloseIcon="true"
+        CloseIconClicked="@Close"
+        data-testid="@DataTestId">
         @ChildContent
     </MudAlert>
 }

--- a/Apps/Admin/Client/Components/HgBannerFeedback.razor.cs
+++ b/Apps/Admin/Client/Components/HgBannerFeedback.razor.cs
@@ -54,6 +54,12 @@ namespace HealthGateway.Admin.Client.Components
         [Parameter]
         public string? DataTestId { get; set; }
 
+        /// <summary>
+        /// Gets or sets class names, separated by space.
+        /// </summary>
+        [Parameter]
+        public string Class { get; set; } = string.Empty;
+
         [Inject]
         private IActionSubscriber ActionSubscriber { get; set; } = default!;
 

--- a/Apps/Admin/Client/Components/HgSelect.razor
+++ b/Apps/Admin/Client/Components/HgSelect.razor
@@ -1,10 +1,12 @@
 @typeparam T
 @inherits HgComponentBase
 
-<MudSelect Class="@CombinedClass"
+<MudSelect @ref="MudComponent"
+           Class="@CombinedClass"
            Style="@Style"
            Tag="@Tag"
            T="T"
+           ValueChanged="@ValueChanged"
            Variant="Variant.Filled"
            Margin="Margin.Dense"
            @attributes="UnmatchedAttributes">

--- a/Apps/Admin/Client/Components/HgSelect.razor.cs
+++ b/Apps/Admin/Client/Components/HgSelect.razor.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Admin.Client.Components
 {
     using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Components;
     using MudBlazor;
 
     /// <summary>
@@ -34,5 +35,16 @@ namespace HealthGateway.Admin.Client.Components
             this.VerticalMarginSize = 3;
             this.TopMargin = Breakpoint.Always;
         }
+
+        /// <summary>
+        /// Gets or sets the event callback that will be triggered when the value changes.
+        /// </summary>
+        [Parameter]
+        public EventCallback<T> ValueChanged { get; set; }
+
+        /// <summary>
+        /// Gets the underlying MudBlazor component.
+        /// </summary>
+        public MudSelect<T> MudComponent { get; private set; } = default!;
     }
 }

--- a/Apps/Admin/Client/Components/HgTextField.razor
+++ b/Apps/Admin/Client/Components/HgTextField.razor
@@ -1,7 +1,8 @@
 @typeparam T
 @inherits HgComponentBase
 
-<MudTextField Class="@CombinedClass"
+<MudTextField @ref="MudComponent"
+              Class="@CombinedClass"
               Style="@Style"
               Tag="@Tag"
               T="T"

--- a/Apps/Admin/Client/Components/HgTextField.razor.cs
+++ b/Apps/Admin/Client/Components/HgTextField.razor.cs
@@ -34,5 +34,10 @@ namespace HealthGateway.Admin.Client.Components
             this.VerticalMarginSize = 3;
             this.TopMargin = Breakpoint.Always;
         }
+
+        /// <summary>
+        /// Gets the underlying MudBlazor component.
+        /// </summary>
+        public MudTextField<T> MudComponent { get; private set; } = default!;
     }
 }

--- a/Apps/Admin/Client/Models/ExtendedBroadcast.cs
+++ b/Apps/Admin/Client/Models/ExtendedBroadcast.cs
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Models;
+
+using HealthGateway.Common.Data.Models;
+
+/// <summary>
+/// A system broadcast with additional state information.
+/// </summary>
+public class ExtendedBroadcast : Broadcast
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtendedBroadcast"/> class.
+    /// </summary>
+    /// <param name="model">The broadcast model.</param>
+    public ExtendedBroadcast(Broadcast model)
+    {
+        this.PopulateFromModel(model);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the broadcast details have been expanded.
+    /// </summary>
+    public bool IsExpanded { get; set; }
+
+    /// <summary>
+    /// Populates all properties from a broadcast model.
+    /// </summary>
+    /// <param name="model">The broadcast model.</param>
+    public void PopulateFromModel(Broadcast model)
+    {
+        this.Id = model.Id;
+        this.CategoryName = model.CategoryName;
+        this.DisplayText = model.DisplayText;
+        this.Enabled = model.Enabled;
+        this.ActionType = model.ActionType;
+        this.ActionUrl = model.ActionUrl;
+        this.ScheduledDateUtc = model.ScheduledDateUtc;
+        this.ExpirationDateUtc = model.ExpirationDateUtc;
+    }
+}

--- a/Apps/Admin/Client/Pages/CommunicationsPage.razor
+++ b/Apps/Admin/Client/Pages/CommunicationsPage.razor
@@ -1,41 +1,54 @@
 @page "/communications"
 @layout MainLayout
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer}")]
+@using HealthGateway.Admin.Client.Store.Broadcasts
 @using HealthGateway.Admin.Client.Store.Communications
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <PageTitle>Health Gateway Admin Communications</PageTitle>
 <HgPageHeading>Communications</HgPageHeading>
 
-<HgBannerFeedback Severity="@Severity.Error" IsEnabled="@(HasLoadError || HasDeleteError)" TResetAction="@CommunicationsActions.ResetStateAction">
-    @ErrorMessage
+<HgBannerFeedback
+    Severity="@Severity.Error"
+    IsEnabled="@(HasBroadcastsLoadError || HasBroadcastsDeleteError)"
+    TResetAction="@BroadcastsActions.ResetStateAction"
+    Class="mb-4">
+    @BroadcastsErrorMessage
 </HgBannerFeedback>
 
-@if (CommunicationsLoaded || CommunicationsLoading)
+<HgBannerFeedback
+    Severity="@Severity.Error"
+    IsEnabled="@(HasCommunicationsLoadError || HasCommunicationsDeleteError)"
+    TResetAction="@CommunicationsActions.ResetStateAction"
+    Class="mb-4">
+    @CommunicationsErrorMessage
+</HgBannerFeedback>
+
+@if (BroadcastsLoaded || BroadcastsLoading || CommunicationsLoaded || CommunicationsLoading)
 {
     <HgTabs @ref="@Tabs" data-testid="banner-tabs">
         <Header>
-            @if (SelectedBannerName != null)
-            {
-                <HgButton EndIcon="@Icons.Material.Filled.Add"
-                          TopMargin="@Breakpoint.Always"
-                          RightMargin="@Breakpoint.Always"
-                          BottomMargin="@Breakpoint.Always"
-                          @onclick="@CreateBannerAsync"
-                          data-testid="create-banner-btn">
-                    Create
-                </HgButton>
-            }
+            <HgButton EndIcon="@Icons.Material.Filled.Add"
+                      TopMargin="@Breakpoint.Always"
+                      RightMargin="@Breakpoint.Always"
+                      BottomMargin="@Breakpoint.Always"
+                      @onclick="@(SelectedCommunicationType == null ? CreateBroadcastAsync : CreateCommunicationAsync)"
+                      data-testid="create-btn">
+                Create
+            </HgButton>
         </Header>
         <ChildContent>
+            <MudTabPanel Text="Notifications">
+                <BroadcastsTable Data="@Broadcasts" IsLoading="@BroadcastsLoading" OnEditCallback="EditBroadcastAsync" />
+            </MudTabPanel>
             <MudTabPanel Text="Public Banners">
-                <CommunicationsTable Data="@PublicCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditBannerAsync" />
+                <CommunicationsTable Data="@PublicCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditCommunicationAsync" />
             </MudTabPanel>
             <MudTabPanel Text="In-App Banners">
-                <CommunicationsTable Data="@InAppCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditBannerAsync" />
+                <CommunicationsTable Data="@InAppCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditCommunicationAsync" />
             </MudTabPanel>
             <MudTabPanel Text="Mobile">
-                <CommunicationsTable Data="@MobileCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditBannerAsync" />
+                <CommunicationsTable Data="@MobileCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditCommunicationAsync" />
             </MudTabPanel>
         </ChildContent>
     </HgTabs>

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Store.Broadcasts;
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using HealthGateway.Common.Data.Models;
@@ -224,5 +225,25 @@ public static class BroadcastsActions
     /// </summary>
     public class ResetStateAction
     {
+    }
+
+    /// <summary>
+    /// The action that toggles whether a particular broadcast is expanded.
+    /// </summary>
+    public class ToggleIsExpandedAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ToggleIsExpandedAction"/> class.
+        /// </summary>
+        /// <param name="id">Represents the ID of the broadcast.</param>
+        public ToggleIsExpandedAction(Guid id)
+        {
+            this.Id = id;
+        }
+
+        /// <summary>
+        /// Gets or sets the ID of the broadcast.
+        /// </summary>
+        public Guid Id { get; set; }
     }
 }

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -18,7 +18,9 @@ namespace HealthGateway.Admin.Client.Store.Broadcasts;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Fluxor;
+using HealthGateway.Admin.Client.Models;
 using HealthGateway.Common.Data.Models;
 
 /// <summary>
@@ -62,7 +64,7 @@ public static class BroadcastsReducers
                 Error = null,
             },
             IsLoading = false,
-            Data = action.Data.ResourcePayload.ToImmutableDictionary(tag => tag.Id),
+            Data = action.Data.ResourcePayload.Select(b => new ExtendedBroadcast(b)).ToImmutableDictionary(tag => tag.Id),
             Error = null,
         };
     }
@@ -115,12 +117,12 @@ public static class BroadcastsReducers
     [ReducerMethod]
     public static BroadcastsState ReduceAddSuccessAction(BroadcastsState state, BroadcastsActions.AddSuccessAction action)
     {
-        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
 
         Broadcast? broadcast = action.Data.ResourcePayload;
         if (broadcast != null)
         {
-            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, new(broadcast));
         }
 
         return state with
@@ -185,12 +187,12 @@ public static class BroadcastsReducers
     [ReducerMethod]
     public static BroadcastsState ReduceUpdateSuccessAction(BroadcastsState state, BroadcastsActions.UpdateSuccessAction action)
     {
-        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
 
         Broadcast? broadcast = action.Data.ResourcePayload;
         if (broadcast != null)
         {
-            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, new(broadcast));
         }
 
         return state with
@@ -255,7 +257,7 @@ public static class BroadcastsReducers
     [ReducerMethod]
     public static BroadcastsState ReduceDeleteSuccessAction(BroadcastsState state, BroadcastsActions.DeleteSuccessAction action)
     {
-        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
 
         Broadcast? broadcast = action.Data.ResourcePayload;
         if (broadcast != null)
@@ -316,5 +318,25 @@ public static class BroadcastsReducers
             Error = null,
             IsLoading = false,
         };
+    }
+
+    /// <summary>
+    /// The reducer for the ToggleIsExpanded action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The ToggleIsExpanded action.</param>
+    /// <returns>The default state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceToggleIsExpandedAction(BroadcastsState state, BroadcastsActions.ToggleIsExpandedAction action)
+    {
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
+
+        ExtendedBroadcast? broadcast = data.GetValueOrDefault(action.Id);
+        if (broadcast != null)
+        {
+            broadcast.IsExpanded = !broadcast.IsExpanded;
+        }
+
+        return state;
     }
 }

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Fluxor;
+using HealthGateway.Admin.Client.Models;
 using HealthGateway.Common.Data.Models;
 using HealthGateway.Common.Data.ViewModels;
 
@@ -53,7 +54,7 @@ public record BroadcastsState
     /// <summary>
     /// Gets the collection of data.
     /// </summary>
-    public IImmutableDictionary<Guid, Broadcast>? Data { get; init; }
+    public IImmutableDictionary<Guid, ExtendedBroadcast>? Data { get; init; }
 
     /// <summary>
     /// Gets the request error if available.

--- a/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
@@ -330,10 +330,10 @@ public static class CommunicationsReducers
     }
 
     /// <summary>
-    /// The reducer for the toggle IsExpanded action.
+    /// The reducer for the ToggleIsExpanded action.
     /// </summary>
     /// <param name="state">The communications state.</param>
-    /// <param name="action">The toggle IsExpanded action.</param>
+    /// <param name="action">The ToggleIsExpanded action.</param>
     /// <returns>The default state.</returns>
     [ReducerMethod]
     public static CommunicationsState ReduceToggleIsExpandedAction(CommunicationsState state, CommunicationsActions.ToggleIsExpandedAction action)

--- a/Apps/Admin/Client/Utils/BroadcastUtility.cs
+++ b/Apps/Admin/Client/Utils/BroadcastUtility.cs
@@ -1,0 +1,51 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Utils
+{
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// Utilities for interacting with system broadcasts.
+    /// </summary>
+    public static class BroadcastUtility
+    {
+        /// <summary>
+        /// Returns the formatted representation of a broadcast's action type.
+        /// </summary>
+        /// <param name="actionType">The broadcast's action type.</param>
+        /// <returns>A string containing the formatted representation of a broadcast's action type.</returns>
+        public static string FormatActionType(BroadcastActionType actionType)
+        {
+            return actionType switch
+            {
+                BroadcastActionType.None => "None",
+                BroadcastActionType.InternalLink => "Internal Link",
+                BroadcastActionType.ExternalLink => "External Link",
+                _ => actionType.ToString(),
+            };
+        }
+
+        /// <summary>
+        /// Returns the formatted representation of a broadcast's enabled status.
+        /// </summary>
+        /// <param name="enabled">The broadcast's enabled status.</param>
+        /// <returns>A string containing the formatted representation of a broadcast's enabled status.</returns>
+        public static string FormatEnabled(bool enabled)
+        {
+            return enabled ? "Publish" : "Draft";
+        }
+    }
+}

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -68,7 +68,7 @@ describe("Communications", () => {
         cy.log("Validate edit subject.");
 
         cy.get("[data-testid=comm-table-edit-btn]").click();
-        cy.get("[data-testid=banner-dialog-modal-text]").within(() => {
+        cy.get("[data-testid=communication-dialog-modal-text]").within(() => {
             cy.get("[data-testid=subject-input]")
                 .clear()
                 .focus()

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -29,7 +29,9 @@ namespace HealthGateway.Common.MapProfiles
         /// </summary>
         public BroadcastProfile()
         {
-            this.CreateMap<BroadcastResponse, Broadcast>();
+            this.CreateMap<BroadcastResponse, Broadcast>()
+                .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.CategoryName ?? string.Empty))
+                .ForMember(dest => dest.DisplayText, opt => opt.MapFrom(src => src.DisplayText ?? string.Empty));
             this.CreateMap<Broadcast, BroadcastRequest>();
         }
     }

--- a/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Models.PHSA
 {
     using System;
     using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Models;
 
     /// <summary>
     /// Model representing a PHSA Broadcast Request.
@@ -42,10 +43,10 @@ namespace HealthGateway.Common.Models.PHSA
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the action text.
+        /// Gets or sets the action type.
         /// </summary>
-        [JsonPropertyName("actionText")]
-        public string? ActionText { get; set; }
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
 
         /// <summary>
         /// Gets or sets the action url.

--- a/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Models.PHSA
 {
     using System;
     using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Models;
 
     /// <summary>
     /// Model representing a PHSA Broadcast Response.
@@ -54,10 +55,10 @@ namespace HealthGateway.Common.Models.PHSA
         public Uri? ActionUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the action text.
+        /// Gets or sets the action type.
         /// </summary>
-        [JsonPropertyName("actionText")]
-        public string? ActionText { get; set; }
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
 
         /// <summary>
         /// Gets or sets the scheduled datetime in UTC.

--- a/Apps/CommonData/src/Models/Broadcast.cs
+++ b/Apps/CommonData/src/Models/Broadcast.cs
@@ -33,13 +33,13 @@ namespace HealthGateway.Common.Data.Models
         /// Gets or sets the category name.
         /// </summary>
         [JsonPropertyName("categoryName")]
-        public string? CategoryName { get; set; }
+        public string CategoryName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the display text.
         /// </summary>
         [JsonPropertyName("displayText")]
-        public string? DisplayText { get; set; }
+        public string DisplayText { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether this broadcast system is enabled.
@@ -48,27 +48,27 @@ namespace HealthGateway.Common.Data.Models
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the action url.
+        /// Gets or sets the action type.
+        /// </summary>
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action URL.
         /// </summary>
         [JsonPropertyName("actionUrl")]
         public Uri? ActionUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the action text.
+        /// Gets or sets the scheduled datetime.
         /// </summary>
-        [JsonPropertyName("actionText")]
-        public string? ActionText { get; set; }
-
-        /// <summary>
-        /// Gets or sets the scheduled datetime in UTC.
-        /// </summary>
-        [JsonPropertyName("scheduledDateUtc")]
+        [JsonPropertyName("scheduledDate")]
         public DateTime ScheduledDateUtc { get; set; }
 
         /// <summary>
-        /// Gets or sets the expiration datetime in UTC.
+        /// Gets or sets the expiration datetime.
         /// </summary>
-        [JsonPropertyName("expirationDateUtc")]
+        [JsonPropertyName("expirationDate")]
         public DateTime? ExpirationDateUtc { get; set; }
     }
 }

--- a/Apps/CommonData/src/Models/BroadcastActionType.cs
+++ b/Apps/CommonData/src/Models/BroadcastActionType.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Data.Models
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Represents the type of action associated with a broadcast.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum BroadcastActionType
+    {
+        /// <summary>
+        /// No action.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The action links to an internal resource.
+        /// </summary>
+        InternalLink,
+
+        /// <summary>
+        /// The action links to an external resource.
+        /// </summary>
+        ExternalLink,
+    }
+}


### PR DESCRIPTION
# Implements [AB#14072](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14072)

## Description

- updates the Communications page in Admin with a new tab for Notifications (broadcasts)
    - adds a new table and dialog for interacting with them
- updates some old code that referred to communications as banners
- introduces a BroadcastActionType enum which is used to replace the "actionText" property in the broadcast model

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2022-10-27-163628](https://user-images.githubusercontent.com/16570293/198418353-f4696696-8d19-46dd-b8cf-4605fecd0620.png)

![localhost-2022-10-27-163640](https://user-images.githubusercontent.com/16570293/198418355-354a3da6-3fff-409b-a22e-28658de44404.png)

![localhost-2022-10-27-163651](https://user-images.githubusercontent.com/16570293/198418363-b182b80a-43d5-4c84-a6b8-3a40033a0203.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
