### PR TITLE
Create ticket service and http delegate helper method for AB#14514.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/constants/serviceCodes.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/serviceCodes.ts
@@ -11,4 +11,5 @@ export const enum ServiceCode {
     PHSA = "PHSA",
     Report = "REP",
     ClinicalDocument = "CDO",
+    Ticket = "TCK",
 }

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -67,6 +67,7 @@ import {
     IPcrTestService,
     IReportService,
     IStoreProvider,
+    ITicketService,
     IUserCommentService,
     IUserFeedbackService,
     IUserNoteService,
@@ -174,6 +175,9 @@ configService
         const pcrTestKitService = container.get<IPcrTestService>(
             SERVICE_IDENTIFIER.PcrTestService
         );
+        const ticketService = container.get<ITicketService>(
+            SERVICE_IDENTIFIER.TicketService
+        );
 
         store.dispatch("config/initialize", config);
 
@@ -200,6 +204,7 @@ configService
         pcrTestKitService.initialize(config, httpDelegate);
         reportService.initialize(config, httpDelegate);
         vaccinationStatusService.initialize(config, httpDelegate);
+        ticketService.initialize(config, httpDelegate);
 
         authInitializePromise.then(async () => {
             Vue.use(IdleVue, {

--- a/Apps/WebClient/src/ClientApp/src/plugins/inversify.config.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/inversify.config.ts
@@ -25,6 +25,7 @@ import {
     IPcrTestService,
     IReportService,
     IStoreProvider,
+    ITicketService,
     IUserCommentService,
     IUserFeedbackService,
     IUserNoteService,
@@ -56,6 +57,7 @@ import StoreProvider from "@/store/StoreProvider";
 import container from "./container";
 import { GatewayStoreOptions } from "@/store/types";
 import { StoreOptions } from "@/store/options";
+import { RestTicketService } from "@/services/restTicketService";
 
 container
     .bind<IConfigService>(SERVICE_IDENTIFIER.ConfigService)
@@ -150,4 +152,8 @@ container
 container
     .bind<IPcrTestService>(SERVICE_IDENTIFIER.PcrTestService)
     .to(RestPcrTestService)
+    .inSingletonScope();
+container
+    .bind<ITicketService>(SERVICE_IDENTIFIER.TicketService)
+    .to(RestTicketService)
     .inSingletonScope();

--- a/Apps/WebClient/src/ClientApp/src/services/httpDelegate.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/httpDelegate.ts
@@ -19,7 +19,16 @@ export default class HttpDelegate implements IHttpDelegate {
     public setAuthorizationHeader(accessToken: string): void {
         this.logger.debug(`ACCESS TOKEN SET`);
         Axios.defaults.headers.common = {
+            ...Axios.defaults.headers.common,
             Authorization: `Bearer ${accessToken}`,
+        };
+    }
+
+    public setTicketAuthorizationHeader(accessToken: string): void {
+        this.logger.debug(`Set Ticket authorization header: ${accessToken}`);
+        Axios.defaults.headers.common = {
+            ...Axios.defaults.headers.common,
+            "hg-ticket": `Bearer ${accessToken}`,
         };
     }
 

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -281,8 +281,8 @@ export interface IStoreProvider {
 }
 
 export interface ITicketService {
+    initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
     createTicket(room: string): Promise<Ticket | undefined>;
     removeTicket(checkInRequest: CheckInRequest): Promise<void>;
     updateTicket(checkInRequest: CheckInRequest): Promise<Ticket>;
-    initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
 }

--- a/Apps/WebClient/src/ClientApp/src/services/restTicketService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restTicketService.ts
@@ -1,0 +1,101 @@
+import { injectable } from "inversify";
+
+import { ServiceCode } from "@/constants/serviceCodes";
+import { CheckInRequest } from "@/models/checkInRequest";
+import { ExternalConfiguration } from "@/models/configData";
+import { HttpError } from "@/models/errors";
+import { Ticket } from "@/models/ticket";
+import container from "@/plugins/container";
+import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
+import { IHttpDelegate, ILogger, ITicketService } from "@/services/interfaces";
+import ErrorTranslator from "@/utility/errorTranslator";
+
+@injectable()
+export class RestTicketService implements ITicketService {
+    private logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+    private readonly TICKET_BASE_URI: string = "Ticket";
+    private http!: IHttpDelegate;
+    private isEnabled = false;
+    private baseUri = "";
+
+    public initialize(
+        config: ExternalConfiguration,
+        http: IHttpDelegate
+    ): void {
+        this.http = http;
+        this.isEnabled = config.webClient.modules["Ticket"];
+        this.baseUri = config.serviceEndpoints["Ticket"];
+    }
+
+    public createTicket(room: string): Promise<Ticket | undefined> {
+        this.logger.debug(`createTicket: ${room}`);
+        return new Promise((resolve, reject) => {
+            if (!this.isEnabled) {
+                resolve(undefined);
+                return;
+            }
+
+            this.http
+                .post<Ticket>(
+                    `${this.baseUri}${this.TICKET_BASE_URI}?room=${room}`,
+                    null
+                )
+                .then((ticket) => resolve(ticket))
+                .catch((err: HttpError) => {
+                    this.logger.error(
+                        `Error in RestTicketService.createTicket() - ${err.statusCode}`
+                    );
+                    reject(
+                        ErrorTranslator.internalNetworkError(
+                            err,
+                            ServiceCode.Ticket
+                        )
+                    );
+                });
+        });
+    }
+    public removeTicket(checkInRequest: CheckInRequest): Promise<void> {
+        this.logger.debug(`removeTicket: ${JSON.stringify(checkInRequest)}`);
+        return new Promise((resolve, reject) => {
+            this.http
+                .delete<void>(
+                    `${this.baseUri}${this.TICKET_BASE_URI}`,
+                    checkInRequest
+                )
+                .then((ticket) => resolve(ticket))
+                .catch((err: HttpError) => {
+                    this.logger.error(
+                        `Error in RestTicketService.removeTicket() - ${err.statusCode}`
+                    );
+                    reject(
+                        ErrorTranslator.internalNetworkError(
+                            err,
+                            ServiceCode.Ticket
+                        )
+                    );
+                });
+        });
+    }
+    public updateTicket(checkInRequest: CheckInRequest): Promise<Ticket> {
+        this.logger.debug(`updateTicket: ${JSON.stringify(checkInRequest)}`);
+        return new Promise((resolve, reject) => {
+            this.http
+                .put<Ticket>(
+                    `${this.baseUri}${this.TICKET_BASE_URI}/check-in`,
+                    checkInRequest
+                )
+                .then((ticket) => resolve(ticket))
+                .catch((err: HttpError) => {
+                    this.logger.error(
+                        `Error in RestTicketService.checkInRequest() - ${err.statusCode}`
+                    );
+                    reject(
+                        ErrorTranslator.internalNetworkError(
+                            err,
+                            ServiceCode.Ticket
+                        )
+                    );
+                });
+        });
+    }
+}

--- a/Apps/WebClient/src/appsettings.Development.json
+++ b/Apps/WebClient/src/appsettings.Development.json
@@ -37,7 +37,8 @@
             "PcrTest": true,
             "ClinicalDocument": true,
             "HospitalVisit": true,
-            "NotificationCentre": true
+            "NotificationCentre": true,
+            "Ticket": true
         }
     },
     "ServiceEndpoints": {
@@ -47,7 +48,8 @@
         "Immunization": "http://localhost:3001/",
         "Laboratory": "http://localhost:3004/",
         "Medication": "http://localhost:3003/",
-        "Patient": "http://localhost:3002/"
+        "Patient": "http://localhost:3002/",
+        "Ticket": "http://localhost:8000/"
     },
     "IdentityProviders": [
         {

--- a/Apps/WebClient/src/appsettings.hgdev.json
+++ b/Apps/WebClient/src/appsettings.hgdev.json
@@ -45,7 +45,8 @@
             "DependentClinicalDocumentTab": true,
             "DependentLaboratoryOrderTab": true,
             "ClinicalDocument": true,
-            "HospitalVisit": true
+            "HospitalVisit": true,
+            "Ticket": true
         }
     },
     "ServiceEndpoints": {
@@ -55,7 +56,8 @@
         "Immunization": "https://hg-dev.api.gov.bc.ca/api/immunizationservice/",
         "Laboratory": "https://hg-dev.api.gov.bc.ca/api/laboratoryservice/",
         "Medication": "https://hg-dev.api.gov.bc.ca/api/medicationservice/",
-        "Patient": "https://hg-dev.api.gov.bc.ca/api/patientservice/"
+        "Patient": "https://hg-dev.api.gov.bc.ca/api/patientservice/",
+        "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/ https://hg-dev.api.gov.bc.ca/",

--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -23,7 +23,8 @@
         "Immunization": "https://hg-test.api.gov.bc.ca/api/immunizationservice/",
         "Laboratory": "https://hg-test.api.gov.bc.ca/api/laboratoryservice/",
         "Medication": "https://hg-test.api.gov.bc.ca/api/medicationservice/",
-        "Patient": "https://hg-test.api.gov.bc.ca/api/patientservice/"
+        "Patient": "https://hg-test.api.gov.bc.ca/api/patientservice/",
+        "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/ https://hg-test.api.gov.bc.ca/",

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -78,7 +78,8 @@
             "AllLaboratory": false,
             "ClinicalDocument": false,
             "HospitalVisit": false,
-            "NotificationCentre": false
+            "NotificationCentre": false,
+            "Ticket": false
         },
         "HoursForDeletion": 720,
         "MinPatientAge": 12,
@@ -93,7 +94,8 @@
         "Patient": "https://hg-prod.api.gov.bc.ca/api/patientservice/",
         "Medication": "https://hg-prod.api.gov.bc.ca/api/medicationservice/",
         "Laboratory": "https://hg-prod.api.gov.bc.ca/api/laboratoryservice/",
-        "Encounter": "https://hg-prod.api.gov.bc.ca/api/encounterservice/"
+        "Encounter": "https://hg-prod.api.gov.bc.ca/api/encounterservice/",
+        "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },
     "AvailabilityFilter": {
         "DumpHeaders": false,


### PR DESCRIPTION
# Implements [AB#14514](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14514)

## Description

- Created ticket service for create ticket, check in and remove ticket - note: remove ticket has not yet been implemented in WaitingQueue. Note: create ticket can be enabled or disabled
- Created helper method in http delegate to set authorization header for ticket related token
- Updated app settings (1) enable or disable Ticket module. (2) endpoint location of waiting queue APIs.  Note: dev, test and prod endpoints are the same.  This is temporary and will be updated once locations have been formalized. See [AB#14558](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14558)
- Also created [AB#14557](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14557). Problem details need to be mapped appropriately to current existing front end error object.  Currently only the status code is being recognized.  The message and other properties need to be mapped.

**Service can successfully call Post for create ticket, Put for check in and Delete for remove ticket.**

<img width="2246" alt="Screenshot 2022-12-16 at 9 24 25 AM" src="https://user-images.githubusercontent.com/58790456/208154494-a4d3d366-6a3d-48fc-a092-ddc92066d1b7.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
