### PR TITLE
Fixes AuthDelegate constructor exception

### DIFF
--- a/Apps/AdminWebClient/test/unit/Services.Test/AuthenticationServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/AuthenticationServiceTests.cs
@@ -134,7 +134,7 @@ public class AuthenticationServiceTests
     {
         Dictionary<string, string?> myConfiguration = new()
         {
-            {"EnabledRoles", "[ \"AdminUser\", \"AdminReviewer\", \"SupportUser\" ]"},
+            { "EnabledRoles", "[ \"AdminUser\", \"AdminReviewer\", \"SupportUser\" ]" },
         };
 
         return new ConfigurationBuilder()
@@ -164,7 +164,7 @@ public class AuthenticationServiceTests
 
         IHeaderDictionary headerDictionary = new HeaderDictionary
         {
-            {"Authorization", this.accessToken},
+            { "Authorization", this.accessToken },
         };
         Mock<HttpRequest> httpRequestMock = new();
         httpRequestMock.Setup(s => s.Headers).Returns(headerDictionary);
@@ -186,7 +186,7 @@ public class AuthenticationServiceTests
         authResult.Properties.StoreTokens(
             new[]
             {
-                new AuthenticationToken {Name = "access_token", Value = this.accessToken},
+                new AuthenticationToken { Name = "access_token", Value = this.accessToken },
             });
         authenticationMock
             .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))

--- a/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
@@ -157,7 +157,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         private static ICovidSupportService GetCovidSupportService(HttpClient httpClient)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(AccessToken);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
             IImmunizationAdminClient immunizationAdminClient = RestService.For<IImmunizationAdminClient>(httpClient);
             ICovidSupportService mockCovidSupportService = new CovidSupportService(
                 new Mock<ILogger<CovidSupportService>>().Object,
@@ -176,7 +176,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         private static ICovidSupportService GetCovidSupportService(CovidAssessmentResponse response, HttpStatusCode statusCode, bool throwException)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(AccessToken);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
 
             Mock<IApiResponse<CovidAssessmentResponse>> mockApiResponse = new();
             mockApiResponse.Setup(s => s.Content).Returns(response);
@@ -213,7 +213,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         private static ICovidSupportService GetCovidSupportService(CovidAssessmentDetailsResponse response, HttpStatusCode statusCode, bool throwException)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(AccessToken);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
 
             Mock<IApiResponse<CovidAssessmentDetailsResponse>> mockApiResponse = new();
             mockApiResponse.Setup(s => s.Content).Returns(response);

--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -34,11 +34,6 @@ namespace HealthGateway.Common.AccessManagement.Authentication
     /// </summary>
     public class AuthenticationDelegate : IAuthenticationDelegate
     {
-        /// <summary>
-        /// The default configuration section to retrieve auth information from.
-        /// </summary>
-        public const string DefaultAuthConfigSectionName = "ClientAuthentication";
-
         private const string CacheConfigSectionName = "AuthCache";
         private readonly ICacheProvider cacheProvider;
         private readonly IConfiguration configuration;
@@ -47,8 +42,6 @@ namespace HealthGateway.Common.AccessManagement.Authentication
 
         private readonly ILogger<IAuthenticationDelegate> logger;
         private readonly int tokenCacheMinutes;
-        private readonly ClientCredentialsTokenRequest tokenRequest;
-        private readonly Uri tokenUri;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthenticationDelegate"/> class.
@@ -73,7 +66,6 @@ namespace HealthGateway.Common.AccessManagement.Authentication
 
             IConfigurationSection? configSection = configuration.GetSection(CacheConfigSectionName);
             this.tokenCacheMinutes = configSection?.GetValue("TokenCacheExpireMinutes", 0) ?? 0;
-            (this.tokenUri, this.tokenRequest) = this.GetConfiguration(DefaultAuthConfigSectionName);
         }
 
         /// <inheritdoc/>
@@ -92,13 +84,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         }
 
         /// <inheritdoc/>
