### PR TITLE
Remove Password grants from Public APIs

### DIFF
--- a/Apps/AdminWebClient/src/appsettings.Development.json
+++ b/Apps/AdminWebClient/src/appsettings.Development.json
@@ -6,7 +6,6 @@
     },
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
-        "ClientId": "healthgateway-admin-local",
         "RequireHttpsMetadata": "false"
     },
     "SwaggerSettings": {

--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -68,17 +68,29 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         }
 
         /// <inheritdoc/>
-        public JwtModel AuthenticateAsSystem(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest)
+        public JwtModel AuthenticateAsSystem(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = true)
         {
-            this.logger.LogDebug("Authenticating Service... {ClientId}", tokenRequest.ClientId);
-            JwtModel? jwtModel = this.ClientCredentialsGrant(tokenUri, tokenRequest);
-            this.logger.LogDebug("Finished authenticating Service. {ClientId}", tokenRequest.ClientId);
-            if (jwtModel == null)
+            JwtModel? jwtModel;
+            string cacheKey = $"{tokenUri}:{tokenRequest.Audience}:{tokenRequest.ClientId}";
+            if (cacheEnabled)
             {
-                this.logger.LogCritical("Unable to authenticate to as {Username} to {TokenUri}", tokenRequest.Username, tokenUri);
-                throw new InvalidOperationException("Auth failure - JwtModel cannot be null");
+                jwtModel = this.cacheProvider.GetItem<JwtModel>(cacheKey);
+                if (jwtModel is null)
+                {
+                    jwtModel = this.GetSystemToken(tokenUri, tokenRequest);
+                    if (jwtModel.ExpiresIn is not null)
+                    {
+                        int expiry = jwtModel.ExpiresIn.Value - 10;
+                        this.cacheProvider.AddItem(cacheKey, jwtModel, TimeSpan.FromSeconds(expiry));
+                    }
+                }
+            }
+            else
+            {
+                jwtModel = this.GetSystemToken(tokenUri, tokenRequest);
             }
 
+            this.logger.LogDebug("Authenticating Service... {ClientId}", tokenRequest.ClientId);
             return jwtModel;
         }
 
@@ -186,6 +198,13 @@ namespace HealthGateway.Common.AccessManagement.Authentication
             ClientCredentialsTokenRequest configTokenRequest = new();
             configSection.Bind(configTokenRequest); // Client ID, Client Secret, Audience, Username, Password
             return (configUri, configTokenRequest);
+        }
+
+        private JwtModel GetSystemToken(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest)
+        {
+            JwtModel? jwtModel = this.ClientCredentialsGrant(tokenUri, tokenRequest);
+            this.logger.LogDebug("Finished authenticating Service. {ClientId}", tokenRequest.ClientId);
+            return jwtModel ?? throw new InvalidOperationException("Auth failure - JwtModel cannot be null");
         }
 
         private JwtModel? ClientCredentialsGrant(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest)

--- a/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
@@ -35,8 +35,9 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         /// </summary>
         /// <param name="tokenUri">Uri to request the the token from.</param>
         /// <param name="tokenRequest">Token request configuration.</param>
+        /// <param name="cacheEnabled">if true caches the result.</param>
         /// <returns>An instance fo the <see cref="JwtModel"/> class.</returns>
-        JwtModel AuthenticateAsSystem(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest);
+        JwtModel AuthenticateAsSystem(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = true);
 
         /// <summary>
         /// Authenticates a resource owner user with direct grant from a defined configuration section.

--- a/Apps/Common/src/AccessManagement/Authentication/Models/IAuthModel.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/Models/IAuthModel.cs
@@ -26,7 +26,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication.Models
         string? AccessToken { get; set; }
 
         /// <summary>
-        /// Gets or sets the token expiration in minutes.
+        /// Gets or sets the token expiration in seconds.
         /// </summary>
         int? ExpiresIn { get; set; }
 

--- a/Apps/Immunization/src/Api/IImmunizationPublicApi.cs
+++ b/Apps/Immunization/src/Api/IImmunizationPublicApi.cs
@@ -29,9 +29,13 @@ public interface IImmunizationPublicApi
     /// </summary>
     /// <param name="query">The model containing details of the request.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
+    /// <param name="clientIp">The ip of the client calling the service.</param>
     /// <returns>
     /// A PhsaResult containing the vaccine status of a given patient.
     /// </returns>
     [Post("/api/v1/Public/Immunizations/VaccineStatusIndicator")]
-    Task<PhsaResult<VaccineStatusResult>> GetVaccineStatus(VaccineStatusQuery query, [Authorize] string token);
+    Task<PhsaResult<VaccineStatusResult>> GetVaccineStatus(
+        VaccineStatusQuery query,
+        [Authorize] string token,
+        [Header("X-Forwarded-For")] string clientIp);
 }

