### PR TITLE
Client Registry Delegate V2 - Change warning to throw ApiException for AB#14315

### DIFF
--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -107,7 +107,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCovid19OrderHandlesHttpStatusCodeNoContent()
+        public async Task GetCovid19OrderHandlesHttpStatusCodeNoContent()
         {
             // Arrange
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
@@ -134,7 +134,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCovid19OrdersHandleApiException()
+        public async Task GetCovid19OrdersHandleApiException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error while retrieving Covid19 Orders";
 
@@ -162,7 +162,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCovid19OrdersHandleHttpRequestException()
+        public async Task GetCovid19OrdersHandleHttpRequestException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.InternalServerError}. Error while retrieving Covid19 Orders";
 
@@ -222,7 +222,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCovid19LabReportHandlesHttpStatusCodeNoContent()
+        public async Task GetCovid19LabReportHandlesHttpStatusCodeNoContent()
         {
             string expectedMessage = "Laboratory Report not found";
 
@@ -249,7 +249,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCovid19LabReportHandlesApiException()
+        public async Task GetCovid19LabReportHandlesApiException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error retrieving Laboratory Report";
 
@@ -277,7 +277,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCovid19LabReportHandlesHttpRequestException()
+        public async Task GetCovid19LabReportHandlesHttpRequestException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.InternalServerError}. Error retrieving Laboratory Report";
 
@@ -338,7 +338,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetPlisLabReportHandlesHttpStatusCodeNoContent()
+        public async Task GetPlisLabReportHandlesHttpStatusCodeNoContent()
         {
             string expectedMessage = "Laboratory Report not found";
 
@@ -366,7 +366,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetPlisLabReportHandlesApiException()
+        public async Task GetPlisLabReportHandlesApiException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error retrieving Laboratory Report";
 
@@ -394,7 +394,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetPlisLabReportHandlesHttpRequestException()
+        public async Task GetPlisLabReportHandlesHttpRequestException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.InternalServerError}. Error retrieving Laboratory Report";
 
@@ -482,7 +482,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetPublicTestResultsHandlesApiException()
+        public async Task GetPublicTestResultsHandlesApiException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error while retrieving Covid19 Test Results";
 
@@ -512,7 +512,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetPublicTestResultsHandlesHttpRequestException()
+        public async Task GetPublicTestResultsHandlesHttpRequestException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.InternalServerError}. Error while retrieving Covid19 Test Results";
 
@@ -577,7 +577,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetLaboratorySummaryHandlesHttpStatusCodeNoContent()
+        public async Task GetLaboratorySummaryHandlesHttpStatusCodeNoContent()
         {
             // Arrange
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
@@ -604,7 +604,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetLaboratorySummaryHandleApiException()
+        public async Task GetLaboratorySummaryHandleApiException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error while retrieving Laboratory Summary";
 
@@ -632,7 +632,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetLaboratorySummaryHandleHttpRequestException()
+        public async Task GetLaboratorySummaryHandleHttpRequestException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.InternalServerError}. Error while retrieving Laboratory Summary";
 

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -487,7 +487,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error while retrieving Covid19 Test Results";
 
             // Arrange
-            ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Get);
+            ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Post);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
             mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
 

--- a/Apps/Patient/src/Services/PatientService.cs
+++ b/Apps/Patient/src/Services/PatientService.cs
@@ -45,19 +45,19 @@ namespace HealthGateway.Patient.Services
         /// The injected logger delegate.
         /// </summary>
         private readonly ILogger<PatientService> logger;
-        private readonly IClientRegistriesDelegate patientDelegate;
+        private readonly IClientRegistriesDelegate clientRegistriesDelegate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PatientService"/> class.
         /// </summary>
         /// <param name="logger">The service Logger.</param>
         /// <param name="configuration">The Configuration to use.</param>
-        /// <param name="patientDelegate">The injected client registries delegate.</param>
+        /// <param name="clientRegistriesDelegate">The injected client registries delegate.</param>
         /// <param name="cacheProvider">The provider responsible for caching.</param>
