### PR TITLE
Update UI to use v2 patient endpoint

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
@@ -23,8 +23,9 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
     using System.ServiceModel.Description;
     using System.ServiceModel.Dispatcher;
     using System.ServiceModel.Security;
+    using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Delegates;
-    using HealthGateway.Common.Exceptions;
+    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Services;
     using Hellang.Middleware.ProblemDetails;
     using Microsoft.AspNetCore.Builder;
@@ -99,7 +100,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                 {
                     setup.IncludeExceptionDetails = (ctx, env) => environment.IsDevelopment();
 
-                    setup.Map<ApiPatientException>(
+                    setup.Map<ApiException>(
                         exception => new ApiProblemDetails
                         {
                             Title = exception.Title,

--- a/Apps/Common/src/ErrorHandling/ApiProblemDetails.cs
+++ b/Apps/Common/src/ErrorHandling/ApiProblemDetails.cs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Exceptions
+namespace HealthGateway.Common.ErrorHandling
 {
     using System.Text.Json;
     using Microsoft.AspNetCore.Mvc;
@@ -28,7 +28,7 @@ namespace HealthGateway.Common.Exceptions
         /// </summary>
         public string? AdditionalInfo { get; set; }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString()
         {
             return JsonSerializer.Serialize(this);

--- a/Apps/CommonData/src/ErrorHandling/ApiException.cs
+++ b/Apps/CommonData/src/ErrorHandling/ApiException.cs
@@ -13,69 +13,70 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Exceptions
+namespace HealthGateway.Common.Data.ErrorHandling
 {
     using System;
     using System.Net;
+    using System.Runtime.Serialization;
     using HealthGateway.Common.Data.Models.ErrorHandling;
 
     /// <summary>
     /// Represents a custom api patient exception.
     /// </summary>
     [Serializable]
-    public class ApiPatientException : Exception
+    public class ApiException : Exception
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiPatientException"/> class.
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         /// <param name="detail">The detail associated with the exception.</param>
         /// <param name="instance">The instance associated with the exception.</param>
         /// <param name="statusCode">The http status code associated with the exception.</param>
-        public ApiPatientException(string detail, string instance, HttpStatusCode statusCode)
+        public ApiException(string detail, string instance, HttpStatusCode statusCode)
         {
-            this.ProblemType = "api-patient-exception";
+            this.ProblemType = "api-exception";
             this.Detail = detail;
-            this.Title = "Api Patient Service Exception";
+            this.Title = "Custom Exception Handling";
             this.AdditionalInfo = "Please try again at a later time.";
             this.Instance = instance;
             this.StatusCode = (int)statusCode;
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiPatientException"/> class.
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         /// <param name="message">The message associated with the exception.</param>
         /// <param name="innerException">The inner exception associated with the exception.</param>
-        public ApiPatientException(string message, Exception innerException)
+        public ApiException(string message, Exception innerException)
             : base(message, innerException)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiPatientException"/> class.
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         /// <param name="message">The message associated with exception.</param>
-        public ApiPatientException(string message)
+        public ApiException(string message)
             : base(message)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiPatientException"/> class.
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
-        public ApiPatientException()
+        public ApiException()
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ApiPatientException"/> class.
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
         /// </summary>
         /// <param name="serializationInfo">The serialization info associated with the exception.</param>
         /// <param name="streamingContext">The streaming context associated with the exception.</param>
-        protected ApiPatientException(System.Runtime.Serialization.SerializationInfo serializationInfo, System.Runtime.Serialization.StreamingContext streamingContext)
+        protected ApiException(SerializationInfo serializationInfo, StreamingContext streamingContext)
             : base(
-            serializationInfo,
-            streamingContext)
+                serializationInfo,
+                streamingContext)
         {
         }
 

--- a/Apps/CommonData/src/ViewModels/ApiResult.cs
+++ b/Apps/CommonData/src/ViewModels/ApiResult.cs
@@ -25,33 +25,17 @@ namespace HealthGateway.Common.Data.ViewModels
         where T : class?
     {
         /// <summary>
-        /// Gets or sets a value indicating whether the PHSA Load State is in the RefreshInProgress status.
-        /// </summary>
-        [JsonPropertyName("refreshInProgress")]
-        public bool RefreshInProgress { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating the number of milliseconds to wait before re-querying.
-        /// </summary>
-        [JsonPropertyName("backOffMilliseconds")]
-        public int BackOffMilliseconds { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether the result is queued for retrieval in the backend.
-        /// </summary>
-        [JsonPropertyName("queued")]
-        public bool Queued { get; set; }
-
-        /// <summary>
         /// Gets or sets a warning.
         /// </summary>
         [JsonPropertyName("warning")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public ApiWarning? Warning { get; set; }
 
         /// <summary>
         /// Gets or sets the result payload.
         /// </summary>
         [JsonPropertyName("resourcePayload")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public T? ResourcePayload { get; set; }
     }
 }

--- a/Apps/Patient/src/Services/PatientService.cs
+++ b/Apps/Patient/src/Services/PatientService.cs
@@ -21,9 +21,9 @@ namespace HealthGateway.Patient.Services
     using System.Threading.Tasks;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Exceptions;
     using HealthGateway.Common.Models;
     using HealthGateway.Patient.Delegates;
     using Microsoft.Extensions.Configuration;
@@ -73,6 +73,7 @@ namespace HealthGateway.Patient.Services
             {
                 ResourcePayload = this.GetFromCache(identifier, identifierType),
             };
+            apiResult.ResourcePayload = null;
 
             if (apiResult.ResourcePayload == null)
             {
@@ -82,7 +83,7 @@ namespace HealthGateway.Patient.Services
                 if (identifierType == PatientIdentifierType.PHN && !PhnValidator.IsValid(identifier))
                 {
                     this.logger.LogDebug("The PHN provided is invalid");
-                    throw new ApiPatientException(ErrorMessages.PhnInvalid, "PatientService.GetPatient", HttpStatusCode.NotFound);
+                    throw new ApiException(ErrorMessages.PhnInvalid, "PatientService.GetPatient", HttpStatusCode.NotFound);
                 }
 
                 apiResult = await this.patientDelegate.GetDemographicsAsync(type, identifier, disableIdValidation).ConfigureAwait(true);

--- a/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -21,9 +21,9 @@ namespace HealthGateway.PatientTests.Delegates
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.Models.ErrorHandling;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Exceptions;
     using HealthGateway.Common.Models;
     using HealthGateway.Patient.Delegates;
     using Microsoft.Extensions.Logging;
@@ -56,11 +56,11 @@ namespace HealthGateway.PatientTests.Delegates
             string expectedLastName = "Doe";
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -68,15 +68,15 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
@@ -84,11 +84,11 @@ namespace HealthGateway.PatientTests.Delegates
                             use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -96,30 +96,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -148,7 +149,7 @@ namespace HealthGateway.PatientTests.Delegates
             string expectedGender = "Female";
             Address expectedPhysicalAddr = new()
             {
-                StreetLines = { "Line 1", "Line 2", "Physical", },
+                StreetLines = { "Line 1", "Line 2", "Physical" },
                 City = "city",
                 Country = "CA",
                 PostalCode = "N0N0N0",
@@ -156,7 +157,7 @@ namespace HealthGateway.PatientTests.Delegates
             };
             Address expectedPostalAddr = new()
             {
-                StreetLines = { "Line 1", "Line 2", "Postal", },
+                StreetLines = { "Line 1", "Line 2", "Postal" },
                 City = "city",
                 Country = "CA",
                 PostalCode = "N0N0N0",
@@ -167,14 +168,14 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = expectedHdId,
-                            displayable = true,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = expectedHdId,
+                        displayable = true,
                     },
+                },
                 addr = new AD[]
                 {
                     new()
@@ -272,11 +273,11 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     },
                 },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -284,15 +285,15 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
@@ -300,11 +301,11 @@ namespace HealthGateway.PatientTests.Delegates
                             use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -312,30 +313,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -372,18 +374,18 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = hdid,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = hdid,
                     },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                },
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "01010101010",
                             extension = expectedPhn,
@@ -391,15 +393,15 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
@@ -407,11 +409,11 @@ namespace HealthGateway.PatientTests.Delegates
                             use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -419,30 +421,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -475,19 +478,19 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = expectedHdId,
-                            displayable = true,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = expectedHdId,
+                        displayable = true,
                     },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                },
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -495,42 +498,42 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { "Wrong Given Name" },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { "Wrong Family Name" },
                                 },
                             },
                             use = new[] { cs_EntityNameUse.L },
                         },
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
                             },
-                            use = new[] { cs_EntityNameUse.C, },
+                            use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -538,30 +541,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -598,19 +602,19 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = expectedHdId,
-                            displayable = true,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = expectedHdId,
+                        displayable = true,
                     },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                },
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -618,26 +622,26 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { "Wrong Given Name" },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { "Wrong Family Name" },
                                 },
                             },
                             use = new[] { cs_EntityNameUse.L },
                         },
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                     qualifier = new[]
@@ -645,7 +649,7 @@ namespace HealthGateway.PatientTests.Delegates
                                         cs_EntityNamePartQualifier.AC,
                                     },
                                 },
