### PR TITLE
Fixes the key and shortens cache time for AB#14405

### DIFF
--- a/Apps/Common/src/Services/AccessTokenService.cs
+++ b/Apps/Common/src/Services/AccessTokenService.cs
@@ -35,6 +35,7 @@ namespace HealthGateway.Common.Services
         /// The generic cache domain to store access token against.
         /// </summary>
         private const string TokenSwapCacheDomain = "TokenSwap";
+        private const int EarlyExpiry = 45;
 
         private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly ICacheProvider cacheProvider;
@@ -83,7 +84,7 @@ namespace HealthGateway.Common.Services
 
                 if (accessToken != null)
                 {
-                    requestResult = await this.SwapToken(userId, accessToken).ConfigureAwait(true);
+                    requestResult = await this.SwapToken(cacheKey, accessToken).ConfigureAwait(true);
                 }
                 else
                 {
@@ -117,7 +118,7 @@ namespace HealthGateway.Common.Services
             if (this.phsaConfigV2.TokenCacheEnabled)
             {
                 this.logger.LogDebug("Attempting to cache access token for cache key: {Key}", cacheKey);
-                TimeSpan? expires = tokenSwapResponse.ExpiresIn > 0 ? TimeSpan.FromSeconds(tokenSwapResponse.ExpiresIn) : null;
+                TimeSpan? expires = tokenSwapResponse.ExpiresIn > 0 ? TimeSpan.FromSeconds(tokenSwapResponse.ExpiresIn - EarlyExpiry) : null;
                 this.cacheProvider.AddItem(cacheKey, tokenSwapResponse, expires);
             }
             else


### PR DESCRIPTION
# Fixes or Implements [AB#14404](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14404)

## Description
The cache was being used but the key was incorrect and the cache duration needed to be shortened to eliminate using stale tokens.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
