### PR TITLE
Fix input fields and error message not clearing on cancel for AB#14233 

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
@@ -97,6 +97,7 @@ export default class NewDependentComponent extends Vue {
     }
 
     public hideModal(): void {
+        this.clear();
         this.$v.$reset();
         this.isVisible = false;
     }
@@ -139,7 +140,6 @@ export default class NewDependentComponent extends Vue {
 
     @Emit()
     private handleSubmit(): void {
-        this.clear();
         // Hide the modal manually
         this.$nextTick(() => this.hideModal());
     }
@@ -152,6 +152,7 @@ export default class NewDependentComponent extends Vue {
             PHN: "",
         };
         this.accepted = false;
+        this.errorMessage = "";
     }
 }
 </script>


### PR DESCRIPTION
# Fixes [AB#14233](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14233)

## Description

On add new dependent when cancel is clicked, input fields and error message are not cleared when cancel button is clicked.

Flow:

**Step ! - try to add a dependent that has already been added;**

<img width="2540" alt="Screenshot 2022-10-31 at 2 03 34 PM" src="https://user-images.githubusercontent.com/58790456/199111347-02bae882-d8c8-4d99-b168-0639acd47972.png">

**Step 2 - after attempting to add a duplicate, an error message will be displayed.  Click on cancel button.**

<img width="2549" alt="Screenshot 2022-10-31 at 2 03 57 PM" src="https://user-images.githubusercontent.com/58790456/199111366-34e2f1fd-fff3-4928-83a0-e49425f1cfd8.png">

**Step 3 - click on add dependent button again to bring back add dependent modal.**

<img width="2540" alt="Screenshot 2022-10-31 at 2 03 34 PM" src="https://user-images.githubusercontent.com/58790456/199111724-6fdd06f0-2544-4ee2-9563-e1c2a554b396.png">

**Step 4 - in add dependent modal, input fields and error message have been cleared.**

<img width="2533" alt="Screenshot 2022-10-31 at 2 04 20 PM" src="https://user-images.githubusercontent.com/58790456/199111389-7808a2e8-26e5-4b48-9535-dfe7dccb2aca.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

UI input fields and error message are cleared when cancel button is clicked.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