-                                new engiven()
+                                new engiven
                                 {
                                     qualifier = new[]
                                     {
@@ -653,7 +657,7 @@ namespace HealthGateway.PatientTests.Delegates
                                     },
                                     Text = new[] { "Bad First Name" },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                     qualifier = new[]
@@ -661,7 +665,7 @@ namespace HealthGateway.PatientTests.Delegates
                                         cs_EntityNamePartQualifier.IN,
                                     },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     qualifier = new[]
                                     {
@@ -673,11 +677,11 @@ namespace HealthGateway.PatientTests.Delegates
                             use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -685,30 +689,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -743,19 +748,19 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = expectedHdId,
-                            displayable = true,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = expectedHdId,
+                        displayable = true,
                     },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                },
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -763,27 +768,27 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
                             },
-                            use = new[] { cs_EntityNameUse.C, },
+                            use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -791,30 +796,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -844,19 +850,19 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = expectedHdId,
-                            displayable = true,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = expectedHdId,
+                        displayable = true,
                     },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                },
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -864,27 +870,27 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
                             },
-                            use = new[] { cs_EntityNameUse.C, },
+                            use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -892,30 +898,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -945,19 +952,19 @@ namespace HealthGateway.PatientTests.Delegates
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
                 id = new[]
+                {
+                    new II
                     {
-                        new II()
-                        {
-                            root = "2.16.840.1.113883.3.51.1.1.6",
-                            extension = expectedHdId,
-                            displayable = true,
-                        },
+                        root = "2.16.840.1.113883.3.51.1.1.6",
+                        extension = expectedHdId,
+                        displayable = true,
                     },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                },
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -965,27 +972,27 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
                             },
