### PR TITLE
Clear errors when add dependent modal is hidden AB#14243

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NewDependentComponent.vue
@@ -97,8 +97,6 @@ export default class NewDependentComponent extends Vue {
     }
 
     public hideModal(): void {
-        this.clear();
-        this.$v.$reset();
         this.isVisible = false;
     }
 
@@ -153,6 +151,7 @@ export default class NewDependentComponent extends Vue {
         };
         this.accepted = false;
         this.errorMessage = "";
+        this.$v.$reset();
     }
 }
 </script>
@@ -168,12 +167,12 @@ export default class NewDependentComponent extends Vue {
         header-bg-variant="primary"
         header-text-variant="light"
         centered
+        @hidden="clear"
     >
         <TooManyRequestsComponent location="addDependentModal" />
         <b-alert
             data-testid="dependentErrorBanner"
             variant="danger"
-            dismissible
             class="no-print"
             :show="!!errorMessage"
         >


### PR DESCRIPTION
# Fixes [AB#14243](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14243)

## Description

- moves cleanup actions out of `hideModal()` since there are ways to hide the modal without calling `hideModal()`
- makes error alert non-dismissible, since dismissing it stops it from re-appearing if another error occurs

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
