### PR TITLE
Fixed deserialization issue with inactive users for AB#14297

### DIFF
--- a/Apps/Admin/Server/Services/InactiveUserService.cs
+++ b/Apps/Admin/Server/Services/InactiveUserService.cs
@@ -117,9 +117,9 @@ public class InactiveUserService : IInactiveUserService
                 IApiResponse<IEnumerable<UserRepresentation>> supportUsersResult =
                     await this.keycloakAdminApi.GetUsers(nameof(IdentityAccessRole.SupportUser), jwtModel.AccessToken).ConfigureAwait(true);
 
-                if (adminUsersResult.IsSuccessStatusCode)
+                if (adminUsersResult.IsSuccessStatusCode && adminUsersResult.Content != null)
                 {
-                    List<UserRepresentation> adminUsers = adminUsersResult.Content?.ToList() ?? new();
+                    List<UserRepresentation> adminUsers = adminUsersResult.Content.ToList();
                     this.PopulateUserDetails(inactiveUsers, adminUsers, IdentityAccessRole.AdminUser);
                     this.AddInactiveUser(inactiveUsers, activeUserProfiles, adminUsers, IdentityAccessRole.AdminUser);
                 }
@@ -134,9 +134,9 @@ public class InactiveUserService : IInactiveUserService
                     };
                 }
 
-                if (supportUsersResult.IsSuccessStatusCode)
+                if (supportUsersResult.IsSuccessStatusCode && supportUsersResult.Content != null)
                 {
-                    List<UserRepresentation> supportUsers = supportUsersResult.Content?.ToList() ?? new();
+                    List<UserRepresentation> supportUsers = supportUsersResult.Content.ToList();
                     this.PopulateUserDetails(inactiveUsers, supportUsers, IdentityAccessRole.SupportUser);
                     this.AddInactiveUser(inactiveUsers, activeUserProfiles, supportUsers, IdentityAccessRole.SupportUser);
                 }

--- a/Apps/Common/src/AccessManagement/Administration/Models/UserRepresentation.cs
+++ b/Apps/Common/src/AccessManagement/Administration/Models/UserRepresentation.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.AccessManagement.Administration.Models
 {
     using System;
+    using System.ComponentModel.DataAnnotations.Schema;
     using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
 
@@ -26,10 +27,17 @@ namespace HealthGateway.Common.AccessManagement.Administration.Models
     public class UserRepresentation
     {
         /// <summary>
-        /// Gets or sets the user created timestamp.
+        /// Gets or sets the user created timestamp.as milliseconds from the Unix Epoch.
         /// </summary>
         [JsonPropertyName("createdTimeStamp")]
-        public DateTime? CreatedTimestamp { get; set; }
+        public long CreatedTimestamp { get; set; }
+
+        /// <summary>
+        /// Gets the Created Datetime of the user.
+        /// </summary>
+        [NotMapped]
+        public DateTime CreatedDatetime =>
+            DateTimeOffset.FromUnixTimeMilliseconds(this.CreatedTimestamp).DateTime;
 
         /// <summary>
         /// Gets or sets the user's email.

--- a/Apps/Common/src/AccessManagement/Administration/Models/UserRepresentation.cs
+++ b/Apps/Common/src/AccessManagement/Administration/Models/UserRepresentation.cs
@@ -27,17 +27,10 @@ namespace HealthGateway.Common.AccessManagement.Administration.Models
     public class UserRepresentation
     {
         /// <summary>
-        /// Gets or sets the user created timestamp.as milliseconds from the Unix Epoch.
+        /// Gets or sets the user created timestamp as milliseconds from the Unix Epoch.
         /// </summary>
         [JsonPropertyName("createdTimeStamp")]
         public long CreatedTimestamp { get; set; }
-
-        /// <summary>
-        /// Gets the Created Datetime of the user.
-        /// </summary>
-        [NotMapped]
-        public DateTime CreatedDatetime =>
-            DateTimeOffset.FromUnixTimeMilliseconds(this.CreatedTimestamp).DateTime;
 
         /// <summary>
         /// Gets or sets the user's email.


### PR DESCRIPTION
# Fixes or Implements [AB#14297](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14297)

## Description

Fixes the deserialization bug that was introduced when switching over to Refit.  The UserRepresentation object had the CreatedTimestamp defined as a Datetime but it was actually milliseconds from the Unix Epoch.  I'm not sure why it didn't fail previously.

Added a get Property to return a Datetime.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
No


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
