### PR TITLE
Add system broadcasts to Admin AB#12086

### DIFF
--- a/Apps/Admin/Client/Components/BannerDialog.razor.cs
+++ b/Apps/Admin/Client/Components/BannerDialog.razor.cs
@@ -94,7 +94,16 @@ public partial class BannerDialog : FluxorComponent
 
     private void SetFormValues()
     {
-        if (!this.IsNewBanner)
+        if (this.IsNewBanner)
+        {
+            DateTime now = DateTime.Now;
+            DateTime tomorrow = now.AddDays(1);
+            this.EffectiveDate = now.Date;
+            this.EffectiveTime = now.TimeOfDay;
+            this.ExpiryDate = tomorrow.Date;
+            this.ExpiryTime = tomorrow.TimeOfDay;
+        }
+        else
         {
             this.EffectiveDate = this.Communication.EffectiveDateTime.ToLocalTime().Date;
             this.EffectiveTime = this.Communication.EffectiveDateTime.ToLocalTime().TimeOfDay;

--- a/Apps/Admin/Client/Components/BroadcastDialog.razor
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor
@@ -1,0 +1,185 @@
+@using HealthGateway.Admin.Client.Store.Broadcasts
+@using HealthGateway.Common.Data.Utils
+@using HealthGateway.Common.Data.Models
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudDialog>
+    <DialogContent>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasAddError"
+            TResetAction="@BroadcastsActions.AddAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasUpdateError"
+            TResetAction="@BroadcastsActions.UpdateAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <MudForm @ref="Form" data-testid="broadcast-dialog-modal-text">
+            <MudGrid Spacing="0">
+                <MudItem xs="6">
+                    <MudDatePicker
+                        @ref="@EffectiveDatePicker"
+                        @bind-Date="@EffectiveDate"
+                        Label="Effective Date"
+                        Required="@true"
+                        PickerVariant="@PickerVariant.Dialog"
+                        Culture="@DateFormatter.CanadianCulture"
+                        AutoClose="@true"
+                        DisableToolbar="@true"
+                        Variant="@Variant.Filled"
+                        Margin="@Margin.Dense"
+                        Class="mt-3 mr-3"
+                        data-testid="effective-date-pkr">
+                        <PickerActions>
+                            <MudButton Class="mr-auto align-self-start"
+                                       OnClick="@(() => EffectiveDatePicker.Clear())">
+                                Clear
+                            </MudButton>
+                        </PickerActions>
+                    </MudDatePicker>
+                </MudItem>
+                <MudItem xs="6">
+                    <div class="mt-3">
+                        <MudTimePicker
+                            @ref="@EffectiveTimePicker"
+                            @bind-Time="@EffectiveTime"
+                            Label="Effective Time"
+                            Required="@true"
+                            PickerVariant="@PickerVariant.Dialog"
+                            AmPm="@true"
+                            TimeFormat="h:mm tt"
+                            Variant="@Variant.Filled"
+                            Margin="@Margin.Dense"
+                            data-testid="effective-time-pkr">
+                            <PickerActions>
+                                <MudButton Class="mr-auto align-self-start"
+                                           OnClick="@(() => EffectiveTimePicker.Clear())">
+                                    Clear
+                                </MudButton>
+                                <MudButton OnClick="@(() => EffectiveTimePicker.Close(false))">
+                                    Cancel
+                                </MudButton>
+                                <MudButton Color="@Color.Primary"
+                                           OnClick="@(() => EffectiveTimePicker.Close())">
+                                    Ok
+                                </MudButton>
+                            </PickerActions>
+                        </MudTimePicker>
+                    </div>
+                </MudItem>
+                <MudItem xs="6">
+                    <MudDatePicker
+                        @ref="@ExpiryDatePicker"
+                        @bind-Date="@ExpiryDate"
+                        Label="Expiry Date"
+                        PickerVariant="@PickerVariant.Dialog"
+                        Culture="@DateFormatter.CanadianCulture"
+                        AutoClose="@true"
+                        DisableToolbar="@true"
+                        Variant="@Variant.Filled"
+                        Margin="@Margin.Dense"
+                        Class="mt-3 mr-3"
+                        data-testid="expiry-date-pkr">
+                        <PickerActions>
+                            <MudButton Class="mr-auto align-self-start"
+                                       OnClick="@(() => ExpiryDatePicker.Clear())">
+                                Clear
+                            </MudButton>
+                        </PickerActions>
+                    </MudDatePicker>
+                </MudItem>
+                <MudItem xs="6">
+                    <div class="mt-3">
+                        <MudTimePicker
+                            @ref="@ExpiryTimePicker"
+                            @bind-Time="@ExpiryTime"
+                            Label="Expiry Time"
+                            PickerVariant="@PickerVariant.Dialog"
+                            AmPm="@true"
+                            TimeFormat="h:mm tt"
+                            Variant="@Variant.Filled"
+                            Margin="@Margin.Dense"
+                            data-testid="expiry-time-pkr">
+                            <PickerActions>
+                                <MudButton Class="mr-auto align-self-start"
+                                           OnClick="@(() => ExpiryTimePicker.Clear())">
+                                    Clear
+                                </MudButton>
+                                <MudButton OnClick="@(() => ExpiryTimePicker.Close(false))">
+                                    Cancel
+                                </MudButton>
+                                <MudButton Color="@Color.Primary"
+                                           OnClick="@(() => ExpiryTimePicker.Close())">
+                                    Ok
+                                </MudButton>
+                            </PickerActions>
+                        </MudTimePicker>
+                    </div>
+                </MudItem>
+                <MudItem xs="6">
+                    <HgTextField
+                        Label="Subject"
+                        @bind-Value="@Broadcast.CategoryName"
+                        T="@string"
+                        Required="@true"
+                        RightMargin="@Breakpoint.Always"
+                        data-testid="subject-input" />
+                </MudItem>
+                <MudItem xs="6">
+                    <HgSelect
+                        Label="Status"
+                        @bind-Value="@Broadcast.Enabled"
+                        T="@bool"
+                        Required="@true"
+                        ToStringFunc="@BroadcastUtility.FormatEnabled"
+                        data-testid="publish-selector">
+                        <MudSelectItem Value="false" />
+                        <MudSelectItem Value="true" />
+                    </HgSelect>
+                </MudItem>
+                <MudItem xs="12" sm="4">
+                    <HgSelect
+                        Label="Action Type"
+                        Value="@Broadcast.ActionType"
+                        ValueChanged="@ActionTypeChanged"
+                        T="BroadcastActionType"
+                        Required="@true"
+                        RightMargin="@Breakpoint.Sm"
+                        data-testid="action-type-select">
+                        @foreach (BroadcastActionType actionType in ActionTypes)
+                        {
+                            <MudSelectItem Value="@actionType" data-testid="action-type">
+                                @BroadcastUtility.FormatActionType(actionType)
+                            </MudSelectItem>
+                        }
+                    </HgSelect>
+                </MudItem>
+                <MudItem xs="12" sm="8">
+                    <HgTextField
+                        @ref="@ActionUrlTextField"
+                        Label="Action URL"
+                        @bind-Value="@ActionUrlString"
+                        T="@string"
+                        Disabled="@(Broadcast.ActionType == BroadcastActionType.None)"
+                        Validation="@(ValidateActionUrl)"
+                        data-testid="action-url-input" />
+                </MudItem>
+                <MudItem xs="12">
+                    <HgTextField
+                        Label="Content"
+                        @bind-Value="@Broadcast.DisplayText"
+                        T="@string"
+                        Lines="@(2)"
+                        data-testid="content-input" />
+                </MudItem>
+            </MudGrid>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <HgButton Color="@Color.Primary" Variant="@Variant.Text" OnClick="@HandleClickCancel" data-testid="cancel-btn">Cancel</HgButton>
+        <HgButton Color="@Color.Primary" OnClick="@HandleClickSaveAsync" data-testid="save-btn">Save</HgButton>
+    </DialogActions>
+</MudDialog>

--- a/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
@@ -1,0 +1,183 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components;
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fluxor;
+using Fluxor.Blazor.Web.Components;
+using HealthGateway.Admin.Client.Store.Broadcasts;
+using HealthGateway.Common.Data.Models;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+/// <summary>
+/// Backing logic for the BroadcastDialog component.
+/// If the Save button is pressed, the dialog's Result will have the Data property populated with a bool value of true.
+/// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
+/// </summary>
+public partial class BroadcastDialog : FluxorComponent
+{
+    /// <summary>
+    /// Gets or sets the broadcast model corresponding to the broadcast that is being edited.
+    /// </summary>
+    [Parameter]
+    public Broadcast Broadcast { get; set; } = default!;
+
+    private static List<BroadcastActionType> ActionTypes => new()
+    {
+        BroadcastActionType.None,
+        BroadcastActionType.InternalLink,
+        BroadcastActionType.ExternalLink,
+    };
+
+    private Func<string, string?> ValidateActionUrl =>
+        urlString =>
+        {
+            switch (this.Broadcast.ActionType)
+            {
+                case BroadcastActionType.InternalLink:
+                case BroadcastActionType.ExternalLink:
+                    return urlString.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? null : "URL is invalid";
+                case BroadcastActionType.None:
+                default:
+                    return urlString.Length == 0 ? null : "Selected Action Type does not support Action URL";
+            }
+        };
+
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; } = default!;
+
+    [Inject]
+    private IDispatcher Dispatcher { get; set; } = default!;
+
+    [Inject]
+    private IActionSubscriber ActionSubscriber { get; set; } = default!;
+
+    [Inject]
+    private IState<BroadcastsState> BroadcastsState { get; set; } = default!;
+
+    private bool IsNewBroadcast => this.Broadcast.Id == Guid.Empty;
+
+    private bool HasAddError => this.BroadcastsState.Value.Add.Error != null && this.BroadcastsState.Value.Add.Error.Message.Length > 0;
+
+    private bool HasUpdateError => this.BroadcastsState.Value.Update.Error != null && this.BroadcastsState.Value.Update.Error.Message.Length > 0;
+
+    private string? ErrorMessage => this.HasAddError ? this.BroadcastsState.Value.Add.Error?.Message : this.BroadcastsState.Value.Update.Error?.Message;
+
+    private MudForm Form { get; set; } = default!;
+
+    private HgTextField<string> ActionUrlTextField { get; set; } = default!;
+
+    private MudDatePicker EffectiveDatePicker { get; set; } = default!;
+
+    private MudTimePicker EffectiveTimePicker { get; set; } = default!;
+
+    private MudDatePicker ExpiryDatePicker { get; set; } = default!;
+
+    private MudTimePicker ExpiryTimePicker { get; set; } = default!;
+
+    private DateTime? EffectiveDate { get; set; }
+
+    private TimeSpan? EffectiveTime { get; set; }
+
+    private DateTime? ExpiryDate { get; set; }
+
+    private TimeSpan? ExpiryTime { get; set; }
+
+    private string ActionUrlString { get; set; } = string.Empty;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        this.ActionSubscriber.SubscribeToAction<BroadcastsActions.AddSuccessAction>(this, _ => this.MudDialog.Close(true));
+        this.ActionSubscriber.SubscribeToAction<BroadcastsActions.UpdateSuccessAction>(this, _ => this.MudDialog.Close(true));
+        this.SetFormValues();
+    }
+
+    private void SetFormValues()
+    {
+        if (this.IsNewBroadcast)
+        {
+            DateTime now = DateTime.Now;
+            DateTime tomorrow = now.AddDays(1);
+            this.EffectiveDate = now.Date;
+            this.EffectiveTime = now.TimeOfDay;
+            this.ExpiryDate = tomorrow.Date;
+            this.ExpiryTime = tomorrow.TimeOfDay;
+        }
+        else
+        {
+            this.EffectiveDate = this.Broadcast.ScheduledDateUtc.ToLocalTime().Date;
+            this.EffectiveTime = this.Broadcast.ScheduledDateUtc.ToLocalTime().TimeOfDay;
+            this.ExpiryDate = this.Broadcast.ExpirationDateUtc?.ToLocalTime().Date;
+            this.ExpiryTime = this.Broadcast.ExpirationDateUtc?.ToLocalTime().TimeOfDay;
+        }
+    }
+
+    private void RetrieveFormValues()
+    {
+        this.Broadcast.ScheduledDateUtc = (this.EffectiveDate!.Value + this.EffectiveTime!.Value).ToUniversalTime();
+        this.Broadcast.ExpirationDateUtc = this.ExpiryDate == null || this.ExpiryTime == null
+            ? null
+            : (this.ExpiryDate.Value + this.ExpiryTime.Value).ToUniversalTime();
+
+        if (this.ActionUrlString.Length > 0 && Uri.TryCreate(this.ActionUrlString, UriKind.Absolute, out Uri? result))
+        {
+            this.Broadcast.ActionUrl = result;
+        }
+        else
+        {
+            this.Broadcast.ActionUrl = null;
+        }
+    }
+
+    private void HandleClickCancel()
+    {
+        this.MudDialog.Cancel();
+    }
+
+    private async Task HandleClickSaveAsync()
+    {
+        await this.Form.Validate().ConfigureAwait(true);
+        if (this.Form.IsValid)
+        {
+            this.RetrieveFormValues();
+
+            if (this.IsNewBroadcast)
+            {
+                this.Dispatcher.Dispatch(new BroadcastsActions.AddAction(this.Broadcast));
+            }
+            else
+            {
+                this.Dispatcher.Dispatch(new BroadcastsActions.UpdateAction(this.Broadcast));
+            }
+        }
+    }
+
+    private void ActionTypeChanged(BroadcastActionType type)
+    {
+        this.Broadcast.ActionType = type;
+        if (type == BroadcastActionType.None)
+        {
+            this.ActionUrlString = string.Empty;
+        }
+
+        this.ActionUrlTextField.MudComponent.ResetValidation();
+    }
+}

