### PR TITLE
Add functional test for notifications AB#14074

### DIFF
--- a/Apps/Admin/Client/Components/BroadcastDialog.razor
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor
@@ -135,9 +135,9 @@
                         T="@bool"
                         Required="@true"
                         ToStringFunc="@BroadcastUtility.FormatEnabled"
-                        data-testid="publish-selector">
-                        <MudSelectItem Value="false" />
-                        <MudSelectItem Value="true" />
+                        data-testid="publish-select">
+                        <MudSelectItem Value="false" data-testid="publish-value" />
+                        <MudSelectItem Value="true" data-testid="publish-value" />
                     </HgSelect>
                 </MudItem>
                 <MudItem xs="12" sm="4">

--- a/Apps/Admin/Client/Components/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/BroadcastsTable.razor
@@ -7,7 +7,8 @@
           Breakpoint="@Breakpoint.Md"
           HorizontalScrollbar="true"
           Striped="true"
-          Dense="true">
+          Dense="true"
+          data-testid="broadcast-table">
     <ColGroup>
         <MudHidden Breakpoint="@Breakpoint.MdAndDown">
             <col />

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -13,7 +13,125 @@ describe("Communications", () => {
         );
     });
 
-    it("Verify banner crud functions.", () => {
+    it("Verify notification CRUD functions.", () => {
+        cy.log("Create notification.");
+
+        cy.get("[data-testid=create-btn]").should("be.visible").click();
+        cy.get("[data-testid=broadcast-dialog-modal-text]").should(
+            "be.visible"
+        );
+        cy.get("[data-testid=subject-input]")
+            .should("not.be.disabled")
+            .clear()
+            .focus()
+            .type("Test Notification Subject");
+        cy.get("[data-testid=content-input]")
+            .should("not.be.disabled")
+            .clear()
+            .focus()
+            .type("Test Notification Content");
+        cy.get("[data-testid=save-btn]").click();
+        cy.get("[data-testid=broadcast-dialog-modal-text]").should("not.exist");
+
+        cy.log("Validate notification was created.");
+
+        const rowSelector =
+            "[data-testid=broadcast-table] tbody tr.mud-table-row";
+
+        cy.get(rowSelector)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=broadcast-table-subject]")
+                    .should("be.visible")
+                    .contains("Test Notification Subject");
+                cy.get("[data-testid=broadcast-table-action-type]")
+                    .should("be.visible")
+                    .contains("None");
+                cy.get("[data-testid=broadcast-table-effective-date]").contains(
+                    getTodayPlusDaysDate(0)
+                );
+                cy.get("[data-testid=broadcast-table-expiry-date]").contains(
+                    getTodayPlusDaysDate(1)
+                );
+                cy.get("[data-testid=broadcast-table-expand-btn]").click();
+            });
+
+        cy.get("[data-testid=broadcast-table-expanded-text]").contains(
+            "Test Notification Content"
+        );
+
+        cy.log("Edit notification.");
+
+        cy.get(rowSelector)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=broadcast-table-edit-btn]").click();
+            });
+
+        cy.get("[data-testid=broadcast-dialog-modal-text]").should(
+            "be.visible"
+        );
+        cy.get("[data-testid=subject-input]")
+            .should("not.be.disabled")
+            .clear()
+            .focus()
+            .type("Edited Test Notification Subject");
+        cy.get("[data-testid=publish-select]").click({ force: true });
+        cy.get("[data-testid=publish-value]")
+            .contains("Publish")
+            .click({ force: true });
+        cy.get("[data-testid=action-type-select]").click({ force: true });
+        cy.get("[data-testid=action-type]")
+            .contains("Internal Link")
+            .click({ force: true });
+        cy.get("[data-testid=action-url-input]")
+            .should("not.be.disabled")
+            .clear()
+            .focus()
+            .type("https://www.healthgateway.gov.bc.ca");
+
+        cy.get("[data-testid=save-btn]").click();
+        cy.get("[data-testid=broadcast-dialog-modal-text]").should("not.exist");
+
+        cy.log("Validate notification was edited.");
+
+        cy.get(rowSelector)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=broadcast-table-subject]")
+                    .should("be.visible")
+                    .contains("Edited Test Notification Subject");
+                cy.get("[data-testid=broadcast-table-action-type]")
+                    .should("be.visible")
+                    .contains("Internal Link");
+            });
+
+        cy.log("Delete notification.");
+
+        cy.get(rowSelector)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=broadcast-table-delete-btn]").click();
+            });
+
+        cy.get("[data-testid=confirm-delete-message]").should("be.visible");
+        cy.get("[data-testid=confirm-delete-btn]").click();
+        cy.get("[data-testid=confirm-delete-message]").should("not.exist");
+
+        cy.log("Validate notification was deleted.");
+
+        cy.validateTableLoad("[data-testid=broadcast-table]");
+        cy.get(rowSelector)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=broadcast-table-subject]").should(
+                    "not.contain",
+                    "Edited Test Notification Subject"
+                );
+            });
+    });
+
+    it("Verify communication CRUD functions.", () => {
         cy.log("Validating data initialized by seed script.");
 
         cy.get("[data-testid=banner-tabs]")

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/feedback-review.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/feedback-review.cy.js
@@ -1,15 +1,6 @@
 const suggestionTag = "suggestion";
 const questionTag = "question";
 
-function validateTableLoad(tableSelector) {
-    cy.get(tableSelector)
-        .find(".mud-table-loading-progress")
-        .should("be.visible");
-    cy.get(tableSelector)
-        .find(".mud-table-loading-progress")
-        .should("not.exist");
-}
-
 function validateTableRowCount(tableSelector, count) {
     cy.log(`Validating table contains ${count} rows of data.`);
     cy.get(tableSelector)
@@ -43,7 +34,7 @@ describe("Feedback Review", () => {
                     .should("have.class", "mud-error-text")
                     .click();
             });
-        validateTableLoad("[data-testid=feedback-table]");
+        cy.validateTableLoad("[data-testid=feedback-table]");
         cy.get(rowSelector)
             .first()
             .within(() => {
@@ -70,7 +61,7 @@ describe("Feedback Review", () => {
                 cy.get("[data-testid=feedback-tag-select]").click();
             });
         cy.get("[data-testid=feedback-tag]").contains(suggestionTag).click();
-        validateTableLoad("[data-testid=feedback-table]");
+        cy.validateTableLoad("[data-testid=feedback-table]");
         cy.get(rowSelector)
             .first()
             .within(() => {
@@ -106,7 +97,7 @@ describe("Feedback Review", () => {
                 cy.get("[data-testid=feedback-tag-select]").click();
             });
         cy.get("[data-testid=feedback-tag]").contains(suggestionTag).click();
-        validateTableLoad("[data-testid=feedback-table]");
+        cy.validateTableLoad("[data-testid=feedback-table]");
         cy.get(rowSelector)
             .first()
             .within(() => {
@@ -140,7 +131,7 @@ describe("Feedback Review", () => {
                     .click();
             });
         cy.location("pathname").should("eq", "/support");
-        //validateTableLoad("[data-testid=user-table]");
+        //cy.validateTableLoad("[data-testid=user-table]");
         validateTableRowCount("[data-testid=user-table]", 1);
     });
 });

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -117,3 +117,12 @@ Cypress.Commands.overwrite(
         cy.wrap(originalFn(subject, valueOrTextOrIndex, options));
     }
 );
+
+Cypress.Commands.add("validateTableLoad", (tableSelector) => {
+    cy.get(tableSelector)
+        .find(".mud-table-loading-progress")
+        .should("be.visible");
+    cy.get(tableSelector)
+        .find(".mud-table-loading-progress")
+        .should("not.exist");
+});


### PR DESCRIPTION
# Implements [AB#14074](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14074)

## Description

Updates the e2e tests for the communications page to test creating, editing, and deleting notifications.

- swaps a function used on the feedback review tests into a global Cypress command

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
