### PR TITLE
Refactor Refit api to not use Dictionary for AB#14343

### DIFF
--- a/Apps/Encounter/src/Api/IHospitalVisitApi.cs
+++ b/Apps/Encounter/src/Api/IHospitalVisitApi.cs
@@ -29,13 +29,14 @@ namespace HealthGateway.Encounter.Api
         /// <summary>
         /// Returns a list of hospital visits.
         /// </summary>
-        /// <param name="query">Query parameters used to query hospital visits.</param>
+        /// <param name="subjectHdid">The Hdid to query hospital visits.</param>
+        /// <param name="limit">The Limit to query hospital visits.</param>
         /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>
         /// The PHSA Result including the load state and the list of hospital visits for the user identified by
         /// the subject id in the query.
         /// </returns>
-        [Get("/api/v1/HospitalVisits")]
-        Task<PhsaResult<IEnumerable<HospitalVisit>>> GetHospitalVisitsAsync(Dictionary<string, string?> query, [Authorize] string token);
+        [Get("/api/v1/HospitalVisits?subjectHdid={subjectHdid}&limit={limit}")]
+        Task<PhsaResult<IEnumerable<HospitalVisit>>> GetHospitalVisitsAsync(string subjectHdid, string limit, [Authorize] string token);
     }
 }

--- a/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
+++ b/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
@@ -83,16 +83,11 @@ namespace HealthGateway.Encounter.Delegates
             };
 
             string? accessToken = this.authenticationDelegate.FetchAuthenticatedUserToken();