--- a/Apps/Admin/Client/Components/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/BroadcastsTable.razor
@@ -1,0 +1,105 @@
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudTable Class="mt-3"
+          Items="@Rows"
+          Loading="@IsLoading"
+          AllowUnsorted="false"
+          Breakpoint="@Breakpoint.Md"
+          HorizontalScrollbar="true"
+          Striped="true"
+          Dense="true">
+    <ColGroup>
+        <MudHidden Breakpoint="@Breakpoint.MdAndDown">
+            <col />
+            <col style="width: 200px;" />
+            <col style="width: 200px;" />
+            <col style="width: 150px;" />
+            <col style="width: 200px;" />
+        </MudHidden>
+    </ColGroup>
+    <HeaderContent>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.Subject)">
+                Subject
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.EffectiveDate)"
+                               InitialDirection="@SortDirection.Descending">
+                Effective On
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.ExpiryDate)">
+                Expires On
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.ActionType)">
+                Action Type
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh Style="text-align:right">
+            Actions
+        </MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd data-testid="broadcast-table-subject" DataLabel="Subject">@context.Subject</MudTd>
+        <MudTd data-testid="broadcast-table-effective-date" DataLabel="Effective On">@context.EffectiveDate</MudTd>
+        <MudTd data-testid="broadcast-table-expiry-date" DataLabel="Expires On">@context.ExpiryDate</MudTd>
+        <MudTd data-testid="broadcast-table-action-type" DataLabel="Action Type">@context.ActionType</MudTd>
+        <MudTd DataLabel="Actions" Style="text-align:right">
+            <div>
+                <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">
+                    <MudIconButton OnClick="@(() => ToggleExpandRow(context.Id))"
+                                   Icon="@(context.IsExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                   Color="@Color.Primary"
+                                   data-testid="broadcast-table-expand-btn" />
+                </MudTooltip>
+                <MudTooltip Text="Edit">
+                    <MudIconButton OnClick="@(async () => await EditBroadcastAsync(context.Id))"
+                                   Icon="@Icons.Material.Filled.Edit"
+                                   Color="@Color.Primary"
+                                   data-testid="broadcast-table-edit-btn" />
+                </MudTooltip>
+                <MudTooltip Text="Delete">
+                    <MudIconButton OnClick="@(() => DeleteBroadcast(context.Id))"
+                                   Icon="@Icons.Material.Filled.Delete"
+                                   Color="@Color.Primary"
+                                   data-testid="broadcast-table-delete-btn" />
+                </MudTooltip>
+            </div>
+        </MudTd>
+    </RowTemplate>
+    <ChildRowContent>
+        @if (context.IsExpanded)
+        {
+            <MudTr>
+                <MudTd data-testid="broadcast-table-expanded-text" colspan="5" Style="text-align:center">
+                    <div class="ma-3">@context.Text</div>
+                </MudTd>
+            </MudTr>
+        }
+    </ChildRowContent>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>
+
+<MudMessageBox @ref="DeleteConfirmation" Title="Delete Broadcast">
+    <MessageContent>
+        <span data-testid="confirm-delete-message">
+            Are you sure you want to delete this?
+        </span>
+    </MessageContent>
+    <YesButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteForever" data-testid="confirm-delete-btn">
+            Delete
+        </MudButton>
+    </YesButton>
+    <CancelButton>
+        <MudButton data-testid="confirm-cancel-btn">
+            Cancel
+        </MudButton>
+    </CancelButton>
+</MudMessageBox>

--- a/Apps/Admin/Client/Components/BroadcastsTable.razor.cs
+++ b/Apps/Admin/Client/Components/BroadcastsTable.razor.cs
@@ -1,0 +1,119 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Fluxor;
+    using Fluxor.Blazor.Web.Components;
+    using HealthGateway.Admin.Client.Models;
+    using HealthGateway.Admin.Client.Store.Broadcasts;
+    using HealthGateway.Admin.Client.Utils;
+    using HealthGateway.Common.Data.Utils;
+    using Microsoft.AspNetCore.Components;
+    using MudBlazor;
+
+    /// <summary>
+    /// Backing logic for the BroadcastsTable component.
+    /// </summary>
+    public partial class BroadcastsTable : FluxorComponent
+    {
+        /// <summary>
+        /// Gets or sets the data with which to populate the table.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public IEnumerable<ExtendedBroadcast> Data { get; set; } = Enumerable.Empty<ExtendedBroadcast>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether data is loading.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public bool IsLoading { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the event callback that will be triggered when the button is clicked.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public EventCallback<ExtendedBroadcast> OnEditCallback { get; set; }
+
+        [Inject]
+        private IDispatcher Dispatcher { get; set; } = default!;
+
+        private MudMessageBox DeleteConfirmation { get; set; } = default!;
+
+        private IEnumerable<BroadcastRow> Rows => this.Data.Select(c => new BroadcastRow(c));
+
+        private void ToggleExpandRow(Guid id)
+        {
+            this.Dispatcher.Dispatch(new BroadcastsActions.ToggleIsExpandedAction(id));
+        }
+
+        private async Task EditBroadcastAsync(Guid id)
+        {
+            ExtendedBroadcast? broadcast = this.Data.FirstOrDefault(c => c.Id == id);
+            if (broadcast != null)
+            {
+                await this.OnEditCallback.InvokeAsync(broadcast).ConfigureAwait(true);
+            }
+        }
+
+        private async Task DeleteBroadcast(Guid id)
+        {
+            bool? delete = await this.DeleteConfirmation.Show().ConfigureAwait(true);
+            if (delete is true)
+            {
+                ExtendedBroadcast? broadcast = this.Data.FirstOrDefault(c => c.Id == id);
+                if (broadcast != null)
+                {
+                    this.Dispatcher.Dispatch(new BroadcastsActions.DeleteAction(broadcast));
+                }
+            }
+        }
+
+        private sealed record BroadcastRow
+        {
+            public BroadcastRow(ExtendedBroadcast model)
+            {
+                this.Id = model.Id;
+                this.Subject = model.CategoryName ?? "-";
+                this.EffectiveDate = DateFormatter.ToShortDateAndTime(model.ScheduledDateUtc.ToLocalTime());
+                this.ExpiryDate = model.ExpirationDateUtc == null ? "-" : DateFormatter.ToShortDateAndTime(model.ExpirationDateUtc.Value.ToLocalTime());
+                this.ActionType = BroadcastUtility.FormatActionType(model.ActionType);
+                this.Text = model.DisplayText;
+                this.IsExpanded = model.IsExpanded;
+            }
+
+            public Guid Id { get; }
+
+            public string Subject { get; }
+
+            public string EffectiveDate { get; }
+
+            public string ExpiryDate { get; }
+
+            public string ActionType { get; }
+
+            public string Text { get; }
+
+            public bool IsExpanded { get; set; }
+        }
+    }
+}

--- a/Apps/Admin/Client/Components/CommunicationDialog.razor
+++ b/Apps/Admin/Client/Components/CommunicationDialog.razor
@@ -8,7 +8,7 @@
         <HgBannerFeedback Severity="@Severity.Error" IsEnabled="@(HasAddError || HasUpdateError)" TResetAction="@CommunicationsActions.ResetStateAction">
             @ErrorMessage
         </HgBannerFeedback>
-        <MudForm @ref="Form" data-testid="banner-dialog-modal-text">
+        <MudForm @ref="Form" data-testid="communication-dialog-modal-text">
             <MudGrid Spacing="0">
                 <MudItem xs="6">
                     <MudDatePicker @ref="@EffectiveDatePicker"