--- a/Apps/Immunization/src/Delegates/IVaccineStatusDelegate.cs
+++ b/Apps/Immunization/src/Delegates/IVaccineStatusDelegate.cs
@@ -41,7 +41,8 @@ namespace HealthGateway.Immunization.Delegates
         /// </summary>
         /// <param name="query">The vaccine status query.</param>
         /// <param name="accessToken">The bearer token to authorize the call.</param>
+        /// <param name="clientIp">The IP of the client calling the service.</param>
         /// <returns>The vaccine status result for the given patient.</returns>
-        Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublic(VaccineStatusQuery query, string accessToken);
+        Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublic(VaccineStatusQuery query, string accessToken, string clientIp);
     }
 }

--- a/Apps/Immunization/src/Delegates/RestVaccineStatusDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestVaccineStatusDelegate.cs
@@ -93,7 +93,7 @@ namespace HealthGateway.Immunization.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublic(VaccineStatusQuery query, string accessToken)
+        public async Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublic(VaccineStatusQuery query, string accessToken, string clientIp)
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug(
@@ -110,7 +110,7 @@ namespace HealthGateway.Immunization.Delegates
 
             try
             {
-                PhsaResult<VaccineStatusResult> phsaResult = await this.immunizationPublicApi.GetVaccineStatus(query, accessToken).ConfigureAwait(true);
+                PhsaResult<VaccineStatusResult> phsaResult = await this.immunizationPublicApi.GetVaccineStatus(query, accessToken, clientIp).ConfigureAwait(true);
 
                 if (phsaResult.Result != null)
                 {

--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -32,7 +32,6 @@ namespace HealthGateway.Immunization.Services
     using HealthGateway.Immunization.Delegates;
     using HealthGateway.Immunization.MapUtils;
     using HealthGateway.Immunization.Models;
-    using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -43,10 +42,10 @@ namespace HealthGateway.Immunization.Services
     public class VaccineStatusService : IVaccineStatusService
     {
         private const string PhsaConfigSectionKey = "PHSA";
-        private const string AuthConfigSectionName = "ClientAuthentication";
+        private const string AuthConfigSectionName = "PublicAuthentication";
         private readonly IAuthenticationDelegate authDelegate;
         private readonly IMapper autoMapper;
-        private readonly IHttpContextAccessor httpContextAccessor;
+        private readonly IHttpContextAccessor? httpContextAccessor;
         private readonly ILogger<VaccineStatusService> logger;
         private readonly PhsaConfig phsaConfig;
         private readonly ClientCredentialsTokenRequest tokenRequest;
@@ -68,7 +67,7 @@ namespace HealthGateway.Immunization.Services
             ILogger<VaccineStatusService> logger,
             IAuthenticationDelegate authDelegate,
             IVaccineStatusDelegate vaccineStatusDelegate,
-            IHttpContextAccessor httpContextAccessor,
+            IHttpContextAccessor? httpContextAccessor,
             IMapper autoMapper)
         {
             this.authDelegate = authDelegate;
@@ -79,7 +78,7 @@ namespace HealthGateway.Immunization.Services
             this.tokenUri = configSection.GetValue<Uri>(@"TokenUri") ??
                             throw new ArgumentNullException(nameof(configuration), $"{AuthConfigSectionName} does not contain a valid TokenUri");
             this.tokenRequest = new ClientCredentialsTokenRequest();
-            configSection.Bind(this.tokenRequest); // Client ID, Client Secret, Audience, Username, Password
+            configSection.Bind(this.tokenRequest); // Client ID, Client Secret, Audience, Scope
 
             this.phsaConfig = new();
             configuration.Bind(PhsaConfigSectionKey, this.phsaConfig);
@@ -248,7 +247,7 @@ namespace HealthGateway.Immunization.Services
 
             try
             {
-                string? accessToken = this.authDelegate.AuthenticateAsUser(this.tokenUri, this.tokenRequest, true).AccessToken;
+                string? accessToken = this.authDelegate.AuthenticateAsSystem(this.tokenUri, this.tokenRequest).AccessToken;
                 retVal = await this.GetVaccineStatusFromDelegate(query, accessToken, phn).ConfigureAwait(true);
             }
             catch (InvalidOperationException e)
@@ -268,7 +267,7 @@ namespace HealthGateway.Immunization.Services
         private async Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatusWithOptionalProof(string hdid, bool includeVaccineProof)
         {
             // Gets the current user access token and pass it along to PHSA
-            string? bearerToken = await this.httpContextAccessor.HttpContext!.GetTokenAsync("access_token").ConfigureAwait(true);
+            string? bearerToken = this.authDelegate.FetchAuthenticatedUserToken();
 
             VaccineStatusQuery query = new()
             {
@@ -289,8 +288,9 @@ namespace HealthGateway.Immunization.Services
                 ResourcePayload = new() { State = VaccineState.NotFound },
             };
 
+            string ipAddress = this.httpContextAccessor?.HttpContext?.Connection.RemoteIpAddress?.MapToIPv4().ToString() ?? "0.0.0.0";
             RequestResult<PhsaResult<VaccineStatusResult>> result = string.IsNullOrEmpty(query.HdId)
-                ? await this.vaccineStatusDelegate.GetVaccineStatusPublic(query, accessToken).ConfigureAwait(true)
+                ? await this.vaccineStatusDelegate.GetVaccineStatusPublic(query, accessToken, ipAddress).ConfigureAwait(true)
                 : await this.vaccineStatusDelegate.GetVaccineStatus(query.HdId, query.IncludeFederalVaccineProof, accessToken).ConfigureAwait(true);
 
             VaccineStatusResult? payload = result.ResourcePayload?.Result;

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -4,9 +4,8 @@
             "HealthGateway": "Trace"
         }
     },
-    "OpenIdConnect": {
-        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
-        "RequireHttpsMetadata": "false"
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
     "ForwardProxies": {
         "Enabled": false
@@ -43,6 +42,6 @@
         "VaccineStatus": false
     },
     "BCMailPlus": {
-        "JobEnvironment": "JOB_TEST",
+        "JobEnvironment": "JOB_TEST"
     }
 }

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -33,11 +33,6 @@
             }
         }
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "ClientId": "healthgateway-admin-local",
-        "TokenCacheExpireMinutes": 4
-    },
     "AvailabilityFilter": {
         "VaccineStatus": false
     },

