### PR TITLE
Standardize Refit API class names and signatures AB#14342

### DIFF
--- a/Apps/Admin/Server/Services/InactiveUserService.cs
+++ b/Apps/Admin/Server/Services/InactiveUserService.cs
@@ -114,9 +114,13 @@ public class InactiveUserService : IInactiveUserService
             JwtModel jwtModel = this.authDelegate.AuthenticateAsUser(this.tokenUri, this.tokenRequest);
             try
             {
-                IApiResponse<IEnumerable<UserRepresentation>> adminUsersResult = await this.keycloakAdminApi.GetUsers(nameof(IdentityAccessRole.AdminUser), jwtModel.AccessToken).ConfigureAwait(true);
+                const int firstRecord = 0;
+                const int maxRecords = -1;
+
+                IApiResponse<IEnumerable<UserRepresentation>> adminUsersResult =
+                    await this.keycloakAdminApi.GetUsers(nameof(IdentityAccessRole.AdminUser), firstRecord, maxRecords, jwtModel.AccessToken).ConfigureAwait(true);
                 IApiResponse<IEnumerable<UserRepresentation>> supportUsersResult =
-                    await this.keycloakAdminApi.GetUsers(nameof(IdentityAccessRole.SupportUser), jwtModel.AccessToken).ConfigureAwait(true);
+                    await this.keycloakAdminApi.GetUsers(nameof(IdentityAccessRole.SupportUser), firstRecord, maxRecords, jwtModel.AccessToken).ConfigureAwait(true);
 
                 if (adminUsersResult.IsSuccessStatusCode && adminUsersResult.Content != null)
                 {

--- a/Apps/AdminWebClient/src/Server/Api/IImmunizationAdminApi.cs
+++ b/Apps/AdminWebClient/src/Server/Api/IImmunizationAdminApi.cs
@@ -24,7 +24,7 @@ using Refit;
 /// <summary>
 /// Interface that defines a client api to access administrative immunization data.
 /// </summary>
-public interface IImmunizationAdminClient
+public interface IImmunizationAdminApi
 {
     /// <summary>
     /// Submit a completed Anti Viral screening form.

--- a/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
+++ b/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
@@ -41,7 +41,7 @@ namespace HealthGateway.Admin.Delegates
     {
         private const string PhsaConfigSectionKey = "PHSA";
         private readonly IMapper autoMapper;
-        private readonly IImmunizationAdminClient immunizationAdminClient;
+        private readonly IImmunizationAdminApi immunizationAdminApi;
         private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly ILogger logger;
         private readonly PhsaConfig phsaConfig;
@@ -50,19 +50,19 @@ namespace HealthGateway.Admin.Delegates
         /// Initializes a new instance of the <see cref="RestImmunizationAdminDelegate"/> class.
         /// </summary>
         /// <param name="logger">Injected Logger Provider.</param>
-        /// <param name="immunizationAdminClient">The injected client for immunization admin api calls.</param>
+        /// <param name="immunizationAdminApi">The injected client for immunization admin api calls.</param>
         /// <param name="configuration">The injected configuration provider.</param>
         /// <param name="authenticationDelegate">The auth delegate to fetch tokens.</param>
         /// <param name="autoMapper">The injected automapper provider.</param>
         public RestImmunizationAdminDelegate(
             ILogger<RestImmunizationAdminDelegate> logger,
-            IImmunizationAdminClient immunizationAdminClient,
+            IImmunizationAdminApi immunizationAdminApi,
             IConfiguration configuration,
             IAuthenticationDelegate authenticationDelegate,
             IMapper autoMapper)
         {
             this.logger = logger;
-            this.immunizationAdminClient = immunizationAdminClient;
+            this.immunizationAdminApi = immunizationAdminApi;
             this.authenticationDelegate = authenticationDelegate;
             this.autoMapper = autoMapper;
             this.phsaConfig = new PhsaConfig();
@@ -186,7 +186,7 @@ namespace HealthGateway.Admin.Delegates
                 {
                     using Activity? activity = Source.StartActivity();
 
-                    IApiResponse<PhsaResult<VaccineDetailsResponse>> response = await this.immunizationAdminClient.GetVaccineDetails(request, bearerToken).ConfigureAwait(true);
+                    IApiResponse<PhsaResult<VaccineDetailsResponse>> response = await this.immunizationAdminApi.GetVaccineDetails(request, bearerToken).ConfigureAwait(true);
                     retVal.ResultStatus = ResultType.Success;
                     retVal.ResourcePayload!.Result = response.Content!.Result;
                     retVal.TotalResultCount = 1;

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -52,7 +52,7 @@ namespace HealthGateway.Admin.Services
         private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly BcMailPlusConfig bcmpConfig;
         private readonly IHttpContextAccessor httpContextAccessor;
-        private readonly IImmunizationAdminClient immunizationAdminClient;
+        private readonly IImmunizationAdminApi immunizationAdminApi;
         private readonly IImmunizationAdminDelegate immunizationDelegate;
         private readonly ILogger<CovidSupportService> logger;
         private readonly IPatientService patientService;
@@ -70,7 +70,7 @@ namespace HealthGateway.Admin.Services
         /// <param name="httpContextAccessor">The Http Context accessor.</param>
         /// <param name="configuration">The configuration to use.</param>
         /// <param name="vaccineProofDelegate">The injected delegate to get the vaccine proof.</param>
-        /// <param name="immunizationAdminClient">The api client to use for immunization.</param>
+        /// <param name="immunizationAdminApi">The api client to use for immunization.</param>
         /// <param name="authenticationDelegate">The auth delegate to fetch tokens.</param>
         public CovidSupportService(
             ILogger<CovidSupportService> logger,
@@ -80,7 +80,7 @@ namespace HealthGateway.Admin.Services
             IHttpContextAccessor httpContextAccessor,
             IConfiguration configuration,
             IVaccineProofDelegate vaccineProofDelegate,
-            IImmunizationAdminClient immunizationAdminClient,
+            IImmunizationAdminApi immunizationAdminApi,
             IAuthenticationDelegate authenticationDelegate)
         {
             this.logger = logger;
@@ -89,7 +89,7 @@ namespace HealthGateway.Admin.Services
             this.vaccineStatusDelegate = vaccineStatusDelegate;
             this.httpContextAccessor = httpContextAccessor;
             this.vaccineProofDelegate = vaccineProofDelegate;
-            this.immunizationAdminClient = immunizationAdminClient;
+            this.immunizationAdminApi = immunizationAdminApi;
             this.authenticationDelegate = authenticationDelegate;
 
             this.bcmpConfig = new();
@@ -335,7 +335,7 @@ namespace HealthGateway.Admin.Services
             try
             {
                 IApiResponse<CovidAssessmentResponse> response =
-                    await this.immunizationAdminClient.SubmitCovidAssessment(request, accessToken).ConfigureAwait(true);
+                    await this.immunizationAdminApi.SubmitCovidAssessment(request, accessToken).ConfigureAwait(true);
                 this.ProcessResponse(requestResult, response);
             }
             catch (HttpRequestException e)
@@ -372,7 +372,7 @@ namespace HealthGateway.Admin.Services
                 try
                 {
                     IApiResponse<CovidAssessmentDetailsResponse> response =
-                        await this.immunizationAdminClient.GetCovidAssessmentDetails(
+                        await this.immunizationAdminApi.GetCovidAssessmentDetails(
                                 new CovidAssessmentDetailsRequest
                                     { Phn = phn },
                                 accessToken)

--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -115,7 +115,7 @@ namespace HealthGateway.Admin
             // Add API Clients
             PhsaConfig phsaConfig = new();
             this.startupConfig.Configuration.Bind(PhsaConfigSectionKey, phsaConfig);
-            services.AddRefitClient<IImmunizationAdminClient>()
+            services.AddRefitClient<IImmunizationAdminApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
 
             services.AddAutoMapper(typeof(Startup), typeof(UserProfileProfile), typeof(MessagingVerificationProfile));

--- a/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
@@ -158,7 +158,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
-            IImmunizationAdminClient immunizationAdminClient = RestService.For<IImmunizationAdminClient>(httpClient);
+            IImmunizationAdminApi immunizationAdminApi = RestService.For<IImmunizationAdminApi>(httpClient);
             ICovidSupportService mockCovidSupportService = new CovidSupportService(
                 new Mock<ILogger<CovidSupportService>>().Object,
                 new Mock<IPatientService>().Object,
@@ -167,7 +167,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
                 new Mock<IHttpContextAccessor>().Object,
                 GetIConfigurationRoot(),
                 new Mock<IVaccineProofDelegate>().Object,
-                immunizationAdminClient,
+                immunizationAdminApi,
                 mockAuthDelegate.Object);
 
             return mockCovidSupportService;
@@ -182,7 +182,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             mockApiResponse.Setup(s => s.Content).Returns(response);
             mockApiResponse.Setup(s => s.StatusCode).Returns(statusCode);
 
-            Mock<IImmunizationAdminClient> mockAdminDelegate = new();
+            Mock<IImmunizationAdminApi> mockAdminDelegate = new();
             if (!throwException)
             {
                 mockAdminDelegate.Setup(
@@ -221,7 +221,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             mockApiResponse.Setup(s => s.Content).Returns(response);
             mockApiResponse.Setup(s => s.StatusCode).Returns(statusCode);
 
-            Mock<IImmunizationAdminClient> mockAdminDelegate = new();
+            Mock<IImmunizationAdminApi> mockAdminDelegate = new();
             if (!throwException)
             {
                 mockAdminDelegate.Setup(

--- a/Apps/Common/src/Api/IKeycloakAdminApi.cs
+++ b/Apps/Common/src/Api/IKeycloakAdminApi.cs
@@ -39,12 +39,12 @@ namespace HealthGateway.Common.Api
         /// Returns users for the role passed in.
         /// </summary>
         /// <param name="role">The requested users role.</param>
-        /// <param name="token">The bearer token to authorize the call.</param>
         /// <param name="first">The first record to return.</param>
         /// <param name="max">The maximum results to return.</param>
+        /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>An Enumerable of UserRepresentation objects.</returns>
         [Get("/roles/{role}/users?first={first}&max={max}")]
-        Task<IApiResponse<IEnumerable<UserRepresentation>>> GetUsers(string role, [Authorize] string token, int first = 0, int max = -1);
+        Task<IApiResponse<IEnumerable<UserRepresentation>>> GetUsers(string role, int first, int max, [Authorize] string token);
 
         /// <summary>
         /// Delete a User account from the Identity and Access Management system.

--- a/Apps/Common/src/Api/INotificationSettingsApi.cs
+++ b/Apps/Common/src/Api/INotificationSettingsApi.cs
@@ -27,11 +27,11 @@ namespace HealthGateway.Common.Api
         /// <summary>
         /// Creates or updates notification settings.
         /// </summary>
-        /// <param name="token">The bearer token to authorize the request.</param>
-        /// <param name="hdid">The subject's HDID.</param>
         /// <param name="request">The notification settings request to be sent.</param>
+        /// <param name="hdid">The subject's HDID.</param>
+        /// <param name="token">The bearer token to authorize the request.</param>
         /// <returns>The notification settings response received.</returns>
         [Put("/")]
-        Task<NotificationSettingsResponse> SetNotificationSettingsAsync([Authorize] string token, [Header("patient")] string hdid, [Body] NotificationSettingsRequest request);
+        Task<NotificationSettingsResponse> SetNotificationSettingsAsync([Body] NotificationSettingsRequest request, [Header("patient")] string hdid, [Authorize] string token);
     }
 }

--- a/Apps/Common/src/Delegates/PHSA/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestNotificationSettingsDelegate.cs
@@ -64,10 +64,8 @@ namespace HealthGateway.Common.Delegates.PHSA
 
             try
             {
-                NotificationSettingsResponse notificationSettingsResponse = await this.notificationSettingsApi.SetNotificationSettingsAsync(
-                        bearerToken,
-                        notificationSettings.SubjectHdid,
-                        notificationSettings)
+                NotificationSettingsResponse notificationSettingsResponse = await this.notificationSettingsApi
+                    .SetNotificationSettingsAsync(notificationSettings, notificationSettings.SubjectHdid, bearerToken)
                     .ConfigureAwait(true);
 
                 retVal.ResultStatus = ResultType.Success;

--- a/Apps/Common/test/unit/Delegates/NotificationSettingsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/NotificationSettingsDelegateTests.cs
@@ -56,7 +56,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             Mock<ILogger<RestNotificationSettingsDelegate>> mockLogger = new();
             Mock<INotificationSettingsApi> mockNotificationSettingsApi = new();
-            mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationSettingsRequest>()))
+            mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(response);
 
             RestNotificationSettingsDelegate notificationSettingsDelegate = new(mockLogger.Object, mockNotificationSettingsApi.Object);
@@ -87,7 +87,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             Mock<ILogger<RestNotificationSettingsDelegate>> mockLogger = new();
             Mock<INotificationSettingsApi> mockNotificationSettingsApi = new();
-            mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationSettingsRequest>()))
+            mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.BadRequest));
 
             RestNotificationSettingsDelegate notificationSettingsDelegate = new(mockLogger.Object, mockNotificationSettingsApi.Object);
@@ -123,7 +123,7 @@ namespace HealthGateway.CommonTests.Delegates
             using HttpResponseMessage responseMessage = new(HttpStatusCode.NotFound);
             ApiException apiException = await ApiException.Create(requestMessage, HttpMethod.Put, responseMessage, new()).ConfigureAwait(true);
 
-            mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<NotificationSettingsRequest>()))
+            mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(apiException);
 
             RestNotificationSettingsDelegate notificationSettingsDelegate = new(mockLogger.Object, mockNotificationSettingsApi.Object);

--- a/Apps/Immunization/src/Api/IImmunizationApi.cs
+++ b/Apps/Immunization/src/Api/IImmunizationApi.cs
@@ -23,7 +23,7 @@ using Refit;
 /// <summary>
 /// Interface that defines a client api to retrieve immunization information.
 /// </summary>
-public interface IImmunizationClient
+public interface IImmunizationApi
 {
     /// <summary>
     /// Returns the matching immunization for the given id.

--- a/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
@@ -41,7 +41,7 @@ namespace HealthGateway.Immunization.Delegates
         /// </summary>
         public const string PhsaConfigSectionKey = "PHSA";
         private readonly IAuthenticationDelegate authenticationDelegate;
-        private readonly IImmunizationClient immunizationClient;
+        private readonly IImmunizationApi immunizationApi;
         private readonly ILogger logger;
         private readonly PhsaConfig phsaConfig;
 
@@ -51,16 +51,16 @@ namespace HealthGateway.Immunization.Delegates
         /// <param name="logger">Injected Logger Provider.</param>
         /// <param name="configuration">The injected configuration provider.</param>
         /// <param name="authenticationDelegate">The auth delegate to fetch tokens.</param>
-        /// <param name="immunizationClient">The client to use for immunization api calls..</param>
+        /// <param name="immunizationApi">The client to use for immunization api calls..</param>
         public RestImmunizationDelegate(
             ILogger<RestImmunizationDelegate> logger,
             IConfiguration configuration,
             IAuthenticationDelegate authenticationDelegate,
-            IImmunizationClient immunizationClient)
+            IImmunizationApi immunizationApi)
         {
             this.logger = logger;
             this.authenticationDelegate = authenticationDelegate;
-            this.immunizationClient = immunizationClient;
+            this.immunizationApi = immunizationApi;
             this.phsaConfig = new();
             configuration.Bind(PhsaConfigSectionKey, this.phsaConfig);
         }
@@ -79,7 +79,7 @@ namespace HealthGateway.Immunization.Delegates
             try
             {
                 IApiResponse<PhsaResult<ImmunizationViewResponse>> response =
-                    await this.immunizationClient.GetImmunization(immunizationId, accessToken).ConfigureAwait(true);
+                    await this.immunizationApi.GetImmunization(immunizationId, accessToken).ConfigureAwait(true);
                 this.ProcessResponse(requestResult, response);
             }
             catch (HttpRequestException e)
@@ -112,7 +112,7 @@ namespace HealthGateway.Immunization.Delegates
             try
             {
                 IApiResponse<PhsaResult<ImmunizationResponse>> response =
-                    await this.immunizationClient.GetImmunizations(query, accessToken).ConfigureAwait(true);
+                    await this.immunizationApi.GetImmunizations(query, accessToken).ConfigureAwait(true);
                 this.ProcessResponse(requestResult, response);
             }
             catch (HttpRequestException e)

--- a/Apps/Immunization/src/Startup.cs
+++ b/Apps/Immunization/src/Startup.cs
@@ -76,7 +76,7 @@ namespace HealthGateway.Immunization
             // Add API Clients
             PhsaConfig phsaConfig = new();
             this.startupConfig.Configuration.Bind(RestImmunizationDelegate.PhsaConfigSectionKey, phsaConfig);
-            services.AddRefitClient<IImmunizationClient>()
+            services.AddRefitClient<IImmunizationApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
 
             services.AddAutoMapper(typeof(Startup));

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -220,15 +220,15 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             mockApiResponse.Setup(s => s.Content).Returns(response);
             mockApiResponse.Setup(s => s.StatusCode).Returns(statusCode);
 
-            Mock<IImmunizationClient> mockImmunizationClient = new();
+            Mock<IImmunizationApi> mockImmunizationApi = new();
             if (!throwException)
             {
-                mockImmunizationClient.Setup(s => s.GetImmunization(It.IsAny<string>(), AccessToken))
+                mockImmunizationApi.Setup(s => s.GetImmunization(It.IsAny<string>(), AccessToken))
                     .ReturnsAsync(mockApiResponse.Object);
             }
             else
             {
-                mockImmunizationClient.Setup(
+                mockImmunizationApi.Setup(
                         s =>
                             s.GetImmunization(It.IsAny<string>(), AccessToken))
                     .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
@@ -238,7 +238,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 new Mock<ILogger<RestImmunizationDelegate>>().Object,
                 GetIConfigurationRoot(),
                 mockAuthDelegate.Object,
-                mockImmunizationClient.Object);
+                mockImmunizationApi.Object);
 
             return mockImmunizationDelegate;
         }
@@ -252,15 +252,15 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             mockApiResponse.Setup(s => s.Content).Returns(response);
             mockApiResponse.Setup(s => s.StatusCode).Returns(statusCode);
 
-            Mock<IImmunizationClient> mockImmunizationClient = new();
+            Mock<IImmunizationApi> mockImmunizationApi = new();
             if (!throwException)
             {
-                mockImmunizationClient.Setup(s => s.GetImmunizations(It.IsAny<Dictionary<string, string?>>(), AccessToken))
+                mockImmunizationApi.Setup(s => s.GetImmunizations(It.IsAny<Dictionary<string, string?>>(), AccessToken))
                     .ReturnsAsync(mockApiResponse.Object);
             }
             else
             {
-                mockImmunizationClient.Setup(
+                mockImmunizationApi.Setup(
                         s =>
                             s.GetImmunizations(It.IsAny<Dictionary<string, string?>>(), AccessToken))
                     .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
@@ -270,7 +270,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 new Mock<ILogger<RestImmunizationDelegate>>().Object,
                 GetIConfigurationRoot(),
                 mockAuthDelegate.Object,
-                mockImmunizationClient.Object);
+                mockImmunizationApi.Object);
 
             return mockImmunizationDelegate;
         }

--- a/Apps/Laboratory/src/Api/ILabTestKitApi.cs
+++ b/Apps/Laboratory/src/Api/ILabTestKitApi.cs
@@ -23,7 +23,7 @@ namespace HealthGateway.Laboratory.Api
     /// <summary>
     /// Interface that defines a client api to register lab tests.
     /// </summary>
-    public interface ILabTestKitClient
+    public interface ILabTestKitApi
     {
         /// <summary>
         /// Registers a lab test kit for a public user.

--- a/Apps/Laboratory/src/Services/LabTestKitService.cs
+++ b/Apps/Laboratory/src/Services/LabTestKitService.cs
@@ -33,7 +33,7 @@ namespace HealthGateway.Laboratory.Services
     public class LabTestKitService : ILabTestKitService
     {
         private readonly IAuthenticationDelegate authenticationDelegate;
-        private readonly ILabTestKitClient labTestKitClient;
+        private readonly ILabTestKitApi labTestKitApi;
         private readonly ILogger<LabTestKitService> logger;
 
         /// <summary>
@@ -41,15 +41,15 @@ namespace HealthGateway.Laboratory.Services
         /// </summary>
         /// <param name="logger">The injected logger.</param>
         /// <param name="authenticationDelegate">The auth delegate to fetch tokens.</param>
-        /// <param name="labTestKitClient">The client to use for lab tests.</param>
+        /// <param name="labTestKitApi">The client to use for lab tests.</param>
         public LabTestKitService(
             ILogger<LabTestKitService> logger,
             IAuthenticationDelegate authenticationDelegate,
-            ILabTestKitClient labTestKitClient)
+            ILabTestKitApi labTestKitApi)
         {
             this.logger = logger;
             this.authenticationDelegate = authenticationDelegate;
-            this.labTestKitClient = labTestKitClient;
+            this.labTestKitApi = labTestKitApi;
         }
 
         /// <inheritdoc/>
@@ -82,7 +82,7 @@ namespace HealthGateway.Laboratory.Services
                     try
                     {
                         HttpResponseMessage response =
-                            await this.labTestKitClient.RegisterLabTest(testKit, accessToken).ConfigureAwait(true);
+                            await this.labTestKitApi.RegisterLabTest(testKit, accessToken).ConfigureAwait(true);
                         ProcessResponse(requestResult, response);
                     }
                     catch (HttpRequestException e)
@@ -122,7 +122,7 @@ namespace HealthGateway.Laboratory.Services
             try
             {
                 HttpResponseMessage response =
-                    await this.labTestKitClient.RegisterLabTest(hdid, testKit, accessToken).ConfigureAwait(true);
+                    await this.labTestKitApi.RegisterLabTest(hdid, testKit, accessToken).ConfigureAwait(true);
                 ProcessResponse(requestResult, response);
             }
             catch (HttpRequestException e)

--- a/Apps/Laboratory/src/Startup.cs
+++ b/Apps/Laboratory/src/Startup.cs
@@ -75,7 +75,7 @@ namespace HealthGateway.Laboratory
             // Add API Clients
             LaboratoryConfig labConfig = new();
             this.startupConfig.Configuration.Bind(LaboratoryService.LabConfigSectionKey, labConfig);
-            services.AddRefitClient<ILabTestKitClient>()
+            services.AddRefitClient<ILabTestKitApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = labConfig.BaseUrl);
             services.AddRefitClient<ILaboratoryApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = labConfig.BaseUrl);

--- a/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
@@ -220,10 +220,10 @@ namespace HealthGateway.LaboratoryTests.Services
         private LabTestKitService GetLabTestKitServiceException()
         {
             HttpRequestException httpRequestException = new("Error with HTTP Request");
-            Mock<ILabTestKitClient> mockLabTestKitClient = new();
-            mockLabTestKitClient.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>()))
+            Mock<ILabTestKitApi> mockLabTestKitApi = new();
+            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>()))
                 .ThrowsAsync(httpRequestException);
