### PR TITLE
Fix browser reload issue for Queued and Busy pages for AB#14580.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -495,11 +495,21 @@ export const beforeEachGuard: NavigationGuard = async (
     const waitlistIsEnabled = enabledModules.includes(ClientModule.Ticket);
     const waitlistTicketIsProcessed: boolean =
         store.getters["waitlist/ticketIsProcessed"];
+    let metaRquiresProcessedWaitlistTicket =
+        meta.requiresProcessedWaitlistTicket;
+
+    if (from.fullPath === QUEUE_FULL_PATH || from.fullPath === QUEUE_PATH) {
+        metaRquiresProcessedWaitlistTicket = true;
+    }
+
+    logger.debug(
+        `Before guard - waitlist enabled: ${waitlistIsEnabled}, waitlist ticket processed: ${waitlistTicketIsProcessed} and meta requires processed waitlist ticket: ${metaRquiresProcessedWaitlistTicket}`
+    );
 
     if (
         waitlistIsEnabled &&
         !waitlistTicketIsProcessed &&
-        meta.requiresProcessedWaitlistTicket
+        metaRquiresProcessedWaitlistTicket
     ) {
         try {
             const ticket: Ticket = await store.dispatch("waitlist/getTicket");

--- a/Apps/WebClient/src/ClientApp/src/store/modules/waitlist/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/waitlist/actions.ts
@@ -49,7 +49,7 @@ export const actions: WaitlistActions = {
         const timeout = Math.max(0, checkInAfter - now);
         return new Promise((resolve) => {
             logger.debug(
-                `Handle ticket: timeout (milliseconds): ${timeout} - check in after (milliseconds): ${checkInAfter} - now (milliseconds): ${now}`
+                `Handle ticket: timeout (ms): ${timeout} - check in after (ms): ${checkInAfter} - now (ms): ${now}`
             );
             if (
                 ticket.status === TicketStatus.Processed &&


### PR DESCRIPTION
# Fixes [AB#14580](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14580)

## Description

- Fixed router so that when browser is reloaded on Queued or Busy page, create ticket is called to ensure that user is accessing the protected page appropriately
- Updated log message in handle ticket action
- Added and updated functional tests to address browser reload issue
- Updated log messages in functional tests

<img width="926" alt="Screenshot 2022-12-21 at 12 21 50 PM" src="https://user-images.githubusercontent.com/58790456/208996565-3b648e35-d6f1-4bf5-9331-5516a5d7aafa.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

NO

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
