### PR TITLE
Update admin cypress to latest version for AB#14501

### DIFF
--- a/Apps/Admin/Tests/Functional/README.md
+++ b/Apps/Admin/Tests/Functional/README.md
@@ -36,7 +36,7 @@ While creating and debugging tests you will want to run Cypress interactively.
 
 ```bash
 export CYPRESS_BASE_URL=http://localhost:5027
-npx cypress open
+npx cypress open --e2e
 ```
 
 If you want to verify the tests against https://dev-admin.healthgateway.gov.bc.ca, then do not set the CYPRESS_BASE_URL environment variable.

--- a/Apps/Admin/Tests/Functional/cypress.config.js
+++ b/Apps/Admin/Tests/Functional/cypress.config.js
@@ -25,6 +25,5 @@ module.exports = defineConfig({
         setupNodeEvents(on, config) {
             on("task", { isFileExist, findFiles });
         },
-        experimentalSessionAndOrigin: true,
     },
 });

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/feedback-review.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/feedback-review.cy.js
@@ -47,11 +47,9 @@ describe("Feedback Review", () => {
         cy.log("Adding tags.");
         cy.get("[data-testid=add-tag-input]").clear().type(suggestionTag);
         cy.get("[data-testid=add-tag-button]").click();
-        cy.get("[data-testid=tags-updating-indicator").should("be.visible");
         cy.get("[data-testid=tag-collection-item]").contains(suggestionTag);
         cy.get("[data-testid=add-tag-input]").clear().type(questionTag);
         cy.get("[data-testid=add-tag-button]").click();
-        cy.get("[data-testid=tags-updating-indicator").should("be.visible");
         cy.get("[data-testid=tag-collection-item]").contains(questionTag);
 
         cy.log("Assigning tags.");
@@ -112,12 +110,10 @@ describe("Feedback Review", () => {
             .contains(suggestionTag)
             .children("button")
             .click();
-        cy.get("[data-testid=tags-updating-indicator").should("be.visible");
         cy.get("[data-testid=tag-collection-item]")
             .contains(questionTag)
             .children("button")
             .click();
-        cy.get("[data-testid=tags-updating-indicator").should("be.visible");
         cy.get("[data-testid=tag-collection-item]").should("not.exist");
     });
 

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -34,7 +34,7 @@ Cypress.Commands.add("logout", () => {
 });
 
 Cypress.Commands.add("login", (username, password, path) => {
-    cy.session([username], () => {
+    cy.session(username, () => {
         cy.log("Logging in using Keycloak.");
         cy.readConfig().then((config) => {
             logout(config);
@@ -93,6 +93,7 @@ Cypress.Commands.add("login", (username, password, path) => {
             });
         });
     });
+    cy.log(`Visiting ${path}`);
     cy.visit(path, { timeout: 60000 });
     // wait for log in to complete
     cy.get("[data-testid=user-account-icon]").should("exist");

--- a/Apps/Admin/Tests/Functional/package-lock.json
+++ b/Apps/Admin/Tests/Functional/package-lock.json
@@ -15,7 +15,7 @@
             "devDependencies": {
                 "@cypress/skip-test": "^2.6.1",
                 "cy-verify-downloads": "^0.1.8",
-                "cypress": "^10.0.3",
+                "cypress": "^12.0.2",
                 "cypress-xpath": "^1.6.2",
                 "eslint": "^8.16.0",
                 "eslint-plugin-chai-friendly": "^0.7.2",
@@ -700,9 +700,9 @@
             "dev": true
         },
         "node_modules/cypress": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.3.tgz",
-            "integrity": "sha512-8C82XTybsEmJC9POYSNITGUhMLCRwB9LadP0x33H+52QVoBjhsWvIzrI+ybCe0+TyxaF0D5/9IL2kSTgjqCB9A==",
+            "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
+            "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -725,7 +725,7 @@
                 "dayjs": "^1.10.4",
                 "debug": "^4.3.2",
                 "enquirer": "^2.3.6",
-                "eventemitter2": "^6.4.3",
+                "eventemitter2": "6.4.7",
                 "execa": "4.1.0",
                 "executable": "^4.1.1",
                 "extract-zip": "2.0.1",
@@ -753,7 +753,7 @@
                 "cypress": "bin/cypress"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
             }
         },
         "node_modules/cypress-xpath": {
@@ -1432,9 +1432,9 @@
             }
         },
         "node_modules/eventemitter2": {
-            "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-            "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
+            "version": "6.4.7",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+            "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
             "dev": true
         },
         "node_modules/execa": {
@@ -3947,9 +3947,9 @@
             "dev": true
         },
         "cypress": {
-            "version": "10.0.3",
-            "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.0.3.tgz",
-            "integrity": "sha512-8C82XTybsEmJC9POYSNITGUhMLCRwB9LadP0x33H+52QVoBjhsWvIzrI+ybCe0+TyxaF0D5/9IL2kSTgjqCB9A==",
+            "version": "12.0.2",
+            "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.0.2.tgz",
+            "integrity": "sha512-WnLx1DpnbF1vbpDBkgP14rK5yS3U+Gvxrv2fsB4Owma26oIyENj7DDRnsJbSZuTfG4mcuUJxAkRHJR2wBqBfMA==",
             "dev": true,
             "requires": {
                 "@cypress/request": "^2.88.10",
@@ -3971,7 +3971,7 @@
                 "dayjs": "^1.10.4",
                 "debug": "^4.3.2",
                 "enquirer": "^2.3.6",
-                "eventemitter2": "^6.4.3",
+                "eventemitter2": "6.4.7",
                 "execa": "4.1.0",
                 "executable": "^4.1.1",
                 "extract-zip": "2.0.1",
@@ -4482,9 +4482,9 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
         },
         "eventemitter2": {
-            "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.5.tgz",
-            "integrity": "sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==",
+            "version": "6.4.7",
+            "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.7.tgz",
+            "integrity": "sha512-tYUSVOGeQPKt/eC1ABfhHy5Xd96N3oIijJvN3O9+TsC28T5V9yX9oEfEK5faP0EFSNVOG97qtAS68GBrQB2hDg==",
             "dev": true
         },
         "execa": {

--- a/Apps/Admin/Tests/Functional/package.json
+++ b/Apps/Admin/Tests/Functional/package.json
@@ -15,7 +15,7 @@
     "devDependencies": {
         "@cypress/skip-test": "^2.6.1",
         "cy-verify-downloads": "^0.1.8",
-        "cypress": "^10.0.3",
+        "cypress": "^12.0.2",
         "cypress-xpath": "^1.6.2",
         "eslint": "^8.16.0",
         "eslint-plugin-chai-friendly": "^0.7.2",

--- a/Testing/functional/tests/README.md
+++ b/Testing/functional/tests/README.md
@@ -38,7 +38,7 @@ While creating and debugging tests you will want to run Cypress interactively.
 
 ```bash
 export CYPRESS_BASE_URL=http://localhost:5002
-npx cypress open --e2e
+npx cypress open --e2e --browser chrome
 ```
 
 If you want to verify the tests against <https://dev.healthgateway.gov.bc.ca> then do not set the CYPRESS_BASE_URL environment variable.


### PR DESCRIPTION
# Implements [AB#14501](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14501)

## Description

- Update admin cypress to latest version
- Update config to remove 'experimentalSessionAndOrigin' as that configuration is no longer experimental
- Update login command to include additional log statement and replaced array declaration with a standard string
- Removed check in feedback review  test to avoid flakiness
- Updated README for both Admin and Healthgateway to use Chrome and e2e as default selections when starting up via 'cypress open'.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