--- a/Apps/Admin/Client/Components/CommunicationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/CommunicationDialog.razor.cs
@@ -27,14 +27,14 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
 /// <summary>
-/// Backing logic for the BannerDialog component.
+/// Backing logic for the CommunicationDialog component.
 /// If the Save button is pressed, the dialog's Result will have the Data property populated with a bool value of true.
 /// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
 /// </summary>
-public partial class BannerDialog : FluxorComponent
+public partial class CommunicationDialog : FluxorComponent
 {
     /// <summary>
-    /// Gets or sets the communication model corresponding to the banner that is being edited.
+    /// Gets or sets the communication model corresponding to the communication that is being edited.
     /// </summary>
     [Parameter]
     public Communication Communication { get; set; } = default!;
@@ -53,7 +53,7 @@ public partial class BannerDialog : FluxorComponent
     [Inject]
     private IState<CommunicationsState> CommunicationsState { get; set; } = default!;
 
-    private bool IsNewBanner => this.Communication.Id == Guid.Empty;
+    private bool IsNewCommunication => this.Communication.Id == Guid.Empty;
 
     private bool HasAddError => this.CommunicationsState.Value.Add.Error != null && this.CommunicationsState.Value.Add.Error.Message.Length > 0;
 
@@ -94,7 +94,7 @@ public partial class BannerDialog : FluxorComponent
 
     private void SetFormValues()
     {
-        if (this.IsNewBanner)
+        if (this.IsNewCommunication)
         {
             DateTime now = DateTime.Now;
             DateTime tomorrow = now.AddDays(1);
@@ -132,7 +132,7 @@ public partial class BannerDialog : FluxorComponent
         {
             await this.RetrieveFormValuesAsync().ConfigureAwait(true);
 
-            if (this.IsNewBanner)
+            if (this.IsNewCommunication)
             {
                 this.Dispatcher.Dispatch(new CommunicationsActions.AddAction(this.Communication));
             }

--- a/Apps/Admin/Client/Components/HgBannerFeedback.razor
+++ b/Apps/Admin/Client/Components/HgBannerFeedback.razor
@@ -3,11 +3,13 @@
 
 @if (IsEnabled && !IsHidden)
 {
-    <MudAlert Variant="Variant.Text"
-              Severity="@Severity"
-              ShowCloseIcon="true"
-              CloseIconClicked="@Close"
-              data-testid="@DataTestId">
+    <MudAlert
+        Class="@Class"
+        Variant="Variant.Text"
+        Severity="@Severity"
+        ShowCloseIcon="true"
+        CloseIconClicked="@Close"
+        data-testid="@DataTestId">
         @ChildContent
     </MudAlert>
 }

--- a/Apps/Admin/Client/Components/HgBannerFeedback.razor.cs
+++ b/Apps/Admin/Client/Components/HgBannerFeedback.razor.cs
@@ -54,6 +54,12 @@ namespace HealthGateway.Admin.Client.Components
         [Parameter]
         public string? DataTestId { get; set; }
 
+        /// <summary>
+        /// Gets or sets class names, separated by space.
+        /// </summary>
+        [Parameter]
+        public string Class { get; set; } = string.Empty;
+
         [Inject]
         private IActionSubscriber ActionSubscriber { get; set; } = default!;
 

--- a/Apps/Admin/Client/Components/HgSelect.razor
+++ b/Apps/Admin/Client/Components/HgSelect.razor
@@ -1,10 +1,12 @@
 @typeparam T
 @inherits HgComponentBase
 
-<MudSelect Class="@CombinedClass"
+<MudSelect @ref="MudComponent"
+           Class="@CombinedClass"
            Style="@Style"
            Tag="@Tag"
            T="T"
+           ValueChanged="@ValueChanged"
            Variant="Variant.Filled"
            Margin="Margin.Dense"
            @attributes="UnmatchedAttributes">

--- a/Apps/Admin/Client/Components/HgSelect.razor.cs
+++ b/Apps/Admin/Client/Components/HgSelect.razor.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Admin.Client.Components
 {
     using System.Diagnostics.CodeAnalysis;
+    using Microsoft.AspNetCore.Components;
     using MudBlazor;
 
     /// <summary>
@@ -34,5 +35,16 @@ namespace HealthGateway.Admin.Client.Components
             this.VerticalMarginSize = 3;
             this.TopMargin = Breakpoint.Always;
         }
+
+        /// <summary>
+        /// Gets or sets the event callback that will be triggered when the value changes.
+        /// </summary>
+        [Parameter]
+        public EventCallback<T> ValueChanged { get; set; }
+
+        /// <summary>
+        /// Gets the underlying MudBlazor component.
+        /// </summary>
+        public MudSelect<T> MudComponent { get; private set; } = default!;
     }
 }

--- a/Apps/Admin/Client/Components/HgTextField.razor
+++ b/Apps/Admin/Client/Components/HgTextField.razor
@@ -1,7 +1,8 @@
 @typeparam T
 @inherits HgComponentBase
 
-<MudTextField Class="@CombinedClass"
+<MudTextField @ref="MudComponent"
+              Class="@CombinedClass"
               Style="@Style"
               Tag="@Tag"
               T="T"

--- a/Apps/Admin/Client/Components/HgTextField.razor.cs
+++ b/Apps/Admin/Client/Components/HgTextField.razor.cs
@@ -34,5 +34,10 @@ namespace HealthGateway.Admin.Client.Components
             this.VerticalMarginSize = 3;
             this.TopMargin = Breakpoint.Always;
         }
+
+        /// <summary>
+        /// Gets the underlying MudBlazor component.
+        /// </summary>
+        public MudTextField<T> MudComponent { get; private set; } = default!;
     }
 }

--- a/Apps/Admin/Client/Models/ExtendedBroadcast.cs
+++ b/Apps/Admin/Client/Models/ExtendedBroadcast.cs
@@ -1,0 +1,55 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Models;
+
+using HealthGateway.Common.Data.Models;
+
+/// <summary>
+/// A system broadcast with additional state information.
+/// </summary>
+public class ExtendedBroadcast : Broadcast
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExtendedBroadcast"/> class.
+    /// </summary>
+    /// <param name="model">The broadcast model.</param>
+    public ExtendedBroadcast(Broadcast model)
+    {
+        this.PopulateFromModel(model);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the broadcast details have been expanded.
+    /// </summary>
+    public bool IsExpanded { get; set; }
+
+    /// <summary>
+    /// Populates all properties from a broadcast model.
+    /// </summary>
+    /// <param name="model">The broadcast model.</param>
+    public void PopulateFromModel(Broadcast model)
+    {
+        this.Id = model.Id;
+        this.CategoryName = model.CategoryName;
+        this.DisplayText = model.DisplayText;
+        this.Enabled = model.Enabled;
+        this.ActionType = model.ActionType;
+        this.ActionUrl = model.ActionUrl;
+        this.ScheduledDateUtc = model.ScheduledDateUtc;
+        this.ExpirationDateUtc = model.ExpirationDateUtc;
+    }
+}

--- a/Apps/Admin/Client/Pages/CommunicationsPage.razor
+++ b/Apps/Admin/Client/Pages/CommunicationsPage.razor
@@ -1,41 +1,54 @@
 @page "/communications"
 @layout MainLayout
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer}")]
+@using HealthGateway.Admin.Client.Store.Broadcasts
 @using HealthGateway.Admin.Client.Store.Communications
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <PageTitle>Health Gateway Admin Communications</PageTitle>
 <HgPageHeading>Communications</HgPageHeading>
 
-<HgBannerFeedback Severity="@Severity.Error" IsEnabled="@(HasLoadError || HasDeleteError)" TResetAction="@CommunicationsActions.ResetStateAction">
-    @ErrorMessage
+<HgBannerFeedback
+    Severity="@Severity.Error"
+    IsEnabled="@(HasBroadcastsLoadError || HasBroadcastsDeleteError)"
+    TResetAction="@BroadcastsActions.ResetStateAction"
+    Class="mb-4">
+    @BroadcastsErrorMessage
 </HgBannerFeedback>
 
