### PR TITLE
Clean up UI AB#14241

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/HeaderComponent.vue
@@ -198,7 +198,7 @@ export default class HeaderComponent extends Vue {
             <!-- Hamburger toggle -->
             <hg-button
                 v-if="isSidebarButtonShown"
-                class="m-2"
+                class="my-2 ml-2"
                 variant="icon"
                 @click="handleToggleClick"
             >
@@ -211,7 +211,7 @@ export default class HeaderComponent extends Vue {
             </hg-button>
 
             <!-- Brand -->
-            <b-navbar-brand class="my-2 mr-0 ml-md-2 d-flex">
+            <b-navbar-brand class="my-2 mr-0 ml-2 d-flex">
                 <router-link to="/">
                     <img
                         class="img-fluid d-none d-md-block"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
@@ -187,7 +187,7 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
                 :key="test.id"
                 :data-testid="`laboratoryTestBlock-${index}`"
             >
-                <hr />
+                <hr v-if="entry.tests.length > 1" />
                 <div data-testid="laboratoryTestType" class="my-2">
                     <strong
                         v-if="test.resultReady && entry.tests.length > 1"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
@@ -154,30 +154,27 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
         </div>
         <div slot="details-body">
             <div
-                v-if="reportAvailable"
+                v-if="reportAvailable && entry.resultReady"
+                class="my-3"
                 data-testid="laboratoryReportAvailable"
-                class="mt-2 mb-n1"
             >
-                <b-spinner v-if="isLoadingDocument" class="mb-1" />
-                <span v-else data-testid="laboratoryReport">
-                    <strong class="align-bottom d-inline-block pb-1">
-                        Report:
-                    </strong>
-                    <hg-button
-                        v-if="entry.resultReady"
-                        data-testid="covid-result-download-btn"
-                        variant="link"
-                        class="p-1 ml-1"
-                        @click="showConfirmationModal()"
-                    >
-                        <hg-icon
-                            icon="download"
-                            size="medium"
-                            square
-                            aria-hidden="true"
-                        />
-                    </hg-button>
-                </span>
+                <hg-button
+                    data-testid="covid-result-download-btn"
+                    variant="secondary"
+                    :disabled="isLoadingDocument"
+                    @click="showConfirmationModal()"
+                >
+                    <b-spinner v-if="isLoadingDocument" class="mr-1" small />
+                    <hg-icon
+                        v-else
+                        icon="download"
+                        size="medium"
+                        square
+                        aria-hidden="true"
+                        class="mr-1"
+                    />
+                    <span>Download Full Report</span>
+                </hg-button>
             </div>
             <div class="my-2">
                 <div data-testid="laboratoryReportingLab">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -215,36 +215,29 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                     </b-popover>
                 </div>
             </div>
-            <b-row class="my-3">
-                <b-col />
-                <b-col
-                    v-if="entry.reportAvailable"
-                    data-testid="laboratory-report-available"
-                    cols="auto"
+            <div
+                v-if="entry.reportAvailable"
+                class="my-3"
+                data-testid="laboratory-report-available"
+            >
+                <hg-button
+                    data-testid="laboratory-report-download-btn"
+                    variant="secondary"
+                    :disabled="isLoadingDocument"
+                    @click="showConfirmationModal()"
                 >
-                    <hg-button
-                        data-testid="laboratory-report-download-btn"
-                        variant="secondary"
-                        :disabled="isLoadingDocument"
-                        @click="showConfirmationModal()"
-                    >
-                        <b-spinner
-                            v-if="isLoadingDocument"
-                            class="mr-1"
-                            small
-                        />
-                        <hg-icon
-                            v-else
-                            icon="download"
-                            size="medium"
-                            square
-                            aria-hidden="true"
-                            class="mr-1"
-                        />
-                        <span>Download Full Report</span>
-                    </hg-button>
-                </b-col>
-            </b-row>
+                    <b-spinner v-if="isLoadingDocument" class="mr-1" small />
+                    <hg-icon
+                        v-else
+                        icon="download"
+                        size="medium"
+                        square
+                        aria-hidden="true"
+                        class="mr-1"
+                    />
+                    <span>Download Full Report</span>
+                </hg-button>
+            </div>
             <b-table-lite
                 :items="entry.tests"
                 :fields="['testName', 'result', 'status']"


### PR DESCRIPTION
# Implements [AB#14241](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14241)

## Description

- aligns download button to left on lab result timeline entry
- updates download button for COVID-19 test results on timeline
- hides divider on COVID-19 timeline card if only 1 test is included
- fixes missing margin on header when not logged in on mobile

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screenshot 2022-11-02 162204](https://user-images.githubusercontent.com/16570293/199625059-8769949d-b613-4694-8e41-4bd5cbcf38bd.png)

![Screenshot 2022-11-02 162230](https://user-images.githubusercontent.com/16570293/199625068-8a55a342-1a85-4a66-a648-2538ce312a6b.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
