### PR TITLE
Add models and controller for agent provisioning AB#14639

### DIFF
--- a/Apps/Admin/Client/Authorization/Roles.cs
+++ b/Apps/Admin/Client/Authorization/Roles.cs
@@ -15,24 +15,26 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Authorization
 {
+    using HealthGateway.Admin.Common.Constants;
+
     /// <summary>
-    /// Represents the valid Authorization roles for the application.
+    /// Represents the valid authorization roles for the application.
     /// </summary>
     public static class Roles
     {
         /// <summary>
         /// Represents an overall Admin User (super).
         /// </summary>
-        public const string Admin = "AdminUser";
+        public const string Admin = nameof(IdentityAccessRole.AdminUser);
 
         /// <summary>
         /// Represents a Reviewer Admin.
         /// </summary>
-        public const string Reviewer = "AdminReviewer";
+        public const string Reviewer = nameof(IdentityAccessRole.AdminReviewer);
 
         /// <summary>
         /// Represents a Support worker.
         /// </summary>
-        public const string Support = "SupportUser";
+        public const string Support = nameof(IdentityAccessRole.SupportUser);
     }
 }

--- a/Apps/Admin/Common/Admin.Common.csproj
+++ b/Apps/Admin/Common/Admin.Common.csproj
@@ -16,4 +16,8 @@
   <ItemGroup>
     <SupportedPlatform Include="browser" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
+  </ItemGroup>
 </Project>

