### PR TITLE
Remove exception rethrowing AB#14434

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/ExceptionHandling.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/ExceptionHandling.cs
@@ -16,11 +16,13 @@
 namespace HealthGateway.Common.AspNetConfiguration.Modules
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.ServiceModel;
     using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.ErrorHandling;
     using Hellang.Middleware.ProblemDetails;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
 
@@ -52,6 +54,8 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                             Instance = exception.Instance,
                             AdditionalInfo = exception.AdditionalInfo,
                         });
+
+                    setup.MapToStatusCode<CommunicationException>(StatusCodes.Status502BadGateway);
                 });
         }
 

--- a/Apps/Common/src/Services/PersonalAccountsService.cs
+++ b/Apps/Common/src/Services/PersonalAccountsService.cs
@@ -17,12 +17,10 @@ namespace HealthGateway.Common.Services
 {
     using System;
     using System.Diagnostics;
-    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.CacheProviders;
-    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.ErrorHandling;
@@ -78,17 +76,9 @@ namespace HealthGateway.Common.Services
                 return account;
             }
 
-            try
-            {
-                account = await this.personalAccountsApi.AccountLookupByHdidAsync(hdid).ConfigureAwait(true);
-                this.PutCache(hdid, account);
-                return account;
-            }
-            catch (Exception e) when (e is ApiException or HttpRequestException)
-            {
-                this.logger.LogError(e, "Error retrieving patient account from PHSA.");
-                throw new Data.ErrorHandling.ApiException(ErrorMessages.RecordsNotAvailable, HttpStatusCode.BadGateway, nameof(PersonalAccountsService));
-            }
+            account = await this.personalAccountsApi.AccountLookupByHdidAsync(hdid).ConfigureAwait(true);
+            this.PutCache(hdid, account);
+            return account;
         }
 
         /// <inheritdoc/>
@@ -106,7 +96,7 @@ namespace HealthGateway.Common.Services
                 requestResult.ResultStatus = ResultType.Success;
                 requestResult.TotalResultCount = 1;
             }
-            catch (Exception e) when (e is Data.ErrorHandling.ApiException)
+            catch (Exception e) when (e is ApiException or HttpRequestException)
             {
                 this.logger.LogCritical("Request Exception {Error}", e.ToString());
                 requestResult.ResultError = new()

--- a/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -1227,28 +1227,6 @@ namespace HealthGateway.PatientTests.Delegates
         }
 
         /// <summary>
-        /// Client registry get demographics throws ApiException given CommunicationException.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task GetDemographicsThrowsApiPatientExceptionGivenCommunicationException()
-        {
-            // Setup
-            string expectedDetail = $"Communication Exception with client registry when trying to retrieve patient information from {OidType.Phn}";
-            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, false, true);
-
-            // Act
-            async Task Actual()
-            {
-                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
-            }
-
-            // Verify
-            ApiException exception = await Assert.ThrowsAsync<ApiException>(Actual).ConfigureAwait(true);
-            Assert.Equal(expectedDetail, exception.Detail);
-        }
-
-        /// <summary>
         /// Client registry get demographics throws api patient exception given client registry records not found.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>


### PR DESCRIPTION
# Implements [AB#14434](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14434)

## Description

Removes instances where exceptions were caught then thrown as new ApiExceptions.

Preserves status 502 (Bad Gateway) responses for CommunicationExceptions in the GetPatientV2 endpoint by mapping all CommunicationExceptions to 502 responses in the problem details middleware.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