--- a/Apps/Immunization/src/appsettings.hgdev.json
+++ b/Apps/Immunization/src/appsettings.hgdev.json
@@ -23,10 +23,6 @@
         },
         "CacheTTL": 90
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
-    },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
     },

--- a/Apps/Immunization/src/appsettings.hgdev.json
+++ b/Apps/Immunization/src/appsettings.hgdev.json
@@ -4,8 +4,8 @@
             "HealthGateway": "Trace"
         }
     },
-    "OpenIdConnect": {
-        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"

--- a/Apps/Immunization/src/appsettings.hgmock.json
+++ b/Apps/Immunization/src/appsettings.hgmock.json
@@ -4,8 +4,8 @@
             "HealthGateway": "Trace"
         }
     },
-    "OpenIdConnect": {
-        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"

--- a/Apps/Immunization/src/appsettings.hgmock.json
+++ b/Apps/Immunization/src/appsettings.hgmock.json
@@ -23,10 +23,6 @@
         },
         "CacheTTL": 90
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
-    },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
     }

--- a/Apps/Immunization/src/appsettings.hgpoc.json
+++ b/Apps/Immunization/src/appsettings.hgpoc.json
@@ -4,8 +4,8 @@
             "HealthGateway": "Trace"
         }
     },
-    "OpenIdConnect": {
-        "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"

--- a/Apps/Immunization/src/appsettings.hgpoc.json
+++ b/Apps/Immunization/src/appsettings.hgpoc.json
@@ -23,10 +23,6 @@
         },
         "CacheTTL": 90
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
-    },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
     }

--- a/Apps/Immunization/src/appsettings.hgtest.json
+++ b/Apps/Immunization/src/appsettings.hgtest.json
@@ -23,10 +23,6 @@
         },
         "CacheTTL": 90
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
-    },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
     }

--- a/Apps/Immunization/src/appsettings.hgtest.json
+++ b/Apps/Immunization/src/appsettings.hgtest.json
@@ -4,8 +4,8 @@
             "HealthGateway": "Debug"
         }
     },
-    "OpenIdConnect": {
-        "Authority": "https://test.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
+    "PublicAuthentication": {
+        "TokenUri": "https://test.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-test.azurewebsites.net"

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -57,6 +57,13 @@
         },
         "CacheTTL": 90
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "ClientId": "hg-public",
+        "ClientSecret": "****",
+        "Audience": "hg",
+        "Scope": "openid"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "Audience": "healthgateway",

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -64,15 +64,6 @@
         "Audience": "hg",
         "Scope": "openid"
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "Audience": "healthgateway",
-        "Scope": "openid",
-        "ClientId": "healthgateway-admin",
-        "ClientSecret": "****",
-        "Username": "****",
-        "Password": "****"
-    },
     "AvailabilityFilter": {
         "VaccineStatus": true
     },

--- a/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
 
             Mock<IImmunizationApi> mockImmunizationApi = new(MockBehavior.Strict);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new();
-            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken)).ReturnsAsync(expectedPayload);
+            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).ReturnsAsync(expectedPayload);
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IVaccineStatusDelegate vaccineStatusDelegate = new RestVaccineStatusDelegate(
@@ -73,7 +73,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -90,7 +90,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
 
             Mock<IImmunizationApi> mockImmunizationApi = new(MockBehavior.Strict);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new();
-            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken))
+            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>()))
                 .ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.BadRequest));
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
@@ -106,7 +106,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -124,7 +124,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
 
             Mock<IImmunizationApi> mockImmunizationApi = new(MockBehavior.Strict);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new();
-            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken)).ReturnsAsync(expectedPayload);
+            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatus(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).ReturnsAsync(expectedPayload);
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IVaccineStatusDelegate vaccineStatusDelegate = new RestVaccineStatusDelegate(
@@ -139,7 +139,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty).ConfigureAwait(true);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);