-            Dictionary<string, string?> query = new()
-            {
-                ["limit"] = this.phsaConfig.FetchSize,
-                ["subjectHdid"] = hdid,
-            };
 
             try
             {
                 PhsaResult<IEnumerable<HospitalVisit>> response =
-                    await this.hospitalVisitApi.GetHospitalVisitsAsync(query, accessToken).ConfigureAwait(true);
+                    await this.hospitalVisitApi.GetHospitalVisitsAsync(hdid, this.phsaConfig.FetchSize, accessToken).ConfigureAwait(true);
                 requestResult.ResultStatus = ResultType.Success;
                 requestResult.ResourcePayload!.Result = response.Result;
                 requestResult.TotalResultCount = requestResult.ResourcePayload.Result.Count();

--- a/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
+++ b/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.EncounterTests.Delegates
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(AccessToken);
             Mock<IHospitalVisitApi> mockHospitalVisitApi = new();
-            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<Dictionary<string, string?>>(), AccessToken)).ReturnsAsync(phsaResponse);
+            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken)).ReturnsAsync(phsaResponse);
             IHospitalVisitDelegate hospitalVisitDelegate = new RestHospitalVisitDelegate(
                 mockAuthDelegate.Object,
                 mockHospitalVisitApi.Object,
@@ -102,7 +102,7 @@ namespace HealthGateway.EncounterTests.Delegates
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(AccessToken);
             Mock<IHospitalVisitApi> mockHospitalVisitApi = new();
-            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<Dictionary<string, string?>>(), AccessToken)).ThrowsAsync(mockException);
+            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken)).ThrowsAsync(mockException);
             IHospitalVisitDelegate hospitalVisitDelegate = new RestHospitalVisitDelegate(
                 mockAuthDelegate.Object,
                 mockHospitalVisitApi.Object,
@@ -131,7 +131,7 @@ namespace HealthGateway.EncounterTests.Delegates
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(AccessToken);
             Mock<IHospitalVisitApi> mockHospitalVisitApi = new();
-            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<Dictionary<string, string?>>(), AccessToken)).ThrowsAsync(mockException);
+            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken)).ThrowsAsync(mockException);
             IHospitalVisitDelegate hospitalVisitDelegate = new RestHospitalVisitDelegate(
                 mockAuthDelegate.Object,
                 mockHospitalVisitApi.Object,

--- a/Apps/Immunization/src/Api/IImmunizationApi.cs
+++ b/Apps/Immunization/src/Api/IImmunizationApi.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Api;
 
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using HealthGateway.Common.Models.PHSA;
 using Refit;
@@ -37,13 +36,14 @@ public interface IImmunizationApi
     /// <summary>
     /// Retrieves a PhsaResult containing the immunizations and recommendations of a given patient.
     /// </summary>
-    /// <param name="query">Query parameters.</param>
+    /// <param name="subjectHdid">The Hdid to query immunizations and recommendations.</param>
+    /// <param name="limit">The Limit to query immunizations and recommendations.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
     /// <returns>
     /// A PhsaResult containing the immunizations and recommendations of a given patient.
     /// </returns>
-    [Get("/api/v1/Immunizations")]
-    Task<PhsaResult<ImmunizationResponse>> GetImmunizationsAsync(Dictionary<string, string?> query, [Authorize] string token);
+    [Get("/api/v1/Immunizations?subjectHdid={subjectHdid}&limit={limit}")]
+    Task<PhsaResult<ImmunizationResponse>> GetImmunizationsAsync(string subjectHdid, string limit, [Authorize] string token);
 
     /// <summary>
     /// Retrieves a PhsaResult containing the vaccine status of a given patient.

--- a/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Immunization.Delegates
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics;
     using System.Net.Http;
     using System.Threading.Tasks;
@@ -104,16 +103,11 @@ namespace HealthGateway.Immunization.Delegates
 
             RequestResult<PhsaResult<ImmunizationResponse>> requestResult = InitializeResult<ImmunizationResponse>();
             string? accessToken = this.authenticationDelegate.FetchAuthenticatedUserToken();
-            Dictionary<string, string?> query = new()
-            {
-                ["limit"] = this.phsaConfig.FetchSize,
-                ["subjectHdid"] = hdid,
-            };
 
             try
             {
                 PhsaResult<ImmunizationResponse> response =
-                    await this.immunizationApi.GetImmunizationsAsync(query, accessToken).ConfigureAwait(true);
+                    await this.immunizationApi.GetImmunizationsAsync(hdid, this.phsaConfig.FetchSize, accessToken).ConfigureAwait(true);
                 requestResult.ResultStatus = ResultType.Success;
                 requestResult.ResourcePayload!.Result = response.Result;
                 requestResult.TotalResultCount = 1;

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -209,14 +209,14 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             Mock<IImmunizationApi> mockImmunizationApi = new();
             if (!throwException)
             {
-                mockImmunizationApi.Setup(s => s.GetImmunizationsAsync(It.IsAny<Dictionary<string, string?>>(), AccessToken))
+                mockImmunizationApi.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken))
                     .ReturnsAsync(response);
             }
             else
             {
                 mockImmunizationApi.Setup(
                         s =>
-                            s.GetImmunizationsAsync(It.IsAny<Dictionary<string, string?>>(), AccessToken))
+                            s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken))
                     .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
             }
 

--- a/Apps/Laboratory/src/Api/ILaboratoryApi.cs
+++ b/Apps/Laboratory/src/Api/ILaboratoryApi.cs
@@ -31,40 +31,41 @@ namespace HealthGateway.Laboratory.Api
         /// Returns a List of COVID-19 Orders for the authenticated user.
         /// It has a collection of one or more COVID-19 results depending on the tests ordered.
         /// </summary>
-        /// <param name="query">Query parameters used to query COVID-19 results.</param>
+        /// <param name="subjectHdid">The Hdid to query COVID-19 results.</param>
+        /// <param name="limit">The Limit to query COVID-19 results.</param>
         /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>The list of COVID-19 Orders available for the user identified by the bearer token.</returns>
-        [Get("/api/v1/LabOrders")]
-        Task<PhsaResult<List<PhsaCovid19Order>>> GetCovid19OrdersAsync(Dictionary<string, string?> query, [Authorize] string token);
+        [Get("/api/v1/LabOrders?subjectHdid={subjectHdid}&limit={limit}")]
+        Task<PhsaResult<List<PhsaCovid19Order>>> GetCovid19OrdersAsync(string subjectHdid, string limit, [Authorize] string token);
 
         /// <summary>
         /// Returns the laboratory report for the provided laboratory order.
         /// </summary>
         /// <param name="id">The id of the laboratory report to return.</param>
