### PR TITLE
Remove Password grants from Admin and cleanout oidc for AB#14403

### DIFF
--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -14,8 +14,8 @@
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/ https://dev.loginproxy.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "PatientService": {
         "ClientRegistry": {
@@ -27,13 +27,8 @@
         }
     },
     "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "BaseUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f"
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "Features": {
         "Showcase": true

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -12,9 +12,9 @@
         }
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/ https://dev.loginproxy.gov.bc.ca/",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "PatientService": {
         "ClientRegistry": {
@@ -26,13 +26,8 @@
         }
     },
     "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "BaseUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f"
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "Features": {
         "Showcase": true

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -12,9 +12,9 @@
         }
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/ https://dev.loginproxy.gov.bc.ca/",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "PatientService": {
         "ClientRegistry": {
@@ -26,13 +26,8 @@
         }
     },
     "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "BaseUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f"
+        "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "Features": {
         "Showcase": true

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -12,9 +12,9 @@
         }
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/ https://test.loginproxy.gov.bc.ca/",
-        "FrameSource": "'self' https://test.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://test.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://test.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://test.loginproxy.gov.bc.ca/"
     },
     "PatientService": {
         "ClientRegistry": {
@@ -26,13 +26,8 @@
         }
     },
     "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "BaseUrl": "https://test.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f"
+        "TokenUri": "https://test.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "BaseUrl": "https://test.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "ServiceEndpoints": {
         "JobScheduler": "https://test.healthgateway.gov.bc.ca/admin/jobscheduler"

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -57,13 +57,13 @@
         "Base": "'self'",
         "DefaultSource": "'self'",
         "ScriptSource": "'self' 'wasm-eval' 'unsafe-eval' 'unsafe-inline'",
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://oidc.gov.bc.ca/ https://loginproxy.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/",
         "ImageSource": "'self' data:",
         "StyleSource": "'self' 'unsafe-inline' https://fonts.googleapis.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",
         "FormAction": "'self'",
         "FontSource": "'self' https://fonts.gstatic.com/ https://use.fontawesome.com/",
-        "FrameSource": "'self' https://oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://oidc.gov.bc.ca"
+        "FrameSource": "'self' https://loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://loginproxy.gov.bc.ca/"
     },
     "PatientService": {
         "ClientRegistry": {
@@ -75,13 +75,10 @@
         "CacheTTL": 90
     },
     "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "BaseUrl": "https://oidc.gov.bc.ca/auth/admin/realms/ff09qn3f"
+        "TokenUri": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
+        "ClientId": "hg-keycloak",
+        "ClientSecret": "****",
+        "BaseUrl": "https://loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "Features": {
         "Showcase": false,

--- a/Apps/AdminWebClient/src/appsettings.Development.json
+++ b/Apps/AdminWebClient/src/appsettings.Development.json
@@ -13,8 +13,8 @@
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "AllowedHosts": "*",
     "AddCors": {
@@ -47,14 +47,5 @@
     },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
-    },
-    "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "GetRolesUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f/roles/"
     }
 }

--- a/Apps/AdminWebClient/src/appsettings.hgdev.json
+++ b/Apps/AdminWebClient/src/appsettings.hgdev.json
@@ -25,14 +25,5 @@
     },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
-    },
-    "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "GetRolesUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f/roles/"
     }
 }

--- a/Apps/AdminWebClient/src/appsettings.hgmock.json
+++ b/Apps/AdminWebClient/src/appsettings.hgmock.json
@@ -25,14 +25,5 @@
     },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
-    },
-    "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "GetRolesUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f/roles/"
     }
 }

--- a/Apps/AdminWebClient/src/appsettings.hgpoc.json
+++ b/Apps/AdminWebClient/src/appsettings.hgpoc.json
@@ -25,14 +25,5 @@
     },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
-    },
-    "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://dev.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "GetRolesUrl": "https://dev.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f/roles/"
     }
 }

--- a/Apps/AdminWebClient/src/appsettings.hgtest.json
+++ b/Apps/AdminWebClient/src/appsettings.hgtest.json
@@ -25,14 +25,5 @@
     },
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
-    },
-    "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://test.oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "GetRolesUrl": "https://test.oidc.gov.bc.ca/auth/admin/realms/ff09qn3f/roles/"
     }
 }