--- a/Apps/Laboratory/src/Api/ILabTestKitApi.cs
+++ b/Apps/Laboratory/src/Api/ILabTestKitApi.cs
@@ -29,10 +29,14 @@ namespace HealthGateway.Laboratory.Api
         /// Registers a lab test kit for a public user.
         /// </summary>
         /// <param name="testKit">The lab test kit to register.</param>
-        /// <param name="token">The bearer token to authorize the call.</param>
+        /// <param name="token">The bearer token to authorize the call.</param>\
+        /// <param name="clientIp">The IP of the client accessing the public service.</param>
         /// <returns>The lab test kit sent.</returns>
         [Post("/api/v1/Public/LabTestKits/Registration")]
-        Task<HttpResponseMessage> RegisterLabTest([Body] PublicLabTestKit testKit, [Authorize] string token);
+        Task<HttpResponseMessage> RegisterLabTest(
+            [Body] PublicLabTestKit testKit,
+            [Authorize] string token,
+            [Header("X-Forwarded-For")] string clientIp);
 
         /// <summary>
         /// Registers a lab test kit for an authenticated user.
@@ -42,6 +46,9 @@ namespace HealthGateway.Laboratory.Api
         /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>The lab test kit sent.</returns>
         [Post("/api/v1/LabTestKits/Registration?subjectHdid={HdId}")]
-        Task<HttpResponseMessage> RegisterLabTest(string hdid, [Body] LabTestKit testKit, [Authorize] string token);
+        Task<HttpResponseMessage> RegisterLabTest(
+            string hdid,
+            [Body] LabTestKit testKit,
+            [Authorize] string token);
     }
 }

--- a/Apps/Laboratory/src/Api/ILaboratoryApi.cs
+++ b/Apps/Laboratory/src/Api/ILaboratoryApi.cs
@@ -71,8 +71,12 @@ namespace HealthGateway.Laboratory.Api
         /// </summary>
         /// <param name="query">Query parameters used to query the public covid test results.</param>
         /// <param name="token">The bearer token to authorize the call.</param>
+        /// <param name="clientIp">The ip of the client to send.</param>
         /// <returns>The public covid test results identified by the query parameters.</returns>
         [Post("/api/v1/Public/LabOrders/Covid19LabSummary")]
-        Task<PhsaResult<IEnumerable<CovidTestResult>>> GetPublicCovidLabSummaryAsync([Body] Dictionary<string, string?> query, [Authorize] string token);
+        Task<PhsaResult<IEnumerable<CovidTestResult>>> GetPublicCovidLabSummaryAsync(
+            [Body] Dictionary<string, string?> query,
+            [Authorize] string token,
+            [Header("X-Forwarded-For")] string clientIp);
     }
 }

--- a/Apps/Laboratory/src/Services/LabTestKitService.cs
+++ b/Apps/Laboratory/src/Services/LabTestKitService.cs
@@ -27,6 +27,7 @@ namespace HealthGateway.Laboratory.Services
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Laboratory.Api;
     using HealthGateway.Laboratory.Models.PHSA;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
@@ -35,6 +36,7 @@ namespace HealthGateway.Laboratory.Services
         private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly ILabTestKitApi labTestKitApi;
         private readonly ILogger<LabTestKitService> logger;
+        private readonly IHttpContextAccessor? httpContextAccessor;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LabTestKitService"/> class.
@@ -42,14 +44,17 @@ namespace HealthGateway.Laboratory.Services
         /// <param name="logger">The injected logger.</param>
         /// <param name="authenticationDelegate">The auth delegate to fetch tokens.</param>
         /// <param name="labTestKitApi">The client to use for lab tests.</param>
+        /// <param name="httpContextAccessor">The injected http context accessor.</param>
         public LabTestKitService(
             ILogger<LabTestKitService> logger,
             IAuthenticationDelegate authenticationDelegate,
-            ILabTestKitApi labTestKitApi)
+            ILabTestKitApi labTestKitApi,
+            IHttpContextAccessor? httpContextAccessor)
         {
             this.logger = logger;
             this.authenticationDelegate = authenticationDelegate;
             this.labTestKitApi = labTestKitApi;
+            this.httpContextAccessor = httpContextAccessor;
         }
 
         /// <inheritdoc/>
@@ -81,8 +86,9 @@ namespace HealthGateway.Laboratory.Services
                 {
                     try
                     {
+                        string ipAddress = this.httpContextAccessor?.HttpContext?.Connection.RemoteIpAddress?.MapToIPv4().ToString() ?? "0.0.0.0";
                         HttpResponseMessage response =
-                            await this.labTestKitApi.RegisterLabTest(testKit, accessToken).ConfigureAwait(true);
+                            await this.labTestKitApi.RegisterLabTest(testKit, accessToken, ipAddress).ConfigureAwait(true);
                         ProcessResponse(requestResult, response);
                     }
                     catch (HttpRequestException e)

--- a/Apps/Laboratory/src/appsettings.Development.json
+++ b/Apps/Laboratory/src/appsettings.Development.json
@@ -32,10 +32,5 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
-    },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "ClientId": "healthgateway-admin-local",
-        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Laboratory/src/appsettings.Development.json
+++ b/Apps/Laboratory/src/appsettings.Development.json
@@ -30,6 +30,9 @@
             }
         }
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "ClientId": "healthgateway-admin-local",

