### PR TITLE
Restore expected property name for serialization AB#14350

### DIFF
--- a/Apps/WebClient/src/Server/Models/TimeoutsConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/TimeoutsConfiguration.cs
@@ -15,6 +15,8 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.WebClient.Server.Models
 {
+    using System.Text.Json.Serialization;
+
     /// <summary>
     /// Various timeout values used by the VUE WebClient application.
     /// </summary>
@@ -36,6 +38,7 @@ namespace HealthGateway.WebClient.Server.Models
         /// Gets or sets the amount of time in minutes after which the user
         /// can retry the verification code.
         /// </summary>
+        [JsonPropertyName("resendSMS")]
         public int ResendSms { get; set; }
     }
 }


### PR DESCRIPTION
# Fixes [AB#14350](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14350)

## Description

Restores the casing for a config property that is passed to the front-end, resolving an error that appears when the property cannot be found.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
