### PR TITLE
Update back-end for notification centre AB#14357

### DIFF
--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -82,7 +82,7 @@ namespace HealthGateway.Admin.Server
 
             WebApplication app = builder.Build();
             HttpWeb.UseForwardHeaders(app, logger, configuration);
-            HttpWeb.UseHttp(app, logger, configuration, environment, true);
+            HttpWeb.UseHttp(app, logger, configuration, environment, true, false);
             HttpWeb.UseContentSecurityPolicy(app, configuration);
             SwaggerDoc.UseSwagger(app, logger);
             Auth.UseAuth(app, logger);

--- a/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
@@ -73,10 +73,10 @@ namespace HealthGateway.ClinicalDocument.Services
             this.logger.LogDebug("Getting clinical documents for hdid: {Hdid}", hdid);
             try
             {
-                RequestResult<PersonalAccount?> patientAccountResponse = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+                RequestResult<PersonalAccount> patientAccountResponse = await this.personalAccountsService.GetPatientAccountResultAsync(hdid).ConfigureAwait(true);
                 if (patientAccountResponse.ResultStatus == ResultType.Success)
                 {
-                    string? pid = patientAccountResponse.ResourcePayload?.PatientIdentity?.Pid.ToString();
+                    string? pid = patientAccountResponse.ResourcePayload?.PatientIdentity.Pid.ToString();
                     this.logger.LogDebug("PID Fetched: {Pid}", pid);
                     PhsaHealthDataResponse apiResponse =
                         await this.clinicalDocumentsApi.GetClinicalDocumentRecordsAsync(pid).ConfigureAwait(true);
@@ -118,10 +118,10 @@ namespace HealthGateway.ClinicalDocument.Services
             this.logger.LogDebug("Getting clinical document file for hdid: {Hdid}", hdid);
             try
             {
-                RequestResult<PersonalAccount?> response = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+                RequestResult<PersonalAccount> response = await this.personalAccountsService.GetPatientAccountResultAsync(hdid).ConfigureAwait(true);
                 if (response.ResultStatus == ResultType.Success)
                 {
-                    string? pid = response.ResourcePayload?.PatientIdentity?.Pid.ToString();
+                    string? pid = response.ResourcePayload?.PatientIdentity.Pid.ToString();
                     this.logger.LogDebug("PID Fetched: {Pid}", pid);
                     EncodedMedia apiResponse =
                         await this.clinicalDocumentsApi.GetClinicalDocumentFileAsync(pid, fileId).ConfigureAwait(true);

--- a/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
+++ b/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
@@ -169,13 +169,13 @@ namespace HealthGateway.ClinicalDocumentTests.Services
             {
                 PatientIdentity = patientIdentity,
             };
-            RequestResult<PersonalAccount?> requestResult = new()
+            RequestResult<PersonalAccount> requestResult = new()
             {
                 ResourcePayload = personalAccount,
                 ResultStatus = ResultType.Success,
             };
             Mock<IPersonalAccountsService> personalAccountServiceMock = new();
-            personalAccountServiceMock.Setup(p => p.GetPatientAccountAsync(It.IsAny<string>())).ReturnsAsync(requestResult);
+            personalAccountServiceMock.Setup(p => p.GetPatientAccountResultAsync(It.IsAny<string>())).ReturnsAsync(requestResult);
 
             return new ClinicalDocumentService(
                 new Mock<ILogger<ClinicalDocumentService>>().Object,

--- a/Apps/Common/src/AspNetConfiguration/Modules/ExceptionHandling.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/ExceptionHandling.cs
@@ -1,0 +1,67 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.AspNetConfiguration.Modules
+{
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.Data.ErrorHandling;
+    using HealthGateway.Common.ErrorHandling;
+    using Hellang.Middleware.ProblemDetails;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
+    /// <summary>
+    /// Provides ASP.Net Services for exception handling.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public static class ExceptionHandling
+    {
+        /// <summary>
+        /// Adds and configures the services required to use problem details.
+        /// </summary>
+        /// <param name="services">The service collection to add forward proxies into.</param>
+        /// <param name="environment">The environment the services are associated with.</param>
+        public static void ConfigureProblemDetails(IServiceCollection services, IWebHostEnvironment environment)
+        {
+            services.AddProblemDetails(
+                setup =>
+                {
+                    setup.IncludeExceptionDetails = (_, _) => environment.IsDevelopment();
+
+                    setup.Map<ApiException>(
+                        exception => new ApiProblemDetails
+                        {
+                            Title = exception.Title,
+                            Detail = exception.Detail,
+                            Status = exception.StatusCode,
+                            Type = exception.ProblemType,
+                            Instance = exception.Instance,
+                            AdditionalInfo = exception.AdditionalInfo,
+                        });
+                });
+        }
+
+        /// <summary>
+        /// Configures the app to use problem details middleware.
+        /// </summary>
+        /// <param name="app">The application builder where modules are specified to be used.</param>
+        public static void UseProblemDetails(IApplicationBuilder app)
+        {
+            app.UseProblemDetails();
+        }
+    }
+}

--- a/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
@@ -73,20 +73,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// <param name="configuration">The configuration to use.</param>
         /// <param name="environment">The environment to use.</param>
         /// <param name="blazor">If true, will add blazor optimizations for static files.</param>
-        public static void UseHttp(IApplicationBuilder app, ILogger logger, IConfiguration configuration, IWebHostEnvironment environment, bool blazor = false)
-        {
-            UseHttp(app, logger, configuration, environment, blazor, true);
-        }
-
-        /// <summary>
-        /// Configures the app to use http.
-        /// </summary>
-        /// <param name="app">The application builder provider.</param>
-        /// <param name="logger">The logger to use.</param>
-        /// <param name="configuration">The configuration to use.</param>
-        /// <param name="environment">The environment to use.</param>
-        /// <param name="blazor">If true, will add blazor optimizations for static files.</param>
-        /// <param name="useExceptionPage">If true, app will use development exception page.</param>
+        /// <param name="useExceptionPage">If true, app will use development exception page. Should be false when using problem details middleware.</param>
         public static void UseHttp(IApplicationBuilder app, ILogger logger, IConfiguration configuration, IWebHostEnvironment environment, bool blazor, bool useExceptionPage)
         {
             app.UseResponseCompression();

--- a/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
@@ -23,16 +23,10 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
     using System.ServiceModel.Description;
     using System.ServiceModel.Dispatcher;
     using System.ServiceModel.Security;
-    using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Delegates;
-    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Services;
-    using Hellang.Middleware.ProblemDetails;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using ServiceReference;
 
@@ -86,41 +80,6 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
             services.AddTransient<IClientRegistriesDelegate, ClientRegistriesDelegate>();
             services.AddTransient<IPatientService, PatientService>();
             GatewayCache.ConfigureCaching(services, logger, configuration);
-        }
-
-        /// <summary>
-        /// Configures patient service to use Problem Details exception handling.
-        /// </summary>
-        /// <param name="services">The service collection to add forward proxies into.</param>
-        /// <param name="environment">The environment the services are associated with.</param>
-        public static void ConfigurePatientExceptionHandling(IServiceCollection services, IWebHostEnvironment environment)
-        {
-            services.AddProblemDetails(
-                setup =>
-                {
-                    setup.IncludeExceptionDetails = (_, _) => environment.IsDevelopment();
-
-                    setup.Map<ApiException>(
-                        exception => new ApiProblemDetails
-                        {
-                            Title = exception.Title,
-                            Detail = exception.Detail,
-                            Status = exception.StatusCode,
-                            Type = exception.ProblemType,
-                            Instance = exception.Instance,
-                            AdditionalInfo = exception.AdditionalInfo,
-                        });
-                });
-        }
-
-        /// <summary>
-        /// Configures patient service to use the specified exception handling.
-        /// </summary>
-        /// <param name="app">The application builder where modules are specified to be used.</param>
-        /// <param name="environment">The environment the services are associated with.</param>
-        public static void ConfigurePatientExceptionHandling(IApplicationBuilder app, IWebHostEnvironment environment)
-        {
-            app.UseProblemDetails();
         }
     }
 }

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -127,6 +127,15 @@ namespace HealthGateway.Common.AspNetConfiguration
         }
 
         /// <summary>
+        /// Configures the services required to use problem details.
+        /// </summary>
+        /// <param name="services">The service collection provider.</param>
+        public void ConfigureProblemDetails(IServiceCollection services)
+        {
+            ExceptionHandling.ConfigureProblemDetails(services, this.environment);
+        }
+
+        /// <summary>
         /// Configures Forward proxies.
         /// </summary>
         /// <param name="services">The service collection to add forward proxies into.</param>
@@ -202,9 +211,13 @@ namespace HealthGateway.Common.AspNetConfiguration
         /// Configures the app to use http.
         /// </summary>
         /// <param name="app">The application builder provider.</param>
-        public void UseHttp(IApplicationBuilder app)
+        /// <param name="useExceptionPage">
+        /// If true, app will use development exception page. Should be false when using problem
+        /// details middleware.
+        /// </param>
+        public void UseHttp(IApplicationBuilder app, bool useExceptionPage = true)
         {
-            HttpWeb.UseHttp(app, this.Logger, this.Configuration, this.environment);
+            HttpWeb.UseHttp(app, this.Logger, this.Configuration, this.environment, false, useExceptionPage);
         }
 
         /// <summary>

--- a/Apps/Common/src/Constants/ErrorMessages.cs
+++ b/Apps/Common/src/Constants/ErrorMessages.cs
@@ -36,6 +36,11 @@ namespace HealthGateway.Common.Constants
         public const string RecordsNotAvailable = "The records you requested are not currently available.";
 
         /// <summary>
+        /// Error message to return when the action cannot currently be performed.
+        /// </summary>
+        public const string CannotPerformAction = "The action cannot currently be performed.";
+
+        /// <summary>
         /// Error message to return when a Pharmanet record is protected.
         /// </summary>
         public const string ProtectiveWordErrorMessage = "Record protected by keyword";

--- a/Apps/Common/src/Models/PHSA/PersonalAccount.cs
+++ b/Apps/Common/src/Models/PHSA/PersonalAccount.cs
@@ -57,6 +57,6 @@ namespace HealthGateway.Common.Models.PHSA
         /// Gets or sets the Patient Identity.
         /// </summary>
         [JsonPropertyName("patientIdentity")]
-        public PatientIdentity? PatientIdentity { get; set; }
+        public PatientIdentity PatientIdentity { get; set; } = null!;
     }
 }

