### PR TITLE
Add waiting queue url to content security policy for AB#14592

### DIFF
--- a/Apps/WebClient/src/appsettings.hgdev.json
+++ b/Apps/WebClient/src/appsettings.hgdev.json
@@ -61,7 +61,7 @@
         "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/ https://hg-dev.api.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/ https://hg-dev.api.gov.bc.ca/ https://tickets.healthgateway.gov.bc.ca/",
         "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },

--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -27,7 +27,7 @@
         "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/ https://hg-test.api.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/ https://hg-test.api.gov.bc.ca/ https://tickets.healthgateway.gov.bc.ca/",
         "FrameSource": "'self' https://test.loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://test.loginproxy.gov.bc.ca/"
     },

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -105,7 +105,7 @@
         "Base": "'self'",
         "DefaultSource": "'self'",
         "ScriptSource": "'self' 'unsafe-eval' 'sha256-Tui7QoFlnLXkJCSl1/JvEZdIXTmBttnWNxzJpXomQjg=' 'sha256-vY0Cwh5hLv8sUQ61m3KQgfrqeAmcY7t6wJ2FAdYPNyU=' https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js",
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/ https://hg-prod.api.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/ https://hg-prod.api.gov.bc.ca/ https://tickets.healthgateway.gov.bc.ca/",
         "ImageSource": "'self' data:",
         "StyleSource": "'self' 'unsafe-inline' https://fonts.googleapis.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",
         "FormAction": "'self'",


### PR DESCRIPTION
# Fixes [AB#14592](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14592)

## Description

- Add waiting queue url to connect source section of content security policy in appsettings.json (dev, test and prod).
- The settings are all the same until the waiting queue urls are created for dev, test and prod.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