-                            use = new[] { cs_EntityNameUse.C, },
+                            use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -993,30 +1000,31 @@ namespace HealthGateway.PatientTests.Delegates
             };
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
-            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                new HCIM_IN_GetDemographicsResponse1()
-                {
-                    HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+            clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                .ReturnsAsync(
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            queryAck = new HCIM_MT_QueryResponseQueryAck()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryResponseCode = new CS()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    code = expectedResponseCode,
+                                    queryResponseCode = new CS
+                                    {
+                                        code = expectedResponseCode,
+                                    },
+                                },
+                                subject = new[]
+                                {
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
+                                    {
+                                        target = subjectTarget,
+                                    },
                                 },
                             },
-                            subject = new[]
-                              {
-                                  new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
-                                  {
-                                      target = subjectTarget,
-                                  },
-                              },
                         },
-                    },
-                });
+                    });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
@@ -1047,18 +1055,18 @@ namespace HealthGateway.PatientTests.Delegates
             {
                 id = new[]
                 {
-                    new II()
+                    new II
                     {
                         root = "2.16.840.1.113883.3.51.1.1.6",
                         extension = expectedHdId,
                         displayable = true,
                     },
                 },
-                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson()
+                identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id = new[]
                     {
-                        new II()
+                        new II
                         {
                             root = "2.16.840.1.113883.3.51.1.1.6.1",
                             extension = expectedPhn,
@@ -1066,27 +1074,27 @@ namespace HealthGateway.PatientTests.Delegates
                     },
                     name = new[]
                     {
-                        new PN()
+                        new PN
                         {
                             Items = new ENXP[]
                             {
-                                new engiven()
+                                new engiven
                                 {
                                     Text = new[] { expectedFirstName },
                                 },
-                                new enfamily()
+                                new enfamily
                                 {
                                     Text = new[] { expectedLastName },
                                 },
                             },
-                            use = new[] { cs_EntityNameUse.C, },
+                            use = new[] { cs_EntityNameUse.C },
                         },
                     },
-                    birthTime = new TS()
+                    birthTime = new TS
                     {
                         value = "20001231",
                     },
-                    administrativeGenderCode = new CE()
+                    administrativeGenderCode = new CE
                     {
                         code = "F",
                     },
@@ -1096,22 +1104,22 @@ namespace HealthGateway.PatientTests.Delegates
             Mock<QUPA_AR101102_PortType> clientMock = new();
             clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
                 .ReturnsAsync(
-                    new HCIM_IN_GetDemographicsResponse1()
+                    new HCIM_IN_GetDemographicsResponse1
                     {
-                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse()
+                        HCIM_IN_GetDemographicsResponse = new HCIM_IN_GetDemographicsResponse
                         {
-                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess()
+                            controlActProcess = new HCIM_IN_GetDemographicsResponseQUQI_MT120001ControlActProcess
                             {
-                                queryAck = new HCIM_MT_QueryResponseQueryAck()
+                                queryAck = new HCIM_MT_QueryResponseQueryAck
                                 {
-                                    queryResponseCode = new CS()
+                                    queryResponseCode = new CS
                                     {
                                         code = expectedResponseCode,
                                     },
                                 },
                                 subject = new[]
                                 {
-                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2()
+                                    new HCIM_IN_GetDemographicsResponseQUQI_MT120001Subject2
                                     {
                                         target = subjectTarget,
                                     },
@@ -1186,7 +1194,8 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         /// <summary>
-        /// Client registry get demographics does not return warning for action type NoHdId given disabled id validation is set to false.
+        /// Client registry get demographics does not return warning for action type NoHdId given disabled id validation is set to
+        /// false.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -1203,7 +1212,7 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         /// <summary>
-        /// Client registry get demographics throws ApiPatientException given CommunicationException.
+        /// Client registry get demographics throws ApiException given CommunicationException.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -1214,10 +1223,13 @@ namespace HealthGateway.PatientTests.Delegates
             IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(false, false, false, true);
 
             // Act
-            async Task Actual() => await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            ApiPatientException exception = await Assert.ThrowsAsync<ApiPatientException>(Actual).ConfigureAwait(true);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
             Assert.Equal(expectedDetail, exception.Detail);
         }
 
@@ -1233,10 +1245,13 @@ namespace HealthGateway.PatientTests.Delegates
             IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
 
             // Act
-            async Task Actual() => await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            ApiPatientException exception = await Assert.ThrowsAsync<ApiPatientException>(Actual).ConfigureAwait(true);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
             Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.Detail);
         }
 
@@ -1252,10 +1267,13 @@ namespace HealthGateway.PatientTests.Delegates
             IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(expectedResponseCode);
 
             // Act
-            async Task Actual() => await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            ApiPatientException exception = await Assert.ThrowsAsync<ApiPatientException>(Actual).ConfigureAwait(true);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
             Assert.Equal(ErrorMessages.ClientRegistryDoesNotReturnPerson, exception.Detail);
         }
 
@@ -1271,10 +1289,13 @@ namespace HealthGateway.PatientTests.Delegates
             IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
 
             // Act
-            async Task Actual() => await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await patientDelegate.GetDemographicsAsync(OidType.PHN, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            ApiPatientException exception = await Assert.ThrowsAsync<ApiPatientException>(Actual).ConfigureAwait(true);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
             Assert.Equal(ErrorMessages.PhnInvalid, exception.Detail);
         }
 
@@ -1309,8 +1330,9 @@ namespace HealthGateway.PatientTests.Delegates
             }
             else
             {
-                clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>())).ReturnsAsync(
-                    GetDemographics(subjectTarget, expectedResponseCode));
+                clientMock.Setup(x => x.HCIM_IN_GetDemographicsAsync(It.IsAny<HCIM_IN_GetDemographicsRequest>()))
+                    .ReturnsAsync(
+                        GetDemographics(subjectTarget, expectedResponseCode));
             }
 
             return new ClientRegistriesDelegate(
@@ -1324,7 +1346,7 @@ namespace HealthGateway.PatientTests.Delegates
             {
                 id = new[]
                 {
-                    new II()
+                    new II
                     {
                         root = "2.16.840.1.113883.3.51.1.1.6",
                         extension = Hdid,
@@ -1332,7 +1354,8 @@ namespace HealthGateway.PatientTests.Delegates
                 },
                 identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
-                    deceasedInd = new BL() { value = deceasedInd },
+                    deceasedInd = new BL
+                        { value = deceasedInd },
                     id = GetIds(noIds),
                     name = GetNames(noNames),
                     birthTime = new TS
@@ -1356,7 +1379,7 @@ namespace HealthGateway.PatientTests.Delegates
 
             return new[]
             {
-                new II()
+                new II
                 {
                     root = "01010101010",
                     extension = Phn,
@@ -1373,7 +1396,7 @@ namespace HealthGateway.PatientTests.Delegates
 
             return new[]
             {
-                new PN()
+                new PN
                 {
                     Items = new ENXP[]
                     {
@@ -1392,7 +1415,8 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         private static HCIM_IN_GetDemographicsResponse1 GetDemographics(
-            HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget, string expectedResponseCode = ResponseCode)
+            HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget,
+            string expectedResponseCode = ResponseCode)
         {
             return new HCIM_IN_GetDemographicsResponse1
             {

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -19,8 +19,8 @@ namespace HealthGateway.PatientTests.Services
     using System.Threading.Tasks;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Exceptions;
     using HealthGateway.Common.Models;
     using HealthGateway.Patient.Delegates;
     using HealthGateway.Patient.Services;
@@ -114,10 +114,13 @@ namespace HealthGateway.PatientTests.Services
             IPatientService service = GetPatientService(expectedPhn, expectedPhn);
 
             // Act
-            async Task Actual() => await service.GetPatient("abc123", PatientIdentifierType.PHN).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await service.GetPatient("abc123", PatientIdentifierType.PHN).ConfigureAwait(true);
+            }
 
             // Verify
-            ApiPatientException exception = await Assert.ThrowsAsync<ApiPatientException>(Actual).ConfigureAwait(true);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
             Assert.Equal(ErrorMessages.PhnInvalid, exception.Detail);
         }
 
@@ -125,7 +128,7 @@ namespace HealthGateway.PatientTests.Services
         {
             ApiResult<PatientModel> requestResult = new()
             {
-                ResourcePayload = new PatientModel()
+                ResourcePayload = new PatientModel
                 {
                     FirstName = "John",
                     LastName = "Doe",

--- a/Apps/WebClient/src/ClientApp/src/models/apiResult.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/apiResult.ts
@@ -1,0 +1,8 @@
+import ApiWarning from "./apiWarning";
+
+export default interface ApiResult<T> {
+    // The request resource payload (could be empty)
+    resourcePayload?: T;
+    // The warning associated to the request (could be empty)
+    warning?: ApiWarning;
+}

--- a/Apps/WebClient/src/ClientApp/src/models/apiWarning.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/apiWarning.ts
@@ -1,0 +1,6 @@
+export default interface ApiWarning {
+    // The code associated with the warning
+    code: string;
+    // The message associated with the warning
+    message: string;
+}

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -1,6 +1,7 @@
 import { Store } from "vuex";
 
 import AddDependentRequest from "@/models/addDependentRequest";
+import ApiResult from "@/models/apiResult";
 import { Dictionary } from "@/models/baseTypes";
 import ClinicalDocument from "@/models/clinicalDocument";
 import Communication, { CommunicationType } from "@/models/communication";
@@ -78,7 +79,7 @@ export interface IVaccinationStatusService {
 
 export interface IPatientService {
     initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
-    getPatientData(hdid: string): Promise<RequestResult<PatientData>>;
+    getPatientData(hdid: string): Promise<ApiResult<PatientData>>;
 }
 
 export interface IMedicationService {

--- a/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
@@ -1,10 +1,10 @@
 import { injectable } from "inversify";
 
 import { ServiceCode } from "@/constants/serviceCodes";
+import ApiResult from "@/models/apiResult";
 import { ExternalConfiguration } from "@/models/configData";
 import { HttpError } from "@/models/errors";
 import PatientData from "@/models/patientData";
-import RequestResult from "@/models/requestResult";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { IHttpDelegate, ILogger, IPatientService } from "@/services/interfaces";
@@ -25,13 +25,13 @@ export class RestPatientService implements IPatientService {
         this.http = http;
     }
 
-    public getPatientData(hdid: string): Promise<RequestResult<PatientData>> {
+    public getPatientData(hdid: string): Promise<ApiResult<PatientData>> {
         return new Promise((resolve, reject) =>
             this.http
-                .get<RequestResult<PatientData>>(
-                    `${this.baseUri}${this.PATIENT_BASE_URI}/${hdid}`
+                .get<ApiResult<PatientData>>(
+                    `${this.baseUri}${this.PATIENT_BASE_URI}/${hdid}?api-version=2.0`
                 )
-                .then((requestResult) => resolve(requestResult))
+                .then((apiResult) => resolve(apiResult))
                 .catch((err: HttpError) => {
                     this.logger.error(
                         `Error in RestPatientService.getPatientData()`

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -3,7 +3,6 @@ import {
     ErrorSourceType,
     ErrorType,
 } from "@/constants/errorType";
-import { ResultType } from "@/constants/resulttype";
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { DateWrapper } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";
@@ -268,7 +267,7 @@ export const actions: UserActions = {
             patientService
                 .getPatientData(context.state.user.hdid)
                 .then((result) => {
-                    if (result.resultStatus === ResultType.Success) {
+                    if (result.resourcePayload) {
                         context.commit(
                             "setPatientData",
                             result.resourcePayload
@@ -306,19 +305,9 @@ export const actions: UserActions = {
                                 resolve();
                             });
                     } else {
-                        if (result.resultError?.statusCode === 429) {
-                            logger.debug(
-                                "Patient retrieval failed because of too many requests"
-                            );
-                            context.commit(
-                                "setAppError",
-                                AppErrorType.TooManyRequests,
-                                { root: true }
-                            );
-                        } else {
-                            logger.debug("Patient retrieval failed");
-                            context.commit("setPatientRetrievalFailed");
-                        }
+                        logger.debug("Patient retrieval failed");
+                        context.commit("setPatientRetrievalFailed");
+
                         resolve();
                     }
                 })


### PR DESCRIPTION
# Implements [AB#14271](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14271)

## Description

- Refactored name and location of ApiPatientException to ApiException
- Refactored location of ApiProblemDetails
- Updated services, delegates and units based on refactoring
- Updated UI to use v2 patient endpoint
- JSON result will only return resource payload and warning if they are not null.  If waning object is null, then it will not be included in the JSON.  Same goes for resource payload.
- Rider format changes applied on some files that had not been previously affected

**200:**

<img width="1273" alt="Screenshot 2022-11-10 at 3 56 56 PM" src="https://user-images.githubusercontent.com/58790456/201230699-c4389e12-ee40-4f0e-bfec-ed6fa5731371.png">


**404:**

<img width="2538" alt="Screenshot 2022-11-10 at 2 39 42 PM" src="https://user-images.githubusercontent.com/58790456/201230873-e81b6275-ff1c-4a30-9f26-c55d7fc231f5.png">


**500:**

<img width="2549" alt="Screenshot 2022-11-10 at 3 40 55 PM" src="https://user-images.githubusercontent.com/58790456/201230813-4b596d57-2903-48cd-9618-12e0360db4c2.png">


**Warning:**

<img width="2525" alt="Screenshot 2022-11-10 at 3 44 40 PM" src="https://user-images.githubusercontent.com/58790456/201230774-7e9ead06-cf9e-46aa-8780-f85095c57f00.png">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No but action, service and model were updated.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