--- a/Apps/Laboratory/src/appsettings.hgdev.json
+++ b/Apps/Laboratory/src/appsettings.hgdev.json
@@ -24,6 +24,9 @@
         },
         "CacheTTL": 90
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "TokenCacheExpireMinutes": 4

--- a/Apps/Laboratory/src/appsettings.hgdev.json
+++ b/Apps/Laboratory/src/appsettings.hgdev.json
@@ -27,9 +27,5 @@
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
-    },
     "RedisAuditing": true
 }

--- a/Apps/Laboratory/src/appsettings.hgmock.json
+++ b/Apps/Laboratory/src/appsettings.hgmock.json
@@ -25,9 +25,5 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
-    },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Laboratory/src/appsettings.hgmock.json
+++ b/Apps/Laboratory/src/appsettings.hgmock.json
@@ -23,6 +23,9 @@
         },
         "CacheTTL": 90
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "TokenCacheExpireMinutes": 4

--- a/Apps/Laboratory/src/appsettings.hgpoc.json
+++ b/Apps/Laboratory/src/appsettings.hgpoc.json
@@ -23,6 +23,9 @@
         "Enabled": true,
         "ConsoleEnabled": true
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "TokenCacheExpireMinutes": 4

--- a/Apps/Laboratory/src/appsettings.hgpoc.json
+++ b/Apps/Laboratory/src/appsettings.hgpoc.json
@@ -25,9 +25,5 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
-    },
-    "ClientAuthentication": {
-        "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Laboratory/src/appsettings.hgtest.json
+++ b/Apps/Laboratory/src/appsettings.hgtest.json
@@ -25,9 +25,5 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
-    },
-    "ClientAuthentication": {
-        "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "TokenCacheExpireMinutes": 4
     }
 }

--- a/Apps/Laboratory/src/appsettings.hgtest.json
+++ b/Apps/Laboratory/src/appsettings.hgtest.json
@@ -23,6 +23,9 @@
         "Enabled": true,
         "ConsoleEnabled": true
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "TokenCacheExpireMinutes": 4

--- a/Apps/Laboratory/src/appsettings.json
+++ b/Apps/Laboratory/src/appsettings.json
@@ -64,6 +64,13 @@
         },
         "CacheTTL": 90
     },
+    "PublicAuthentication": {
+        "TokenUri": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "ClientId": "hg-public",
+        "ClientSecret": "****",
+        "Audience": "hg",
+        "Scope": "openid"
+    },
     "ClientAuthentication": {
         "TokenUri": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
         "Audience": "healthgateway",

--- a/Apps/Laboratory/src/appsettings.json
+++ b/Apps/Laboratory/src/appsettings.json
@@ -71,16 +71,6 @@
         "Audience": "hg",
         "Scope": "openid"
     },
-    "ClientAuthentication": {
-        "TokenUri": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-        "Audience": "healthgateway",
-        "Scope": "openid",
-        "ClientId": "healthgateway-admin",
-        "ClientSecret": "****",
-        "Username": "****",
-        "Password": "****",
-        "TokenCacheExpireMinutes": 30
-    },
     "AuthCache": {
         "TokenCacheExpireMinutes": "20"
     }

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -33,6 +33,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
     using HealthGateway.Laboratory.Models;
     using HealthGateway.Laboratory.Models.PHSA;
     using HealthGateway.LaboratoryTests.Utils;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -90,7 +91,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
@@ -118,7 +120,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
@@ -147,7 +150,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
@@ -175,7 +179,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
@@ -207,7 +212,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
@@ -234,7 +240,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
@@ -262,7 +269,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
@@ -290,7 +298,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
@@ -323,7 +332,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
@@ -351,7 +361,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
@@ -379,7 +390,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
@@ -407,7 +419,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
@@ -459,14 +472,15 @@ namespace HealthGateway.LaboratoryTests.Delegates
             };
 
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ReturnsAsync(response);
+            mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<IEnumerable<CovidTestResult>>> actualResult =
@@ -489,14 +503,15 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Post);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<IEnumerable<CovidTestResult>>> actualResult =
@@ -519,14 +534,15 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             HttpRequestException mockException = MockRefitException.CreateHttpRequestException("Internal Server Error", HttpStatusCode.InternalServerError);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPublicCovidLabSummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<IEnumerable<CovidTestResult>>> actualResult =
@@ -562,7 +578,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
@@ -588,7 +605,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
@@ -617,7 +635,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
@@ -645,7 +664,8 @@ namespace HealthGateway.LaboratoryTests.Delegates
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
                 mockLaboratoryApi.Object,