-        public string? AccessTokenAsUser()
-        {
-            return this.AccessTokenAsUser(this.tokenUri, this.tokenRequest);
-        }
-
-        /// <inheritdoc/>
-        public string? AccessTokenAsUser(string sectionName)
+        public string? AccessTokenAsUser(string sectionName = IAuthenticationDelegate.DefaultAuthConfigSectionName)
         {
             (Uri tUri, ClientCredentialsTokenRequest tRequest) = this.GetConfiguration(sectionName);
             return this.AccessTokenAsUser(tUri, tRequest);

--- a/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
@@ -26,6 +26,11 @@ namespace HealthGateway.Common.AccessManagement.Authentication
     public interface IAuthenticationDelegate
     {
         /// <summary>
+        /// The default configuration section to retrieve auth information from.
+        /// </summary>
+        public const string DefaultAuthConfigSectionName = "ClientAuthentication";
+
+        /// <summary>
         /// Authenticates as a 'system admin account' concept, using OAuth 2.0 Client Credentials Grant.
         /// </summary>
         /// <param name="tokenUri">Uri to request the the token from.</param>
@@ -34,17 +39,11 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         JwtModel AuthenticateAsSystem(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest);
 
         /// <summary>
-        /// Authenticates a resource owner user with direct grant from the default configuration section.
-        /// </summary>
-        /// <returns>The access token for the user information provided in configuration.</returns>
-        string? AccessTokenAsUser();
-
-        /// <summary>
         /// Authenticates a resource owner user with direct grant from a defined configuration section.
         /// </summary>
         /// <param name="sectionName">The configuration section used to lookup values.</param>
         /// <returns>The access token for the user information provided in configuration.</returns>
-        string? AccessTokenAsUser(string sectionName);
+        string? AccessTokenAsUser(string sectionName = DefaultAuthConfigSectionName);
 
         /// <summary>
         /// Authenticates a resource owner user with direct grant, no user intervention.

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -141,7 +141,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             {
                 Result = new ImmunizationResponse(
                     new List<ImmunizationViewResponse>
-                        {expectedViewResponse},
+                        { expectedViewResponse },
                     new List<ImmunizationRecommendationResponse>()),
             };
 
@@ -195,7 +195,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             {
                 Result = new ImmunizationResponse(
                     new List<ImmunizationViewResponse>
-                        {expectedViewResponse},
+                        { expectedViewResponse },
                     new List<ImmunizationRecommendationResponse>()),
             };
 
@@ -209,7 +209,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
         {
             Dictionary<string, string?> myConfiguration = new()
             {
-                {"Section:Key", "Value"},
+                { "Section:Key", "Value" },
             };
 
             return new ConfigurationBuilder()

--- a/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
+++ b/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
@@ -139,7 +139,7 @@ namespace HealthGateway.LaboratoryTests.Mock
         private static IAuthenticationDelegate GetMockAuthDelegate(string token)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(token);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(token);
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(token);
             return mockAuthDelegate.Object;
         }

--- a/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
@@ -228,7 +228,7 @@ namespace HealthGateway.LaboratoryTests
                 .ThrowsAsync(httpRequestException);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(this.accessToken);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(this.accessToken);
 
             LabTestKitService labTestKitService = new(
                 new Mock<ILogger<LabTestKitService>>().Object,
@@ -249,7 +249,7 @@ namespace HealthGateway.LaboratoryTests
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             if (!nullToken)
             {
-                mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(this.accessToken);
+                mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(this.accessToken);
             }
 
             LabTestKitService labTestKitService = new(

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -473,7 +473,7 @@ namespace HealthGateway.LaboratoryTests.Services
         public void ShouldGetCovidTestsWithInvalidPhn()
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(TOKEN);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(TOKEN);
 
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,
@@ -503,7 +503,7 @@ namespace HealthGateway.LaboratoryTests.Services
         public void ShouldGetCovidTestsWithInvalidDateOfBirth(string dateFormat)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(TOKEN);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(TOKEN);
 
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,
@@ -532,7 +532,7 @@ namespace HealthGateway.LaboratoryTests.Services
         public void ShouldGetCovidTestsWithInvalidCollectionDate(string dateFormat)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser()).Returns(TOKEN);
+            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(TOKEN);
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,
                 new Mock<ILogger<LaboratoryService>>().Object,


### PR DESCRIPTION
# Fixes or Implements [AB#14309](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14309)

## Description
Removed TokenRequest and TokenUri properties and initialization from constructor which isn't always populated.
Updated Interface to use optional section name instead of two methods.
Updated Unit Tests to reference optional parameter.
Fixed space warnings.


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
None


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
