### PR TITLE
Enable Blazor Admin to use appropirate config for PHSA V2 for AB#14451. 

### DIFF
--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -68,7 +68,7 @@ namespace HealthGateway.Admin.Server
 
             // Add Refit clients
             PhsaConfigV2 phsaConfig = new();
-            configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfig);
+            configuration.Bind(PhsaConfigV2.AdminConfigurationSectionKey, phsaConfig);
 
             services.AddRefitClient<ISystemBroadcastApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl)
@@ -116,7 +116,7 @@ namespace HealthGateway.Admin.Server
             SwaggerDoc.ConfigureSwaggerServices(services, configuration);
             JobScheduler.ConfigureHangfireQueue(services, configuration);
             Patient.ConfigurePatientAccess(services, logger, configuration);
-            PhsaV2.ConfigurePhsaV2Access(services, logger, configuration);
+            PhsaV2.ConfigurePhsaV2Access(services, logger, configuration, PhsaConfigV2.AdminConfigurationSectionKey);
         }
 
         private static void AddServices(IServiceCollection services)

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -36,7 +36,7 @@
     "ServiceEndpoints": {
         "JobScheduler": "http://localhost:5005/"
     },
-    "PhsaV2": {
+    "PhsaV2Admin": {
         "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -35,7 +35,7 @@
     "ServiceEndpoints": {
         "JobScheduler": "https://dev.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
-    "PhsaV2": {
+    "PhsaV2Admin": {
         "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     },

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -35,7 +35,7 @@
     "ServiceEndpoints": {
         "JobScheduler": "https://mock.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
-    "PhsaV2": {
+    "PhsaV2Admin": {
         "TokenBaseUrl": "https://phsa-ccd-api-identity-dev.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-dev.azurewebsites.net"
     }

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -32,7 +32,7 @@
     "ServiceEndpoints": {
         "JobScheduler": "https://test.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
-    "PhsaV2": {
+    "PhsaV2Admin": {
         "TokenBaseUrl": "https://phsa-ccd-api-identity-test.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-test.azurewebsites.net"
     }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -87,7 +87,7 @@
     "ServiceEndpoints": {
         "JobScheduler": "https://www.healthgateway.gov.bc.ca/admin/jobscheduler"
     },
-    "PhsaV2": {
+    "PhsaV2Admin": {
         "TokenBaseUrl": "https://phsa-ccd-api-identity-prod.azurewebsites.net",
         "BaseUrl": "https://phsa-ccd-api-healthgatewayadmin-prod.azurewebsites.net",
         "ClientId": "****",

--- a/Apps/Common/src/Delegates/PHSA/RestTokenSwapDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestTokenSwapDelegate.cs
@@ -47,15 +47,17 @@ namespace HealthGateway.Common.Delegates.PHSA
         /// <param name="logger">The logger to use.</param>
         /// <param name="tokenSwapApi">The refit api responsible for swapping tokens with PHSA.</param>
         /// <param name="configuration">The configuration to use.</param>
+        /// <param name="configurationSectionKey">The configuration section to use when binding values.</param>
         public RestTokenSwapDelegate(
             ILogger<RestTokenSwapDelegate> logger,
             ITokenSwapApi tokenSwapApi,
-            IConfiguration configuration)
+            IConfiguration configuration,
+            string? configurationSectionKey = PhsaConfigV2.ConfigurationSectionKey)
         {
             this.logger = logger;
             this.tokenSwapApi = tokenSwapApi;
             this.phsaConfigV2 = new PhsaConfigV2();
-            configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, this.phsaConfigV2); // Initializes ClientId, ClientSecret, GrantType and Scope.
+            configuration.Bind(configurationSectionKey, this.phsaConfigV2); // Initializes ClientId, ClientSecret, GrantType and Scope.
         }
 
         private static ActivitySource Source { get; } = new(nameof(RestTokenSwapDelegate));

--- a/Apps/Common/src/Models/PHSA/PhsaConfigV2.cs
+++ b/Apps/Common/src/Models/PHSA/PhsaConfigV2.cs
@@ -28,6 +28,11 @@ namespace HealthGateway.Common.Models.PHSA
         public const string ConfigurationSectionKey = "PhsaV2";
 
         /// <summary>
+        /// The section key to use when binding this object.
+        /// </summary>
+        public const string AdminConfigurationSectionKey = "PhsaV2Admin";
+
+        /// <summary>
         /// Gets or sets the phsa base endpoint for tokens.
         /// </summary>
         public Uri TokenBaseUrl { get; set; } = null!;


### PR DESCRIPTION
# Fixes [AB#14451](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14451)

## Description

- Enable Blazor Admin to use PHSA V2 Configuration when calling Token Swap and other APIs that require V2 configuration.
- Changed PhsaV2 block in settings to PhsaV2Admin
- Changed Refit access that require V2 configuration to access PhsaV2Admin in settings
- Changed Token Swap delegate dependency injection declaration to utilize PhsaV2Admin configuration if needed 

**Blazor Admin Notifications:**

<img width="2523" alt="Screenshot 2022-12-02 at 4 32 35 PM" src="https://user-images.githubusercontent.com/58790456/205413740-f8349cfa-e8cf-481b-931c-bce92eacec4f.png">


**Web Client Clinical Docs - uses V2 not affected:**

<img width="2551" alt="Screenshot 2022-12-02 at 4 50 38 PM" src="https://user-images.githubusercontent.com/58790456/205414162-4d8b802b-4d9c-4f7e-b430-efb2cb115884.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