-                this.configuration);
+                this.configuration,
+                new Mock<IHttpContextAccessor>().Object);
 
             // Act
             RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);

--- a/Apps/Laboratory/test/unit/Factories/LaboratoryDelegateFactoryTests.cs
+++ b/Apps/Laboratory/test/unit/Factories/LaboratoryDelegateFactoryTests.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.LaboratoryTests.Factories
     using HealthGateway.Laboratory.Delegates;
     using HealthGateway.Laboratory.Factories;
     using HealthGateway.Laboratory.Services;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -79,6 +80,7 @@ namespace HealthGateway.LaboratoryTests.Factories
             IConfigurationRoot config = GetIConfigurationRoot();
             services.AddSingleton<IConfiguration>(config);
 
+            services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
             return services.BuildServiceProvider();
         }
     }

--- a/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
+++ b/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
@@ -15,10 +15,12 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.LaboratoryTests.Mock
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using AutoMapper;
     using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.AccessManagement.Authentication.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Laboratory.Factories;
@@ -138,8 +140,17 @@ namespace HealthGateway.LaboratoryTests.Mock
 
         private static IAuthenticationDelegate GetMockAuthDelegate(string token)
         {
+            JwtModel jwt = new JwtModel()
+            {
+                AccessToken = token,
+            };
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(token);
+            mockAuthDelegate.Setup(
+                    s => s.AuthenticateAsSystem(
+                        It.IsAny<Uri>(),
+                        It.IsAny<ClientCredentialsTokenRequest>(),
+                        It.IsAny<bool>()))
+                .Returns(jwt);
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(token);
             return mockAuthDelegate.Object;
         }

--- a/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
@@ -221,7 +221,7 @@ namespace HealthGateway.LaboratoryTests.Services
         {
             HttpRequestException httpRequestException = new("Error with HTTP Request");
             Mock<ILabTestKitApi> mockLabTestKitApi = new();
-            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>()))
+            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(httpRequestException);
             mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<string>(), It.IsAny<LabTestKit>(), It.IsAny<string>()))
                 .ThrowsAsync(httpRequestException);
@@ -232,7 +232,8 @@ namespace HealthGateway.LaboratoryTests.Services
             LabTestKitService labTestKitService = new(
                 new Mock<ILogger<LabTestKitService>>().Object,
                 mockAuthDelegate.Object,
-                mockLabTestKitApi.Object);
+                mockLabTestKitApi.Object,
+                null);
 
             return labTestKitService;
         }
@@ -240,7 +241,7 @@ namespace HealthGateway.LaboratoryTests.Services
         private LabTestKitService GetLabTestKitService(HttpResponseMessage responseMessage, bool nullToken = false)
         {
             Mock<ILabTestKitApi> mockLabTestKitApi = new();
-            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>()))
+            mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<PublicLabTestKit>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ReturnsAsync(responseMessage);
             mockLabTestKitApi.Setup(s => s.RegisterLabTest(It.IsAny<string>(), It.IsAny<LabTestKit>(), It.IsAny<string>()))
                 .ReturnsAsync(responseMessage);
@@ -254,7 +255,8 @@ namespace HealthGateway.LaboratoryTests.Services
             LabTestKitService labTestKitService = new(
                 new Mock<ILogger<LabTestKitService>>().Object,
                 mockAuthDelegate.Object,
-                mockLabTestKitApi.Object);
+                mockLabTestKitApi.Object,
+                null);
 
             return labTestKitService;
         }

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -354,9 +354,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string dateOfBirthString = this.dateOfBirth.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string collectionDateString = this.collectionDate.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<PublicCovidTestResponse> actualResult = Task.Run(async () => await service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).ConfigureAwait(true))
-                .Result;
-
+            RequestResult<PublicCovidTestResponse> actualResult = service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).GetAwaiter().GetResult();
             expectedResult.ShouldDeepEqual(actualResult);
         }
 
@@ -389,8 +387,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string dateOfBirthString = this.dateOfBirth.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string collectionDateString = this.collectionDate.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<PublicCovidTestResponse> actualResult = Task.Run(async () => await service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).ConfigureAwait(true))
-                .Result;
+            RequestResult<PublicCovidTestResponse> actualResult = service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).GetAwaiter().GetResult();
 
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.Equal(ActionType.DataMismatch, actualResult.ResultError?.ActionCode);
@@ -426,8 +423,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string dateOfBirthString = this.dateOfBirth.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string collectionDateString = this.collectionDate.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<PublicCovidTestResponse> actualResult = Task.Run(async () => await service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).ConfigureAwait(true))
-                .Result;
+            RequestResult<PublicCovidTestResponse> actualResult = service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).GetAwaiter().GetResult();
 
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.Equal(ActionType.Invalid, actualResult.ResultError?.ActionCode);
@@ -458,8 +454,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string dateOfBirthString = this.dateOfBirth.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string collectionDateString = this.collectionDate.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<PublicCovidTestResponse> actualResult = Task.Run(async () => await service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).ConfigureAwait(true))
-                .Result;
+            RequestResult<PublicCovidTestResponse> actualResult = service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, collectionDateString).GetAwaiter().GetResult();
 
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.Equal(ActionType.Refresh, actualResult.ResultError?.ActionCode);
@@ -486,8 +481,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string dateOfBirthString = this.dateOfBirth.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string collectionDateString = this.collectionDate.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<PublicCovidTestResponse> actualResult = Task.Run(async () => await service.GetPublicCovidTestsAsync(invalidPhn, dateOfBirthString, collectionDateString).ConfigureAwait(true))
-                .Result;
+            RequestResult<PublicCovidTestResponse> actualResult = service.GetPublicCovidTestsAsync(invalidPhn, dateOfBirthString, collectionDateString).GetAwaiter().GetResult();
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -516,7 +510,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string collectionDateString = this.collectionDate.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
             RequestResult<PublicCovidTestResponse> actualResult =