--- a/Apps/Admin/Common/Constants/IdentityAccessRole.cs
+++ b/Apps/Admin/Common/Constants/IdentityAccessRole.cs
@@ -13,20 +13,36 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Constants
+namespace HealthGateway.Admin.Common.Constants
 {
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
     /// <summary>
     /// An enum representing identity access realm role names.
     /// </summary>
+    [JsonStringEnumMemberConverterOptions(deserializationFailureFallbackValue: Unknown)]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum IdentityAccessRole
     {
         /// <summary>
-        /// Represents AdminUser role.
+        /// Unknown role.
+        /// </summary>
+        [EnumMember(Value = "")]
+        Unknown,
+
+        /// <summary>
+        /// The role associated with general access to the admin website.
         /// </summary>
         AdminUser,
 
         /// <summary>
-        /// Represents SupportUser role.
+        /// The role associated with access to the feedback module on the admin website.
+        /// </summary>
+        AdminReviewer,
+
+        /// <summary>
+        /// The role associated with service desk access to the admin website.
         /// </summary>
         SupportUser,
     }

--- a/Apps/Admin/Common/Constants/KeycloakIdentityProvider.cs
+++ b/Apps/Admin/Common/Constants/KeycloakIdentityProvider.cs
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Constants
+{
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
+    /// <summary>
+    /// An enum representing Keycloak identity providers.
+    /// </summary>
+    [JsonStringEnumMemberConverterOptions(deserializationFailureFallbackValue: Unknown)]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
+    public enum KeycloakIdentityProvider
+    {
+        /// <summary>
+        /// Unknown identity provider.
+        /// </summary>
+        [EnumMember(Value = "")]
+        Unknown,
+
+        /// <summary>
+        /// The IDIR identity provider.
+        /// </summary>
+        [EnumMember(Value = "idir")]
+        Idir,
+
+        /// <summary>
+        /// The PHSA Azure identity provider.
+        /// </summary>
+        [EnumMember(Value = "phsaazure")]
+        PhsaAzure,
+    }
+}

--- a/Apps/Admin/Common/Models/AdminAgent.cs
+++ b/Apps/Admin/Common/Models/AdminAgent.cs
@@ -1,0 +1,48 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using HealthGateway.Admin.Common.Constants;
+
+    /// <summary>
+    /// Model representing a user of the admin website.
+    /// </summary>
+    public class AdminAgent
+    {
+        /// <summary>
+        /// Gets or sets the agent's unique account identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the agent's username.
+        /// </summary>
+        public string Username { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the agent's identity provider.
+        /// </summary>
+        public KeycloakIdentityProvider IdentityProvider { get; set; } = KeycloakIdentityProvider.Unknown;
+
+        /// <summary>
+        /// Gets or sets the roles assigned to the agent.
+        /// </summary>
+        public IEnumerable<IdentityAccessRole> Roles { get; set; } = Enumerable.Empty<IdentityAccessRole>();
+    }
+}

--- a/Apps/Admin/Server/Controllers/AgentAccessController.cs
+++ b/Apps/Admin/Server/Controllers/AgentAccessController.cs
@@ -1,0 +1,136 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Server.Services;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// Web API to manage agent access to the admin website.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/api/[controller]")]
+    [Produces("application/json")]
+    [Authorize(Roles = "AdminUser")]
+    public class AgentAccessController
+    {
+        private readonly IAgentAccessService agentAccessService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AgentAccessController"/> class.
+        /// </summary>
+        /// <param name="agentAccessService">The injected agent access service.</param>
+        public AgentAccessController(IAgentAccessService agentAccessService)
+        {
+            this.agentAccessService = agentAccessService;
+        }
+
+        /// <summary>
+        /// Provisions agent access to the admin website.
+        /// </summary>
+        /// <returns>The created agent.</returns>
+        /// <param name="agent">The agent model.</param>
+        /// <response code="200">Returns the created agent.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        /// <response code="502">Unable to get response from Keycloak.</response>
+        [HttpPost]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<AdminAgent> ProvisionAgentAccess(AdminAgent agent)
+        {
+            return await this.agentAccessService.ProvisionAgentAccessAsync(agent).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Retrieves agents with access to the admin website that match the query.
+        /// </summary>
+        /// <param name="query">The query string to match agents against.</param>
+        /// <returns>The collection of matching agents.</returns>
+        /// <response code="200">Returns the collection of matching agents.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        /// <response code="502">Unable to get response from Keycloak.</response>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<IEnumerable<AdminAgent>> GetAgents(string query)
+        {
+            return await this.agentAccessService.GetAgentsAsync(query).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Updates agent access to the admin website.
+        /// </summary>
+        /// <param name="agent">The agent model.</param>
+        /// <returns>The updated agent.</returns>
+        /// <response code="200">Returns the updated agent.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        /// <response code="502">Unable to get response from Keycloak.</response>
+        [HttpPut]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<AdminAgent> UpdateAgentAccess(AdminAgent agent)
+        {
+            return await this.agentAccessService.UpdateAgentAccessAsync(agent).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Removes an agent's access to the admin website.
+        /// </summary>
+        /// <param name="id">The unique identifier of the agent whose access should be terminated.</param>
+        /// <returns>True if the agent's access was successfully removed.</returns>
+        /// <response code="200">Returns a boolean indicating if the agent's access was successfully removed.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        /// <response code="502">Unable to get response from Keycloak.</response>
+        [HttpDelete]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [ProducesResponseType(StatusCodes.Status502BadGateway)]
+        public async Task<bool> RemoveAgentAccess(Guid id)
+        {
+            return await this.agentAccessService.RemoveAgentAccessAsync(id).ConfigureAwait(true);
+        }
+    }
+}

--- a/Apps/Admin/Server/Services/IAgentAccessService.cs
+++ b/Apps/Admin/Server/Services/IAgentAccessService.cs
@@ -1,0 +1,57 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
+
+    /// <summary>
+    /// Service to manage agent access to the admin website.
+    /// </summary>
+    public interface IAgentAccessService
+    {
+        /// <summary>
+        /// Provisions agent access to the admin website.
+        /// </summary>
+        /// <param name="agent">The agent model.</param>
+        /// <returns>The created agent.</returns>
+        Task<AdminAgent> ProvisionAgentAccessAsync(AdminAgent agent);
+
+        /// <summary>
+        /// Retrieves agents with access to the admin website that match the query.
+        /// </summary>
+        /// <param name="queryString">The query string to match agents against.</param>
+        /// <param name="resultLimit">The maximum number of results to return.</param>
+        /// <returns>The collection of matching agents.</returns>
+        Task<IEnumerable<AdminAgent>> GetAgentsAsync(string queryString, int? resultLimit = 25);
+
+        /// <summary>
+        /// Updates agent access to the admin website.
+        /// </summary>
+        /// <param name="agent">The agent model.</param>
+        /// <returns>The updated agent.</returns>
+        Task<AdminAgent> UpdateAgentAccessAsync(AdminAgent agent);
+
+        /// <summary>
+        /// Removes an agent's access to the admin website.
+        /// </summary>
+        /// <param name="agentId">The unique identifier of the agent whose access should be terminated.</param>
+        /// <returns>True if the agent's access was successfully removed.</returns>
+        Task<bool> RemoveAgentAccessAsync(Guid agentId);
+    }
+}

--- a/Apps/Admin/Server/Services/InactiveUserService.cs
+++ b/Apps/Admin/Server/Services/InactiveUserService.cs
@@ -21,12 +21,12 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using AutoMapper;
+using HealthGateway.Admin.Common.Constants;
 using HealthGateway.Admin.Server.Models;
 using HealthGateway.Common.AccessManagement.Administration.Models;
 using HealthGateway.Common.AccessManagement.Authentication;
 using HealthGateway.Common.AccessManagement.Authentication.Models;
 using HealthGateway.Common.Api;
-using HealthGateway.Common.Constants;
 using HealthGateway.Common.Data.Constants;
 using HealthGateway.Common.Data.ViewModels;
 using HealthGateway.Common.ErrorHandling;
@@ -129,7 +129,7 @@ public class InactiveUserService : IInactiveUserService
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogError("Error communicating with Keycloak, exception: {Exception}",  e.ToString());
+                this.logger.LogError("Error communicating with Keycloak, exception: {Exception}", e.ToString());
                 requestResult.ResultStatus = ResultType.Error;
                 requestResult.ResultError = new RequestResultError
                 {


### PR DESCRIPTION
# Implements [AB#14639](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14639)

## Description

- moves IdentityAccessRole to Admin.Common
- adds models for agent provisioning
- adds interface for agent access service
- adds agent access controller

## Swagger

![localhost-2023-01-05-183212](https://user-images.githubusercontent.com/16570293/210921198-9c83f676-791d-43de-b213-a27cbb20bf74.png)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
