### PR TITLE
Oust HttpClientService from VaccineProofDelegate for AB#14324

### DIFF
--- a/Apps/Common/src/Delegates/VaccineProofDelegate.cs
+++ b/Apps/Common/src/Delegates/VaccineProofDelegate.cs
@@ -33,7 +33,6 @@ namespace HealthGateway.Common.Delegates
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.BCMailPlus;
-    using HealthGateway.Common.Services;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -46,7 +45,7 @@ namespace HealthGateway.Common.Delegates
         private readonly string bcMailPlusEndpoint;
         private readonly string bcMailPlusJobClass;
         private readonly string bcMailPlusSchemaVersion;
-        private readonly IHttpClientService httpClientService;
+        private readonly IHttpClientFactory httpClientFactory;
 
         private readonly ILogger logger;
 
@@ -54,15 +53,15 @@ namespace HealthGateway.Common.Delegates
         /// Initializes a new instance of the <see cref="VaccineProofDelegate"/> class.
         /// </summary>
         /// <param name="logger">Injected Logger Provider.</param>
-        /// <param name="httpClientService">The injected http client service.</param>
+        /// <param name="httpClientFactory">The injected http client factory.</param>
         /// <param name="configuration">The injected configuration provider.</param>
         public VaccineProofDelegate(
             ILogger<VaccineProofDelegate> logger,
-            IHttpClientService httpClientService,
+            IHttpClientFactory httpClientFactory,
             IConfiguration configuration)
         {
             this.logger = logger;
-            this.httpClientService = httpClientService;
+            this.httpClientFactory = httpClientFactory;
 
             BcMailPlusConfig bcMailPlusConfig = new();
             configuration.GetSection(BcMailPlusSectionKey).Bind(bcMailPlusConfig);
@@ -193,7 +192,7 @@ namespace HealthGateway.Common.Delegates
                 PageIndex = 0,
             };
 
-            using HttpClient client = this.httpClientService.CreateDefaultHttpClient();
+            using HttpClient client = this.httpClientFactory.CreateClient();
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
 
@@ -260,7 +259,7 @@ namespace HealthGateway.Common.Delegates
                 PageIndex = 0,
             };
 
-            using HttpClient client = this.httpClientService.CreateDefaultHttpClient();
+            using HttpClient client = this.httpClientFactory.CreateClient();
             client.DefaultRequestHeaders.Accept.Clear();
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
             Uri endpoint = new(endpointString);

--- a/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
@@ -30,7 +30,6 @@ namespace HealthGateway.CommonTests.Delegates
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Models.BCMailPlus;
-    using HealthGateway.Common.Services;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -107,7 +106,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
@@ -143,7 +142,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
@@ -176,7 +175,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
@@ -230,7 +229,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
@@ -266,7 +265,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
@@ -299,7 +298,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
@@ -342,7 +341,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
@@ -371,7 +370,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
@@ -401,7 +400,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
@@ -429,7 +428,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             IVaccineProofDelegate vaccineProofDelegate = new VaccineProofDelegate(
                 loggerFactory.CreateLogger<VaccineProofDelegate>(),
-                GetHttpClientServiceMock(httpResponseMessage).Object,
+                GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
@@ -460,7 +459,7 @@ namespace HealthGateway.CommonTests.Delegates
                 .Build();
         }
 
-        private static Mock<IHttpClientService> GetHttpClientServiceMock(HttpResponseMessage httpResponseMessage)
+        private static Mock<IHttpClientFactory> GetHttpClientFactoryMock(HttpResponseMessage httpResponseMessage)
         {
             Mock<HttpMessageHandler> handlerMock = new();
             handlerMock
@@ -471,10 +470,10 @@ namespace HealthGateway.CommonTests.Delegates
                     ItExpr.IsAny<CancellationToken>())
                 .ReturnsAsync(httpResponseMessage)
                 .Verifiable();
-            Mock<IHttpClientService> mockHttpClientService = new();
-            mockHttpClientService.Setup(s => s.CreateDefaultHttpClient()).Returns(() => new HttpClient(handlerMock.Object));
+            Mock<IHttpClientFactory> mockHttpClientFactory = new();
+            mockHttpClientFactory.Setup(s => s.CreateClient(It.IsAny<string>())).Returns(() => new HttpClient(handlerMock.Object));
 
-            return mockHttpClientService;
+            return mockHttpClientFactory;
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements AB#14324

## Description
Replace IHttpClientService with IHttpClientFactory as the VaccineProofDelegate endpoint returns odd errors in the payload.


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
None


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