-@if (CommunicationsLoaded || CommunicationsLoading)
+<HgBannerFeedback
+    Severity="@Severity.Error"
+    IsEnabled="@(HasCommunicationsLoadError || HasCommunicationsDeleteError)"
+    TResetAction="@CommunicationsActions.ResetStateAction"
+    Class="mb-4">
+    @CommunicationsErrorMessage
+</HgBannerFeedback>
+
+@if (BroadcastsLoaded || BroadcastsLoading || CommunicationsLoaded || CommunicationsLoading)
 {
     <HgTabs @ref="@Tabs" data-testid="banner-tabs">
         <Header>
-            @if (SelectedBannerName != null)
-            {
-                <HgButton EndIcon="@Icons.Material.Filled.Add"
-                          TopMargin="@Breakpoint.Always"
-                          RightMargin="@Breakpoint.Always"
-                          BottomMargin="@Breakpoint.Always"
-                          @onclick="@CreateBannerAsync"
-                          data-testid="create-banner-btn">
-                    Create
-                </HgButton>
-            }
+            <HgButton EndIcon="@Icons.Material.Filled.Add"
+                      TopMargin="@Breakpoint.Always"
+                      RightMargin="@Breakpoint.Always"
+                      BottomMargin="@Breakpoint.Always"
+                      @onclick="@(SelectedCommunicationType == null ? CreateBroadcastAsync : CreateCommunicationAsync)"
+                      data-testid="create-btn">
+                Create
+            </HgButton>
         </Header>
         <ChildContent>
+            <MudTabPanel Text="Notifications">
+                <BroadcastsTable Data="@Broadcasts" IsLoading="@BroadcastsLoading" OnEditCallback="EditBroadcastAsync" />
+            </MudTabPanel>
             <MudTabPanel Text="Public Banners">
-                <CommunicationsTable Data="@PublicCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditBannerAsync" />
+                <CommunicationsTable Data="@PublicCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditCommunicationAsync" />
             </MudTabPanel>
             <MudTabPanel Text="In-App Banners">
-                <CommunicationsTable Data="@InAppCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditBannerAsync" />
+                <CommunicationsTable Data="@InAppCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditCommunicationAsync" />
             </MudTabPanel>
             <MudTabPanel Text="Mobile">
-                <CommunicationsTable Data="@MobileCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditBannerAsync" />
+                <CommunicationsTable Data="@MobileCommunications" IsLoading="@CommunicationsLoading" OnEditCallback="EditCommunicationAsync" />
             </MudTabPanel>
         </ChildContent>
     </HgTabs>

--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -103,6 +103,7 @@ namespace HealthGateway.Admin.Client
         private static void RegisterRefitClients(this WebAssemblyHostBuilder builder)
         {
             RegisterRefitClient<IAnalyticsApi>(builder, "v1/api/CsvExport", true);
+            RegisterRefitClient<IBroadcastsApi>(builder, "v1/api/Broadcast", true);
             RegisterRefitClient<ICommunicationsApi>(builder, "v1/api/Communication", true);
             RegisterRefitClient<IConfigurationApi>(builder, "v1/api/Configuration", false);
             RegisterRefitClient<IDashboardApi>(builder, "v1/api/Dashboard", true);

--- a/Apps/Admin/Client/Services/IBroadcastsApi.cs
+++ b/Apps/Admin/Client/Services/IBroadcastsApi.cs
@@ -1,0 +1,60 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Services
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
+    using Refit;
+
+    /// <summary>
+    /// API for interacting with broadcasts.
+    /// </summary>
+    public interface IBroadcastsApi
+    {
+        /// <summary>
+        /// Adds a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The model to add.</param>
+        /// <returns>The wrapped model.</returns>
+        [Post("/")]
+        Task<ApiResponse<RequestResult<Broadcast>>> Add([Body] Broadcast broadcast);
+
+        /// <summary>
+        /// Gets all broadcasts.
+        /// </summary>
+        /// <returns>The wrapped collection of models.</returns>
+        [Get("/")]
+        Task<ApiResponse<RequestResult<IEnumerable<Broadcast>>>> GetAll();
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The model to update.</param>
+        /// <returns>The wrapped model.</returns>
+        [Put("/")]
+        Task<ApiResponse<RequestResult<Broadcast>>> Update([Body] Broadcast broadcast);
+
+        /// <summary>
+        /// Deletes a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The model to delete.</param>
+        /// <returns>The wrapped model.</returns>
+        [Delete("/")]
+        Task<ApiResponse<RequestResult<Broadcast>>> Delete([Body] Broadcast broadcast);
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Store.Broadcasts;
 
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using HealthGateway.Common.Data.Models;
@@ -224,5 +225,25 @@ public static class BroadcastsActions
     /// </summary>
     public class ResetStateAction
     {
+    }
+
+    /// <summary>
+    /// The action that toggles whether a particular broadcast is expanded.
+    /// </summary>
+    public class ToggleIsExpandedAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ToggleIsExpandedAction"/> class.
+        /// </summary>
+        /// <param name="id">Represents the ID of the broadcast.</param>
+        public ToggleIsExpandedAction(Guid id)
+        {
+            this.Id = id;
+        }
+
+        /// <summary>
+        /// Gets or sets the ID of the broadcast.
+        /// </summary>
+        public Guid Id { get; set; }
     }
 }

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
@@ -1,0 +1,228 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.ViewModels;
+
+/// <summary>
+/// Static class that implements all actions for the feature.
+/// </summary>
+[SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Team decision")]
+public static class BroadcastsActions
+{
+    /// <summary>
+    /// The action representing the initiation of an add.
+    /// </summary>
+    public class AddAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddAction"/> class.
+        /// </summary>
+        /// <param name="broadcast">Represents the broadcast model.</param>
+        public AddAction(Broadcast broadcast)
+        {
+            this.Broadcast = broadcast;
+        }
+
+        /// <summary>
+        /// Gets or sets the broadcast.
+        /// </summary>
+        public Broadcast Broadcast { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed add.
+    /// </summary>
+    public class AddFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public AddFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful add.
+    /// </summary>
+    public class AddSuccessAction : BaseSuccessAction<RequestResult<Broadcast>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">Broadcast data.</param>
+        public AddSuccessAction(RequestResult<Broadcast> data)
+            : base(data)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of a load.
+    /// </summary>
+    public class LoadAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadAction"/> class.
+        /// </summary>
+        public LoadAction()
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a failed load.
+    /// </summary>
+    public class LoadFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public LoadFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful load.
+    /// </summary>
+    public class LoadSuccessAction : BaseSuccessAction<RequestResult<IEnumerable<Broadcast>>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LoadSuccessAction"/> class.
+        /// </summary>
+        /// <param name="requestResultModel">Broadcasts data.</param>
+        public LoadSuccessAction(RequestResult<IEnumerable<Broadcast>> requestResultModel)
+            : base(requestResultModel)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of an update.
+    /// </summary>
+    public class UpdateAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateAction"/> class.
+        /// </summary>
+        /// <param name="broadcast">Represents the broadcast model.</param>
+        public UpdateAction(Broadcast broadcast)
+        {
+            this.Broadcast = broadcast;
+        }
+
+        /// <summary>
+        /// Gets or sets the broadcast.
+        /// </summary>
+        public Broadcast Broadcast { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed update.
+    /// </summary>
+    public class UpdateFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public UpdateFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful update.
+    /// </summary>
+    public class UpdateSuccessAction : BaseSuccessAction<RequestResult<Broadcast>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UpdateSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">Broadcast data.</param>
+        public UpdateSuccessAction(RequestResult<Broadcast> data)
+            : base(data)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing the initiation of a deletion.
+    /// </summary>
+    public class DeleteAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteAction"/> class.
+        /// </summary>
+        /// <param name="broadcast">Represents the broadcast model.</param>
+        public DeleteAction(Broadcast broadcast)
+        {
+            this.Broadcast = broadcast;
+        }
+
+        /// <summary>
+        /// Gets or sets the broadcast.
+        /// </summary>
+        public Broadcast Broadcast { get; set; }
+    }
+
+    /// <summary>
+    /// The action representing a failed deletion.
+    /// </summary>
+    public class DeleteFailAction : BaseFailAction
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteFailAction"/> class.
+        /// </summary>
+        /// <param name="error">The request error.</param>
+        public DeleteFailAction(RequestError error)
+            : base(error)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action representing a successful deletion.
+    /// </summary>
+    public class DeleteSuccessAction : BaseSuccessAction<RequestResult<Broadcast>>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DeleteSuccessAction"/> class.
+        /// </summary>
+        /// <param name="data">Broadcast data.</param>
+        public DeleteSuccessAction(RequestResult<Broadcast> data)
+            : base(data)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The action that clears the state.
+    /// </summary>
+    public class ResetStateAction
+    {
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
@@ -1,0 +1,147 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Fluxor;
+using HealthGateway.Admin.Client.Services;
+using HealthGateway.Admin.Client.Utils;
+using HealthGateway.Common.Data.Constants;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.ViewModels;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using Refit;
+
+/// <summary>
+/// The effects for the feature.
+/// </summary>
+public class BroadcastsEffects
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BroadcastsEffects"/> class.
+    /// </summary>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="api">The injected API.</param>
+    public BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi api)
+    {
+        this.Logger = logger;
+        this.Api = api;
+    }
+
+    [Inject]
+    private ILogger<BroadcastsEffects> Logger { get; set; }
+
+    [Inject]
+    private IBroadcastsApi Api { get; set; }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="action">The triggering action.</param>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod]
+    public async Task HandleAddAction(BroadcastsActions.AddAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Adding broadcast");
+
+        ApiResponse<RequestResult<Broadcast>> response = await this.Api.Add(action.Broadcast).ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcast added successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.AddSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error adding broadcast, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.AddFailAction(error));
+    }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod(typeof(BroadcastsActions.LoadAction))]
+    public async Task HandleLoadAction(IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Loading broadcasts");
+
+        ApiResponse<RequestResult<IEnumerable<Broadcast>>> response = await this.Api.GetAll().ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcasts loaded successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.LoadSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error loading broadcasts, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.LoadFailAction(error));
+    }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="action">The triggering action.</param>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod]
+    public async Task HandleUpdateAction(BroadcastsActions.UpdateAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Updating broadcast");
+
+        ApiResponse<RequestResult<Broadcast>> response = await this.Api.Update(action.Broadcast).ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcast updated successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.UpdateSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error updating broadcast, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.UpdateFailAction(error));
+    }
+
+    /// <summary>
+    /// Handler that calls the service and dispatches resulting actions.
+    /// </summary>
+    /// <param name="action">The triggering action.</param>
+    /// <param name="dispatcher">The injected dispatcher.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    [EffectMethod]
+    public async Task HandleDeleteAction(BroadcastsActions.DeleteAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Deleting broadcast");
+
+        ApiResponse<RequestResult<Broadcast>> response = await this.Api.Delete(action.Broadcast).ConfigureAwait(true);
+        if (response.IsSuccessStatusCode && response.Content != null && response.Content.ResultStatus == ResultType.Success)
+        {
+            this.Logger.LogInformation("Broadcast deleted successfully!");
+            dispatcher.Dispatch(new BroadcastsActions.DeleteSuccessAction(response.Content));
+            return;
+        }
+
+        RequestError error = StoreUtility.FormatRequestError(response.Error, response.Content?.ResultError);
+        this.Logger.LogError("Error deleting broadcast, reason: {ErrorMessage}", error.Message);
+        dispatcher.Dispatch(new BroadcastsActions.DeleteFailAction(error));
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -1,0 +1,320 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Fluxor;
+using HealthGateway.Common.Data.Models;
+
+/// <summary>
+/// The set of reducers for the feature.
+/// </summary>
+public static class BroadcastsReducers
+{
+    /// <summary>
+    /// The reducer for loading broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.LoadAction))]
+    public static BroadcastsState ReduceLoadAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Load = state.Load with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the load success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The load success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceLoadSuccessAction(BroadcastsState state, BroadcastsActions.LoadSuccessAction action)
+    {
+        return state with
+        {
+            Load = state.Load with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = action.Data.ResourcePayload.ToImmutableDictionary(tag => tag.Id),
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the load fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The load fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceLoadFailAction(BroadcastsState state, BroadcastsActions.LoadFailAction action)
+    {
+        return state with
+        {
+            Load = state.Load with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for adding broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.AddAction))]
+    public static BroadcastsState ReduceAddAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the add success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The add success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceAddSuccessAction(BroadcastsState state, BroadcastsActions.AddSuccessAction action)
+    {
+        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+
+        Broadcast? broadcast = action.Data.ResourcePayload;
+        if (broadcast != null)
+        {
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+        }
+
+        return state with
+        {
+            Add = state.Add with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = data,
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the add fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The add fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceAddFailAction(BroadcastsState state, BroadcastsActions.AddFailAction action)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for updating broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.UpdateAction))]
+    public static BroadcastsState ReduceUpdateAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the update success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The update success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceUpdateSuccessAction(BroadcastsState state, BroadcastsActions.UpdateSuccessAction action)
+    {
+        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+
+        Broadcast? broadcast = action.Data.ResourcePayload;
+        if (broadcast != null)
+        {
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+        }
+
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = data,
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the update fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The update fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceUpdateFailAction(BroadcastsState state, BroadcastsActions.UpdateFailAction action)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for deleting broadcasts.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.DeleteAction))]
+    public static BroadcastsState ReduceDeleteAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Delete = state.Delete with
+            {
+                IsLoading = true,
+            },
+            IsLoading = true,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the delete success action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The delete success action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceDeleteSuccessAction(BroadcastsState state, BroadcastsActions.DeleteSuccessAction action)
+    {
+        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+
+        Broadcast? broadcast = action.Data.ResourcePayload;
+        if (broadcast != null)
+        {
+            data = data.Remove(broadcast.Id);
+        }
+
+        return state with
+        {
+            Delete = state.Delete with
+            {
+                IsLoading = false,
+                Result = action.Data,
+                Error = null,
+            },
+            IsLoading = false,
+            Data = data,
+            Error = null,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the delete fail action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The delete fail action.</param>
+    /// <returns>The new state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceDeleteFailAction(BroadcastsState state, BroadcastsActions.DeleteFailAction action)
+    {
+        return state with
+        {
+            Delete = state.Delete with
+            {
+                IsLoading = false,
+                Error = action.Error,
+            },
+            IsLoading = false,
+            Error = action.Error,
+        };
+    }
+
+    /// <summary>
+    /// The reducer for the reset state action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <returns>The default state.</returns>
+    [ReducerMethod(typeof(BroadcastsActions.ResetStateAction))]
+    public static BroadcastsState ReduceResetStateAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Add = new(),
+            Load = new(),
+            Update = new(),
+            Delete = new(),
+            Data = null,
+            Error = null,
+            IsLoading = false,
+        };
+    }
+}

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -18,7 +18,9 @@ namespace HealthGateway.Admin.Client.Store.Broadcasts;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 using Fluxor;
+using HealthGateway.Admin.Client.Models;
 using HealthGateway.Common.Data.Models;
 
 /// <summary>
