### PR TITLE
Disable Add Vaccines on Dashboard

### DIFF
--- a/Apps/WebClient/Dockerfile
+++ b/Apps/WebClient/Dockerfile
@@ -1,4 +1,4 @@
-FROM healthopenshift/hg-base:latest
+FROM healthopenshift/hg-base:1.0.0.402
 COPY . .
 EXPOSE 8080
 ENTRYPOINT ["dotnet","WebClient.dll"]

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -642,54 +642,54 @@ export default class HomeView extends Vue {
                     </div>
                 </hg-card-button>
             </b-col>
-            <b-col v-if="showImmunizationRecordButton" class="p-3">
-                <hg-card-button
-                    title="Add Vaccines"
-                    data-testid="immunization-record-card"
-                    @click="handleClickImmunizationRecord()"
-                >
-                    <template #icon>
-                        <hg-icon
-                            class="quick-link-card-icon align-self-center"
-                            icon="upload"
-                            size="large"
-                            square
-                        />
-                    </template>
-                    <template #menu>
-                        <b-nav align="right">
-                            <b-nav-item-dropdown
-                                right
-                                text=""
-                                :no-caret="true"
-                                menu-class="quick-link-menu"
-                                toggle-class="quick-link-menu-button"
-                            >
-                                <template slot="button-content">
-                                    <hg-icon
-                                        icon="ellipsis-v"
-                                        size="medium"
-                                        data-testid="quick-link-menu-button"
-                                    />
-                                </template>
-                                <b-dropdown-item
-                                    data-testid="remove-quick-link-button"
-                                    @click.stop="
-                                        handleClickRemoveImmunizationRecordQuickLink()
-                                    "
-                                >
-                                    Remove
-                                </b-dropdown-item>
-                            </b-nav-item-dropdown>
-                        </b-nav>
-                    </template>
-                    <div>
-                        Add immunizations from family practice or travel
-                        clinics. This helps make sure your immunization records
-                        and forecasts are up to date in Health Gateway.
-                    </div>
-                </hg-card-button>
-            </b-col>
+            <!--            <b-col v-if="showImmunizationRecordButton" class="p-3">-->
+            <!--                <hg-card-button-->
+            <!--                    title="Add Vaccines"-->
+            <!--                    data-testid="immunization-record-card"-->
+            <!--                    @click="handleClickImmunizationRecord()"-->
+            <!--                >-->
+            <!--                    <template #icon>-->
+            <!--                        <hg-icon-->
+            <!--                            class="quick-link-card-icon align-self-center"-->
+            <!--                            icon="upload"-->
+            <!--                            size="large"-->
+            <!--                            square-->
+            <!--                        />-->
+            <!--                    </template>-->
+            <!--                    <template #menu>-->
+            <!--                        <b-nav align="right">-->
+            <!--                            <b-nav-item-dropdown-->
+            <!--                                right-->
+            <!--                                text=""-->
+            <!--                                :no-caret="true"-->
+            <!--                                menu-class="quick-link-menu"-->
+            <!--                                toggle-class="quick-link-menu-button"-->
+            <!--                            >-->
+            <!--                                <template slot="button-content">-->
+            <!--                                    <hg-icon-->
+            <!--                                        icon="ellipsis-v"-->
+            <!--                                        size="medium"-->
+            <!--                                        data-testid="quick-link-menu-button"-->
+            <!--                                    />-->
+            <!--                                </template>-->
+            <!--                                <b-dropdown-item-->
+            <!--                                    data-testid="remove-quick-link-button"-->
+            <!--                                    @click.stop="-->
+            <!--                                        handleClickRemoveImmunizationRecordQuickLink()-->
+            <!--                                    "-->
+            <!--                                >-->
+            <!--                                    Remove-->
+            <!--                                </b-dropdown-item>-->
+            <!--                            </b-nav-item-dropdown>-->
+            <!--                        </b-nav>-->
+            <!--                    </template>-->
+            <!--                    <div>-->
+            <!--                        Add immunizations from family practice or travel-->
+            <!--                        clinics. This helps make sure your immunization records-->
+            <!--                        and forecasts are up to date in Health Gateway.-->
+            <!--                    </div>-->
+            <!--                </hg-card-button>-->
+            <!--            </b-col>-->
             <b-col v-for="card in quickLinkCards" :key="card.title" class="p-3">
                 <hg-card-button
                     :title="card.title"


### PR DESCRIPTION
# Fixes or Implements [AB#14316](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14316)

## Description
Disables (commented out) Add Vaccine temporarily on the Dashboard.
We can discuss the permanent removal when Nino returns.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
Dashboard Add Vaccine commented out.


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
