### PR TITLE
Change health visit popover and date format for all modules for AB#14239

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -65,7 +65,7 @@ export default class EncounterTimelineComponent extends Vue {
                         triggers="hover focus"
                         placement="topright"
                         boundary="viewport"
-                        data-testid="health-visit-location-info-popover"
+                        data-testid="health-visit-clinic-name-info-popover"
                     >
                         <span>
                             Information is from the billing claim and may show a

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -48,24 +48,32 @@ export default class EncounterTimelineComponent extends Vue {
             <b-col>
                 <div class="d-inline-flex" data-testid="encounterClinicLabel">
                     <strong>Clinic/Practitioner:</strong>
-                    <div
+                    <hg-button
+                        v-if="entry.clinic.name"
                         :id="`tooltip-info${index}-${datekey}`"
-                        class="infoIcon ml-2"
-                        tabindex="0"
+                        aria-label="Info"
+                        href="#"
+                        variant="link"
+                        data-testid="health-visit-clinic-name-info-button"
+                        class="shadow-none align-baseline p-0 ml-1"
                     >
-                        <hg-icon icon="info-circle" size="medium" />
-                    </div>
-                    <b-tooltip
-                        variant="secondary"
+                        <hg-icon icon="info-circle" size="small" />
+                    </hg-button>
+                    <b-popover
+                        v-if="entry.clinic.name"
                         :target="`tooltip-info${index}-${datekey}`"
-                        placement="top"
                         triggers="hover focus"
+                        placement="topright"
+                        boundary="viewport"
+                        data-testid="health-visit-location-info-popover"
                     >
-                        Information is from the billing claim and may show a
-                        different practitioner or clinic from the one you
-                        visited. For more information, visit the
-                        <router-link to="/faq">FAQ</router-link> page.
-                    </b-tooltip>
+                        <span>
+                            Information is from the billing claim and may show a
+                            different practitioner or clinic from the one you
+                            visited. For more information, visit the
+                            <router-link to="/faq">FAQ</router-link> page.
+                        </span>
+                    </b-popover>
                 </div>
                 <div data-testid="encounterClinicName">
                     {{ entry.clinic.name }}

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -8,7 +8,6 @@ import { Getter } from "vuex-class";
 
 import EventBus, { EventMessageName } from "@/eventbus";
 import type { WebClientConfiguration } from "@/models/configData";
-import { DateWrapper } from "@/models/dateWrapper";
 import TimelineEntry from "@/models/timelineEntry";
 import User from "@/models/user";
 import container from "@/plugins/container";
@@ -72,14 +71,7 @@ export default class EntrycardTimelineComponent extends Vue {
     }
 
     private get dateString(): string {
-        const today = new DateWrapper();
-        if (this.entry.date.isSame(today, "day")) {
-            return "Today";
-        } else if (this.entry.date.year() === today.year()) {
-            return this.entry.date.format("MMM d");
-        } else {
-            return this.entry.date.format();
-        }
+        return this.entry.date.format();
     }
 
     private get isCommentEnabled(): boolean {


### PR DESCRIPTION
# Implements [AB#14239](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14239)

## Description

- Update health visits popover to match others (see  lab popover)
- Add year back to all timeline records within past last year

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

**Health Visit Popover:**

<img width="2538" alt="Screenshot 2022-11-02 at 3 33 51 PM" src="https://user-images.githubusercontent.com/58790456/199615947-482f397c-cf67-4dd1-9349-b5db3b903453.png">

<img width="2537" alt="Screenshot 2022-11-02 at 3 34 01 PM" src="https://user-images.githubusercontent.com/58790456/199615917-b9f08fc3-67f4-497d-9fd6-fccbaf2547dc.png">

**Return full date for all date entries:**

<img width="2545" alt="Screenshot 2022-11-02 at 3 33 18 PM" src="https://user-images.githubusercontent.com/58790456/199615909-89b7d557-3683-4aa0-aff1-b9d748219a28.png">

<img width="2535" alt="Screenshot 2022-11-02 at 3 33 31 PM" src="https://user-images.githubusercontent.com/58790456/199615900-83740431-3a4d-4d85-a0e4-d72237070b57.png">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