@@ -62,7 +64,7 @@ public static class BroadcastsReducers
                 Error = null,
             },
             IsLoading = false,
-            Data = action.Data.ResourcePayload.ToImmutableDictionary(tag => tag.Id),
+            Data = action.Data.ResourcePayload.Select(b => new ExtendedBroadcast(b)).ToImmutableDictionary(tag => tag.Id),
             Error = null,
         };
     }
@@ -115,12 +117,12 @@ public static class BroadcastsReducers
     [ReducerMethod]
     public static BroadcastsState ReduceAddSuccessAction(BroadcastsState state, BroadcastsActions.AddSuccessAction action)
     {
-        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
 
         Broadcast? broadcast = action.Data.ResourcePayload;
         if (broadcast != null)
         {
-            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, new(broadcast));
         }
 
         return state with
@@ -185,12 +187,12 @@ public static class BroadcastsReducers
     [ReducerMethod]
     public static BroadcastsState ReduceUpdateSuccessAction(BroadcastsState state, BroadcastsActions.UpdateSuccessAction action)
     {
-        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
 
         Broadcast? broadcast = action.Data.ResourcePayload;
         if (broadcast != null)
         {
-            data = data.Remove(broadcast.Id).Add(broadcast.Id, broadcast);
+            data = data.Remove(broadcast.Id).Add(broadcast.Id, new(broadcast));
         }
 
         return state with
@@ -255,7 +257,7 @@ public static class BroadcastsReducers
     [ReducerMethod]
     public static BroadcastsState ReduceDeleteSuccessAction(BroadcastsState state, BroadcastsActions.DeleteSuccessAction action)
     {
-        IImmutableDictionary<Guid, Broadcast> data = state.Data ?? new Dictionary<Guid, Broadcast>().ToImmutableDictionary();
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
 
         Broadcast? broadcast = action.Data.ResourcePayload;
         if (broadcast != null)
@@ -316,5 +318,25 @@ public static class BroadcastsReducers
             Error = null,
             IsLoading = false,
         };
+    }
+
+    /// <summary>
+    /// The reducer for the ToggleIsExpanded action.
+    /// </summary>
+    /// <param name="state">The broadcasts state.</param>
+    /// <param name="action">The ToggleIsExpanded action.</param>
+    /// <returns>The default state.</returns>
+    [ReducerMethod]
+    public static BroadcastsState ReduceToggleIsExpandedAction(BroadcastsState state, BroadcastsActions.ToggleIsExpandedAction action)
+    {
+        IImmutableDictionary<Guid, ExtendedBroadcast> data = state.Data ?? new Dictionary<Guid, ExtendedBroadcast>().ToImmutableDictionary();
+
+        ExtendedBroadcast? broadcast = data.GetValueOrDefault(action.Id);
+        if (broadcast != null)
+        {
+            broadcast.IsExpanded = !broadcast.IsExpanded;
+        }
+
+        return state;
     }
 }

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Fluxor;
+using HealthGateway.Admin.Client.Models;
 using HealthGateway.Common.Data.Models;
 using HealthGateway.Common.Data.ViewModels;
 
@@ -53,7 +54,7 @@ public record BroadcastsState
     /// <summary>
     /// Gets the collection of data.
     /// </summary>
-    public IImmutableDictionary<Guid, Broadcast>? Data { get; init; }
+    public IImmutableDictionary<Guid, ExtendedBroadcast>? Data { get; init; }
 
     /// <summary>
     /// Gets the request error if available.

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsState.cs
@@ -1,0 +1,72 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Store.Broadcasts;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Fluxor;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.ViewModels;
+
+/// <summary>
+/// The state for the feature.
+/// State should be decorated with [FeatureState] for automatic discovery when services. AddFluxor is called.
+/// </summary>
+[FeatureState]
+public record BroadcastsState
+{
+    /// <summary>
+    /// Gets the request state for adds.
+    /// </summary>
+    public BaseRequestState<RequestResult<Broadcast>> Add { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for loads.
+    /// </summary>
+    public BaseRequestState<RequestResult<IEnumerable<Broadcast>>> Load { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for updates.
+    /// </summary>
+    public BaseRequestState<RequestResult<Broadcast>> Update { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for deletions.
+    /// </summary>
+    public BaseRequestState<RequestResult<Broadcast>> Delete { get; init; } = new();
+
+    /// <summary>
+    /// Gets the collection of data.
+    /// </summary>
+    public IImmutableDictionary<Guid, Broadcast>? Data { get; init; }
+
+    /// <summary>
+    /// Gets the request error if available.
+    /// </summary>
+    public RequestError? Error { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether a request is loading.
+    /// </summary>
+    public bool IsLoading { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the data has been loaded.
+    /// </summary>
+    public bool Loaded => this.Data != null;
+}

--- a/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
@@ -330,10 +330,10 @@ public static class CommunicationsReducers
     }
 
     /// <summary>
-    /// The reducer for the toggle IsExpanded action.
+    /// The reducer for the ToggleIsExpanded action.
     /// </summary>
     /// <param name="state">The communications state.</param>
-    /// <param name="action">The toggle IsExpanded action.</param>
+    /// <param name="action">The ToggleIsExpanded action.</param>
     /// <returns>The default state.</returns>
     [ReducerMethod]
     public static CommunicationsState ReduceToggleIsExpandedAction(CommunicationsState state, CommunicationsActions.ToggleIsExpandedAction action)

--- a/Apps/Admin/Client/Utils/BroadcastUtility.cs
+++ b/Apps/Admin/Client/Utils/BroadcastUtility.cs
@@ -1,0 +1,51 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Utils
+{
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// Utilities for interacting with system broadcasts.
+    /// </summary>
+    public static class BroadcastUtility
+    {
+        /// <summary>
+        /// Returns the formatted representation of a broadcast's action type.
+        /// </summary>
+        /// <param name="actionType">The broadcast's action type.</param>
+        /// <returns>A string containing the formatted representation of a broadcast's action type.</returns>
+        public static string FormatActionType(BroadcastActionType actionType)
+        {
+            return actionType switch
+            {
+                BroadcastActionType.None => "None",
+                BroadcastActionType.InternalLink => "Internal Link",
+                BroadcastActionType.ExternalLink => "External Link",
+                _ => actionType.ToString(),
+            };
+        }
+
+        /// <summary>
+        /// Returns the formatted representation of a broadcast's enabled status.
+        /// </summary>
+        /// <param name="enabled">The broadcast's enabled status.</param>
+        /// <returns>A string containing the formatted representation of a broadcast's enabled status.</returns>
+        public static string FormatEnabled(bool enabled)
+        {
+            return enabled ? "Publish" : "Draft";
+        }
+    }
+}

--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Admin.Server.Controllers
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
@@ -93,6 +92,23 @@ namespace HealthGateway.Admin.Server.Controllers
         public async Task<RequestResult<Broadcast>> UpdateBroadcast(Broadcast broadcast)
         {
             return await this.broadcastService.UpdateBroadcastAsync(broadcast).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Deletes a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The deleted broadcast wrapped in a RequestResult.</returns>
+        /// <response code="200">Returns the deleted broadcast wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpDelete]
+        public async Task<RequestResult<Broadcast>> DeleteBroadcast(Broadcast broadcast)
+        {
+            return await this.broadcastService.DeleteBroadcastAsync(broadcast).ConfigureAwait(true);
         }
     }
 }

--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Controllers
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;

--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -1,0 +1,80 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Controllers
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Services;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// Web API to handle system broadcasts.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/api/[controller]")]
+    [Produces("application/json")]
+    [Authorize(Roles = "AdminUser,AdminReviewer")]
+    public class BroadcastController
+    {
+        private readonly IBroadcastService broadcastService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastController"/> class.
+        /// </summary>
+        /// <param name="broadcastService">The injected broadcast service.</param>
+        public BroadcastController(IBroadcastService broadcastService)
+        {
+            this.broadcastService = broadcastService;
+        }
+
+        /// <summary>
+        /// Creates a broadcast.
+        /// </summary>
+        /// <returns>The created broadcast wrapped in a RequestResult.</returns>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <response code="200">Returns the created broadcast wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpPost]
+        public async Task<RequestResult<Broadcast>> CreateBroadcast(Broadcast broadcast)
+        {
+            return await this.broadcastService.CreateBroadcastAsync(broadcast).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Retrieves all broadcasts.
+        /// </summary>
+        /// <returns>The collection of broadcasts wrapped in a RequestResult.</returns>
+        /// <response code="200">Returns the collection of broadcasts wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        public async Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcasts()
+        {
+            return await this.broadcastService.GetBroadcastsAsync().ConfigureAwait(true);
+        }
+    }
+}

--- a/Apps/Admin/Server/Controllers/BroadcastController.cs
+++ b/Apps/Admin/Server/Controllers/BroadcastController.cs
@@ -77,5 +77,22 @@ namespace HealthGateway.Admin.Server.Controllers
         {
             return await this.broadcastService.GetBroadcastsAsync().ConfigureAwait(true);
         }
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The updated broadcast wrapped in a RequestResult.</returns>
+        /// <response code="200">Returns the updated broadcast  wrapped in a RequestResult.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpPut]
+        public async Task<RequestResult<Broadcast>> UpdateBroadcast(Broadcast broadcast)
+        {
+            return await this.broadcastService.UpdateBroadcastAsync(broadcast).ConfigureAwait(true);
+        }
     }
 }

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -73,41 +73,17 @@ namespace HealthGateway.Admin.Server
             // Add services to the container.
             services.AddControllersWithViews();
 
-            // Add HG Services
-            services.AddTransient<IAccessTokenService, AccessTokenService>();
-            services.AddTransient<IBroadcastService, BroadcastService>();
-            services.AddTransient<IConfigurationService, ConfigurationService>();
-            services.AddTransient<IUserFeedbackService, UserFeedbackService>();
-            services.AddTransient<IDashboardService, DashboardService>();
-            services.AddTransient<ICommunicationService, CommunicationService>();
-            services.AddTransient<ICsvExportService, CsvExportService>();
-            services.AddTransient<IInactiveUserService, InactiveUserService>();
-            services.AddTransient<ISupportService, SupportService>();
+            AddServices(services);
+            AddDelegates(services);
 
-            // Add HG Delegates
+            // Configure token swapping
             services.AddTransient<AuthHeaderHandler>();
-            services.AddTransient<IMessagingVerificationDelegate, DBMessagingVerificationDelegate>();
-            services.AddTransient<IFeedbackDelegate, DBFeedbackDelegate>();
-            services.AddTransient<IRatingDelegate, DBRatingDelegate>();
-            services.AddTransient<IUserProfileDelegate, DBProfileDelegate>();
-            services.AddTransient<ICommunicationDelegate, DBCommunicationDelegate>();
-            services.AddTransient<INoteDelegate, DBNoteDelegate>();
-            services.AddTransient<IResourceDelegateDelegate, DBResourceDelegateDelegate>();
-            services.AddTransient<ICommentDelegate, DBCommentDelegate>();
-            services.AddTransient<IAdminTagDelegate, DBAdminTagDelegate>();
-            services.AddTransient<IFeedbackTagDelegate, DBFeedbackTagDelegate>();
-            services.AddTransient<IVaccineStatusDelegate, RestVaccineStatusDelegate>();
-            services.AddTransient<IVaccineProofDelegate, VaccineProofDelegate>();
-            services.AddTransient<IAdminUserProfileDelegate, DbAdminUserProfileDelegate>();
-            services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
-            services.AddTransient<ITokenSwapDelegate, RestTokenSwapDelegate>();
-            services.AddTransient<IUserAdminDelegate, KeycloakUserAdminDelegate>();
-
-            // Add API clients
             PhsaConfigV2 phsaConfig = new();
             configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfig);
             services.AddRefitClient<ITokenSwapApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.TokenBaseUrl);