--- a/Apps/Common/src/Services/IPersonalAccountsService.cs
+++ b/Apps/Common/src/Services/IPersonalAccountsService.cs
@@ -25,17 +25,17 @@ namespace HealthGateway.Common.Services
     public interface IPersonalAccountsService
     {
         /// <summary>
-        /// Gets the Personal Account information from PHSA using the supplied HDID.
+        /// Gets personal account information from PHSA using the supplied HDID.
         /// </summary>
-        /// <param name="hdid">The Hdid to lookup.</param>
-        /// <returns>The PHSA PersonalAccount wrapped in a RequestResult.</returns>
-        Task<RequestResult<PersonalAccount?>> GetPatientAccountAsync(string hdid);
+        /// <param name="hdid">The HDID to look up.</param>
+        /// <returns>The personal account model.</returns>
+        Task<PersonalAccount> GetPatientAccountAsync(string hdid);
 
         /// <summary>
-        /// Gets the Personal Account information from PHSA using the supplied HDID.
+        /// Gets personal account information from PHSA using the supplied HDID.
         /// </summary>
-        /// <param name="hdid">The Hdid to lookup.</param>
-        /// <returns>The PHSA PersonalAccount wrapped in a RequestResult.</returns>
-        RequestResult<PersonalAccount?> GetPatientAccount(string hdid);
+        /// <param name="hdid">The HDID to look up.</param>
+        /// <returns>The personal account model wrapped in a RequestResult.</returns>
+        Task<RequestResult<PersonalAccount>> GetPatientAccountResultAsync(string hdid);
     }
 }

