### PR TITLE
In Cypress use client not server client id when accesing Keycloak for AB#14453

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -9,6 +9,8 @@
 // ***********************************************
 require("cy-verify-downloads").addCustomCommand();
 
+const openIdConnectClientId = "hg-admin-blazor";
+
 function generateRandomString(length) {
     var text = "";
     var possible =
@@ -46,9 +48,8 @@ Cypress.Commands.add("login", (username, password, path) => {
                 code_verifier: codeVerifier,
                 redirect_uri: config.openIdConnect.callbacks.Logon,
                 authority: config.openIdConnect.authority,
-                client_id: config.openIdConnect.clientId,
+                client_id: openIdConnectClientId,
                 response_mode: "query",
-                scope: config.openIdConnect.scope,
                 extraTokenParams: {},
             };
 
@@ -65,11 +66,10 @@ Cypress.Commands.add("login", (username, password, path) => {
                 url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
                 followRedirect: false,
                 qs: {
-                    scope: config.openIdConnect.scope,
                     response_type: config.openIdConnect.responseType,
                     approval_prompt: "auto",
                     redirect_uri: config.openIdConnect.callbacks.Logon,
-                    client_id: config.openIdConnect.clientId,
+                    client_id: openIdConnectClientId,
                     response_mode: "query",
                     state: stateStore.id,
                 },


### PR DESCRIPTION
# Fixes [AB#14453](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14453)

## Description

- Running Functional tests locally was not erroring out because of incorrect client id
- Configuration was returning server client id not the client for Keycloak
- Will hardcode 'hg-admin-blazor' until fix for configuration is done to return client specific configuration details instead of server
- Spoke with @sslaws removed scope as it is not required.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
