### PR TITLE
Reduce size of device preview images on landing page AB#14283

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
@@ -423,21 +423,21 @@ export default class LandingView extends Vue {
                     <img
                         v-show="selectedPreviewDevice === 'laptop'"
                         src="@/assets/images/landing/preview-laptop.png"
-                        class="img-fluid mw-60"
+                        class="img-fluid device-preview"
                         data-testid="preview-image-laptop"
                         alt="Preview of Health Gateway on a Laptop"
                     />
                     <img
                         v-show="selectedPreviewDevice === 'tablet'"
                         src="@/assets/images/landing/preview-tablet.png"
-                        class="img-fluid mw-30"
+                        class="img-fluid device-preview"
                         data-testid="preview-image-tablet"
                         alt="Preview of Health Gateway on a Tablet"
                     />
                     <img
                         v-show="selectedPreviewDevice === 'smartphone'"
                         src="@/assets/images/landing/preview-smartphone.png"
-                        class="img-fluid mw-20"
+                        class="img-fluid device-preview"
                         data-testid="preview-image-smartphone"
                         alt="Preview of Health Gateway on a Smartphone"
                     />
@@ -537,6 +537,9 @@ export default class LandingView extends Vue {
 </template>
 
 <style lang="scss" scoped>
+@import "~bootstrap/scss/functions";
+@import "~bootstrap/scss/variables";
+@import "~bootstrap/scss/mixins/_breakpoints";
 @import "@/assets/scss/_variables.scss";
 
 .landing {
@@ -561,18 +564,6 @@ export default class LandingView extends Vue {
     .btn-auth-landing {
         background-color: #1a5a95;
         border-color: #1a5a95;
-    }
-
-    .mw-20 {
-        max-width: 20%;
-    }
-
-    .mw-30 {
-        max-width: 30%;
-    }
-
-    .mw-60 {
-        max-width: 60%;
     }
 
     .vaccine-card-banner {
@@ -603,6 +594,18 @@ export default class LandingView extends Vue {
 
         &[disabled] {
             color: $hg-brand-primary;
+        }
+    }
+
+    @include media-breakpoint-down(sm) {
+        .device-preview {
+            max-height: 212px;
+        }
+    }
+
+    @include media-breakpoint-up(md) {
+        .device-preview {
+            max-height: 412px;
         }
     }
 }

--- a/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
@@ -423,21 +423,21 @@ export default class LandingView extends Vue {
                     <img
                         v-show="selectedPreviewDevice === 'laptop'"
                         src="@/assets/images/landing/preview-laptop.png"
-                        class="img-fluid"
+                        class="img-fluid mw-60"
                         data-testid="preview-image-laptop"
                         alt="Preview of Health Gateway on a Laptop"
                     />
                     <img
                         v-show="selectedPreviewDevice === 'tablet'"
                         src="@/assets/images/landing/preview-tablet.png"
-                        class="img-fluid"
+                        class="img-fluid mw-30"
                         data-testid="preview-image-tablet"
                         alt="Preview of Health Gateway on a Tablet"
                     />
                     <img
                         v-show="selectedPreviewDevice === 'smartphone'"
                         src="@/assets/images/landing/preview-smartphone.png"
-                        class="img-fluid"
+                        class="img-fluid mw-20"
                         data-testid="preview-image-smartphone"
                         alt="Preview of Health Gateway on a Smartphone"
                     />
@@ -561,6 +561,18 @@ export default class LandingView extends Vue {
     .btn-auth-landing {
         background-color: #1a5a95;
         border-color: #1a5a95;
+    }
+
+    .mw-20 {
+        max-width: 20%;
+    }
+
+    .mw-30 {
+        max-width: 30%;
+    }
+
+    .mw-60 {
+        max-width: 60%;
     }
 
     .vaccine-card-banner {


### PR DESCRIPTION
# Implements [AB#14283](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14283)

## Description

Sets a maximum height on the device preview images to prevent them from taking up all of the available space.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

### Phone

![localhost-2022-11-07-123704](https://user-images.githubusercontent.com/16570293/200413131-58c1d7c5-8c92-4c23-ab65-dcbcb3a33627.png)
![localhost-2022-11-07-123708](https://user-images.githubusercontent.com/16570293/200413132-ec1aebe9-9d0f-4a5e-9026-0fd085a3328a.png)
![localhost-2022-11-07-123712](https://user-images.githubusercontent.com/16570293/200413133-00eabe68-5e36-42fb-b145-381851e995e9.png)


### Tablet

![localhost-2022-11-07-124004](https://user-images.githubusercontent.com/16570293/200413147-74d01843-8de9-4fe8-9776-fe750b0115ab.png)
![localhost-2022-11-07-124008](https://user-images.githubusercontent.com/16570293/200413148-094d67ca-57f4-4e48-87b5-af9b122ec2ec.png)
![localhost-2022-11-07-124011](https://user-images.githubusercontent.com/16570293/200413150-f39adb5b-af8d-4141-8c78-0e5389198649.png)


### Desktop

![localhost-2022-11-07-124034](https://user-images.githubusercontent.com/16570293/200413162-0feb0d01-4b92-4805-93ba-0c99237ecbfd.png)
![localhost-2022-11-07-124037](https://user-images.githubusercontent.com/16570293/200413159-2ec06115-e00a-4f9c-a8cc-83e43e73c6c1.png)
![localhost-2022-11-07-124040](https://user-images.githubusercontent.com/16570293/200413161-ddaf30a3-dbbf-4aec-8cfd-ab158fbdfeb5.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
