### PR TITLE
Suppress excessive class coupling warning for AB#14228

### DIFF
--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -44,6 +44,7 @@ namespace HealthGateway.Admin.Server
     /// The entry point for the project.
     /// </summary>
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
     public static class Program
     {
         /// <summary>


### PR DESCRIPTION
# Fixes [AB#14228](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14228)

## Description

Fixes build error due to "CA1506: Avoid excessive class coupling" in Program.cs file.
Will suppress warning until a permanent fix can be implemented via [AB#14229](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14229)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
