### PR TITLE
Date Extending beyond Timeline Card

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -141,9 +141,9 @@ export default class EntrycardTimelineComponent extends Vue {
                                 <strong>{{ displayTitle }}</strong>
                             </span>
                         </b-col>
-                        <b-col cols="4" class="text-right">
+                        <b-col class="text-right text-nowrap">
                             <span
-                                class="text-muted text-nowrap"
+                                class="text-muted entry-card-date"
                                 data-testid="entryCardDate"
                                 >{{ dateString }}</span
                             >
@@ -284,5 +284,9 @@ div[class*=" row"] {
 .detailsButton {
     padding: 0px;
     color: $primary;
+}
+
+.entry-card-date {
+    font-size: 0.875rem;
 }
 </style>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -141,7 +141,7 @@ export default class EntrycardTimelineComponent extends Vue {
                                 <strong>{{ displayTitle }}</strong>
                             </span>
                         </b-col>
-                        <b-col class="text-right text-nowrap">
+                        <b-col cols="auto" class="text-right text-nowrap">
                             <span
                                 class="text-muted entry-card-date"
                                 data-testid="entryCardDate"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -143,7 +143,7 @@ export default class EntrycardTimelineComponent extends Vue {
                         </b-col>
                         <b-col cols="auto" class="text-right text-nowrap">
                             <span
-                                class="text-muted entry-card-date"
+                                class="text-muted small"
                                 data-testid="entryCardDate"
                                 >{{ dateString }}</span
                             >
@@ -284,9 +284,5 @@ div[class*=" row"] {
 .detailsButton {
     padding: 0px;
     color: $primary;
-}
-
-.entry-card-date {
-    font-size: 0.875rem;
 }
 </style>


### PR DESCRIPTION
# Fixes [AB#14448](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14448)

## Description

Date Extending beyond Timeline Card

After a discussion with Mandad:
- applied the secondary text sizing of .875rem to the timeline date
- added "text-nowrap" at column level and removed from the span
- the only way I could prevent this bug's date-extending problem while using "text-nowrap" was to remove the cols="4" setting from the column
- I tried using non-breaking hyphens in the date, but it made no difference to the behavior

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screenshot 2022-12-05 at 2 02 26 PM](https://user-images.githubusercontent.com/5408101/205752693-6da7112e-3457-4179-b327-9948bed043fe.png)


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
