### PR TITLE
Fixes flakey unit test for AB#14318

### DIFF
--- a/Apps/Common/test/unit/FileDownload/FileDownloadServiceTests.cs
+++ b/Apps/Common/test/unit/FileDownload/FileDownloadServiceTests.cs
@@ -84,8 +84,6 @@ namespace HealthGateway.CommonTests.FileDownload
             ILogger<FileDownloadService> logger = loggerFactory.CreateLogger<FileDownloadService>();
             FileDownloadService service = new(logger, new Mock<IHttpClientService>().Object);
 
-            Task.Run(async () => await service.GetFileFromUrl(new Uri("https://localhost/fake.txt"), "tmp", true).ConfigureAwait(true));
-
             Assert.ThrowsAsync<AggregateException>(() => Task.Run(async () => await service.GetFileFromUrl(new Uri("https://localhost/fake.txt"), targetFolder, true).ConfigureAwait(true)));
             Directory.Delete(Path.Combine(Directory.GetCurrentDirectory(), targetFolder));
         }


### PR DESCRIPTION
# Fixes or Implements [AB#14318](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14318)

## Description

Removed a duplicate call that was causing a thread race issue with the delete.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
