### PR TITLE
Add automapper for VaccineStatus model AB#14289

### DIFF
--- a/Apps/Immunization/src/MapProfiles/VaccineStatusProfile.cs
+++ b/Apps/Immunization/src/MapProfiles/VaccineStatusProfile.cs
@@ -1,0 +1,39 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Immunization.MapProfiles
+{
+    using System;
+    using AutoMapper;
+    using HealthGateway.Common.Constants.PHSA;
+    using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Immunization.Models;
+
+    /// <summary>
+    /// An AutoMapper profile that defines mappings between PHSA and Health Gateway Models.
+    /// </summary>
+    public class VaccineStatusProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VaccineStatusProfile"/> class.
+        /// </summary>
+        public VaccineStatusProfile()
+        {
+            this.CreateMap<VaccineStatusResult, VaccineStatus>()
+                .ForMember(dest => dest.Doses, opt => opt.MapFrom(src => src.DoseCount))
+                .ForMember(dest => dest.State, opt => opt.MapFrom(src => Enum.Parse<VaccineState>(src.StatusIndicator)));
+        }
+    }
+}

--- a/Apps/Immunization/src/MapUtils/VaccineStatusMapUtils.cs
+++ b/Apps/Immunization/src/MapUtils/VaccineStatusMapUtils.cs
@@ -14,31 +14,30 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-namespace HealthGateway.Admin.Server.MapUtils
+namespace HealthGateway.Immunization.MapUtils
 {
     using AutoMapper;
-    using HealthGateway.Admin.Common.Models;
-    using HealthGateway.Database.Models;
+    using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Immunization.Models;
 
     /// <summary>
-    /// Static Helper classes for conversion of model objects.
+    /// Static helper class for conversion of model objects.
     /// </summary>
-    public static class UserFeedbackMapUtils
+    public static class VaccineStatusMapUtils
     {
         /// <summary>
-        /// Creates a UI model from a DB model.
+        /// Creates a UI model from a PHSA model.
         /// </summary>
-        /// <param name="userFeedback">The DB model to convert.</param>
-        /// <param name="email">The email address associated with the person who created the feedback.</param>
         /// <param name="mapper">The AutoMapper IMapper.</param>
+        /// <param name="phsaModel">The PHSA model to convert.</param>
+        /// <param name="personalHealthNumber">The patient's personal health number.</param>
         /// <returns>The created UI model.</returns>
-        public static UserFeedbackView ToUiModel(UserFeedback userFeedback, string email, IMapper mapper)
+        public static VaccineStatus ToUiModel(IMapper mapper, VaccineStatusResult phsaModel, string? personalHealthNumber)
         {
-            UserFeedbackView userFeedbackView = mapper.Map<UserFeedback, UserFeedbackView>(
-                userFeedback,
-                opts =>
-                    opts.AfterMap((_, dest) => dest.Email = email));
-            return userFeedbackView;
+            VaccineStatus uiModel = mapper.Map<VaccineStatusResult, VaccineStatus>(
+                phsaModel,
+                opts => opts.AfterMap((_, dest) => dest.PersonalHealthNumber = personalHealthNumber));
+            return uiModel;
         }
     }
 }

--- a/Apps/Immunization/src/Models/VaccineStatus.cs
+++ b/Apps/Immunization/src/Models/VaccineStatus.cs
@@ -13,11 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Models.PHSA
+namespace HealthGateway.Immunization.Models
 {
     using System;
     using System.Text.Json.Serialization;
     using HealthGateway.Common.Constants.PHSA;
+    using HealthGateway.Common.Models.PHSA;
 
     /// <summary>
     /// The Vaccine Status model.
@@ -98,27 +99,5 @@ namespace HealthGateway.Common.Models.PHSA
         /// </summary>
         [JsonPropertyName("federalVaccineProof")]
         public EncodedMedia? FederalVaccineProof { get; set; } = new();
-
-        /// <summary>
-        /// Converts a VaccineStatusResult to a VaccineStatus model.
-        /// </summary>
-        /// <param name="model">The result model.</param>
-        /// <param name="personalHealthNumber">the patient's personal health number.</param>
-        /// <returns>The vaccine status model.</returns>
-        public static VaccineStatus FromModel(VaccineStatusResult model, string? personalHealthNumber = null)
-        {
-            return new VaccineStatus
-            {
-                Birthdate = model.Birthdate,
-                PersonalHealthNumber = personalHealthNumber,
-                FirstName = model.FirstName,
-                LastName = model.LastName,
-                Doses = model.DoseCount,
-                State = Enum.Parse<VaccineState>(model.StatusIndicator),
-                VaccineDate = model.VaccineDate,
-                QRCode = model.QRCode,
-                FederalVaccineProof = model.FederalVaccineProof,
-            };
-        }
     }
 }

--- a/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
@@ -21,8 +21,8 @@ namespace HealthGateway.Immunization.Test.Controllers
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Immunization.Controllers;
+    using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
     using Microsoft.Extensions.Logging;
     using Moq;

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -20,22 +20,23 @@ namespace HealthGateway.Immunization.Test.Services
     using System.Globalization;
     using System.Security.Claims;
     using System.Threading.Tasks;
