### PR TITLE
Switch to dotCover from OpenCover

### DIFF
--- a/Apps/sonar-config.xml
+++ b/Apps/sonar-config.xml
@@ -19,8 +19,7 @@
 <SonarQubeAnalysisProperties  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
   <Property Name="sonar.verbose">false</Property>
   <Property Name="sonar.host.url">https://sonarcloud.io</Property>
-  <Property Name="sonar.cs.opencover.reportsPaths">**/coverage.opencover.xml</Property>
-  <Property Name="sonar.cs.xunit.reportsPaths">**/TestResults/results.xml</Property>
+  <Property Name="sonar.cs.dotcover.reportsPaths">dotCover.Output.html</Property>
   <Property Name="sonar.sources">**/src/**</Property>
   <Property Name="sonar.scm.disabled">true</Property>
   <Property Name="sonar.coverage.exclusions">**/*Controller.cs, Common/src/Models/**, Admin/**, Database/**, DBMaintainer/**, JobScheduler/**, WebClient/**</Property>

--- a/Apps/sonar-config.xml
+++ b/Apps/sonar-config.xml
@@ -19,7 +19,7 @@
 <SonarQubeAnalysisProperties  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
   <Property Name="sonar.verbose">false</Property>
   <Property Name="sonar.host.url">https://sonarcloud.io</Property>
-  <Property Name="sonar.cs.dotcover.reportsPaths">dotCover.Output.html</Property>
+  <Property Name="sonar.cs.dotcover.reportsPaths">**/dotCover.Output.html</Property>
   <Property Name="sonar.sources">**/src/**</Property>
   <Property Name="sonar.scm.disabled">true</Property>
   <Property Name="sonar.coverage.exclusions">**/*Controller.cs, Common/src/Models/**, Admin/**, Database/**, DBMaintainer/**, JobScheduler/**, WebClient/**</Property>

--- a/Tools/SonarCloud/azure/build.yaml
+++ b/Tools/SonarCloud/azure/build.yaml
@@ -18,29 +18,17 @@ jobs:
     timeoutInMinutes: 120
     steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET Core sdk'
+        displayName: 'Install .NET SDK'
         condition: eq(variables['EnableAzure'], True)
         inputs:
           packageType: sdk
           version: 7.x
           installationPath: $(Agent.ToolsDirectory)/dotnet
 
-      # - script: |
-      #     npm --prefix WebClient/src/ClientApp install --only=dev
-      #     npm --prefix WebClient/src/ClientApp test
-      #   displayName: "Run npm Tests"
-      #   continueOnError: true
-      #   workingDirectory: $(Build.SourcesDirectory)/Apps/
-      #   enabled: true
-
       - script: |
-          export CollectCoverage=true
-          export CoverletOutputFormat=opencover
+          dotnet tool install --global JetBrains.dotCover.GlobalTool
           dotnet tool install --global dotnet-sonarscanner --version $(SONARSCANNER_VERSION)
-          dotnet test --logger:"xunit;LogFileName=results.xml"
-        displayName: "Run dotnet Tests"
-        continueOnError: true
-        workingDirectory: $(Build.SourcesDirectory)/Apps/
+        displayName: "Install SonarScanner and dotCover"
         enabled: true
 
       - script: |
@@ -60,8 +48,9 @@ jobs:
         enabled: "true"
 
       - script: |
-          dotnet build    
-        displayName: "Build Solution"
+          dotnet build --no-incremental
+          dotnet dotcover test --dcReportType=HTML
+        displayName: "Build and Test"
         continueOnError: true
         workingDirectory: $(Build.SourcesDirectory)/Apps/
         enabled: "true"

--- a/Tools/SonarCloud/azure/build.yaml
+++ b/Tools/SonarCloud/azure/build.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - script: |
           dotnet build --no-incremental
-          dotnet dotcover test --dcReportType=HTML
+          dotnet dotcover test --dcReportType=HTML --dcAttributeFilters=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute;
         displayName: "Build and Test"
         continueOnError: true
         workingDirectory: $(Build.SourcesDirectory)/Apps/


### PR DESCRIPTION
# Fixes or Implements [AB#14529](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14529)

## Description

OpenCover appears to be reporting 0% on Common and I don't see a clear indication of why other than the tests may run long.  I tested locally with dotCover and did get coverage so I'm switching the solution to use that tool.

<img width="1002" alt="image" src="https://user-images.githubusercontent.com/51342761/207261128-4c43cb85-f10f-42c1-8ab2-dd723fdc0d81.png">

Note:  The local run does not include our exclusions but some tweaking maybe required after merging.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