--- a/Apps/AdminWebClient/src/appsettings.json
+++ b/Apps/AdminWebClient/src/appsettings.json
@@ -96,14 +96,5 @@
     "VaccineCard": {
         "PrintTemplate": "CombinedCover",
         "MailTemplate": "CombinedCover"
-    },
-    "KeycloakAdmin": {
-        "Authentication": {
-            "TokenUri": "https://oidc.gov.bc.ca/auth/realms/ff09qn3f/protocol/openid-connect/token",
-            "ClientId": "admin-cli",
-            "Username": "****",
-            "Password": "****"
-        },
-        "GetRolesUrl": "https://oidc.gov.bc.ca/auth/admin/realms/ff09qn3f/roles/"
     }
 }

--- a/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
     using HealthGateway.Admin.Models.CovidSupport;
     using HealthGateway.Admin.Services;
     using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.AccessManagement.Authentication.Models;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.ViewModels;
@@ -156,7 +157,12 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         private static ICovidSupportService GetCovidSupportService(HttpClient httpClient)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
+            JwtModel jwt = new()
+            {
+                AccessToken = AccessToken,
+            };
+
+            mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwt);
             IImmunizationAdminApi immunizationAdminApi = RestService.For<IImmunizationAdminApi>(httpClient);
             ICovidSupportService mockCovidSupportService = new CovidSupportService(
                 new Mock<ILogger<CovidSupportService>>().Object,
@@ -175,7 +181,12 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         private static ICovidSupportService GetCovidSupportService(CovidAssessmentResponse response, HttpStatusCode statusCode, bool throwException)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
+            JwtModel jwt = new()
+            {
+                AccessToken = AccessToken,
+            };
+
+            mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwt);
 
             Mock<IApiResponse<CovidAssessmentResponse>> mockApiResponse = new();
             mockApiResponse.Setup(s => s.Content).Returns(response);
@@ -214,7 +225,12 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         private static ICovidSupportService GetCovidSupportService(CovidAssessmentDetailsResponse response, HttpStatusCode statusCode, bool throwException)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(AccessToken);
+            JwtModel jwt = new()
+            {
+                AccessToken = AccessToken,
+            };
+
+            mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwt);
 
             Mock<IApiResponse<CovidAssessmentDetailsResponse>> mockApiResponse = new();
             mockApiResponse.Setup(s => s.Content).Returns(response);

--- a/Apps/ClinicalDocument/src/appsettings.json
+++ b/Apps/ClinicalDocument/src/appsettings.json
@@ -56,7 +56,7 @@
         "BaseUrl": "https://phsa-ccd-api-identity-prod.azurewebsites.net",
         "ClientId": "****",
         "ClientSecret": "****",
-        "GrantType": "delegation",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
         "Scope": "healthdata.read",
         "TokenCacheEnabled": true
     }

--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -95,29 +95,6 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         }
 
         /// <inheritdoc/>
