### PR TITLE
Fix logout issue by using cypress session to store login

### DIFF
--- a/Testing/functional/tests/cypress.json
+++ b/Testing/functional/tests/cypress.json
@@ -9,6 +9,7 @@
     },
     "viewportWidth": 1920,
     "viewportHeight": 1080,
+    "experimentalSessionAndOrigin": true,
     "reporter": "mocha-junit-reporter",
     "reporterOptions": {
         "mochaFile": "reports/junit/test-results.[hash].xml",

--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -3,6 +3,7 @@ const { AuthMethod, localDevUri } = require("../../../support/constants");
 describe("Authentication", () => {
     beforeEach(() => {
         cy.enableModules("");
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("BCSC UI Login", () => {
@@ -83,7 +84,6 @@ describe("Authentication", () => {
     });
 
     it("KeyCloak Login", () => {
-        Cypress.session.clearAllSavedSessions();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -83,10 +83,12 @@ describe("Authentication", () => {
     });
 
     it("KeyCloak Login", () => {
+        Cypress.session.clearAllSavedSessions();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
+            AuthMethod.KeyCloak,
+            "/home"
         );
         cy.get("[data-testid=headerDropdownBtn]").click();
         cy.get("[data-testid=logoutBtn]")

--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -45,9 +45,9 @@ describe("Authentication", () => {
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
+            AuthMethod.KeyCloak,
+            "/home"
         );
-        cy.checkTimelineHasLoaded();
         cy.get("[data-testid=headerDropdownBtn]").click();
         cy.get("[data-testid=logoutBtn]").click();
         cy.get("[data-testid=ratingModalSkipBtn]").click();
@@ -87,7 +87,8 @@ describe("Authentication", () => {
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
+            AuthMethod.KeyCloak,
+            "/home"
         );
         cy.get("[data-testid=headerDropdownBtn]").click();
         cy.get("[data-testid=logoutBtn]")
@@ -99,7 +100,8 @@ describe("Authentication", () => {
         cy.login(
             Cypress.env("keycloak.deceased.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
+            AuthMethod.KeyCloak,
+            "/home"
         );
         cy.url().should("include", "/patientRetrievalError");
     });

--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -3,6 +3,9 @@ const { AuthMethod, localDevUri } = require("../../../support/constants");
 describe("Authentication", () => {
     beforeEach(() => {
         cy.enableModules("");
+    });
+
+    afterEach(() => {
         Cypress.session.clearAllSavedSessions();
     });
 

--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -87,8 +87,7 @@ describe("Authentication", () => {
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/home"
+            AuthMethod.KeyCloak
         );
         cy.get("[data-testid=headerDropdownBtn]").click();
         cy.get("[data-testid=logoutBtn]")
@@ -100,8 +99,7 @@ describe("Authentication", () => {
         cy.login(
             Cypress.env("keycloak.deceased.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/home"
+            AuthMethod.KeyCloak
         );
         cy.url().should("include", "/patientRetrievalError");
     });

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
@@ -31,6 +31,7 @@ const processedBanner = "[data-testid=alreadyProcessedBanner]";
 
 describe("Authenticated PCR Test Kit Registration", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
@@ -31,7 +31,6 @@ const processedBanner = "[data-testid=alreadyProcessedBanner]";
 
 describe("Authenticated PCR Test Kit Registration", () => {
     beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -39,6 +38,10 @@ describe("Authenticated PCR Test Kit Registration", () => {
             AuthMethod.KeyCloak,
             "/home"
         );
+    });
+
+    afterEach(() => {
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("Success with Test Kit CID", () => {

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -408,7 +408,6 @@ describe("dependents", () => {
         cy.get("[data-testid=genericMessageSubmitBtn]").click();
         cy.get("[data-testid=genericMessageModal]").should("not.exist");
 
-        /*
         cy.log("Adding same dependent as another user");
 
         cy.login(
@@ -458,9 +457,6 @@ describe("dependents", () => {
             AuthMethod.KeyCloak,
             "/dependents"
         );
-*/
-
-        cy.log("Removing dependent from user");
 
         cy.get("@newDependentCard").within(() => {
             cy.get("[data-testid=dependentMenuBtn]").click();

--- a/Testing/functional/tests/cypress/integration/e2e/user/starRating.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/starRating.js
@@ -6,8 +6,7 @@ describe("Validate Star Rating", () => {
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/home"
+            AuthMethod.KeyCloak
         );
     });
 

--- a/Testing/functional/tests/cypress/integration/e2e/user/starRating.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/starRating.js
@@ -2,13 +2,13 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Validate Star Rating", () => {
     beforeEach(() => {
-        cy.enableModules(["Medication", "Note"]);
+        Cypress.session.clearAllSavedSessions();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
+            AuthMethod.KeyCloak,
+            "/home"
         );
-        cy.checkTimelineHasLoaded();
     });
 
     it("Clicking the 5 star button should log out", () => {

--- a/Testing/functional/tests/cypress/integration/e2e/user/starRating.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/starRating.js
@@ -2,12 +2,15 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Validate Star Rating", () => {
     beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak
         );
+    });
+
+    afterEach(() => {
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("Clicking the 5 star button should log out", () => {

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
@@ -31,7 +31,6 @@ const feedbackTestKitCodeValidSelector =
 
 describe("Authenticated Pcr Test Registration", () => {
     beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -43,6 +42,10 @@ describe("Authenticated Pcr Test Registration", () => {
         cy.intercept("POST", `**/Laboratory/${HDID}/LabTestKit`, {
             fixture: "LaboratoryService/authenticatedPcrTest.json",
         });
+    });
+
+    afterEach(() => {
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("Successful Test Kit", () => {

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
@@ -31,6 +31,7 @@ const feedbackTestKitCodeValidSelector =
 
 describe("Authenticated Pcr Test Registration", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -95,6 +96,7 @@ describe("Authenticated Pcr Test Registration", () => {
 
 describe("Authenticated Pcr Test Registration with Error", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -131,6 +133,7 @@ describe("Authenticated Pcr Test Registration with Error", () => {
 
 describe("Authenticated Pcr Test Registration Previously Processed", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
@@ -23,7 +23,6 @@ const feedbackTestTakenIsRequiredSelector =
 
 describe("Authenticated Pcr Test Registration", () => {
     beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -35,6 +34,10 @@ describe("Authenticated Pcr Test Registration", () => {
         cy.intercept("POST", `**/Laboratory/${HDID}/LabTestKit`, {
             fixture: "LaboratoryService/authenticatedPcrTestWithTestKit.json",
         });
+    });
+
+    afterEach(() => {
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("Successful Test Kit", () => {
@@ -67,7 +70,6 @@ describe("Authenticated Pcr Test Registration", () => {
 
 describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
     beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -80,6 +82,10 @@ describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
             fixture:
                 "LaboratoryService/authenticatedPcrTestErrorWithTestKit.json",
         });
+    });
+
+    afterEach(() => {
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("Error Test Kit", () => {
@@ -98,7 +104,6 @@ describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
 
 describe("Previously Registered Test Kit", () => {
     beforeEach(() => {
-        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -111,6 +116,10 @@ describe("Previously Registered Test Kit", () => {
             fixture:
                 "LaboratoryService/authenticatedPcrTestDuplicateWithTestKit.json",
         });
+    });
+
+    afterEach(() => {
+        Cypress.session.clearAllSavedSessions();
     });
 
     it("Already Processed Test Kit", () => {

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
@@ -23,6 +23,7 @@ const feedbackTestTakenIsRequiredSelector =
 
 describe("Authenticated Pcr Test Registration", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -66,6 +67,7 @@ describe("Authenticated Pcr Test Registration", () => {
 
 describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),
@@ -96,6 +98,7 @@ describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
 
 describe("Previously Registered Test Kit", () => {
     beforeEach(() => {
+        Cypress.session.clearAllSavedSessions();
         cy.enableModules("PcrTest");
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/pages/faq.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/faq.js
@@ -1,17 +1,16 @@
 describe("FAQ Page", () => {
     beforeEach(() => {
         cy.logout();
+        cy.visit("/faq");
     });
 
     it("Page exists", () => {
-        cy.visit("/faq");
         cy.contains("h1", "Frequently Asked Questions");
 
         cy.get("[data-testid=questionBtn]").its("length").should("be.gte", 1);
     });
 
     it("Expand question", () => {
-        cy.visit("/faq");
         cy.get("[data-testid=answerTxt]").should("not.be.visible");
 
         cy.get("[data-testid=questionBtn]")

--- a/Testing/functional/tests/cypress/integration/ui/pages/faq.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/faq.js
@@ -11,6 +11,7 @@ describe("FAQ Page", () => {
     });
 
     it("Expand question", () => {
+        cy.visit("/faq");
         cy.get("[data-testid=answerTxt]").should("not.be.visible");
 
         cy.get("[data-testid=questionBtn]")

--- a/Testing/functional/tests/cypress/integration/ui/timeline/encounter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/encounter.js
@@ -1,7 +1,7 @@
 const { AuthMethod } = require("../../../support/constants");
 
 describe("MSP Visits Rolloff", () => {
-    before(() => {
+    beforeEach(() => {
         cy.intercept("GET", "**/Encounter/*", (req) => {
             req.reply({
                 fixture: "EncounterService/encountersrolloff.json",

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -35,80 +35,83 @@ Cypress.Commands.add(
     "login",
     (username, password, authMethod = AuthMethod.BCSC, path = "/timeline") => {
         if (authMethod == AuthMethod.KeyCloak) {
-            cy.readConfig().then((config) => {
-                cy.logout();
-                let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
-                let codeVerifier = generateRandomString(96);
-                cy.log(
-                    `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
-                );
-                const stateStore = {
-                    id: stateId,
-                    created: new Date().getTime(),
-                    request_type: "si:r",
-                    code_verifier: codeVerifier,
-                    redirect_uri: config.openIdConnect.callbacks.Logon,
-                    authority: config.openIdConnect.authority,
-                    client_id: config.openIdConnect.clientId,
-                    response_mode: "query",
-                    scope: config.openIdConnect.scope,
-                    extraTokenParams: {},
-                };
-                cy.log("Creating OIDC StateStore in Local storage");
-                window.sessionStorage.setItem(
-                    `oidc.${stateStore.id}`,
-                    JSON.stringify(stateStore)
-                );
-
-                const escapedRedirectPath = encodeURI(path);
-                const redirectUri = `${config.openIdConnect.callbacks.Logon}?redirect=${escapedRedirectPath}`;
-
-                cy.log("Requesting Keycloak Authentication form");
-                cy.request({
-                    url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
-                    followRedirect: false,
-                    qs: {
-                        scope: config.openIdConnect.scope,
-                        response_type: config.openIdConnect.responseType,
-                        approval_prompt: "auto",
-                        redirect_uri: redirectUri,
+            cy.session([username, password], () => {
+                cy.readConfig().then((config) => {
+                    cy.logout();
+                    let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
+                    let codeVerifier = generateRandomString(96);
+                    cy.log(
+                        `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
+                    );
+                    const stateStore = {
+                        id: stateId,
+                        created: new Date().getTime(),
+                        request_type: "si:r",
+                        code_verifier: codeVerifier,
+                        redirect_uri: config.openIdConnect.callbacks.Logon,
+                        authority: config.openIdConnect.authority,
                         client_id: config.openIdConnect.clientId,
                         response_mode: "query",
-                        state: stateStore.id,
-                    },
-                })
-                    .then((response) => {
-                        cy.log("Posting credentials");
-                        const html = document.createElement("html");
-                        html.innerHTML = response.body;
-                        const form = html.getElementsByTagName("form")[0];
-                        const url = form.action;
-                        return cy.request({
-                            method: "POST",
-                            url,
-                            followRedirect: false,
-                            form: true,
-                            body: {
-                                username: username,
-                                password: password,
-                            },
-                        });
+                        scope: config.openIdConnect.scope,
+                        extraTokenParams: {},
+                    };
+                    cy.log("Creating OIDC StateStore in Local storage");
+                    window.sessionStorage.setItem(
+                        `oidc.${stateStore.id}`,
+                        JSON.stringify(stateStore)
+                    );
+
+                    const escapedRedirectPath = encodeURI(path);
+                    const redirectUri = `${config.openIdConnect.callbacks.Logon}?redirect=${escapedRedirectPath}`;
+
+                    cy.log("Requesting Keycloak Authentication form");
+                    cy.request({
+                        url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
+                        followRedirect: false,
+                        qs: {
+                            scope: config.openIdConnect.scope,
+                            response_type: config.openIdConnect.responseType,
+                            approval_prompt: "auto",
+                            redirect_uri: redirectUri,
+                            client_id: config.openIdConnect.clientId,
+                            response_mode: "query",
+                            state: stateStore.id,
+                        },
                     })
-                    .then((response) => {
-                        let callBackQS = response.headers["location"];
-                        const callbackURL = `${callBackQS}`;
-                        cy.log(`Visiting Callback ${callBackQS}`, response);
-                        cy.visit(callbackURL, { timeout: 60000 });
-                        // Wait for cookies are set before store them in cypress.
-                        cy.get("[data-testid=headerDropdownBtn]").should(
-                            "exist"
-                        );
-                        // store auth cookies
-                        cy.getCookies().then((cookies) => {
-                            globalStorage.authCookies = cookies;
+                        .then((response) => {
+                            cy.log("Posting credentials");
+                            const html = document.createElement("html");
+                            html.innerHTML = response.body;
+                            const form = html.getElementsByTagName("form")[0];
+                            const url = form.action;
+                            return cy.request({
+                                method: "POST",
+                                url,
+                                followRedirect: false,
+                                form: true,
+                                body: {
+                                    username: username,
+                                    password: password,
+                                },
+                            });
+                        })
+                        .then((response) => {
+                            let callBackQS = response.headers["location"];
+                            const callbackURL = `${callBackQS}`;
+                            cy.log(`Visiting Callback ${callBackQS}`, response);
+                            cy.visit(callbackURL, { timeout: 60000 });
+                            // Wait for cookies are set before store them in cypress.
+                            cy.get("[data-testid=headerDropdownBtn]").should(
+                                "exist"
+                            );
+                            // store auth cookies
+                            cy.getCookies().then((cookies) => {
+                                globalStorage.authCookies = cookies;
+                            });
                         });
-                    });
+                });
             });
+            cy.visit(path, { timeout: 60000 });
         } else if (authMethod == AuthMethod.BCSC) {
             cy.log(
                 `Authenticating as BC Services Card user ${username} using the UI`

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -35,7 +35,7 @@ Cypress.Commands.add(
     "login",
     (username, password, authMethod = AuthMethod.BCSC, path = "/timeline") => {
         if (authMethod == AuthMethod.KeyCloak) {
-            cy.session([username, password], () => {
+            cy.session([username, authMethod], () => {
                 cy.readConfig().then((config) => {
                     cy.logout();
                     let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -111,6 +111,7 @@ Cypress.Commands.add(
                         });
                 });
             });
+            cy.log(`Visit path: ${path}`);
             cy.visit(path, { timeout: 60000 });
         } else if (authMethod == AuthMethod.BCSC) {
             cy.log(


### PR DESCRIPTION
# Fixes [AB#14397](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14397)

## Description

Cypress session documentation: [https://www.cypress.io/blog/2021/08/04/authenticate-faster-in-tests-cy-session-command/](url)

There have been issues with keycloak logout in tests whether it be in beforeEach or having multiple login/lgout attempts in a single test.

To solve this issue and also improve performance, the use of  cypress session to store logins (username/password) has been implemented for this fix.

- In login call use cypress session to store login by username and auth method as key
- Enable experimentalSessionAndOrigin in cypress.json
- Reverted previous changes to dependent functional test i.e., uncommented out code that was failing.
- For some functional tests the session had to be cleared. This is due to some tests logging out of Healthgateway and this would cause issue with the next test expecting user to be logged in.  Also, some tests are submitting requests between pages and these values stay in the session.


<img width="2557" alt="Screenshot 2022-12-01 at 9 43 38 AM" src="https://user-images.githubusercontent.com/58790456/205123586-36512154-399c-4960-ae48-6d87f158d03c.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