--- a/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.CommonTests.Services
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
@@ -40,8 +41,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// Get Personal Account.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetPatientAccount()
+        public async Task ShouldGetPatientAccount()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -50,7 +52,7 @@ namespace HealthGateway.CommonTests.Services
             IPersonalAccountsService personalAccountsServiceService = GetPersonalAccountsService(expectedPersonalAccount, false, false);
 
             // Act
-            RequestResult<PersonalAccount?> actualResult = personalAccountsServiceService.GetPatientAccount(It.IsAny<string>());
+            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>()).ConfigureAwait(true);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -61,8 +63,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// Get Personal Account - from cache.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetPatientAccountUseCache()
+        public async Task ShouldGetPatientAccountUseCache()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -71,7 +74,7 @@ namespace HealthGateway.CommonTests.Services
             IPersonalAccountsService personalAccountsServiceService = GetPersonalAccountsService(expectedPersonalAccount, true, false);
 
             // Act
-            RequestResult<PersonalAccount?> actualResult = personalAccountsServiceService.GetPatientAccount(It.IsAny<string>());
+            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>()).ConfigureAwait(true);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -82,8 +85,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// Get Personal Account throws HttpRequestException.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetPatientAccountThrowsException()
+        public async Task ShouldGetPatientAccountThrowsException()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -92,7 +96,7 @@ namespace HealthGateway.CommonTests.Services
             IPersonalAccountsService personalAccountsServiceService = GetPersonalAccountsService(expectedPersonalAccount, false, true);
 
             // Act
-            RequestResult<PersonalAccount?> actualResult = personalAccountsServiceService.GetPatientAccount(It.IsAny<string>());
+            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>()).ConfigureAwait(true);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -121,6 +125,7 @@ namespace HealthGateway.CommonTests.Services
                 Id = id,
                 CreationTimeStampUtc = DateTime.Today,
                 ModifyTimeStampUtc = DateTime.Today,
+                PatientIdentity = new(),
             };
         }
 