-        /// <param name="query">Query parameters used to query the laboratory report.</param>
+        /// <param name="subjectHdid">The Hdid to query the laboratory report.</param>
         /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>The laboratory report identified by the id and query parameters.</returns>
-        [Get("/api/v1/LabOrders/{id}/LabReportDocument")]
-        Task<LaboratoryReport> GetLaboratoryReportAsync(string id, Dictionary<string, string?> query, [Authorize] string token);
+        [Get("/api/v1/LabOrders/{id}/LabReportDocument?subjectHdid={subjectHdid}")]
+        Task<LaboratoryReport> GetLaboratoryReportAsync(string id, string subjectHdid, [Authorize] string token);
 
         /// <summary>
         /// Returns the plis pdf document for the provided laboratory order.
         /// </summary>
         /// <param name="id">The id of the plis pdf document to return.</param>
-        /// <param name="query">Query parameters used to query the plis pdf document.</param>
+        /// <param name="subjectHdid">The Hdid to query the plis pdf document.</param>
         /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>The plis pdf document identified by the id and query parameters.</returns>
-        [Get("/api/v1/Lab/Plis/{id}/LabReportDocument")]
-        Task<LaboratoryReport> GetPlisLaboratoryReportAsync(string id, Dictionary<string, string?> query, [Authorize] string token);
+        [Get("/api/v1/Lab/Plis/{id}/LabReportDocument?subjectHdid={subjectHdid}")]
+        Task<LaboratoryReport> GetPlisLaboratoryReportAsync(string id, string subjectHdid, [Authorize] string token);
 
         /// <summary>
         /// Returns the provincial lab information system laboratory summary belonging to the authenticated user.
         /// </summary>
-        /// <param name="query">Query parameters used to query the plis laboratory summary.</param>
+        /// <param name="subjectHdid">The Hdid to query the plis laboratory summary.</param>
         /// <param name="token">The bearer token to authorize the call.</param>
         /// <returns>The plis laboratory summary identified by the query parameters.</returns>
-        [Get("/api/v1/Lab/Plis/LabSummary")]
-        Task<PhsaResult<PhsaLaboratorySummary>> GetPlisLaboratorySummaryAsync(Dictionary<string, string?> query, [Authorize] string token);
+        [Get("/api/v1/Lab/Plis/LabSummary?subjectHdid={subjectHdid}")]
+        Task<PhsaResult<PhsaLaboratorySummary>> GetPlisLaboratorySummaryAsync(string subjectHdid, [Authorize] string token);
 
         /// <summary>
         /// Returns the public COVID-19 test results for the given patient.

--- a/Apps/Laboratory/src/Delegates/RestLaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/RestLaboratoryDelegate.cs
@@ -82,16 +82,10 @@ namespace HealthGateway.Laboratory.Delegates
                     PageSize = int.Parse(this.labConfig.FetchSize, CultureInfo.InvariantCulture),
                 };
 
-                Dictionary<string, string?> query = new()
-                {
-                    ["limit"] = this.labConfig.FetchSize,
-                    ["subjectHdid"] = hdid,
-                };
-
                 try
                 {
                     PhsaResult<List<PhsaCovid19Order>> response =
-                        await this.laboratoryApi.GetCovid19OrdersAsync(query, bearerToken).ConfigureAwait(true);
+                        await this.laboratoryApi.GetCovid19OrdersAsync(hdid, this.labConfig.FetchSize, bearerToken).ConfigureAwait(true);
                     retVal.ResultStatus = ResultType.Success;
                     retVal.ResourcePayload = response;
                     retVal.TotalResultCount = retVal.ResourcePayload.Result!.Count;
@@ -135,20 +129,15 @@ namespace HealthGateway.Laboratory.Delegates
                     TotalResultCount = 0,
                 };
 