+    using AutoMapper;
     using DeepEqual.Syntax;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authentication.Models;
-    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Constants.PHSA;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models.ErrorHandling;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Delegates.PHSA;
     using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
+    using HealthGateway.ImmunizationTests.Utils;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
@@ -45,6 +46,7 @@ namespace HealthGateway.Immunization.Test.Services
     /// </summary>
     public class VaccineStatusServiceTests
     {
+        private readonly IMapper autoMapper = MapperUtil.InitializeAutoMapper();
         private readonly string phn = "9735353315";
         private readonly DateTime dob = new(1967, 06, 02);
         private readonly DateTime dov = new(2021, 07, 04);
@@ -71,10 +73,11 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new PhsaResult<VaccineStatusResult>()
+                ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = false, BackOffMilliseconds = 500 },
-                    Result = new VaccineStatusResult()
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
                         LastName = "Test",
@@ -92,7 +95,7 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<VaccineStatus> expectedResult = new()
             {
                 ResultStatus = delegateResult.ResultStatus,
-                ResourcePayload = new VaccineStatus()
+                ResourcePayload = new VaccineStatus
                 {
                     Loaded = true,
                     RetryIn = 0,
@@ -116,7 +119,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             if (isPublicEndpoint)
             {
@@ -135,7 +139,8 @@ namespace HealthGateway.Immunization.Test.Services
         }
 
         /// <summary>
-        /// GetPublicVaccineStatus and GetAuthenticatedVaccineStatus - get the error result when the status indicator is DataMismatch.
+        /// GetPublicVaccineStatus and GetAuthenticatedVaccineStatus - get the error result when the status indicator is
+        /// DataMismatch.
         /// </summary>
         /// <param name="isPublicEndpoint">check to determine if the test is for public or authenticated page.</param>
         [Theory]
@@ -146,10 +151,11 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
                 ResultStatus = ResultType.ActionRequired,
-                ResourcePayload = new PhsaResult<VaccineStatusResult>()
+                ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = false, BackOffMilliseconds = 500 },
-                    Result = new VaccineStatusResult()
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
                         LastName = "Test",
@@ -166,7 +172,7 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<VaccineStatus> expectedResult = new()
             {
                 ResultStatus = delegateResult.ResultStatus,
-                ResourcePayload = new VaccineStatus()
+                ResourcePayload = new VaccineStatus
                 {
                     Loaded = true,
                     RetryIn = 0,
@@ -193,7 +199,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             if (isPublicEndpoint)
             {
@@ -226,10 +233,11 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
                 ResultStatus = ResultType.ActionRequired,
-                ResourcePayload = new PhsaResult<VaccineStatusResult>()
+                ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = true, BackOffMilliseconds = 500 },
-                    Result = new VaccineStatusResult()
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = true, BackOffMilliseconds = 500 },
+                    Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
                         LastName = "Test",
@@ -250,7 +258,7 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<VaccineStatus> expectedResult = new()
             {
                 ResultStatus = delegateResult.ResultStatus,
-                ResourcePayload = new VaccineStatus()
+                ResourcePayload = new VaccineStatus
                 {
                     Loaded = true,
                     RetryIn = 10000,
@@ -277,7 +285,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             if (isPublicEndpoint)
             {
@@ -312,10 +321,11 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
                 ResultStatus = ResultType.ActionRequired,
-                ResourcePayload = new PhsaResult<VaccineStatusResult>()
+                ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = false, BackOffMilliseconds = 500 },
-                    Result = new VaccineStatusResult()
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
                         LastName = "Test",
@@ -336,7 +346,7 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<VaccineStatus> expectedResult = new()
             {
                 ResultStatus = delegateResult.ResultStatus,
-                ResourcePayload = new VaccineStatus()
+                ResourcePayload = new VaccineStatus
                 {
                     Loaded = true,
                     RetryIn = 0,
@@ -363,7 +373,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             if (isPublicEndpoint)
             {
@@ -385,7 +396,8 @@ namespace HealthGateway.Immunization.Test.Services
         }
 
         /// <summary>
-        /// GetPublicVaccineProof and GetAuthenticatedVaccineProof - get the vaccine proof for public and authenticated site (happy path).
+        /// GetPublicVaccineProof and GetAuthenticatedVaccineProof - get the vaccine proof for public and authenticated site (happy
+        /// path).
         /// </summary>
         /// <param name="isPublicEndpoint">check to determine if the test is for public (true) or authenticated (false) page.</param>
         [Theory]
@@ -396,10 +408,11 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new PhsaResult<VaccineStatusResult>()
+                ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
-                    LoadState = new PhsaLoadState() { RefreshInProgress = false, BackOffMilliseconds = 500 },
-                    Result = new VaccineStatusResult()
+                    LoadState = new PhsaLoadState
+                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
                         LastName = "Test",
@@ -422,7 +435,7 @@ namespace HealthGateway.Immunization.Test.Services
             RequestResult<VaccineStatus> expectedResult = new()
             {
                 ResultStatus = delegateResult.ResultStatus,
-                ResourcePayload = new VaccineStatus()
+                ResourcePayload = new VaccineStatus
                 {
                     Loaded = true,
                     RetryIn = 0,
@@ -451,14 +464,15 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 mockAuthDelegate.Object,
                 mockDelegate.Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             if (isPublicEndpoint)
             {
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<Models.VaccineProofDocument> actualResultPublic = Task.Run(async () => await service.GetPublicVaccineProof(this.phn, dobString, dovString).ConfigureAwait(true)).Result;
+                RequestResult<VaccineProofDocument> actualResultPublic = Task.Run(async () => await service.GetPublicVaccineProof(this.phn, dobString, dovString).ConfigureAwait(true)).Result;
 
                 Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResultPublic.ResourcePayload?.Document.Data);
                 Assert.NotNull(actualResultPublic.ResourcePayload?.Document.Data);
@@ -466,7 +480,7 @@ namespace HealthGateway.Immunization.Test.Services
             }
             else
             {
-                RequestResult<Models.VaccineProofDocument> actualResultAuthenticated = Task.Run(async () => await service.GetAuthenticatedVaccineProof(this.hdid).ConfigureAwait(true)).Result;
+                RequestResult<VaccineProofDocument> actualResultAuthenticated = Task.Run(async () => await service.GetAuthenticatedVaccineProof(this.hdid).ConfigureAwait(true)).Result;
 
                 Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResultAuthenticated.ResourcePayload?.Document.Data);
                 Assert.NotNull(actualResultAuthenticated.ResourcePayload?.Document.Data);
@@ -485,7 +499,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
@@ -506,7 +521,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
@@ -526,7 +542,8 @@ namespace HealthGateway.Immunization.Test.Services
                 new Mock<ILogger<VaccineStatusService>>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<IVaccineStatusDelegate>().Object,
-                this.GetHttpContextAccessor().Object);
+                this.GetHttpContextAccessor().Object,
+                this.autoMapper);
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
@@ -538,9 +555,9 @@ namespace HealthGateway.Immunization.Test.Services
         private static IConfigurationRoot GetIConfigurationRoot()
         {
             return new ConfigurationBuilder()
-                .AddJsonFile("appsettings.json", optional: true)
-                .AddJsonFile("appsettings.Development.json", optional: true)
-                .AddJsonFile("appsettings.local.json", optional: true)
+                .AddJsonFile("appsettings.json", true)
+                .AddJsonFile("appsettings.Development.json", true)
+                .AddJsonFile("appsettings.local.json", true)
                 .Build();
         }
 
@@ -565,10 +582,11 @@ namespace HealthGateway.Immunization.Test.Services
                 .Setup(x => x.HttpContext!.RequestServices.GetService(typeof(IAuthenticationService)))
                 .Returns(authenticationMock.Object);
             AuthenticateResult authResult = AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, JwtBearerDefaults.AuthenticationScheme));
-            authResult.Properties.StoreTokens(new[]
-            {
-                new AuthenticationToken { Name = "access_token", Value = this.accessToken },
-            });
+            authResult.Properties.StoreTokens(
+                new[]
+                {
+                    new AuthenticationToken { Name = "access_token", Value = this.accessToken },
+                });
             authenticationMock
                 .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))
                 .ReturnsAsync(authResult);

--- a/Apps/Immunization/test/unit/Utils/MapperUtil.cs
+++ b/Apps/Immunization/test/unit/Utils/MapperUtil.cs
@@ -31,15 +31,17 @@ namespace HealthGateway.ImmunizationTests.Utils
         /// <returns>A configured AutoMapper.</returns>
         public static IMapper InitializeAutoMapper()
         {
-            MapperConfiguration config = new MapperConfiguration(cfg =>
-            {
-                cfg.AddProfile(new AgentProfile());
-                cfg.AddProfile(new DefinitionProfile());
-                cfg.AddProfile(new EventProfile());
-                cfg.AddProfile(new ForecastProfile());
-                cfg.AddProfile(new LoadStateProfile());
-                cfg.AddProfile(new TargetDiseaseProfile());
-            });
+            MapperConfiguration config = new(
+                cfg =>
+                {
+                    cfg.AddProfile(new AgentProfile());
+                    cfg.AddProfile(new DefinitionProfile());
+                    cfg.AddProfile(new EventProfile());
+                    cfg.AddProfile(new ForecastProfile());
+                    cfg.AddProfile(new LoadStateProfile());
+                    cfg.AddProfile(new TargetDiseaseProfile());
+                    cfg.AddProfile(new VaccineStatusProfile());
+                });
 
             return config.CreateMapper();
         }


### PR DESCRIPTION
# Implements [AB#14289](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14289)

## Description

- replaces conversion method in model class with AutoMapper profile
- moves UI model from Common to Immunization
- fixes associated unit tests

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