--- a/Apps/CommonData/src/ErrorHandling/ApiException.cs
+++ b/Apps/CommonData/src/ErrorHandling/ApiException.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Data.ErrorHandling
 {
     using System;
     using System.Net;
+    using System.Runtime.CompilerServices;
     using System.Runtime.Serialization;
 
     /// <summary>
@@ -30,7 +31,7 @@ namespace HealthGateway.Common.Data.ErrorHandling
         /// </summary>
         /// <param name="detail">The detail associated with the exception.</param>
         /// <param name="instance">The instance associated with the exception.</param>
-        /// <param name="statusCode">The http status code associated with the exception.</param>
+        /// <param name="statusCode">The HTTP status code associated with the exception.</param>
         public ApiException(string detail, string instance, HttpStatusCode statusCode)
         {
             this.ProblemType = "api-exception";
@@ -39,6 +40,18 @@ namespace HealthGateway.Common.Data.ErrorHandling
             this.AdditionalInfo = "Please try again at a later time.";
             this.Instance = instance;
             this.StatusCode = (int)statusCode;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ApiException"/> class.
+        /// </summary>
+        /// <param name="detail">The detail associated with the exception.</param>
+        /// <param name="statusCode">The HTTP status code associated with the exception.</param>
+        /// <param name="typeName">The name of the type where the exception was generated.</param>
+        /// <param name="memberName">The type of the method or property where the exception was generated.</param>
+        public ApiException(string detail, HttpStatusCode statusCode, string typeName, [CallerMemberName] string memberName = "")
+            : this(detail, $"{typeName}.{memberName}", statusCode)
+        {
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Api/IWebAlertApi.cs
+++ b/Apps/GatewayApi/src/Api/IWebAlertApi.cs
@@ -1,0 +1,54 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Api
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.GatewayApi.Models.Phsa;
+    using Refit;
+
+    /// <summary>
+    /// Interface to interact with PHSA Web Alert API.
+    /// </summary>
+    public interface IWebAlertApi
+    {
+        /// <summary>
+        /// Retrieves all web alerts for a patient.
+        /// </summary>
+        /// <param name="pid">The patient's PID.</param>
+        /// <returns>The collection of web alerts for the specified patient.</returns>
+        [Get("/personal-accounts/{pid}/web-alerts")]
+        Task<IList<PhsaWebAlert>> GetWebAlertsAsync(string pid);
+
+        /// <summary>
+        /// Dismisses all web alerts for a patient.
+        /// </summary>
+        /// <param name="pid">The patient's PID.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        [Delete("/personal-accounts/{pid}/web-alerts")]
+        Task DeleteWebAlertsAsync(string pid);
+
+        /// <summary>
+        /// Dismisses a web alert for a patient.
+        /// </summary>
+        /// <param name="pid">The patient's PID.</param>
+        /// <param name="id">The ID of the web alert to be deleted.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        [Delete("/personal-accounts/{pid}/web-alerts/{id}")]
+        Task DeleteWebAlertAsync(string pid, Guid id);
+    }
+}

--- a/Apps/GatewayApi/src/Controllers/NotificationController.cs
+++ b/Apps/GatewayApi/src/Controllers/NotificationController.cs
@@ -1,0 +1,118 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.AccessManagement.Authorization.Policy;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Services;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// Web API to handle patient notes interactions.
+    /// </summary>
+    [Authorize]
+    [ApiVersion("1.0")]
+    [Route("[controller]")]
+    [ApiController]
+    public class NotificationController : ControllerBase
+    {
+        private readonly IWebAlertService webAlertService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationController"/> class.
+        /// </summary>
+        /// <param name="webAlertService">The injected web alert service.</param>
+        public NotificationController(IWebAlertService webAlertService)
+        {
+            this.webAlertService = webAlertService;
+        }
+
+        /// <summary>
+        /// Gets all notifications for a user.
+        /// </summary>
+        /// <param name="hdid">The HDID of the user.</param>
+        /// <returns>The collection of notifications.</returns>
+        /// <response code="200">Returns the collection of notifications.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        [Route("{hdid}")]
+        [Authorize(Policy = UserProfilePolicy.Read)]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WebAlert>))]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Get(string hdid)
+        {
+            IList<WebAlert> notifications = await this.webAlertService.GetWebAlertsAsync(hdid).ConfigureAwait(true);
+            return this.Ok(notifications);
+        }
+
+        /// <summary>
+        /// Dismisses all notifications for a user.
+        /// </summary>
+        /// <returns>An empty result.</returns>
+        /// <param name="hdid">The HDID of the user.</param>
+        /// <response code="200">The notifications were dismissed.</response>
+        /// <response code="401">The client must authenticate itself to perform the operation.</response>
+        /// <response code="403">
+        /// The client does not have access rights to perform the operation; that is, it is unauthorized.
+        /// Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpDelete]
+        [Route("{hdid}")]
+        [Authorize(Policy = UserProfilePolicy.Write)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> DismissAll(string hdid)
+        {
+            await this.webAlertService.DismissWebAlertsAsync(hdid).ConfigureAwait(true);
+            return this.Ok();
+        }
+
+        /// <summary>
+        /// Dismisses a notification for a user.
+        /// </summary>
+        /// <returns>An empty result.</returns>
+        /// <param name="hdid">The HDID of the user.</param>
+        /// <param name="id">The ID of the notification to be dismissed.</param>
+        /// <response code="200">The notification was dismissed.</response>
+        /// <response code="401">The client must authenticate itself to perform the operation.</response>
+        /// <response code="403">
+        /// The client does not have access rights to perform the operation; that is, it is unauthorized.
+        /// Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpDelete]
+        [Route("{hdid}/{id:guid}")]
+        [Authorize(Policy = UserProfilePolicy.Write)]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IActionResult> Dismiss(string hdid, [FromQuery] Guid id)
+        {
+            await this.webAlertService.DismissWebAlertAsync(hdid, id).ConfigureAwait(true);
+            return this.Ok();
+        }
+    }
+}