-                Dictionary<string, string?> query = new()
-                {
-                    ["subjectHdid"] = hdid,
-                };
-
                 try
                 {
                     if (isCovid19)
                     {
-                        retVal.ResourcePayload = await this.laboratoryApi.GetLaboratoryReportAsync(id, query, bearerToken).ConfigureAwait(true);
+                        retVal.ResourcePayload = await this.laboratoryApi.GetLaboratoryReportAsync(id, hdid, bearerToken).ConfigureAwait(true);
                     }
                     else
                     {
-                        retVal.ResourcePayload = await this.laboratoryApi.GetPlisLaboratoryReportAsync(id, query, bearerToken).ConfigureAwait(true);
+                        retVal.ResourcePayload = await this.laboratoryApi.GetPlisLaboratoryReportAsync(id, hdid, bearerToken).ConfigureAwait(true);
                     }
 
                     retVal.ResultStatus = ResultType.Success;
@@ -184,15 +173,10 @@ namespace HealthGateway.Laboratory.Delegates
                 PageSize = int.Parse(this.labConfig.FetchSize, CultureInfo.InvariantCulture),
             };
 
-            Dictionary<string, string?> query = new()
-            {
-                ["subjectHdid"] = hdid,
-            };
-
             try
             {
                 PhsaResult<PhsaLaboratorySummary> response =
-                    await this.laboratoryApi.GetPlisLaboratorySummaryAsync(query, bearerToken).ConfigureAwait(true);
+                    await this.laboratoryApi.GetPlisLaboratorySummaryAsync(hdid, bearerToken).ConfigureAwait(true);
                 retVal.ResultStatus = ResultType.Success;
                 retVal.ResourcePayload = response;
                 retVal.TotalResultCount = retVal.ResourcePayload.Result!.LabOrderCount;

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -86,7 +86,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ReturnsAsync(response);
+            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -115,7 +115,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.NoContent, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -145,7 +145,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -174,7 +174,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             HttpRequestException mockException = MockRefitException.CreateHttpRequestException("Internal Server Error", HttpStatusCode.InternalServerError);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetCovid19OrdersAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -207,7 +207,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             };
 
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ReturnsAsync(response);
+            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -235,7 +235,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.NoContent, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -263,7 +263,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
@@ -292,7 +292,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             HttpRequestException mockException = MockRefitException.CreateHttpRequestException("Internal Server Error", HttpStatusCode.InternalServerError);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
@@ -326,7 +326,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             };
 
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ReturnsAsync(response);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
@@ -355,7 +355,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.NoContent, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
@@ -384,7 +384,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
@@ -413,7 +413,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             // Arrange
             HttpRequestException mockException = MockRefitException.CreateHttpRequestException("Internal Server Error", HttpStatusCode.InternalServerError);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratoryReportAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
@@ -573,7 +573,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
 
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ReturnsAsync(response);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(response);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -600,7 +600,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.NoContent, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -630,7 +630,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             ApiException mockException = MockRefitException.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Get);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,
@@ -659,7 +659,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
             Mock<ILogger<RestLaboratoryDelegate>> mockLogger = new();
             HttpRequestException mockException = MockRefitException.CreateHttpRequestException("Internal Server Error", HttpStatusCode.InternalServerError);
             Mock<ILaboratoryApi> mockLaboratoryApi = new();
-            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<Dictionary<string, string?>>(), It.IsAny<string>())).ThrowsAsync(mockException);
+            mockLaboratoryApi.Setup(s => s.GetPlisLaboratorySummaryAsync(It.IsAny<string>(), It.IsAny<string>())).ThrowsAsync(mockException);
 
             ILaboratoryDelegate labDelegate = new RestLaboratoryDelegate(
                 mockLogger.Object,


### PR DESCRIPTION
# Fixes [AB#14343](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14343)

## Description

Refit API interfaces should not use dictionaries to pass query string parameters unless the parameters are optional. All mandatory parameters are included in the method signature.

<img width="795" alt="Screenshot 2022-12-07 at 9 14 04 AM" src="https://user-images.githubusercontent.com/58790456/206247464-84c35c3d-cc58-430d-8d9f-614c7ec5a4b7.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