+
+            // Add API clients
             services.AddRefitClient<ISystemBroadcastApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl)
                 .AddHttpMessageHandler<AuthHeaderHandler>();
@@ -137,6 +113,39 @@ namespace HealthGateway.Admin.Server
             app.MapFallbackToFile("index.html");
 
             await app.RunAsync().ConfigureAwait(true);
+        }
+
+        private static void AddServices(IServiceCollection services)
+        {
+            services.AddTransient<IAccessTokenService, AccessTokenService>();
+            services.AddTransient<IBroadcastService, BroadcastService>();
+            services.AddTransient<IConfigurationService, ConfigurationService>();
+            services.AddTransient<IUserFeedbackService, UserFeedbackService>();
+            services.AddTransient<IDashboardService, DashboardService>();
+            services.AddTransient<ICommunicationService, CommunicationService>();
+            services.AddTransient<ICsvExportService, CsvExportService>();
+            services.AddTransient<IInactiveUserService, InactiveUserService>();
+            services.AddTransient<ISupportService, SupportService>();
+        }
+
+        private static void AddDelegates(IServiceCollection services)
+        {
+            services.AddTransient<IMessagingVerificationDelegate, DBMessagingVerificationDelegate>();
+            services.AddTransient<IFeedbackDelegate, DBFeedbackDelegate>();
+            services.AddTransient<IRatingDelegate, DBRatingDelegate>();
+            services.AddTransient<IUserProfileDelegate, DBProfileDelegate>();
+            services.AddTransient<ICommunicationDelegate, DBCommunicationDelegate>();
+            services.AddTransient<INoteDelegate, DBNoteDelegate>();
+            services.AddTransient<IResourceDelegateDelegate, DBResourceDelegateDelegate>();
+            services.AddTransient<ICommentDelegate, DBCommentDelegate>();
+            services.AddTransient<IAdminTagDelegate, DBAdminTagDelegate>();
+            services.AddTransient<IFeedbackTagDelegate, DBFeedbackTagDelegate>();
+            services.AddTransient<IVaccineStatusDelegate, RestVaccineStatusDelegate>();
+            services.AddTransient<IVaccineProofDelegate, VaccineProofDelegate>();
+            services.AddTransient<IAdminUserProfileDelegate, DbAdminUserProfileDelegate>();
+            services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
+            services.AddTransient<ITokenSwapDelegate, RestTokenSwapDelegate>();
+            services.AddTransient<IUserAdminDelegate, KeycloakUserAdminDelegate>();
         }
     }
 }

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Admin.Server
     using HealthGateway.Common.AspNetConfiguration.Modules;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Delegates.PHSA;
+    using HealthGateway.Common.MapProfiles;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.Common.Utils.Phsa;
@@ -111,7 +112,7 @@ namespace HealthGateway.Admin.Server
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl)
                 .AddHttpMessageHandler<AuthHeaderHandler>();
 
-            services.AddAutoMapper(typeof(Program));
+            services.AddAutoMapper(typeof(Program), typeof(BroadcastProfile));
 
             WebApplication app = builder.Build();
             HttpWeb.UseForwardHeaders(app, logger, configuration);

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -41,5 +41,9 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "http://localhost:5005/"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -40,5 +40,9 @@
     "ServiceEndpoints": {
         "JobScheduler": "https://dev.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
+    },
     "RedisAuditing": true
 }

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -39,5 +39,9 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://mock.healthgateway.gov.bc.ca/admin/jobscheduler"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -36,5 +36,9 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://test.healthgateway.gov.bc.ca/admin/jobscheduler"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-test.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-test.azurewebsites.net"
     }
 }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -95,8 +95,8 @@
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-prod.azurewebsites.net",
         "ClientId": "****",
         "ClientSecret": "****",