--- a/Apps/GatewayApi/src/MapProfiles/WebAlertProfile.cs
+++ b/Apps/GatewayApi/src/MapProfiles/WebAlertProfile.cs
@@ -1,0 +1,35 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.MapProfiles
+{
+    using AutoMapper;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Models.Phsa;
+
+    /// <summary>
+    /// An AutoMapper profile that defines mappings between PHSA and Health Gateway Models.
+    /// </summary>
+    public class WebAlertProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebAlertProfile"/> class.
+        /// </summary>
+        public WebAlertProfile()
+        {
+            this.CreateMap<PhsaWebAlert, WebAlert>();
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Models/Phsa/PhsaWebAlert.cs
+++ b/Apps/GatewayApi/src/Models/Phsa/PhsaWebAlert.cs
@@ -1,0 +1,93 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Models.Phsa
+{
+    using System;
+    using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// Model representing a PHSA web alert.
+    /// </summary>
+    public class PhsaWebAlert
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category name.
+        /// </summary>
+        [JsonPropertyName("categoryName")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        [JsonPropertyName("type")]
+        public PhsaWebAlertType Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text.
+        /// </summary>
+        [JsonPropertyName("displayText")]
+        public string? DisplayText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action URL.
+        /// </summary>
+        [JsonPropertyName("actionUrl")]
+        public Uri? ActionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action type.
+        /// </summary>
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the creator.
+        /// </summary>
+        [JsonPropertyName("creator")]
+        public string? Creator { get; set; }
+
+        /// <summary>
+        /// Gets or sets the target ID.
+        /// </summary>
+        [JsonPropertyName("targetId")]
+        public string? TargetId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scheduled datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("scheduledDateUtc")]
+        public DateTime ScheduledDateTimeUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expiration datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("expirationDateUtc")]
+        public DateTime ExpirationDateTimeUtc { get; set; }
+
+        /// <summary>
+        /// Gets or sets the created datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("creationDateUtc")]
+        public DateTime CreationDateTimeUtc { get; set; }
+    }
+}

--- a/Apps/GatewayApi/src/Models/Phsa/PhsaWebAlertType.cs
+++ b/Apps/GatewayApi/src/Models/Phsa/PhsaWebAlertType.cs
@@ -1,0 +1,36 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Models.Phsa
+{
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// Represents the type of a web alert.
+    /// </summary>
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum PhsaWebAlertType
+    {
+        /// <summary>
+        /// System.
+        /// </summary>
+        System,
+
+        /// <summary>
+        /// Account.
+        /// </summary>
+        Account,
+    }
+}

--- a/Apps/GatewayApi/src/Models/WebAlert.cs
+++ b/Apps/GatewayApi/src/Models/WebAlert.cs
@@ -1,0 +1,63 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// Model representing a Health Gateway web alert.
+    /// </summary>
+    public class WebAlert
+    {
+        /// <summary>
+        /// Gets or sets the id.
+        /// </summary>
+        [JsonPropertyName("id")]
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the category name.
+        /// </summary>
+        [JsonPropertyName("categoryName")]
+        public string? CategoryName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text.
+        /// </summary>
+        [JsonPropertyName("displayText")]
+        public string? DisplayText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action URL.
+        /// </summary>
+        [JsonPropertyName("actionUrl")]
+        public Uri? ActionUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action type.
+        /// </summary>
+        [JsonPropertyName("actionType")]
+        public BroadcastActionType ActionType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the scheduled datetime in UTC.
+        /// </summary>
+        [JsonPropertyName("scheduledDateTimeUtc")]
+        public DateTime ScheduledDateTimeUtc { get; set; }
+    }
+}

--- a/Apps/GatewayApi/src/Services/IWebAlertService.cs
+++ b/Apps/GatewayApi/src/Services/IWebAlertService.cs
@@ -1,0 +1,50 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.GatewayApi.Models;
+
+    /// <summary>
+    /// Service to interact with the the PHSA web alert API.
+    /// </summary>
+    public interface IWebAlertService
+    {
+        /// <summary>
+        /// Gets all web alerts for a user.
+        /// </summary>
+        /// <param name="hdid">The HDID of the user.</param>
+        /// <returns>The list of web alerts for the user.</returns>
+        Task<IList<WebAlert>> GetWebAlertsAsync(string hdid);
+
+        /// <summary>
+        /// Dismisses all web alert for a user.
+        /// </summary>
+        /// <param name="hdid">The HDID of the user.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task DismissWebAlertsAsync(string hdid);
+
+        /// <summary>
+        /// Dismisses a web alert for a user.
+        /// </summary>
+        /// <param name="hdid">The HDID of the user.</param>
+        /// <param name="webAlertId">The ID of the web alert to be dismissed.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task DismissWebAlertAsync(string hdid, Guid webAlertId);
+    }
+}