-            mockLabTestKitClient.Setup(s => s.RegisterLabTest(It.IsAny<string>(), It.IsAny<LabTestKit>(), It.IsAny<string>()))
+            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<string>(), It.IsAny<LabTestKit>(), It.IsAny<string>()))
                 .ThrowsAsync(httpRequestException);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
@@ -232,17 +232,17 @@ namespace HealthGateway.LaboratoryTests.Services
             LabTestKitService labTestKitService = new(
                 new Mock<ILogger<LabTestKitService>>().Object,
                 mockAuthDelegate.Object,
-                mockLabTestKitClient.Object);
+                mockLabTestKitApi.Object);
 
             return labTestKitService;
         }
 
         private LabTestKitService GetLabTestKitService(HttpResponseMessage responseMessage, bool nullToken = false)
         {
-            Mock<ILabTestKitClient> mockLabTestKitClient = new();
-            mockLabTestKitClient.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>()))
+            Mock<ILabTestKitApi> mockLabTestKitApi = new();
+            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>()))
                 .ReturnsAsync(responseMessage);
-            mockLabTestKitClient.Setup(s => s.RegisterLabTest(It.IsAny<string>(), It.IsAny<LabTestKit>(), It.IsAny<string>()))
+            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<string>(), It.IsAny<LabTestKit>(), It.IsAny<string>()))
                 .ReturnsAsync(responseMessage);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
@@ -254,7 +254,7 @@ namespace HealthGateway.LaboratoryTests.Services
             LabTestKitService labTestKitService = new(
                 new Mock<ILogger<LabTestKitService>>().Object,
                 mockAuthDelegate.Object,
-                mockLabTestKitClient.Object);
+                mockLabTestKitApi.Object);
 
             return labTestKitService;
         }


### PR DESCRIPTION
# Implements [AB#14342](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14342)

## Description

- standardizes signatures of Refit APIs to include meta parameters last
- renames IImmunizationClient to IImmunizationApi
- renames IImmunizationAdminClient to IImmunizationAdminApi
- renames ILabTestKitClient to ILabTestKitApi

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