-        "GrantType": "delegation",
-        "Scope": "healthdata.read",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "Scope": "admin_profile",
         "TokenCacheEnabled": true
     }
 }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -89,5 +89,14 @@
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://www.healthgateway.gov.bc.ca/admin/jobscheduler"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-prod.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-prod.azurewebsites.net",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "delegation",
+        "Scope": "healthdata.read",
+        "TokenCacheEnabled": true
     }
 }

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -68,7 +68,7 @@ describe("Communications", () => {
         cy.log("Validate edit subject.");
 
         cy.get("[data-testid=comm-table-edit-btn]").click();
-        cy.get("[data-testid=banner-dialog-modal-text]").within(() => {
+        cy.get("[data-testid=communication-dialog-modal-text]").within(() => {
             cy.get("[data-testid=subject-input]")
                 .clear()
                 .focus()

--- a/Apps/Common/src/Api/ISystemBroadcastApi.cs
+++ b/Apps/Common/src/Api/ISystemBroadcastApi.cs
@@ -23,21 +23,21 @@ namespace HealthGateway.Common.Api
     /// <summary>
     /// Interface to interact with PHSA System Broadcasts API.
     /// </summary>
-    public interface ISystemBroadcastsApi
+    public interface ISystemBroadcastApi
     {
         /// <summary>
-        /// Retrieves the broadcasts.
+        /// Retrieves broadcasts.
         /// </summary>
-        /// <returns>The collection of Broadcasts.</returns>
-        [Get("/api/system-broadcasts")]
+        /// <returns>A response containing the collection of broadcasts.</returns>
+        [Get("/system-broadcasts")]
         Task<IApiResponse<IEnumerable<BroadcastResponse>>> GetBroadcasts();
 
         /// <summary>
         /// Creates a broadcast.
         /// </summary>
         /// <param name="request">The broadcast to create.</param>
-        /// <returns>The Broadcasts that was created.</returns>
-        [Post("/api/system-broadcasts")]
+        /// <returns>A response containing the broadcast that was created.</returns>
+        [Post("/system-broadcasts")]
         Task<IApiResponse<BroadcastResponse>> CreateBroadcast([Body] BroadcastRequest request);
 
         /// <summary>
@@ -45,16 +45,16 @@ namespace HealthGateway.Common.Api
         /// </summary>
         /// <param name="id">The id of the broadcast that is being updated.</param>
         /// <param name="request">The broadcast values to update.</param>
-        /// <returns>The Broadcasts that was updated.</returns>
-        [Put("/api/system-broadcasts/{id}")]
+        /// <returns>A response containing the broadcast that was updated.</returns>
+        [Put("/system-broadcasts/{id}")]
         Task<IApiResponse<BroadcastResponse>> UpdateBroadcast(string id, [Body] BroadcastRequest request);
 
         /// <summary>
         /// Deletes a broadcast.
         /// </summary>
-        /// <param name="id">The id of the broadcast that is being deleted..</param>
-        /// <returns>The Broadcasts that was created.</returns>
-        [Delete("/api/system-broadcasts/{id}")]
+        /// <param name="id">The id of the broadcast that is being deleted.</param>
+        /// <returns>A response indicating success or failure.</returns>
+        [Delete("/system-broadcasts/{id}")]
         Task<IApiResponse> DeleteBroadcast(string id);
     }
 }

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.MapProfiles
 {
     using AutoMapper;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.PHSA;
 

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -1,0 +1,36 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.MapProfiles
+{
+    using AutoMapper;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.PHSA;
+
+    /// <summary>
+    /// An AutoMapper profile class which defines mapping between PHSA and front-end models.
+    /// </summary>
+    public class BroadcastProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastProfile"/> class.
+        /// </summary>
+        public BroadcastProfile()
+        {
+            this.CreateMap<BroadcastResponse, Broadcast>();
+            this.CreateMap<Broadcast, BroadcastRequest>();
+        }
+    }
+}

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Common.MapProfiles
 {
     using AutoMapper;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.PHSA;
 
     /// <summary>

--- a/Apps/Common/src/MapProfiles/BroadcastProfile.cs
+++ b/Apps/Common/src/MapProfiles/BroadcastProfile.cs
@@ -29,7 +29,9 @@ namespace HealthGateway.Common.MapProfiles
         /// </summary>
         public BroadcastProfile()
         {
-            this.CreateMap<BroadcastResponse, Broadcast>();
+            this.CreateMap<BroadcastResponse, Broadcast>()
+                .ForMember(dest => dest.CategoryName, opt => opt.MapFrom(src => src.CategoryName ?? string.Empty))
+                .ForMember(dest => dest.DisplayText, opt => opt.MapFrom(src => src.DisplayText ?? string.Empty));
             this.CreateMap<Broadcast, BroadcastRequest>();
         }
     }

--- a/Apps/Common/src/Models/Broadcast.cs
+++ b/Apps/Common/src/Models/Broadcast.cs
@@ -1,0 +1,74 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Model representing a broadcast.
+    /// </summary>
+    public class Broadcast
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category name.
+        /// </summary>
+        [JsonPropertyName("categoryName")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text.
+        /// </summary>
+        [JsonPropertyName("displayText")]
+        public string? DisplayText { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this broadcast system is enabled.
+        /// </summary>
+        [JsonPropertyName("enabled")]
+        public bool Enabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action url.
+        /// </summary>
+        [JsonPropertyName("actionUrl")]
+        public Uri? ActionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action text.
+        /// </summary>
+        [JsonPropertyName("actionText")]
+        public string? ActionText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scheduled datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("scheduledDateUtc")]
+        public DateTime ScheduledDateUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("expirationDateUtc")]
+        public DateTime? ExpirationDateUtc { get; set; }
+    }
+}

--- a/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastRequest.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Models.PHSA
 {
     using System;
     using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Models;
 
     /// <summary>
     /// Model representing a PHSA Broadcast Request.
@@ -42,10 +43,10 @@ namespace HealthGateway.Common.Models.PHSA
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the action text.
+        /// Gets or sets the action type.
         /// </summary>
-        [JsonPropertyName("actionText")]
-        public string? ActionText { get; set; }
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
 
         /// <summary>
         /// Gets or sets the action url.

--- a/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
+++ b/Apps/Common/src/Models/PHSA/BroadcastResponse.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Models.PHSA
 {
     using System;
     using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Models;
 
     /// <summary>
     /// Model representing a PHSA Broadcast Response.
@@ -54,10 +55,10 @@ namespace HealthGateway.Common.Models.PHSA
         public Uri? ActionUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the action text.
+        /// Gets or sets the action type.
         /// </summary>
-        [JsonPropertyName("actionText")]
-        public string? ActionText { get; set; }
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
 
         /// <summary>
         /// Gets or sets the scheduled datetime in UTC.

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.Common.Services
     using AutoMapper;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -1,0 +1,147 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Services
+{
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.ErrorHandling;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.PHSA;
+    using Microsoft.Extensions.Logging;
+    using Refit;
+
+    /// <inheritdoc/>
+    public class BroadcastService : IBroadcastService
+    {
+        private readonly ILogger logger;
+        private readonly IMapper autoMapper;
+        private readonly ISystemBroadcastApi systemBroadcastApi;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BroadcastService"/> class.
+        /// </summary>
+        /// <param name="logger">The injected logger.</param>
+        /// <param name="systemBroadcastApi">The injected API for interacting with system broadcasts.</param>
+        /// <param name="autoMapper">The injected automapper provider.</param>
+        public BroadcastService(ILogger<BroadcastService> logger, ISystemBroadcastApi systemBroadcastApi, IMapper autoMapper)
+        {
+            this.logger = logger;
+            this.systemBroadcastApi = systemBroadcastApi;
+            this.autoMapper = autoMapper;
+        }
+
+        private static ActivitySource Source { get; } = new(nameof(BroadcastService));
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<Broadcast>> CreateBroadcastAsync(Broadcast broadcast)
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Creating broadcast");
+
+            RequestResult<Broadcast> requestResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+
+            try
+            {
+                BroadcastRequest broadcastRequest = this.autoMapper.Map<BroadcastRequest>(broadcast);
+                IApiResponse<BroadcastResponse> response = await this.systemBroadcastApi.CreateBroadcast(broadcastRequest).ConfigureAwait(true);
+
+                if (response.StatusCode == HttpStatusCode.OK && response.Error is null && response.Content is not null)
+                {
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = this.autoMapper.Map<Broadcast>(response.Content);
+                    requestResult.TotalResultCount = 1;
+                }
+                else
+                {
+                    this.logger.LogError("Broadcast request returned unsuccessful response");
+                    requestResult.ResultError = new()
+                    {
+                        ResultMessage = "An unexpected error occurred while processing external call",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}", e.ToString());
+                requestResult.ResultError = new()
+                {
+                    ResultMessage = "Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            this.logger.LogDebug("Finished creating broadcast");
+            return requestResult;
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcastsAsync()
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Retrieving broadcasts");
+
+            RequestResult<IEnumerable<Broadcast>> requestResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+
+            try
+            {
+                IApiResponse<IEnumerable<BroadcastResponse>> response = await this.systemBroadcastApi.GetBroadcasts().ConfigureAwait(true);
+
+                if (response.StatusCode == HttpStatusCode.OK && response.Error is null && response.Content is not null)
+                {
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = this.autoMapper.Map<List<Broadcast>>(response.Content);
+                    requestResult.TotalResultCount = requestResult.ResourcePayload.Count();
+                }
+                else
+                {
+                    this.logger.LogError("Broadcast request returned unsuccessful response");
+                    requestResult.ResultError = new()
+                    {
+                        ResultMessage = "An unexpected error occurred while processing external call",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}", e.ToString());
+                requestResult.ResultError = new()
+                {
+                    ResultMessage = "Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            this.logger.LogDebug("Finished retrieving broadcasts");
+            return requestResult;
+        }
+    }
+}

--- a/Apps/Common/src/Services/BroadcastService.cs
+++ b/Apps/Common/src/Services/BroadcastService.cs
@@ -34,8 +34,8 @@ namespace HealthGateway.Common.Services
     /// <inheritdoc/>
     public class BroadcastService : IBroadcastService
     {
-        private readonly ILogger logger;
         private readonly IMapper autoMapper;
+        private readonly ILogger logger;
         private readonly ISystemBroadcastApi systemBroadcastApi;
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace HealthGateway.Common.Services
             return requestResult;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public async Task<RequestResult<Broadcast>> UpdateBroadcastAsync(Broadcast broadcast)
         {
             using Activity? activity = Source.StartActivity();
@@ -187,6 +187,51 @@ namespace HealthGateway.Common.Services
             }
 
             this.logger.LogDebug("Finished updating broadcast");
+            return requestResult;
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<Broadcast>> DeleteBroadcastAsync(Broadcast broadcast)
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Deleting broadcast for id: {Id}", broadcast.Id.ToString());
+
+            RequestResult<Broadcast> requestResult = new()
+            {
+                ResultStatus = ResultType.Error,
+            };
+
+            try
+            {
+                IApiResponse response = await this.systemBroadcastApi.DeleteBroadcast(broadcast.Id.ToString()).ConfigureAwait(true);
+
+                if (response.StatusCode == HttpStatusCode.OK && response.Error is null)
+                {
+                    requestResult.ResultStatus = ResultType.Success;
+                    requestResult.ResourcePayload = broadcast;
+                    requestResult.TotalResultCount = 1;
+                }
+                else
+                {
+                    this.logger.LogError("Broadcast delete returned unsuccessful response");
+                    requestResult.ResultError = new()
+                    {
+                        ResultMessage = "An unexpected error occurred while processing external call",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                    };
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                this.logger.LogCritical("HTTP Request Exception {Error}", e.ToString());
+                requestResult.ResultError = new()
+                {
+                    ResultMessage = "Error with HTTP Request",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.PHSA),
+                };
+            }
+
+            this.logger.LogDebug("Finished deleting broadcast");
             return requestResult;
         }
     }

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Common.Services
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
 
     /// <summary>
     /// Service to interact with broadcasts.
@@ -45,5 +44,12 @@ namespace HealthGateway.Common.Services
         /// <param name="broadcast">The broadcast model.</param>
         /// <returns>The updated broadcast wrapped in a RequestResult.</returns>
         Task<RequestResult<Broadcast>> UpdateBroadcastAsync(Broadcast broadcast);
+
+        /// <summary>
+        /// Deletes a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast to delete.</param>
+        /// <returns>The deleted broadcast wrapped in a RequestResult.</returns>
+        Task<RequestResult<Broadcast>> DeleteBroadcastAsync(Broadcast broadcast);
     }
 }

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Services
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
 

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -38,5 +38,12 @@ namespace HealthGateway.Common.Services
         /// </summary>
         /// <returns>The collection of broadcasts wrapped in a RequestResult.</returns>
         Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcastsAsync();
+
+        /// <summary>
+        /// Updates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The updated broadcast wrapped in a RequestResult.</returns>
+        Task<RequestResult<Broadcast>> UpdateBroadcastAsync(Broadcast broadcast);
     }
 }

--- a/Apps/Common/src/Services/IBroadcastService.cs
+++ b/Apps/Common/src/Services/IBroadcastService.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Services
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
+
+    /// <summary>
+    /// Service to interact with broadcasts.
+    /// </summary>
+    public interface IBroadcastService
+    {
+        /// <summary>
+        /// Creates a broadcast.
+        /// </summary>
+        /// <param name="broadcast">The broadcast model.</param>
+        /// <returns>The created broadcast wrapped in a RequestResult.</returns>
+        Task<RequestResult<Broadcast>> CreateBroadcastAsync(Broadcast broadcast);
+
+        /// <summary>
+        /// Retrieves all broadcasts.
+        /// </summary>
+        /// <returns>The collection of broadcasts wrapped in a RequestResult.</returns>
+        Task<RequestResult<IEnumerable<Broadcast>>> GetBroadcastsAsync();
+    }
+}

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -1,0 +1,312 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Common.Services;
+    using HealthGateway.CommonTests.Utils;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Refit;
+    using Xunit;
+
+    /// <summary>
+    /// BroadcastService's Unit Tests.
+    /// </summary>
+    public class BroadcastServiceTests
+    {
+        private const string CategoryName = "Test Category Name";
+        private const string UnexpectedErrorMessage = "An unexpected error occurred while processing external call";
+        private const string ThrownExceptionMessage = "Error with HTTP Request";
+
+        /// <summary>
+        /// CreateBroadcast.
+        /// </summary>
+        [Fact]
+        public void ShouldCreateBroadcast()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(new Broadcast()).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(CategoryName, actualResult.ResourcePayload.CategoryName);
+        }
+
+        /// <summary>
+        /// CreateBroadcast - api returns error.
+        /// </summary>
+        [Fact]
+        public void CreateBroadcastShouldReturnsError()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(new Broadcast()).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// CreateBroadcast - api throws exception.
+        /// </summary>
+        [Fact]
+        public void CreateBroadcastShouldThrowsException()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(new Broadcast()).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - api returns one row.
+        /// </summary>
+        [Fact]
+        public void ShouldGetBroadcasts()
+        {
+            // Arrange
+            Guid expectedId = Guid.NewGuid();
+            IBroadcastService service = GetBroadcastService(expectedId, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.ResourcePayload.Count() == 1);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(expectedId, actualResult.ResourcePayload.First().Id);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - returns no rows.
+        /// </summary>
+        [Fact]
+        public void ShouldGetBroadcastsNoRowsReturned()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(!actualResult.ResourcePayload.Any());
+            Assert.True(actualResult.TotalResultCount == 0);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - api returns error.
+        /// </summary>
+        [Fact]
+        public void GetBroadcastsShouldReturnsError()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// GetBroadcasts - api throws exception.
+        /// </summary>
+        [Fact]
+        public void GetBroadcastsShouldThrowsException()
+        {
+            // Arrange
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// UpdateBroadcast.
+        /// </summary>
+        [Fact]
+        public void ShouldUpdateBroadcast()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(expectedId, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(expectedId, actualResult.ResourcePayload.Id);
+        }
+
+        /// <summary>
+        /// UpdateBroadcast -api returns error.
+        /// </summary>
+        [Fact]
+        public void UpdateBroadcastShouldReturnsError()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// CreateBroadcast -api throws exception.
+        /// </summary>
+        [Fact]
+        public void UpdateBroadcastShouldThrowsException()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        private static BroadcastResponse GetApiResponse(Guid? id)
+        {
+            BroadcastResponse response = new()
+            {
+                Id = id ?? Guid.NewGuid(),
+                CategoryName = CategoryName,
+                ModifiedDateUtc = DateTime.UtcNow,
+                CreationDateUtc = DateTime.UtcNow,
+            };
+            return response;
+        }
+
+        private static IBroadcastService GetBroadcastService(Guid? id, HttpStatusCode? statusCode, bool throwException)
+        {
+            Mock<IApiResponse> mockApiDeleteResponse = new();
+            mockApiDeleteResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<IApiResponse<BroadcastResponse>> mockApiUpdateResponse = new();
+            mockApiUpdateResponse.Setup(r => r.Content).Returns(GetApiResponse(id));
+            mockApiUpdateResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<IApiResponse<BroadcastResponse>> mockApiCreateResponse = new();
+            mockApiCreateResponse.Setup(r => r.Content).Returns(GetApiResponse(null));
+            mockApiCreateResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<IApiResponse<IEnumerable<BroadcastResponse>>> mockApiGetResponse = new();
+            List<BroadcastResponse> responses = new();
+            if (id != null)
+            {
+                responses.Add(GetApiResponse(id));
+            }
+
+            mockApiGetResponse.Setup(r => r.Content).Returns(responses);
+            mockApiGetResponse.Setup(r => r.StatusCode).Returns(statusCode ?? HttpStatusCode.OK);
+
+            Mock<ISystemBroadcastApi> mockSystemBroadcastApi = new();
+
+            if (!throwException)
+            {
+                mockSystemBroadcastApi.Setup(s => s.GetBroadcasts()).ReturnsAsync(mockApiGetResponse.Object);
+                mockSystemBroadcastApi.Setup(s => s.UpdateBroadcast(It.IsAny<string>(), It.IsAny<BroadcastRequest>())).ReturnsAsync(mockApiUpdateResponse.Object);
+                mockSystemBroadcastApi.Setup(s => s.CreateBroadcast(It.IsAny<BroadcastRequest>())).ReturnsAsync(mockApiCreateResponse.Object);
+                mockSystemBroadcastApi.Setup(s => s.DeleteBroadcast(It.IsAny<string>())).ReturnsAsync(mockApiDeleteResponse.Object);
+            }
+            else
+            {
+                mockSystemBroadcastApi.Setup(s => s.GetBroadcasts()).ThrowsAsync(new HttpRequestException(string.Empty));
+                mockSystemBroadcastApi.Setup(s => s.UpdateBroadcast(It.IsAny<string>(), It.IsAny<BroadcastRequest>())).ThrowsAsync(new HttpRequestException(string.Empty));
+                mockSystemBroadcastApi.Setup(s => s.CreateBroadcast(It.IsAny<BroadcastRequest>())).ThrowsAsync(new HttpRequestException(string.Empty));
+                mockSystemBroadcastApi.Setup(s => s.DeleteBroadcast(It.IsAny<string>())).ThrowsAsync(new HttpRequestException(string.Empty));
+            }
+
+            return new BroadcastService(
+                new Mock<ILogger<BroadcastService>>().Object,
+                mockSystemBroadcastApi.Object,
+                MapperUtil.InitializeAutoMapper());
+        }
+    }
+}

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -202,7 +202,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// UpdateBroadcast -api returns error.
+        /// UpdateBroadcast - api returns error.
         /// </summary>
         [Fact]
         public void UpdateBroadcastShouldReturnsError()
@@ -227,7 +227,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// CreateBroadcast -api throws exception.
+        /// CreateBroadcast - api throws exception.
         /// </summary>
         [Fact]
         public void UpdateBroadcastShouldThrowsException()
@@ -243,6 +243,81 @@ namespace HealthGateway.CommonTests.Services
 
             // Act
             RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(ThrownExceptionMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// DeleteBroadcast.
+        /// </summary>
+        [Fact]
+        public void ShouldDeleteBroadcast()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(expectedId, HttpStatusCode.OK, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.NotNull(actualResult.ResourcePayload);
+            Assert.True(actualResult.TotalResultCount == 1);
+            Assert.Equal(expectedId, actualResult.ResourcePayload.Id);
+        }
+
+        /// <summary>
+        /// DeleteBroadcast - api returns error.
+        /// </summary>
+        [Fact]
+        public void DeleteBroadcastShouldReturnError()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, HttpStatusCode.InternalServerError, false);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+
+            // Assert
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
+            Assert.Null(actualResult.ResourcePayload);
+            Assert.NotNull(actualResult.ResultError);
+            Assert.Equal(UnexpectedErrorMessage, actualResult.ResultError?.ResultMessage);
+        }
+
+        /// <summary>
+        /// DeleteBroadcast - api throws exception.
+        /// </summary>
+        [Fact]
+        public void DeleteBroadcastShouldThrowException()
+        {
+            Guid expectedId = Guid.NewGuid();
+
+            // Arrange
+            Broadcast broadcast = new()
+            {
+                Id = expectedId,
+            };
+            IBroadcastService service = GetBroadcastService(null, null, true);
+
+            // Act
+            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Common/test/unit/Utils/MapperUtil.cs
+++ b/Apps/Common/test/unit/Utils/MapperUtil.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.CommonTests.Utils
 {
     using AutoMapper;
     using HealthGateway.Admin.Server.MapProfiles;
+    using HealthGateway.Common.MapProfiles;
 
     /// <summary>
     /// Static utility class to provide a fully initialized AutoMapper.
@@ -30,11 +31,13 @@ namespace HealthGateway.CommonTests.Utils
         /// <returns>A configured AutoMapper.</returns>
         public static IMapper InitializeAutoMapper()
         {
-            MapperConfiguration config = new MapperConfiguration(cfg =>
-            {
-                cfg.AddProfile(new MessagingVerificationModelProfile());
-                cfg.AddProfile(new SupportUserProfile());
-            });
+            MapperConfiguration config = new(
+                cfg =>
+                {
+                    cfg.AddProfile(new MessagingVerificationModelProfile());
+                    cfg.AddProfile(new SupportUserProfile());
+                    cfg.AddProfile(new BroadcastProfile());
+                });
 
             return config.CreateMapper();
         }

--- a/Apps/CommonData/src/Models/Broadcast.cs
+++ b/Apps/CommonData/src/Models/Broadcast.cs
@@ -33,13 +33,13 @@ namespace HealthGateway.Common.Data.Models
         /// Gets or sets the category name.
         /// </summary>
         [JsonPropertyName("categoryName")]
-        public string? CategoryName { get; set; }
+        public string CategoryName { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the display text.
         /// </summary>
         [JsonPropertyName("displayText")]
-        public string? DisplayText { get; set; }
+        public string DisplayText { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets a value indicating whether this broadcast system is enabled.
@@ -48,27 +48,27 @@ namespace HealthGateway.Common.Data.Models
         public bool Enabled { get; set; }
 
         /// <summary>
-        /// Gets or sets the action url.
+        /// Gets or sets the action type.
+        /// </summary>
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action URL.
         /// </summary>
         [JsonPropertyName("actionUrl")]
         public Uri? ActionUrl { get; set; }
 
         /// <summary>
-        /// Gets or sets the action text.
+        /// Gets or sets the scheduled datetime.
         /// </summary>
-        [JsonPropertyName("actionText")]
-        public string? ActionText { get; set; }
-
-        /// <summary>
-        /// Gets or sets the scheduled datetime in UTC.
-        /// </summary>
-        [JsonPropertyName("scheduledDateUtc")]
+        [JsonPropertyName("scheduledDate")]
         public DateTime ScheduledDateUtc { get; set; }
 
         /// <summary>
-        /// Gets or sets the expiration datetime in UTC.
+        /// Gets or sets the expiration datetime.
         /// </summary>
-        [JsonPropertyName("expirationDateUtc")]
+        [JsonPropertyName("expirationDate")]
         public DateTime? ExpirationDateUtc { get; set; }
     }
 }

--- a/Apps/CommonData/src/Models/Broadcast.cs
+++ b/Apps/CommonData/src/Models/Broadcast.cs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Models
+namespace HealthGateway.Common.Data.Models
 {
     using System;
     using System.Text.Json.Serialization;

--- a/Apps/CommonData/src/Models/BroadcastActionType.cs
+++ b/Apps/CommonData/src/Models/BroadcastActionType.cs
@@ -1,0 +1,41 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Data.Models
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Represents the type of action associated with a broadcast.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum BroadcastActionType
+    {
+        /// <summary>
+        /// No action.
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// The action links to an internal resource.
+        /// </summary>
+        InternalLink,
+
+        /// <summary>
+        /// The action links to an external resource.
+        /// </summary>
+        ExternalLink,
+    }
+}


### PR DESCRIPTION
# Implements [AB#12086](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12086)

## Description

Adds the ability to create, view, edit, and delete system broadcasts (notifications) on the communications page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