--- a/Apps/GatewayApi/src/Services/WebAlertService.cs
+++ b/Apps/GatewayApi/src/Services/WebAlertService.cs
@@ -19,18 +19,14 @@ namespace HealthGateway.GatewayApi.Services
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
-    using System.Net;
-    using System.Net.Http;
     using System.Threading.Tasks;
     using AutoMapper;
-    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.GatewayApi.Api;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Models.Phsa;
     using Microsoft.Extensions.Logging;
-    using Refit;
 
     /// <summary>
     /// The Patient data service.
@@ -64,22 +60,14 @@ namespace HealthGateway.GatewayApi.Services
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Retrieving web alerts from PHSA.");
-            try
-            {
-                PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
-                string pid = personalAccount.PatientIdentity.Pid.ToString();
+            PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+            string pid = personalAccount.PatientIdentity.Pid.ToString();
 
-                IList<PhsaWebAlert> phsaWebAlerts = await this.webAlertApi.GetWebAlertsAsync(pid).ConfigureAwait(true);
-                IList<WebAlert> webAlerts = this.autoMapper.Map<IEnumerable<PhsaWebAlert>, IList<WebAlert>>(
-                    phsaWebAlerts.Where(a => a.ExpirationDateTimeUtc > DateTime.UtcNow && a.ScheduledDateTimeUtc < DateTime.UtcNow));
-                this.logger.LogDebug("Finished retrieving web alerts from PHSA.");
-                return webAlerts;
-            }
-            catch (Exception e) when (e is ApiException or HttpRequestException)
-            {
-                this.logger.LogError(e, "Error retrieving web alerts from PHSA.");
-                throw new Common.Data.ErrorHandling.ApiException(ErrorMessages.RecordsNotAvailable, HttpStatusCode.BadGateway, nameof(WebAlertService));
-            }
+            IList<PhsaWebAlert> phsaWebAlerts = await this.webAlertApi.GetWebAlertsAsync(pid).ConfigureAwait(true);
+            IList<WebAlert> webAlerts = this.autoMapper.Map<IEnumerable<PhsaWebAlert>, IList<WebAlert>>(
+                phsaWebAlerts.Where(a => a.ExpirationDateTimeUtc > DateTime.UtcNow && a.ScheduledDateTimeUtc < DateTime.UtcNow));
+            this.logger.LogDebug("Finished retrieving web alerts from PHSA.");
+            return webAlerts;
         }
 
         /// <inheritdoc/>
@@ -87,19 +75,11 @@ namespace HealthGateway.GatewayApi.Services
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Sending request to dismiss web alerts to PHSA.");
-            try
-            {
-                PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
-                string pid = personalAccount.PatientIdentity.Pid.ToString();
+            PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+            string pid = personalAccount.PatientIdentity.Pid.ToString();
 
-                await this.webAlertApi.DeleteWebAlertsAsync(pid).ConfigureAwait(true);
-                this.logger.LogDebug("Finished sending request to dismiss web alerts to PHSA.");
-            }
-            catch (Exception e) when (e is ApiException or HttpRequestException)
-            {
-                this.logger.LogError(e, "Error sending request to dismiss web alerts to PHSA.");
-                throw new Common.Data.ErrorHandling.ApiException(ErrorMessages.CannotPerformAction, HttpStatusCode.BadGateway, nameof(WebAlertService));
-            }
+            await this.webAlertApi.DeleteWebAlertsAsync(pid).ConfigureAwait(true);
+            this.logger.LogDebug("Finished sending request to dismiss web alerts to PHSA.");
         }
 
         /// <inheritdoc/>
