### PR TITLE
Avoid exposing test credentials in functional tests AB#14287

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -73,7 +73,7 @@ describe("Authentication", () => {
                 .type(Cypress.env("idir.username"));
             cy.get("#password")
                 .should("be.visible")
-                .type(Cypress.env("idir.password"));
+                .type(Cypress.env("idir.password"), { log: false });
             cy.get('input[name="btnSubmit"]').should("be.visible").click();
             cy.contains("h1", "403");
             cy.contains("h2", "IDIR Login");


### PR DESCRIPTION
# Fixes [AB#14287](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14287)

## Description

Prevents text typed into the password field from being recorded in the test logs.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
