### PR TITLE
Fix draft communications shown for AB#14244

### DIFF
--- a/Apps/Common/src/Services/CommunicationService.cs
+++ b/Apps/Common/src/Services/CommunicationService.cs
@@ -142,7 +142,8 @@ namespace HealthGateway.Common.Services
                     {
                         this.logger.LogInformation("{Action} ChangeEvent for Communication {Id} found in Cache", changeEvent.Action, communication.Id);
                         this.RemoveCommunicationFromCache(communication.CommunicationTypeCode);
-                        if (changeEvent.Action is Insert or Update)
+                        if (changeEvent.Action is Insert or Update &&
+                            communication.CommunicationStatusCode is CommunicationStatus.New)
                         {
                             this.AddCommunicationToCache(communication, communication.CommunicationTypeCode);
                         }
@@ -155,7 +156,8 @@ namespace HealthGateway.Common.Services
                     else
                     {
                         // Check the new comm to see if it is effective earlier and not expired
-                        if (DateTime.UtcNow < communication.ExpiryDateTime && communication.EffectiveDateTime < cachedComm.EffectiveDateTime)
+                        if (DateTime.UtcNow < communication.ExpiryDateTime && communication.EffectiveDateTime < cachedComm.EffectiveDateTime &&
+                            communication.CommunicationStatusCode is CommunicationStatus.New)
                         {
                             this.logger.LogInformation("{Action} ChangeEvent for Communication {Id} replacing {CachedId}", changeEvent.Action, communication.Id, cachedComm.Id);
                             this.AddCommunicationToCache(communication, communication.CommunicationTypeCode);
@@ -169,7 +171,8 @@ namespace HealthGateway.Common.Services
                 else
                 {
                     this.logger.LogInformation("No Communications in the Cache, processing {Action} for communication {Id}", changeEvent.Action, communication.Id);
-                    if (changeEvent.Action is Insert or Update)
+                    if (changeEvent.Action is Insert or Update &&
+                        communication.CommunicationStatusCode is CommunicationStatus.New)
                     {
                         this.AddCommunicationToCache(communication, communication.CommunicationTypeCode);
                     }


### PR DESCRIPTION
# Fixes [AB#14244](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14244)

## Description

Draft Communications - Communications that are set as "Draft" are still being displayed on landing/in-app banners. 
- added check that communication status code is 'new' before adding to cache

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