@@ -107,19 +87,11 @@ namespace HealthGateway.GatewayApi.Services
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Sending request to dismiss web alert to PHSA.");
-            try
-            {
-                PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
-                string pid = personalAccount.PatientIdentity.Pid.ToString();
+            PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+            string pid = personalAccount.PatientIdentity.Pid.ToString();
 
-                await this.webAlertApi.DeleteWebAlertAsync(pid, webAlertId).ConfigureAwait(true);
-                this.logger.LogDebug("Finished sending request to dismiss web alert to PHSA.");
-            }
-            catch (Exception e) when (e is ApiException or HttpRequestException)
-            {
-                this.logger.LogError(e, "Error sending request to dismiss web alert to PHSA.");
-                throw new Common.Data.ErrorHandling.ApiException(ErrorMessages.CannotPerformAction, HttpStatusCode.BadGateway, nameof(WebAlertService));
-            }
+            await this.webAlertApi.DeleteWebAlertAsync(pid, webAlertId).ConfigureAwait(true);
+            this.logger.LogDebug("Finished sending request to dismiss web alert to PHSA.");
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/WebAlertService.cs
+++ b/Apps/GatewayApi/src/Services/WebAlertService.cs
@@ -1,0 +1,125 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Common.Services;
+    using HealthGateway.GatewayApi.Api;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Models.Phsa;
+    using Microsoft.Extensions.Logging;
+    using Refit;
+
+    /// <summary>
+    /// The Patient data service.
+    /// </summary>
+    public class WebAlertService : IWebAlertService
+    {
+        private readonly ILogger<WebAlertService> logger;
+        private readonly IPersonalAccountsService personalAccountsService;
+        private readonly IWebAlertApi webAlertApi;
+        private readonly IMapper autoMapper;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WebAlertService"/> class.
+        /// </summary>
+        /// <param name="logger">The injected logger.</param>
+        /// <param name="personalAccountsService">The injected personal accounts service.</param>
+        /// <param name="webAlertApi">The injected Refit API.</param>
+        /// <param name="autoMapper">The injected automapper.</param>
+        public WebAlertService(ILogger<WebAlertService> logger, IPersonalAccountsService personalAccountsService, IWebAlertApi webAlertApi, IMapper autoMapper)
+        {
+            this.logger = logger;
+            this.personalAccountsService = personalAccountsService;
+            this.webAlertApi = webAlertApi;
+            this.autoMapper = autoMapper;
+        }
+
+        private static ActivitySource Source { get; } = new(nameof(WebAlertService));
+
+        /// <inheritdoc/>
+        public async Task<IList<WebAlert>> GetWebAlertsAsync(string hdid)
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Retrieving web alerts from PHSA.");
+            try
+            {
+                PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+                string pid = personalAccount.PatientIdentity.Pid.ToString();
+
+                IList<PhsaWebAlert> phsaWebAlerts = await this.webAlertApi.GetWebAlertsAsync(pid).ConfigureAwait(true);
+                IList<WebAlert> webAlerts = this.autoMapper.Map<IEnumerable<PhsaWebAlert>, IList<WebAlert>>(
+                    phsaWebAlerts.Where(a => a.ExpirationDateTimeUtc > DateTime.UtcNow && a.ScheduledDateTimeUtc < DateTime.UtcNow));
+                this.logger.LogDebug("Finished retrieving web alerts from PHSA.");
+                return webAlerts;
+            }
+            catch (Exception e) when (e is ApiException or HttpRequestException)
+            {
+                this.logger.LogError(e, "Error retrieving web alerts from PHSA.");
+                throw new Common.Data.ErrorHandling.ApiException(ErrorMessages.RecordsNotAvailable, HttpStatusCode.BadGateway, nameof(WebAlertService));
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task DismissWebAlertsAsync(string hdid)
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Sending request to dismiss web alerts to PHSA.");
+            try
+            {
+                PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+                string pid = personalAccount.PatientIdentity.Pid.ToString();
+
+                await this.webAlertApi.DeleteWebAlertsAsync(pid).ConfigureAwait(true);
+                this.logger.LogDebug("Finished sending request to dismiss web alerts to PHSA.");
+            }
+            catch (Exception e) when (e is ApiException or HttpRequestException)
+            {
+                this.logger.LogError(e, "Error sending request to dismiss web alerts to PHSA.");
+                throw new Common.Data.ErrorHandling.ApiException(ErrorMessages.CannotPerformAction, HttpStatusCode.BadGateway, nameof(WebAlertService));
+            }
+        }
+
+        /// <inheritdoc/>
+        public async Task DismissWebAlertAsync(string hdid, Guid webAlertId)
+        {
+            using Activity? activity = Source.StartActivity();
+            this.logger.LogDebug("Sending request to dismiss web alert to PHSA.");
+            try
+            {
+                PersonalAccount personalAccount = await this.personalAccountsService.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+                string pid = personalAccount.PatientIdentity.Pid.ToString();
+
+                await this.webAlertApi.DeleteWebAlertAsync(pid, webAlertId).ConfigureAwait(true);
+                this.logger.LogDebug("Finished sending request to dismiss web alert to PHSA.");
+            }
+            catch (Exception e) when (e is ApiException or HttpRequestException)
+            {
+                this.logger.LogError(e, "Error sending request to dismiss web alert to PHSA.");
+                throw new Common.Data.ErrorHandling.ApiException(ErrorMessages.CannotPerformAction, HttpStatusCode.BadGateway, nameof(WebAlertService));
+            }
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -60,6 +60,7 @@ namespace HealthGateway.GatewayApi
         /// <param name="services">The injected services provider.</param>
         public void ConfigureServices(IServiceCollection services)
         {
+            this.startupConfig.ConfigureProblemDetails(services);
             this.startupConfig.ConfigureForwardHeaders(services);
             this.startupConfig.ConfigureDatabaseServices(services);
             this.startupConfig.ConfigureHttpServices(services);
@@ -131,9 +132,10 @@ namespace HealthGateway.GatewayApi
         /// <param name="env">The hosting environment.</param>
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            ExceptionHandling.UseProblemDetails(app);
             this.startupConfig.UseForwardHeaders(app);
             this.startupConfig.UseSwagger(app);
-            this.startupConfig.UseHttp(app);
+            this.startupConfig.UseHttp(app, false);
             this.startupConfig.UseAuth(app);
             this.startupConfig.UseRest(app);
 

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -35,5 +35,9 @@
     "CDOGS": {
         "DynamicServiceLookup": "false",
         "BaseEndpoint": "https://dev-hgcdogs.healthgateway.gov.bc.ca"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgateway-dev.azurewebsites.net"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgdev.json
+++ b/Apps/GatewayApi/src/appsettings.hgdev.json
@@ -25,5 +25,9 @@
         "Enabled": true,
         "ConsoleEnabled": true
     },
-    "RedisAuditing": true
+    "RedisAuditing": true,
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgateway-dev.azurewebsites.net"
+    }
 }

--- a/Apps/GatewayApi/src/appsettings.hgmock.json
+++ b/Apps/GatewayApi/src/appsettings.hgmock.json
@@ -24,5 +24,9 @@
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgateway-dev.azurewebsites.net"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgpoc.json
+++ b/Apps/GatewayApi/src/appsettings.hgpoc.json
@@ -24,5 +24,9 @@
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
+        "BaseUrl": "https://phsa-ccd-api-healthgateway-dev.azurewebsites.net"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgtest.json
+++ b/Apps/GatewayApi/src/appsettings.hgtest.json
@@ -24,5 +24,8 @@
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true
+    },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-identity-test.azurewebsites.net"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -98,8 +98,8 @@
         "BaseUrl": "https://phsa-ccd-api-identity-prod.azurewebsites.net",
         "ClientId": "****",
         "ClientSecret": "****",
