### PR TITLE
Prevent awkward word wrapping on hyphenated text

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/components/covidTreatmentAssessment/CovidTreatmentAssessment.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/components/covidTreatmentAssessment/CovidTreatmentAssessment.vue
@@ -335,8 +335,8 @@ export default class CovidTreatmentAssessmentComponent extends Vue {
                             </ValidationProvider>
                         </Card>
                         <Card
-                            title="2. Have you recently tested positive for COVID-19 in the last 7 days?*"
-                            additional-info="This citizen has tested positive for COVID-19 within the last 7 days."
+                            title="2. Have you recently tested positive for COVID‑19 in the last 7 days?*"
+                            additional-info="This citizen has tested positive for COVID‑19 within the last 7 days."
                             :display-additional-info="
                                 details.hasKnownPositiveC19Past7Days
                             "
@@ -357,7 +357,7 @@ export default class CovidTreatmentAssessmentComponent extends Vue {
                             </ValidationProvider>
                         </Card>
                         <Card
-                            title="3. Do you have any severe symptoms of COVID-19?*"
+                            title="3. Do you have any severe symptoms of COVID‑19?*"
                         >
                             <ValidationProvider
                                 v-slot="{ errors }"
@@ -374,7 +374,7 @@ export default class CovidTreatmentAssessmentComponent extends Vue {
                             </ValidationProvider>
                         </Card>
                         <Card
-                            title="4. COVID-19 symptoms can range from mild to moderate. Mild and moderate symptoms are symptoms that can be managed at home. Do you have any symptoms of COVID-19?*"
+                            title="4. COVID‑19 symptoms can range from mild to moderate. Mild and moderate symptoms are symptoms that can be managed at home. Do you have any symptoms of COVID‑19?*"
                         >
                             <ValidationProvider
                                 v-slot="{ errors }"
@@ -449,7 +449,7 @@ export default class CovidTreatmentAssessmentComponent extends Vue {
                                 v-if="symptomOnsetTooLongAgo"
                                 class="option-message-color"
                             >
-                                Citizen would likely not benefit from COVID-19
+                                Citizen would likely not benefit from COVID‑19
                                 treatment.
                             </div>
                         </Card>
@@ -516,7 +516,7 @@ export default class CovidTreatmentAssessmentComponent extends Vue {
                         </Card>
                         <Card
                             title="10. Do you agree to the information being added to your CareConnect electronic 
-                            health record as part of the process to obtain COVID-19 treatment?*"
+                            health record as part of the process to obtain COVID‑19 treatment?*"
                         >
                             <ValidationProvider
                                 v-slot="{ errors }"

--- a/Apps/AdminWebClient/src/ClientApp/src/components/covidTreatmentAssessment/OptionDetails.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/components/covidTreatmentAssessment/OptionDetails.vue
@@ -75,10 +75,10 @@ export default class OptionDetails extends Vue {
             />
         </v-radio-group>
         <div v-if="showMessageWithNoBenefit" class="option-message-color">
-            Citizen would likely not benefit from COVID-19 treatment.
+            Citizen would likely not benefit from COVID‑19 treatment.
         </div>
         <div v-if="showMessageWithBenefit" class="option-message-color">
-            Citizen may benefit from COVID-19 treatment.
+            Citizen may benefit from COVID‑19 treatment.
         </div>
     </div>
 </template>

--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -416,7 +416,7 @@ export default class CovidCardView extends Vue {
                     type: FeedbackType.Success,
                     title: "Success",
                     message:
-                        "COVID-19 treatment assessment submitted successfully.",
+                        "COVID‑19 treatment assessment submitted successfully.",
                 });
             })
             .catch(() => {
@@ -424,7 +424,7 @@ export default class CovidCardView extends Vue {
                     type: FeedbackType.Warning,
                     title: "Warning",
                     message:
-                        "COVID-19 treatment assessment submitted successfully, but updated assessment history could not be retrieved.",
+                        "COVID‑19 treatment assessment submitted successfully, but updated assessment history could not be retrieved.",
                 });
             })
             .finally(() => {
@@ -436,7 +436,7 @@ export default class CovidCardView extends Vue {
         this.showBannerFeedback({
             type: FeedbackType.Error,
             title: "Error",
-            message: "Unable to submit COVID-19 treatment assessment.",
+            message: "Unable to submit COVID‑19 treatment assessment.",
         });
         this.isLoading = false;
     }
@@ -569,7 +569,7 @@ export default class CovidCardView extends Vue {
                     </v-row>
                     <v-row align="center" dense>
                         <v-col cols="auto">
-                            <h2>COVID-19 Immunizations</h2>
+                            <h2>COVID‑19 Immunizations</h2>
                         </v-col>
                         <v-col class="text-right">
                             <v-btn
@@ -688,7 +688,7 @@ export default class CovidCardView extends Vue {
                                 class="mx-2 success"
                                 @click="startCovidTreatmentAssessment"
                             >
-                                <span>Start COVID-19 Treatment Assessment</span>
+                                <span>Start COVID‑19 Treatment Assessment</span>
                                 <v-icon class="ml-2" size="sm">
                                     fas fa-clipboard-list
                                 </v-icon>

--- a/Apps/Laboratory/src/Delegates/MockLaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/MockLaboratoryDelegate.cs
@@ -60,8 +60,8 @@ namespace HealthGateway.Laboratory.Delegates
                         new(
                             new List<string>
                             {
-                                "Nasopharyngeal Swab<br>HEALTH CARE WORKER<br>Negative.<br>No COVID-19 virus (2019-nCoV) detected by NAT.",
-                                "This test targets the RdRP and E gene regions of COVID-19 virus (2019-nCoV) and has not been fully validated.",
+                                "Nasopharyngeal Swab<br>HEALTH CARE WORKER<br>Negative.<br>No COVID‑19 virus (2019-nCoV) detected by NAT.",
+                                "This test targets the RdRP and E gene regions of COVID‑19 virus (2019-nCoV) and has not been fully validated.",
                             })
                         {
                             Id = Guid.Parse("dee12642-fb2c-481f-9ae4-c672b045b2b1"),
@@ -73,7 +73,7 @@ namespace HealthGateway.Laboratory.Delegates
                             ReceivedDateTime = DateTime.Now.AddDays(-1),
                             ResultDateTime = DateTime.Now.AddHours(-1),
                             Loinc = "XXX-3286",
-                            LoincName = "COVID-19 n-Coronavirus  NAT",
+                            LoincName = "COVID‑19 n-Coronavirus  NAT",
                         },
                     },
                 },

--- a/Apps/WebClient/src/ClientApp/public/index.html
+++ b/Apps/WebClient/src/ClientApp/public/index.html
@@ -9,7 +9,7 @@
         <meta name="viewport" content="width=device-width,initial-scale=1.0" />
         <meta
             name="Description"
-            content="The Health Gateway is a Ministry of Health initiative which provides BC residents and their families with secure access to a single view of their health information. View and download your health information, such as COVID-19 tests, COVID-19 immunizations, medications, immunizations and health visits."
+            content="The Health Gateway is a Ministry of Health initiative which provides BC residents and their families with secure access to a single view of their health information. View and download your health information, such as COVID‑19 tests, COVID‑19 immunizations, medications, immunizations and health visits."
         />
         <meta
             name="google-site-verification"

--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -858,7 +858,7 @@ export default class DependentCardComponent extends Vue {
                     @click="fetchCovid19LaboratoryTests"
                 >
                     <template #title>
-                        <div data-testid="covid19TabTitle">COVID-19</div>
+                        <div data-testid="covid19TabTitle">COVID‑19</div>
                     </template>
                     <div class="p-3">
                         <div class="d-flex justify-content-center">
@@ -898,7 +898,7 @@ export default class DependentCardComponent extends Vue {
                         borderless
                         :items="testRows"
                         class="w-100 mb-0"
-                        aria-describedby="COVID-19 Test Results"
+                        aria-describedby="COVID‑19 Test Results"
                     >
                         <b-thead>
                             <b-tr>
@@ -921,7 +921,7 @@ export default class DependentCardComponent extends Vue {
                             <b-tr v-for="(row, index) in testRows" :key="index">
                                 <b-td
                                     data-testid="dependentCovidTestDate"
-                                    class="align-middle"
+                                    class="align-middle text-nowrap"
                                 >
                                     {{ formatDate(row.test.collectedDateTime) }}
                                 </b-td>
@@ -1165,7 +1165,7 @@ export default class DependentCardComponent extends Vue {
                                                 >
                                                     <b-td
                                                         :data-testid="`history-immunization-date-${dependent.ownerId}-${index}`"
-                                                        class="align-middle"
+                                                        class="align-middle text-nowrap"
                                                     >
                                                         {{ row.date }}
                                                     </b-td>
@@ -1323,7 +1323,7 @@ export default class DependentCardComponent extends Vue {
                                                 </b-td>
                                                 <b-td
                                                     :data-testid="`forecast-due-date-${dependent.ownerId}-${index}`"
-                                                    class="align-middle"
+                                                    class="align-middle text-nowrap"
                                                 >
                                                     {{ row.due_date }}
                                                 </b-td>

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
@@ -247,7 +247,7 @@ export default class SidebarComponent extends Vue {
                         :class="{ selected: isCovid19 }"
                     >
                         <b-row class="align-items-center" no-gutters>
-                            <b-col title="COVID-19" cols="auto" class="pr-md-4">
+                            <b-col title="COVID‑19" cols="auto" class="pr-md-4">
                                 <hg-icon
                                     icon="check-circle"
                                     size="large"
@@ -259,7 +259,7 @@ export default class SidebarComponent extends Vue {
                                 data-testid="covid19Label"
                                 class="button-text pl-3"
                             >
-                                <span>COVID-19</span>
+                                <span>COVID‑19</span>
                             </b-col>
                         </b-row>
                     </hg-button>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/HealthlinkSidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/HealthlinkSidebarComponent.vue
@@ -23,14 +23,14 @@ export default class HealthlinkSidebarComponent extends Vue {
     };
     private cardPool: Healthcard[] = [
         {
-            title: "COVID-19",
-            description: "View more information about COVID-19.",
+            title: "COVID‑19",
+            description: "View more information about COVID‑19.",
             imageSrc: CovidImage,
             urlLink:
                 "http://www.bccdc.ca/health-info/diseases-conditions/covid-19",
         },
         {
-            title: "8-1-1",
+            title: "8‑1‑1",
             description:
                 "Speak to a pharmacist from 5pm to 9am Pacific Time everyday of the year.",
             imageSrc: PhoneImage,
@@ -40,7 +40,7 @@ export default class HealthlinkSidebarComponent extends Vue {
         {
             title: "Healthlink",
             description:
-                "HealthLink BC provides reliable non-emergency health information and advice in British Columbia.",
+                "HealthLink BC provides reliable non‑emergency health information and advice in British Columbia.",
             imageSrc: HealthlinkImage,
             urlLink: "https://www.healthlinkbc.ca",
         },

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/CommentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/CommentComponent.vue
@@ -114,7 +114,7 @@ export default class CommentComponent extends Vue {
                         <span data-testid="commentText">{{
                             comment.text
                         }}</span>
-                        <p class="m-0 timestamp">
+                        <p class="m-0 timestamp text-nowrap">
                             {{ formatDate(comment.createdDateTime) }}
                         </p>
                     </b-col>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
@@ -212,11 +212,15 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
                 </div>
                 <div class="my-2">
                     <strong>Collection Date:</strong>
-                    {{ formatDate(test.collectedDateTime) }}
+                    <span class="text-nowrap">
+                        {{ formatDate(test.collectedDateTime) }}
+                    </span>
                 </div>
                 <div class="my-2">
                     <strong>Result Date:</strong>
-                    {{ formatDate(test.resultDateTime) }}
+                    <span class="text-nowrap">
+                        {{ formatDate(test.resultDateTime) }}
+                    </span>
                 </div>
                 <div
                     v-if="test.resultDescription.length > 0"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -143,7 +143,7 @@ export default class EntrycardTimelineComponent extends Vue {
                         </b-col>
                         <b-col cols="4" class="text-right">
                             <span
-                                class="text-muted"
+                                class="text-muted text-nowrap"
                                 data-testid="entryCardDate"
                                 >{{ dateString }}</span
                             >

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/HospitalVisitTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/HospitalVisitTimelineComponent.vue
@@ -126,7 +126,10 @@ export default class HospitalVisitTimelineComponent extends Vue {
                 </div>
                 <div data-testid="hospital-visit-date">
                     <strong>Visit Date: </strong>
-                    <span data-testid="laboratory-collection-date-value">
+                    <span
+                        data-testid="laboratory-collection-date-value"
+                        class="text-nowrap"
+                    >
                         {{ formatDate(entry.admitDateTime) }}
                     </span>
                     <hg-button
@@ -156,7 +159,10 @@ export default class HospitalVisitTimelineComponent extends Vue {
                 </div>
                 <div data-testid="hospital-visit-discharge-date">
                     <strong>Discharge Date: </strong>
-                    <span v-if="entry.endDateTime !== undefined">
+                    <span
+                        v-if="entry.endDateTime !== undefined"
+                        class="text-nowrap"
+                    >
                         {{ formatDate(entry.endDateTime) }}
                     </span>
                 </div>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -141,6 +141,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
                     <strong>Collection Date: </strong>
                     <span
                         v-if="entry.collectionDateTime !== undefined"
+                        class="text-nowrap"
                         data-testid="laboratory-collection-date-value"
                     >
                         {{ formatDate(entry.collectionDateTime) }}

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationRequestTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationRequestTimelineComponent.vue
@@ -58,11 +58,15 @@ export default class MedicationRequestTimelineComponent extends Vue {
                     <div class="detailSection">
                         <div>
                             <strong>Effective Date:</strong>
-                            {{ formatDate(entry.effectiveDate) }}
+                            <span class="text-nowrap">
+                                {{ formatDate(entry.effectiveDate) }}
+                            </span>
                         </div>
                         <div>
                             <strong>Expiry Date:</strong>
-                            {{ formatDate(entry.expiryDate) }}
+                            <span class="text-nowrap">
+                                {{ formatDate(entry.expiryDate) }}
+                            </span>
                         </div>
                         <div>
                             <strong>Reference Number:</strong>

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
@@ -336,7 +336,7 @@ export const actions: LaboratoryActions = {
                 customBannerError.description =
                     "The information you entered does not match our records. Please try again.";
                 customBannerError.detail =
-                    "Please note that it can take up to 48 hours from the time of test before a result is available. If it has been at least 48 hours since you tested, please contact the COVID-19 Results Line (1‐833‐707‐2792) to investigate the issue.";
+                    "Please note that it can take up to 48 hours from the time of test before a result is available. If it has been at least 48 hours since you tested, please contact the COVID‑19 Results Line (1‐833‐707‐2792) to investigate the issue.";
             }
 
             context.commit(

--- a/Apps/WebClient/src/ClientApp/src/views/ContactUsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ContactUsView.vue
@@ -38,7 +38,7 @@ export default class ContactUsView extends Vue {
                     <p>
                         If you have questions about the BC Vaccine Card, please
                         contact
-                        <a href="tel:18338382323">1-833-838-2323</a>. Service is
+                        <a href="tel:18338382323">1‑833‑838‑2323</a>. Service is
                         available every day: 7 am to 7 pm or 9 am to 5 pm on
                         holidays.
                     </p>
@@ -67,7 +67,7 @@ export default class ContactUsView extends Vue {
                     >
                 </h5>
                 <p>
-                    By dialing 8-1-1 toll-free in British Columbia, you can
+                    By dialing 8‑1‑1 toll‑free in British Columbia, you can
                     speak with a person who can help you connect with a health
                     professional.
                 </p>
@@ -77,12 +77,12 @@ export default class ContactUsView extends Vue {
                         href="http://www.bccdc.ca/health-info/diseases-conditions/covid-19/testing/testing-information"
                         target="_blank"
                     >
-                        COVID-19 Testing Information
+                        COVID‑19 Testing Information
                     </a>
                 </h5>
                 <p>
-                    Non-medical information about COVID-19 is available
-                    7:30am-8pm, 7 days a week at 1-888-COVID19 (1-888-268-4319).
+                    Non-medical information about COVID‑19 is available
+                    7:30am‑8pm, 7 days a week at 1‑888‑COVID19 (1‑888‑268‑4319).
                 </p>
             </b-col>
             <b-col class="my-3 col-3 col-lg-3 no-print">

--- a/Apps/WebClient/src/ClientApp/src/views/Covid19View.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/Covid19View.vue
@@ -123,7 +123,7 @@ export default class Covid19View extends Vue {
 
     private breadcrumbItems: BreadcrumbItem[] = [
         {
-            text: "COVID-19",
+            text: "COVID‑19",
             to: "/covid19",
             active: true,
             dataTestId: "breadcrumb-covid-19",
@@ -469,7 +469,7 @@ export default class Covid19View extends Vue {
                             </b-col>
                             <b-col cols="auto">
                                 <h3 class="text-center m-0">
-                                    COVID-19 Vaccination Record
+                                    COVID‑19 Vaccination Record
                                 </h3>
                             </b-col>
                         </b-row>

--- a/Apps/WebClient/src/ClientApp/src/views/FaqView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/FaqView.vue
@@ -246,7 +246,7 @@ export default class FaqView extends Vue {
                 </b-card-body>
             </b-collapse>
         </b-card>
-        <h3 class="pt-3">COVID-19 information</h3>
+        <h3 class="pt-3">COVID‑19 information</h3>
         <b-card no-body class="mb-1 border-0">
             <b-card-header
                 header-tag="header"
@@ -259,7 +259,7 @@ export default class FaqView extends Vue {
                     block
                     variant="info"
                     class="text-left"
-                    >When can I get my COVID-19 booster dose?
+                    >When can I get my COVID‑19 booster dose?
                 </b-button>
             </b-card-header>
             <b-collapse id="accordion-faqAnswer5" role="tabpanel">
@@ -294,7 +294,7 @@ export default class FaqView extends Vue {
                     block
                     variant="info"
                     class="text-left"
-                    >I got the COVID-19 vaccine outside of BC. How do I add it
+                    >I got the COVID‑19 vaccine outside of BC. How do I add it
                     to Health Gateway?</b-button
                 >
             </b-card-header>
@@ -340,7 +340,7 @@ export default class FaqView extends Vue {
                     block
                     variant="info"
                     class="text-left"
-                    >My COVID-19 vaccination record has an error. What should I
+                    >My COVID‑19 vaccination record has an error. What should I
                     do?
                 </b-button>
             </b-card-header>
@@ -512,8 +512,8 @@ export default class FaqView extends Vue {
                                 </li>
                                 <li>
                                     <div>
-                                        Call 1-800-663-7100 (toll-free) or
-                                        604-683-7151 (from the Lower Mainland)
+                                        Call 1‑800‑663‑7100 (toll‑free) or
+                                        604‑683‑7151 (from the Lower Mainland)
                                     </div>
                                 </li>
                             </ul>
@@ -606,7 +606,7 @@ export default class FaqView extends Vue {
                         <div data-testid="answerTxt">
                             <p>
                                 Currently, only parents or guardians can access
-                                COVID-19 test results for their children that
+                                COVID‑19 test results for their children that
                                 are 11 years old and younger. We’re working to
                                 provide more family and caregiver access in the
                                 future.

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -570,7 +570,7 @@ export default class HomeView extends Vue {
                     </template>
                     <div>
                         View and manage all your available health records,
-                        including dispensed medications, health visits, COVID-19
+                        including dispensed medications, health visits, COVID‑19
                         test results, immunizations and more.
                     </div>
                 </hg-card-button>

--- a/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PcrTestView.vue
@@ -480,7 +480,7 @@ export default class PcrTestView extends Vue {
             <b-row class="pt-3">
                 <b-col>
                     <strong>
-                        Register your COVID-19 test kit using one of the
+                        Register your COVID‑19 test kit using one of the
                         following methods:
                     </strong>
                 </b-col>
@@ -917,7 +917,7 @@ export default class PcrTestView extends Vue {
                                     <b-col>
                                         <label for="pcrMobileNumber">
                                             Mobile Number (to receive a
-                                            notification once your COVID-19 test
+                                            notification once your COVID‑19 test
                                             result is available)
                                         </label>
                                         <b-form-input
@@ -1018,7 +1018,7 @@ export default class PcrTestView extends Vue {
                                     boundary="viewport"
                                 >
                                     Your information is being collected to
-                                    provide you with your COVID-19 test result
+                                    provide you with your COVID‑19 test result
                                     under s. 26(c) of the
                                     <em
                                         >Freedom of Information and Protection

--- a/Apps/WebClient/src/ClientApp/src/views/PublicCovidTestView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicCovidTestView.vue
@@ -266,7 +266,7 @@ export default class PublicCovidTestView extends Vue {
                         data-testid="public-covid-test-result-form-title"
                         class="vaccine-card-form-title text-center pb-3 mb-4"
                     >
-                        Your COVID-19 Test Result
+                        Your COVID‑19 Test Result
                     </h2>
                     <div
                         v-if="publicCovidTests.length"
@@ -460,10 +460,10 @@ export default class PublicCovidTestView extends Vue {
                         data-testid="public-covid-test-form-title"
                         class="vaccine-card-form-title text-center pb-3 mb-4"
                     >
-                        Get Your COVID-19 Test Result
+                        Get Your COVID‑19 Test Result
                     </h2>
                     <p class="mb-4">
-                        To get your COVID-19 test result, please provide:
+                        To get your COVID‑19 test result, please provide:
                     </p>
                     <b-form-group
                         label="Personal Health Number"
@@ -532,7 +532,7 @@ export default class PublicCovidTestView extends Vue {
                         </b-form-invalid-feedback>
                     </b-form-group>
                     <b-form-group
-                        label="Date of COVID-19 Test"
+                        label="Date of COVID‑19 Test"
                         label-for="dateOfCollection"
                         :state="isValid($v.dateOfCollection)"
                     >
@@ -543,7 +543,7 @@ export default class PublicCovidTestView extends Vue {
                             :allow-future="false"
                             :min-year="2020"
                             data-testid="dateOfCollectionInput"
-                            aria-label="Date of COVID-19 Test"
+                            aria-label="Date of COVID‑19 Test"
                             @blur="$v.dateOfBirth.$touch()"
                         />
                         <b-form-invalid-feedback
@@ -614,7 +614,7 @@ export default class PublicCovidTestView extends Vue {
                         boundary="viewport"
                     >
                         Your information is being collected to provide you with
-                        your COVID-19 test result under s. 26(c) of the
+                        your COVID‑19 test result under s. 26(c) of the
                         <em
                             >Freedom of Information and Protection of Privacy
                             Act</em

--- a/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
@@ -598,7 +598,7 @@ export default class PublicVaccineCardView extends Vue {
                         boundary="viewport"
                     >
                         Your information is being collected to provide you with
-                        your COVID-19 vaccination status under s. 26(c) of the
+                        your COVID‑19 vaccination status under s. 26(c) of the
                         <em
                             >Freedom of Information and Protection of Privacy
                             Act</em
@@ -656,7 +656,7 @@ export default class PublicVaccineCardView extends Vue {
                 </p>
                 <div class="my-3">
                     <hg-button variant="secondary" href="tel:+18338382323">
-                        Call: 1-833-838-2323 (Toll-Free)
+                        Call: 1‑833‑838‑2323 (Toll‑Free)
                     </hg-button>
                 </div>
                 <div class="my-3">

--- a/Apps/WebClient/src/ClientApp/src/views/ReleaseNotesView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReleaseNotesView.vue
@@ -528,11 +528,11 @@ export default class ReleaseNotesView extends Vue {
         <release-note
             date="March 10, 2021"
             version="v1.3.10"
-            title="COVID-19 Immunization Card, Date Formats"
+            title="COVID‑19 Immunization Card, Date Formats"
         >
             <ul>
                 <li>
-                    We added date of birth to the COVID-19 Immunization Card, to
+                    We added date of birth to the COVID‑19 Immunization Card, to
                     support identity validation.
                 </li>
                 <li>
@@ -584,7 +584,7 @@ export default class ReleaseNotesView extends Vue {
         <release-note
             date="February 17, 2021"
             version="v1.3.7"
-            title="Email Verification, COVID-19 Immunization Card, Error Messaging"
+            title="Email Verification, COVID‑19 Immunization Card, Error Messaging"
         >
             <ul>
                 <li>
@@ -592,8 +592,8 @@ export default class ReleaseNotesView extends Vue {
                     registration flow and minimize errors when verifying.
                 </li>
                 <li>
-                    We added a COVID-19 Immunization Card to provide a summary
-                    card of COVID-19 vaccine doses, similar to the one provided
+                    We added a COVID‑19 Immunization Card to provide a summary
+                    card of COVID‑19 vaccine doses, similar to the one provided
                     at clinics.
                 </li>
                 <li>
@@ -653,8 +653,8 @@ export default class ReleaseNotesView extends Vue {
                 <li>
                     We updated our immunization records to include recommended
                     future immunizations based on our BC immunization schedule
-                    and COVID-19 immunization program. If you've received the
-                    first dose of your COVID-19 immunization, you will see a
+                    and COVID‑19 immunization program. If you've received the
+                    first dose of your COVID‑19 immunization, you will see a
                     recommended date for your next dose in both the health care
                     timeline and export records pages.
                 </li>
@@ -723,7 +723,7 @@ export default class ReleaseNotesView extends Vue {
             <ul>
                 <li>
                     We launched the feature which will allow Health Gateway
-                    users to view their immunization records, including COVID-19
+                    users to view their immunization records, including COVID‑19
                     immunizations.
                 </li>
             </ul>
@@ -731,12 +731,12 @@ export default class ReleaseNotesView extends Vue {
         <release-note
             date="December 9, 2020"
             version="v1.3.1.3"
-            title="Fix for Dependent Name Validation, COVID-19 Test Result Export"
+            title="Fix for Dependent Name Validation, COVID‑19 Test Result Export"
         >
             <ul>
                 <li>
                     We fixed a bug on dependent name validation and implemented
-                    the COVID-19 Test Result record export.
+                    the COVID‑19 Test Result record export.
                 </li>
             </ul>
         </release-note>
@@ -755,12 +755,12 @@ export default class ReleaseNotesView extends Vue {
         <release-note
             date="December 7, 2020"
             version="v1.3.1.1"
-            title="Launched Parent Access to Children's COVID-19 Results"
+            title="Launched Parent Access to Children's COVID‑19 Results"
         >
             <ul>
                 <li>
                     We launched the feature enabling parent access to their
-                    children's COVID-19 results. This will allow parents to view
+                    children's COVID‑19 results. This will allow parents to view
                     results for their children under the age of 12.
                 </li>
             </ul>
@@ -793,7 +793,7 @@ export default class ReleaseNotesView extends Vue {
                 <li>
                     We enabled non-photo BC Services card access for those over
                     19. This will support temporary residents and students of BC
-                    who need access to their COVID-19 test results through the
+                    who need access to their COVID‑19 test results through the
                     Health Gateway.
                 </li>
             </ul>
@@ -801,12 +801,12 @@ export default class ReleaseNotesView extends Vue {
         <release-note
             date="November 12, 2020"
             version="v1.2.10"
-            title="Parent Access to Children's COVID-19 Results, OpenShift Upgrade"
+            title="Parent Access to Children's COVID‑19 Results, OpenShift Upgrade"
         >
             <ul>
                 <li>
                     We continued development to support parent access to their
-                    children's COVID-19 results. This update will also enable
+                    children's COVID‑19 results. This update will also enable
                     parents to receive text notifications when the results are
                     ready. Further work to complete this feature will require
                     2-4 weeks.
@@ -836,7 +836,7 @@ export default class ReleaseNotesView extends Vue {
                 </li>
                 <li>
                     We started working on a feature which will allow parents to
-                    access their children's COVID-19 results.
+                    access their children's COVID‑19 results.
                 </li>
             </ul>
         </release-note>
@@ -937,7 +937,7 @@ export default class ReleaseNotesView extends Vue {
         >
             <ul>
                 <li>
-                    This was a minor fix to the COVID-19 Lab Result timeline
+                    This was a minor fix to the COVID‑19 Lab Result timeline
                     entry, to show a more descriptive title, rather than the
                     type of test administered.
                 </li>
@@ -950,14 +950,14 @@ export default class ReleaseNotesView extends Vue {
         <release-note
             date="August 26, 2020"
             version="v1.2.5"
-            title="COVID-19 Test Results, Calendar Enhancements, Application Star Rating, Health Insights"
+            title="COVID‑19 Test Results, Calendar Enhancements, Application Star Rating, Health Insights"
         >
             <ul>
                 <li>
-                    To support the COVID-19 response, the Health Gateway will
-                    now provide access to COVID-19 test results for BC
+                    To support the COVID‑19 response, the Health Gateway will
+                    now provide access to COVID‑19 test results for BC
                     residents. This feature includes a notification via
-                    SMS/Email that the COVID-19 result is available.
+                    SMS/Email that the COVID‑19 result is available.
                 </li>
                 <li>
                     We enhanced the date picker for the calendar to be easier to

--- a/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
@@ -204,7 +204,7 @@ export default class ReportsView extends Vue {
         if (this.config.modules["Laboratory"]) {
             this.reportTypeOptions.push({
                 value: covid19Report,
-                text: "COVID-19 Test Results",
+                text: "COVID‑19 Test Results",
             });
         }
         if (this.config.modules["Immunization"]) {
@@ -341,7 +341,7 @@ export default class ReportsView extends Vue {
                 reportName = "Health Visits";
                 break;
             case covid19Report:
-                reportName = "COVID-19 Test";
+                reportName = "COVID‑19 Test";
                 break;
             case immunizationReport:
                 reportName = "Immunization";


### PR DESCRIPTION
# Implements [AB#14375](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14375)

## Description

Prevent awkward word wrapping on hyphenated text
- added 'text-nowrap' class to dates in tables and timeline cards
- changed hyphen to non-breaking hyphen in text for things like 'Covid-19', phone numbers, etc.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