-        public PatientService(ILogger<PatientService> logger, IConfiguration configuration, IClientRegistriesDelegate patientDelegate, ICacheProvider cacheProvider)
+        public PatientService(ILogger<PatientService> logger, IConfiguration configuration, IClientRegistriesDelegate clientRegistriesDelegate, ICacheProvider cacheProvider)
         {
             this.logger = logger;
-            this.patientDelegate = patientDelegate;
+            this.clientRegistriesDelegate = clientRegistriesDelegate;
             this.cacheProvider = cacheProvider;
             this.cacheTtl = configuration.GetSection("PatientService").GetValue("CacheTTL", 0);
         }
@@ -85,7 +85,7 @@ namespace HealthGateway.Patient.Services
                     throw new ApiException(ErrorMessages.PhnInvalid, "PatientService.GetPatient", HttpStatusCode.NotFound);
                 }
 
-                apiResult = await this.patientDelegate.GetDemographicsAsync(type, identifier, disableIdValidation).ConfigureAwait(true);
+                apiResult = await this.clientRegistriesDelegate.GetDemographicsAsync(type, identifier, disableIdValidation).ConfigureAwait(true);
 
                 // Only cache if validation is enabled (as some clients could get invalid data) and when successful.
                 if (!disableIdValidation && apiResult.ResourcePayload != null)

--- a/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -46,7 +46,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task LookUpByPhnNoHdid()
+        public async Task ShouldGetDemographicsThrowsApiExceptionGivenNoHdid()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.0.0013";
@@ -121,19 +121,23 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, "9875023209").ConfigureAwait(true);
+            async Task Actual()
+            {
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            Assert.NotEmpty(actual.Warning?.Message);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
+            Assert.Equal(ErrorMessages.InvalidServicesCard, exception.Detail);
         }
 
         /// <summary>
-        /// GetDemographicsByHDID - Happy Path.
+        /// Client registry get demographics by hdid - Happy Path.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
@@ -338,12 +342,12 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
 
             // Verify
             Assert.Equal(expectedHdId, actual.ResourcePayload?.HdId);
@@ -357,11 +361,11 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         /// <summary>
-        /// GetDemographics - Invalid ID Error.
+        /// Client registry get demographics throws api exception given invalid id error.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldErrorIfInvalidIdentifier()
+        public async Task ShouldGetDemographicsThrowsApiExceptionGivenInvalidIdentifier()
         {
             // Setup
             string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -446,24 +450,27 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Hdid, hdid).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, hdid).ConfigureAwait(true);
+            }
 
             // Verify
-            Assert.Equal(ActionType.NoHdId.Value, actual.Warning?.Code);
-            Assert.Equal(ErrorMessages.InvalidServicesCard, actual.Warning?.Message);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
+            Assert.Equal(ErrorMessages.InvalidServicesCard, exception.Detail);
         }
 
         /// <summary>