-        "GrantType": "delegation",
-        "Scope": "healthdata.read",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "Scope": "healthdata.read webalert.read",
         "TokenCacheEnabled": true
     }
 }

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -93,5 +93,13 @@
     },
     "HttpClient": {
         "Timeout": "00:02:00"
+    },
+    "PhsaV2": {
+        "BaseUrl": "https://phsa-ccd-api-identity-prod.azurewebsites.net",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "delegation",
+        "Scope": "healthdata.read",
+        "TokenCacheEnabled": true
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Utils/MapperUtil.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Utils/MapperUtil.cs
@@ -35,13 +35,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Utils
             MapperConfiguration config = new(
                 cfg =>
                 {
-                    cfg.AddProfile(new DependentInformationProfile());
-                    cfg.AddProfile(new DependentProfile());
-                    cfg.AddProfile(new TermsOfServiceProfile());
-                    cfg.AddProfile(new UserCommentProfile());
-                    cfg.AddProfile(new UserNoteProfile());
-                    cfg.AddProfile(new UserPreferenceProfile());
-                    cfg.AddProfile(new UserProfileProfile());
+                    cfg.AddProfile<DependentInformationProfile>();
+                    cfg.AddProfile<DependentProfile>();
+                    cfg.AddProfile<TermsOfServiceProfile>();
+                    cfg.AddProfile<UserCommentProfile>();
+                    cfg.AddProfile<UserNoteProfile>();
+                    cfg.AddProfile<UserPreferenceProfile>();
+                    cfg.AddProfile<UserProfileProfile>();
+                    cfg.AddProfile<WebAlertProfile>();
                 });
 
             return config.CreateMapper();

--- a/Apps/Medication/src/Delegates/RestMedStatementDelegate.cs
+++ b/Apps/Medication/src/Delegates/RestMedStatementDelegate.cs
@@ -34,6 +34,7 @@ namespace HealthGateway.Medication.Delegates
     using HealthGateway.Medication.Models.ODR;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
+    using ApiException = Refit.ApiException;
 
     /// <summary>
     /// ODR Implementation for Rest Medication Statements.

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -47,7 +47,7 @@ namespace HealthGateway.Patient
             ILogger logger = ProgramConfiguration.GetInitialLogger(configuration);
             IWebHostEnvironment environment = builder.Environment;
 
-            Patient.ConfigurePatientExceptionHandling(services, environment);
+            ExceptionHandling.ConfigureProblemDetails(services, environment);
             HttpWeb.ConfigureForwardHeaders(services, logger, configuration);
             Db.ConfigureDatabaseServices(services, logger, configuration);
             HttpWeb.ConfigureHttpServices(services, logger);
@@ -64,8 +64,7 @@ namespace HealthGateway.Patient
             Utility.ConfigureTracing(services, logger, configuration);
 
             WebApplication app = builder.Build();
-            Patient.ConfigurePatientExceptionHandling(app, environment);
-
+            ExceptionHandling.UseProblemDetails(app);
             HttpWeb.UseForwardHeaders(app, logger, configuration);
             SwaggerDoc.UseSwagger(app, logger);
             HttpWeb.UseHttp(app, logger, configuration, environment, false, false);


### PR DESCRIPTION
# Implements [AB#14357](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14357)

## Description

- catches Refit.ApiException instead of the ApiException in Common.Data (bugfix)
- refactors problem details configuration into ExceptionHandling module
- updates GatewayApi to use problem details
- introduces overload for instantiating ApiException
- refactors GetPatientAccountAsync to forgo RequestResult
- updates back-end for notification centre
- removed try/catch block in service to allow middleware (ProblemDetails) to handle exceptions
- updated token config in appsetttings to communicate with PHSA token swap.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