-                Task.Run(async () => await service.GetPublicCovidTestsAsync(this.phn, invalidDateOfBirthString, collectionDateString).ConfigureAwait(true)).Result;
+                service.GetPublicCovidTestsAsync(this.phn, invalidDateOfBirthString, collectionDateString).GetAwaiter().GetResult();
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -544,7 +538,7 @@ namespace HealthGateway.LaboratoryTests.Services
             string invalidCollectionDateString = this.collectionDate.ToString(dateFormat, CultureInfo.CurrentCulture);
 
             RequestResult<PublicCovidTestResponse> actualResult =
-                Task.Run(async () => await service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, invalidCollectionDateString).ConfigureAwait(true)).Result;
+                service.GetPublicCovidTestsAsync(this.phn, dateOfBirthString, invalidCollectionDateString).GetAwaiter().GetResult();
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }

--- a/Tools/KeyCloak/Terraform/client_hg_admin_blazor.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_admin_blazor.tf
@@ -64,7 +64,7 @@ resource "keycloak_openid_user_attribute_protocol_mapper" "hgadminblazor_auth_me
 
 resource "keycloak_openid_audience_protocol_mapper" "hgadminblazor_audience" {
   realm_id                 = data.keycloak_realm.hg_realm.id
-  client_id                = keycloak_openid_client.hgadminblazor_client.id 
+  client_id                = keycloak_openid_client.hgadminblazor_client.id
   name                     = "hg-admin-audience"
   included_client_audience = keycloak_openid_client.hgadmin_client.client_id #Grant HG Admin Audience not Blazor
   add_to_id_token          = true

--- a/Tools/KeyCloak/Terraform/client_hg_phsa.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_phsa.tf
@@ -20,7 +20,8 @@ resource "keycloak_openid_client_default_scopes" "hgphsa_client_default_scopes" 
   default_scopes = [
     "web-origins",
     keycloak_openid_client_scope.audience_scope.name,
-    keycloak_openid_client_scope.system_patient_read_scope.name
+    keycloak_openid_client_scope.system_patient_read_scope.name,
+    keycloak_openid_client_scope.phsa_scope.name
   ]
 }
 resource "keycloak_openid_client_optional_scopes" "hgphsa_client_optional_scopes" {

--- a/Tools/KeyCloak/Terraform/client_hg_phsa.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_phsa.tf
@@ -20,7 +20,7 @@ resource "keycloak_openid_client_default_scopes" "hgphsa_client_default_scopes" 
   default_scopes = [
     "web-origins",
     keycloak_openid_client_scope.audience_scope.name,
-    keycloak_openid_client_scope.patient_read_scope.name
+    keycloak_openid_client_scope.system_patient_read_scope.name
   ]
 }
 resource "keycloak_openid_client_optional_scopes" "hgphsa_client_optional_scopes" {

--- a/Tools/KeyCloak/Terraform/client_hg_public.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_public.tf
@@ -1,0 +1,62 @@
+resource "keycloak_openid_client" "hgpublic_client" {
+  realm_id                     = data.keycloak_realm.hg_realm.id
+  client_id                    = var.client_hg_public.id
+  name                         = "Health Gateway Public - ${var.environment.name}"
+  description                  = "Health Gateway PHSA integration"
+  enabled                      = true
+  access_type                  = "CONFIDENTIAL"
+  login_theme                  = "bcgov"
+  standard_flow_enabled        = true
+  direct_access_grants_enabled = true
+  service_accounts_enabled     = true
+  valid_redirect_uris          = var.client_hg_public.valid_redirects
+  web_origins                  = var.client_hg_public.web_origins
+  full_scope_allowed           = false
+}
+
+resource "keycloak_openid_client_default_scopes" "hgpublic_client_default_scopes" {
+  realm_id  = data.keycloak_realm.hg_realm.id
+  client_id = keycloak_openid_client.hgpublic_client.id
+  default_scopes = [
+    "profile",
+    "web-origins",
+    "roles",
+    keycloak_openid_client_scope.audience_scope.name,
+    keycloak_openid_client_scope.patient_read_scope.name,
+    keycloak_openid_client_scope.laboratory_read_scope.name,
+    keycloak_openid_client_scope.immunization_read_scope.name,
+  ]
+}
+
+resource "keycloak_generic_role_mapper" "hgpublic_anonymous" {
+  realm_id  = data.keycloak_realm.hg_realm.id
+  client_id = keycloak_openid_client.hgpublic_client.id
+  role_id   = keycloak_role.Anonymous.id
+}
+
+resource "keycloak_openid_audience_protocol_mapper" "hgpublic_audience" {
+  realm_id                 = data.keycloak_realm.hg_realm.id
+  client_id                = keycloak_openid_client.hgpublic_client.id
+  name                     = "health-gateway-audience"
+  included_client_audience = keycloak_openid_client.hg_client.client_id
+  add_to_id_token          = true
+  add_to_access_token      = true
+}
+
+resource "keycloak_openid_client_service_account_realm_role" "hgpublic_sa_anonymous_role" {
+  realm_id                = data.keycloak_realm.hg_realm.id
+  service_account_user_id = keycloak_openid_client.hgpublic_client.service_account_user_id
+  role                    = keycloak_role.Anonymous.name
+}
+
+resource "keycloak_openid_user_realm_role_protocol_mapper" "hgpublic_realmroles" {
+  realm_id            = data.keycloak_realm.hg_realm.id
+  client_id           = keycloak_openid_client.hgpublic_client.id
+  name                = "realm roles"
+  multivalued         = true
+  claim_name          = "roles"
+  claim_value_type    = "String"
+  add_to_id_token     = true
+  add_to_access_token = true
+  add_to_userinfo     = true
+}

--- a/Tools/KeyCloak/Terraform/client_scopes.tf
+++ b/Tools/KeyCloak/Terraform/client_scopes.tf
@@ -68,6 +68,13 @@ resource "keycloak_openid_client_scope" "system_notification_write_scope" {
   include_in_token_scope = true
 }
 
+resource "keycloak_openid_client_scope" "phsa_scope" {
+  realm_id               = data.keycloak_realm.hg_realm.id
+  name                   = "phsa"
+  description            = "Used by kong to remove API limits for PHSA"
+  include_in_token_scope = true
+}
+
 resource "keycloak_openid_client_scope" "audience_scope" {
   realm_id               = data.keycloak_realm.hg_realm.id
   name                   = "audience"

--- a/Tools/KeyCloak/Terraform/client_scopes.tf
+++ b/Tools/KeyCloak/Terraform/client_scopes.tf
@@ -47,6 +47,13 @@ resource "keycloak_openid_client_scope" "patient_read_scope" {
   include_in_token_scope = true
 }
 
+resource "keycloak_openid_client_scope" "system_patient_read_scope" {
+  realm_id               = data.keycloak_realm.hg_realm.id
+  name                   = "system/Patient.read"
+  description            = "Abilty to read any patient's as a system"
+  include_in_token_scope = true
+}
+
 resource "keycloak_openid_client_scope" "system_notification_read_scope" {
   realm_id               = data.keycloak_realm.hg_realm.id
   name                   = "system/Notification.read"

--- a/Tools/KeyCloak/Terraform/client_scopes.tf
+++ b/Tools/KeyCloak/Terraform/client_scopes.tf
@@ -54,6 +54,20 @@ resource "keycloak_openid_client_scope" "system_patient_read_scope" {
   include_in_token_scope = true
 }
 
+resource "keycloak_openid_client_scope" "system_laboratory_read_scope" {
+  realm_id               = data.keycloak_realm.hg_realm.id
+  name                   = "system/Laboratory.read"
+  description            = "Abilty to read any patient's lab data as a system"
+  include_in_token_scope = true
+}
+
+resource "keycloak_openid_client_scope" "system_immunization_read_scope" {
+  realm_id               = data.keycloak_realm.hg_realm.id
+  name                   = "system/Immunization.read"
+  description            = "Abilty to read any patient's Immunization data as a system"
+  include_in_token_scope = true
+}
+
 resource "keycloak_openid_client_scope" "system_notification_read_scope" {
   realm_id               = data.keycloak_realm.hg_realm.id
   name                   = "system/Notification.read"

--- a/Tools/KeyCloak/Terraform/variables.tf
+++ b/Tools/KeyCloak/Terraform/variables.tf
@@ -130,6 +130,15 @@ variable "client_hg" {
   description = "HealthGateway client configuration"
 }
 
+variable "client_hg_public" {
+  type = object({
+    id              = optional(string, "hg-public")
+    valid_redirects = list(string)
+    web_origins     = list(string)
+  })
+  description = "HealthGateway Public Authentication for PHSA"
+}
+
 locals {
   development = var.environment.name == "Development"
 }


### PR DESCRIPTION
# Fixes or Implements [AB#14275](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14275)

## Description

Replaces password grants with credentials grant for public apis

This should fix a good chunk of the broken Cypress tests.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