-        /// GetDemographicsByHDID - Happy Path (Validate Multiple Names).
+        /// Client registry get demographics - Happy Path (Validate Multiple Names).
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldUseCorrectNameSection()
+        public async Task ShouldGetDemographicsGivenCorrectNameSection()
         {
             // Setup
             string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -566,12 +573,12 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
 
             // Verify
             Assert.Equal(expectedHdId, actual.ResourcePayload?.HdId);
@@ -583,11 +590,11 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         /// <summary>
-        /// GetDemographicsByHDID - Happy Path (Validate Multiple Names Qualifiers).
+        /// Client registry get demographics by hdid - Happy Path (Validate Multiple Names Qualifiers).
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldUseCorrectNameQualifier()
+        public async Task ShouldGetDemographicsGivenCorrectNameQualifier()
         {
             // Setup
             string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -714,12 +721,12 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
 
             // Verify
             Assert.Equal(expectedHdId, actual.ResourcePayload?.HdId);
@@ -731,11 +738,11 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         /// <summary>
-        /// Get patient by PHN is subject of overlay returns success.
+        /// Client registry get demographics given subject of overlay returns response code.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnSuccessForSubjectOfOverlay()
+        public async Task ShouldGetDemographicsGivenSubjectOfOverlay()
         {
             // Setup
             string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -821,23 +828,23 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0019", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>
-        /// Get patient by PHN is subject of potential duplicate returns success.
+        /// Client registry get demographics by phn is subject of potential duplicate returns response code.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnSuccessForSubjectOfPotentialDuplicate()
+        public async Task ShouldGetDemographicsGivenSubjectOfPotentialDuplicate()
         {
             // Setup
             string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -923,23 +930,23 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0021", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>
-        /// Get patient by PHN is subject of potential linkage returns success.
+        /// Client registry get demographics by phn given subject of potential linkage returns response code.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnSuccessForSubjectOfPotentialLinkage()
+        public async Task ShouldGetDemographicsGivenSubjectOfPotentialLinkage()
         {
             // Setup
             string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -1025,23 +1032,23 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0022", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>
-        /// Get patient by PHN is subject of review identifier returns success.
+        /// Client registry get demographics by phn is subject of review identifier returns response code.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnSuccessForSubjectOfReviewIdentifier()
+        public async Task ShouldGetDemographicsGivenSubjectOfReviewIdentifier()
         {
             // Setup
             string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -1127,69 +1134,78 @@ namespace HealthGateway.PatientTests.Delegates
                         },
                     });
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
-            IClientRegistriesDelegate patientDelegate = new ClientRegistriesDelegate(
+            IClientRegistriesDelegate clientRegistryDelegate = new ClientRegistriesDelegate(
                 loggerFactory.CreateLogger<ClientRegistriesDelegate>(),
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0023", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
         }
 
         /// <summary>
-        /// Client registry get demographics returns warning given client registry could not find legal name.
+        /// Client registry get demographics throws api exception given client registry could not find legal name.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnWarningGivenNoLegalName()
+        public async Task ShouldGetDemographicsThrowsApiExceptionGivenNoLegalName()
         {
             // Setup
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, true);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            Assert.Equal(ActionType.InvalidName.Value, actual.Warning?.Code);
-            Assert.Equal(ErrorMessages.InvalidServicesCard, actual.Warning?.Message);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
+            Assert.Equal(ErrorMessages.InvalidServicesCard, exception.Detail);
         }
 
         /// <summary>
-        /// Client registry get demographics returns warning given client registry could not find any ids.
+        /// Client registry get demographics throws api exception given client registry could not find any ids.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnWarningGivenNoIds()
+        public async Task ShouldGetDemographicsThrowsApiExceptionGivenNoIds()
         {
             // Setup
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(false, false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, true);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            Assert.Equal(ActionType.NoHdId.Value, actual.Warning?.Code);
-            Assert.Equal(ErrorMessages.InvalidServicesCard, actual.Warning?.Message);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
+            Assert.Equal(ErrorMessages.InvalidServicesCard, exception.Detail);
         }
 
         /// <summary>
-        /// Client registry get demographics returns warning given user deceased indicator is true.
+        /// Client registry get demographics throws api exception given given user deceased indicator is true.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldReturnWarningGivenDeceasedIndicatorTrue()
+        public async Task ShouldGetDemographicsThrowsApiExceptionGivenDeceasedIndicatorTrue()
         {
             // Setup
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(true);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            async Task Actual()
+            {
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+            }
 
             // Verify
-            Assert.Equal(ActionType.Deceased.Value, actual.Warning?.Code);
-            Assert.Equal(ErrorMessages.ClientRegistryReturnedDeceasedPerson, actual.Warning?.Message);
+            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
+            Assert.Equal(ErrorMessages.ClientRegistryReturnedDeceasedPerson, exception.Detail);
         }
 
         /// <summary>
@@ -1198,16 +1214,16 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldNotReturnWarningGivenDisabledIdValidationIsFalse()
+        public async Task ShouldGetDemographicsGivenDisabledIdValidationIsTrue()
         {
             // Setup
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(false, false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, true);
 
             // Act
-            ApiResult<PatientModel> actual = await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn, true).ConfigureAwait(true);
+            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn, true).ConfigureAwait(true);
 
             // Verify
-            Assert.Null(actual.Warning);
+            Assert.NotNull(actual.ResourcePayload);
         }
 
         /// <summary>
@@ -1215,16 +1231,16 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldThrowApiPatientExceptionGivenCommunicationException()
+        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenCommunicationException()
         {
             // Setup
             string expectedDetail = $"Communication Exception with client registry when trying to retrieve patient information from {OidType.Phn}";
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(false, false, false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, false, true);
 
             // Act
             async Task Actual()
             {
-                await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
             }
 
             // Verify
@@ -1237,16 +1253,16 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldThrowApiPatientExceptionGivenClientRegistryRecordsNotFound()
+        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenClientRegistryRecordsNotFound()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.2.0018";
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
 
             // Act
             async Task Actual()
             {
-                await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
             }
 
             // Verify
@@ -1259,16 +1275,16 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldThrowApiPatientExceptionGivenClientRegistryDoesNotReturnPerson()
+        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenClientRegistryDoesNotReturnPerson()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.0.0099";
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(expectedResponseCode);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode);
 
             // Act
             async Task Actual()
             {
-                await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
             }
 
             // Verify
@@ -1281,16 +1297,16 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldThrowApiPatientExceptionGivenClientRegistryPhnInvalid()
+        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenClientRegistryPhnInvalid()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.2.0006";
-            IClientRegistriesDelegate patientDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
 
             // Act
             async Task Actual()
             {
-                await patientDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
             }
 
             // Verify

--- a/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -46,7 +46,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowsApiExceptionGivenNoHdid()
+        public async Task GetDemographicsThrowsApiExceptionGivenNoHdid()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.0.0013";
@@ -365,7 +365,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowsApiExceptionGivenInvalidIdentifier()
+        public async Task GetDemographicsThrowsApiExceptionGivenInvalidIdentifier()
         {
             // Setup
             string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
@@ -1150,7 +1150,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowsApiExceptionGivenNoLegalName()
+        public async Task GetDemographicsThrowsApiExceptionGivenNoLegalName()
         {
             // Setup
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, true);
@@ -1171,7 +1171,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowsApiExceptionGivenNoIds()
+        public async Task GetDemographicsThrowsApiExceptionGivenNoIds()
         {
             // Setup
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, true);
@@ -1192,7 +1192,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowsApiExceptionGivenDeceasedIndicatorTrue()
+        public async Task GetDemographicsThrowsApiExceptionGivenDeceasedIndicatorTrue()
         {
             // Setup
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(true);
@@ -1231,7 +1231,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenCommunicationException()
+        public async Task GetDemographicsThrowsApiPatientExceptionGivenCommunicationException()
         {
             // Setup
             string expectedDetail = $"Communication Exception with client registry when trying to retrieve patient information from {OidType.Phn}";
@@ -1253,7 +1253,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenClientRegistryRecordsNotFound()
+        public async Task GetDemographicsThrowsApiPatientExceptionGivenClientRegistryRecordsNotFound()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.2.0018";
@@ -1275,7 +1275,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenClientRegistryDoesNotReturnPerson()
+        public async Task GetDemographicsThrowsApiPatientExceptionGivenClientRegistryDoesNotReturnPerson()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.0.0099";
@@ -1297,7 +1297,7 @@ namespace HealthGateway.PatientTests.Delegates
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsThrowApiPatientExceptionGivenClientRegistryPhnInvalid()
+        public async Task GetDemographicsThrowsApiPatientExceptionGivenClientRegistryPhnInvalid()
         {
             // Setup
             string expectedResponseCode = "BCHCIM.GD.2.0006";


### PR DESCRIPTION
# Implements [AB#14315](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14315)

## Description

- Updated warnings to ApiException in ClientRegistriesDelegate.GetDemographicsAsync.
- Updated unit tests to reflect warnings to ApiException change.
- Updated unit test names and associated comments.
- Updated delegate name and comments in PatientService.
- Updated call to use correct HttpMethod when creating ApiException for Laboratory unit test.

<img width="1283" alt="Screenshot 2022-11-21 at 1 30 20 PM" src="https://user-images.githubusercontent.com/58790456/203162108-f1da57b6-b7ad-4aa1-b8ae-dd6ddb4036df.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