-        public string? AccessTokenAsUser(string sectionName = IAuthenticationDelegate.DefaultAuthConfigSectionName)
-        {
-            (Uri tUri, ClientCredentialsTokenRequest tRequest) = this.GetConfiguration(sectionName);
-            return this.AccessTokenAsUser(tUri, tRequest);
-        }
-
-        /// <inheritdoc/>
-        public string? AccessTokenAsUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = true)
-        {
-            string? accessToken = null;
-            try
-            {
-                accessToken = this.AuthenticateAsUser(tokenUri, tokenRequest, cacheEnabled).AccessToken;
-            }
-            catch (InvalidOperationException e)
-            {
-                this.logger.LogDebug("Internal issue - returning null access token {Exception}", e.ToString());
-            }
-
-            return accessToken;
-        }
-
-        /// <inheritdoc/>
         public JwtModel AuthenticateAsUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = false)
         {
             (JwtModel jwtModel, _) = this.AuthenticateUser(tokenUri, tokenRequest, cacheEnabled);

--- a/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/IAuthenticationDelegate.cs
@@ -26,11 +26,6 @@ namespace HealthGateway.Common.AccessManagement.Authentication
     public interface IAuthenticationDelegate
     {
         /// <summary>
-        /// The default configuration section to retrieve auth information from.
-        /// </summary>
-        public const string DefaultAuthConfigSectionName = "ClientAuthentication";
-
-        /// <summary>
         /// Authenticates as a 'system admin account' concept, using OAuth 2.0 Client Credentials Grant.
         /// </summary>
         /// <param name="tokenUri">Uri to request the the token from.</param>
@@ -38,23 +33,6 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         /// <param name="cacheEnabled">if true caches the result.</param>
         /// <returns>An instance fo the <see cref="JwtModel"/> class.</returns>
         JwtModel AuthenticateAsSystem(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = true);
-
-        /// <summary>
-        /// Authenticates a resource owner user with direct grant from a defined configuration section.
-        /// </summary>
-        /// <param name="sectionName">The configuration section used to lookup values.</param>
-        /// <returns>The access token for the user information provided in configuration.</returns>
-        string? AccessTokenAsUser(string sectionName = DefaultAuthConfigSectionName);
-
-        /// <summary>
-        /// Authenticates a resource owner user with direct grant, no user intervention.
-        /// Proxies to AuthenticateAsUser.
-        /// </summary>
-        /// <param name="tokenUri">Uri to request the the token from.</param>
-        /// <param name="tokenRequest">Token request configuration.</param>
-        /// <param name="cacheEnabled">if true caches the result.</param>
-        /// <returns>The access token for the user tokenRequest.</returns>
-        string? AccessTokenAsUser(Uri tokenUri, ClientCredentialsTokenRequest tokenRequest, bool cacheEnabled = true);
 
         /// <summary>
         /// Authenticates a resource owner user with direct grant, no user intervention.

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -16,8 +16,8 @@
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "PatientService": {
         "ClientRegistry": {

--- a/Apps/GatewayApi/src/appsettings.hgdev.json
+++ b/Apps/GatewayApi/src/appsettings.hgdev.json
@@ -17,9 +17,9 @@
         "CacheTTL": 90
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
         "Enabled": true,

--- a/Apps/GatewayApi/src/appsettings.hgmock.json
+++ b/Apps/GatewayApi/src/appsettings.hgmock.json
@@ -17,9 +17,9 @@
         "CacheTTL": 90
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
         "Enabled": true,

--- a/Apps/GatewayApi/src/appsettings.hgpoc.json
+++ b/Apps/GatewayApi/src/appsettings.hgpoc.json
@@ -17,9 +17,9 @@
         "CacheTTL": 90
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.oidc.gov.bc.ca/",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
         "Enabled": true,

--- a/Apps/GatewayApi/src/appsettings.hgtest.json
+++ b/Apps/GatewayApi/src/appsettings.hgtest.json
@@ -17,9 +17,9 @@
         "CacheTTL": 90
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.oidc.gov.bc.ca/",
-        "FrameSource": "'self' https://test.oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://test.oidc.gov.bc.ca/"
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/",
+        "FrameSource": "'self' https://test.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://test.loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
         "Enabled": true,

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -55,13 +55,13 @@
         "Base": "'self'",
         "DefaultSource": "'self'",
         "ScriptSource": "'self' 'unsafe-eval' 'sha256-Tui7QoFlnLXkJCSl1/JvEZdIXTmBttnWNxzJpXomQjg=' 'sha256-vY0Cwh5hLv8sUQ61m3KQgfrqeAmcY7t6wJ2FAdYPNyU=' https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js",
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://oidc.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/",
         "ImageSource": "'self' data:",
         "StyleSource": "'self' 'unsafe-inline' https://fonts.googleapis.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",
         "FormAction": "'self'",
         "FontSource": "'self' https://fonts.gstatic.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",
-        "FrameSource": "'self' https://oidc.gov.bc.ca/",
-        "FrameAncestors": "'self' https://oidc.gov.bc.ca"
+        "FrameSource": "'self' https://loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
         "Enabled": false,

--- a/Apps/JobScheduler/src/Jobs/NotificationSettingsJob.cs
+++ b/Apps/JobScheduler/src/Jobs/NotificationSettingsJob.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.JobScheduler.Jobs
 {
     using System;
     using System.Text.Json;
-    using System.Threading.Tasks;
     using Hangfire;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authentication.Models;

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.LaboratoryTests.Services
     using AutoMapper;
     using DeepEqual.Syntax;
     using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.AccessManagement.Authentication.Models;
     using HealthGateway.Common.Constants.PHSA;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
@@ -468,7 +469,12 @@ namespace HealthGateway.LaboratoryTests.Services
         public void ShouldGetCovidTestsWithInvalidPhn()
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(Token);
+            JwtModel jwt = new()
+            {
+                AccessToken = Token,
+            };
+
+            mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwt);
 
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,
@@ -497,7 +503,12 @@ namespace HealthGateway.LaboratoryTests.Services
         public void ShouldGetCovidTestsWithInvalidDateOfBirth(string dateFormat)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(Token);
+            JwtModel jwt = new()
+            {
+                AccessToken = Token,
+            };
+
+            mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwt);
 
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,
@@ -526,7 +537,12 @@ namespace HealthGateway.LaboratoryTests.Services
         public void ShouldGetCovidTestsWithInvalidCollectionDate(string dateFormat)
         {
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
-            mockAuthDelegate.Setup(s => s.AccessTokenAsUser(IAuthenticationDelegate.DefaultAuthConfigSectionName)).Returns(Token);
+            JwtModel jwt = new()
+            {
+                AccessToken = Token,
+            };
+
+            mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwt);
             ILaboratoryService service = new LaboratoryService(
                 this.configuration,
                 new Mock<ILogger<LaboratoryService>>().Object,

--- a/Apps/WebClient/src/appsettings.hgpoc.json
+++ b/Apps/WebClient/src/appsettings.hgpoc.json
@@ -53,8 +53,8 @@
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/",
-        "FrameSource": "'self' https://dev.oidc.gov.bc.ca/ https://dev.loginproxy.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.oidc.gov.bc.ca/ https://dev.loginproxy.gov.bc.ca/"
+        "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
         "Enabled": true,

--- a/Tools/KeyCloak/Terraform/client_hg_admin.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_admin.tf
@@ -5,7 +5,7 @@ resource "keycloak_openid_client" "hgadmin_client" {
   description                  = "Health Gateway Administration web application"
   enabled                      = true
   access_type                  = "CONFIDENTIAL"
-  login_theme                  = "bcgov"
+  login_theme                  = local.development ? "bcgov" : "bcgov-idp-login-no-brand"
   standard_flow_enabled        = true
   direct_access_grants_enabled = true
   service_accounts_enabled     = true

--- a/Tools/KeyCloak/Terraform/client_hg_admin_blazor.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_admin_blazor.tf
@@ -5,7 +5,7 @@ resource "keycloak_openid_client" "hgadminblazor_client" {
   description                  = "Health Gateway Blazor Admin web application"
   enabled                      = true
   access_type                  = "PUBLIC"
-  login_theme                  = "bcgov"
+  login_theme                  = local.development ? "bcgov" : "bcgov-idp-login-no-brand"
   standard_flow_enabled        = true
   direct_access_grants_enabled = true
   valid_redirect_uris          = var.client_hg_admin_blazor.valid_redirects

--- a/Tools/KeyCloak/Terraform/client_hg_keycloak.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_keycloak.tf
@@ -8,9 +8,10 @@ resource "keycloak_openid_client" "hgkeycloak_client" {
   standard_flow_enabled        = false
   direct_access_grants_enabled = false
   service_accounts_enabled     = true
-   valid_redirect_uris          = var.client_hg_keycloak.valid_redirects
-   web_origins                  = var.client_hg_keycloak.web_origins
+  valid_redirect_uris          = var.client_hg_keycloak.valid_redirects
+  web_origins                  = var.client_hg_keycloak.web_origins
   full_scope_allowed           = true
+  access_token_lifespan        = var.client_hg_keycloak.token_lifespan
 }
 
 resource "keycloak_openid_client_default_scopes" "hgkeycloak_client_default_scopes" {

--- a/Tools/KeyCloak/Terraform/client_hg_phsa_public.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_phsa_public.tf
@@ -6,12 +6,13 @@ resource "keycloak_openid_client" "hgphsapublic_client" {
   enabled                      = true
   access_type                  = "CONFIDENTIAL"
   login_theme                  = "bcgov"
-  standard_flow_enabled        = true
-  direct_access_grants_enabled = true
+  standard_flow_enabled        = false
+  direct_access_grants_enabled = false
   service_accounts_enabled     = true
   valid_redirect_uris          = var.client_hg_phsa_public.valid_redirects
   web_origins                  = var.client_hg_phsa_public.web_origins
   full_scope_allowed           = false
+  access_token_lifespan        = var.client_hg_phsa_public.token_lifespan
 }
 
 resource "keycloak_openid_client_default_scopes" "hgphsapublic_client_default_scopes" {

--- a/Tools/KeyCloak/Terraform/client_hg_phsa_system.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_phsa_system.tf
@@ -6,12 +6,13 @@ resource "keycloak_openid_client" "hgphsasystem_client" {
   enabled                      = true
   access_type                  = "CONFIDENTIAL"
   login_theme                  = "bcgov"
-  standard_flow_enabled        = true
-  direct_access_grants_enabled = true
+  standard_flow_enabled        = false
+  direct_access_grants_enabled = false
   service_accounts_enabled     = true
   valid_redirect_uris          = var.client_hg_phsa_system.valid_redirects
   web_origins                  = var.client_hg_phsa_system.web_origins
   full_scope_allowed           = false
+  access_token_lifespan        = var.client_hg_phsa_system.token_lifespan
 }
 
 resource "keycloak_openid_client_default_scopes" "hgphsasystem_client_default_scopes" {

--- a/Tools/KeyCloak/Terraform/variables.tf
+++ b/Tools/KeyCloak/Terraform/variables.tf
@@ -137,6 +137,7 @@ variable "client_hg_phsa_public" {
     id              = optional(string, "hg-phsa-public")
     valid_redirects = list(string)
     web_origins     = list(string)
+    token_lifespan  = number
   })
   description = "HealthGateway Public Authentication for PHSA"
 }
@@ -146,6 +147,7 @@ variable "client_hg_phsa_system" {
     id              = optional(string, "hg-phsa-system")
     valid_redirects = list(string)
     web_origins     = list(string)
+    token_lifespan  = number
   })
   description = "HealthGateway System Authentication for PHSA"
 }
@@ -155,6 +157,7 @@ variable "client_hg_keycloak" {
     id              = optional(string, "hg-keycloak")
     valid_redirects = list(string)
     web_origins     = list(string)
+    token_lifespan  = number
   })
   description = "HealthGateway Keycloak Administration Client"
 }

--- a/Tools/KeyCloak/dev_users.json
+++ b/Tools/KeyCloak/dev_users.json
@@ -174,8 +174,33 @@
                     "temporary": false
                 }
             ]
+        },
+        {
+            "username": "blazoradmin",
+            "enabled": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "{PASSWORD}",
+                    "temporary": false
+                }
+            ]
+        },
+        {
+            "username": "blazorreviewer",
+            "enabled": true,
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "{PASSWORD}",
+                    "temporary": false
+                }
+            ]
         }
 
     ],
-    "roleMappings": { }
+    "roleMappings": { 
+        "blazoradmin": ["AdminUser"],
+        "blazorreviewer": ["AdminReviewer"]
+    }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#14403](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14403), [AB#14400](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14400), [AB#14406](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14406), [AB#13404](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13404)

## Description
Removes obsolete methods from IAuthenticationDelegate and implementation
Removes Password grants from Admin
Cleans up unit tests that were using Password auth
Removes xxx.oidc... from remaining appsettings
Remove oidc appsettings from AdminWebClient as it appears they are not used
Added longer token lifespans for system, public and key cloak admin clients
Disabled auth flows on system, public clients


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
