### PR TITLE
Add edit dialog for agent provisioning AB#14641

### DIFF
--- a/Apps/Admin/Client/Components/AgentAccessDialog.razor
+++ b/Apps/Admin/Client/Components/AgentAccessDialog.razor
@@ -1,0 +1,90 @@
+@using HealthGateway.Admin.Client.Store.Broadcasts
+@using HealthGateway.Admin.Common.Constants
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudDialog>
+    <DialogContent>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasAddError"
+            TResetAction="@BroadcastsActions.AddAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasUpdateError"
+            TResetAction="@BroadcastsActions.UpdateAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <MudForm @ref="Form" data-testid="broadcast-dialog-modal-text">
+            <MudGrid Spacing="0">
+                <MudItem xs="12">
+                    <HgTextField
+                        Label="Username"
+                        @bind-Value="@Agent.Username"
+                        T="@string"
+                        Required="@(!IsEdit)"
+                        RequiredError="Username is required"
+                        Disabled="@IsEdit"
+                        data-testid="username-input" />
+                </MudItem>
+                <MudItem xs="12">
+                    <HgSelect
+                        Label="Identity Provider"
+                        @bind-Value="@Agent.IdentityProvider"
+                        T="KeycloakIdentityProvider"
+                        Required="@(!IsEdit)"
+                        RequiredError="Identity provider is required"
+                        Disabled="@IsEdit"
+                        data-testid="identity-provider-select">
+                        <MudSelectItem T="KeycloakIdentityProvider" Value="@KeycloakIdentityProvider.Unknown" data-testid="identity-provider">
+                            None
+                        </MudSelectItem>
+                        @foreach (KeycloakIdentityProvider identityProvider in IdentityProviders)
+                        {
+                            <MudSelectItem T="KeycloakIdentityProvider" Value="@identityProvider" data-testid="identity-provider">
+                                @AgentUtility.FormatKeycloakIdentityProvider(identityProvider)
+                            </MudSelectItem>
+                        }
+                    </HgSelect>
+                </MudItem>
+                <MudItem xs="12">
+                    <MudSelect T="IdentityAccessRole"
+                               Label="Roles"
+                               MultiSelection="@true"
+                               SelectedValues="@Agent.Roles"
+                               SelectedValuesChanged="@(UpdateRoles)"
+                               Variant="@Variant.Filled"
+                               Dense="@true"
+                               Class="mt-3"
+                               data-testid="roles-select">
+                        @foreach (IdentityAccessRole role in AccessRoles)
+                        {
+                            <MudSelectItem Value="@role" data-testid="query-type">@role.ToString()</MudSelectItem>
+                        }
+                    </MudSelect>
+                </MudItem>
+            </MudGrid>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <HgButton
+            Color="@Color.Primary"
+            Variant="@Variant.Text"
+            OnClick="@HandleClickCancel"
+            RightMargin="Breakpoint.Always"
+            BottomMargin="Breakpoint.Always"
+            data-testid="cancel-btn">
+            Cancel
+        </HgButton>
+        <HgButton
+            Color="@Color.Primary"
+            OnClick="@HandleClickSaveAsync"
+            Disabled="@SaveButtonDisabled"
+            RightMargin="Breakpoint.Always"
+            BottomMargin="Breakpoint.Always"
+            data-testid="save-btn">
+            Save
+        </HgButton>
+    </DialogActions>
+</MudDialog>

--- a/Apps/Admin/Client/Components/AgentAccessDialog.razor.cs
+++ b/Apps/Admin/Client/Components/AgentAccessDialog.razor.cs
@@ -1,0 +1,117 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Threading.Tasks;
+using Fluxor;
+using Fluxor.Blazor.Web.Components;
+using HealthGateway.Admin.Client.Store.AgentAccess;
+using HealthGateway.Admin.Common.Constants;
+using HealthGateway.Admin.Common.Models;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+/// <summary>
+/// Backing logic for the BroadcastDialog component.
+/// If the Save button is pressed, the dialog's Result will have the Data property populated with a bool value of true.
+/// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
+/// </summary>
+public partial class AgentAccessDialog : FluxorComponent
+{
+    /// <summary>
+    /// Gets or sets the broadcast model corresponding to the broadcast that is being edited.
+    /// </summary>
+    [Parameter]
+    public AdminAgent Agent { get; set; } = default!;
+
+    private static List<KeycloakIdentityProvider> IdentityProviders => new()
+    {
+        KeycloakIdentityProvider.Idir,
+        KeycloakIdentityProvider.PhsaAzure,
+    };
+
+    private static List<IdentityAccessRole> AccessRoles => new()
+    {
+        IdentityAccessRole.AdminUser,
+        IdentityAccessRole.AdminReviewer,
+        IdentityAccessRole.SupportUser,
+    };
+
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; } = default!;
+
+    [Inject]
+    private IDispatcher Dispatcher { get; set; } = default!;
+
+    [Inject]
+    private IActionSubscriber ActionSubscriber { get; set; } = default!;
+
+    [Inject]
+    private IState<AgentAccessState> AgentAccessState { get; set; } = default!;
+
+    private bool IsEdit => this.Agent.Id != Guid.Empty;
+
+    private bool HasAddError => this.AgentAccessState.Value.Add.Error is { Message.Length: > 0 };
+
+    private bool HasUpdateError => this.AgentAccessState.Value.Update.Error is { Message.Length: > 0 };
+
+    private string? ErrorMessage => this.HasAddError ? this.AgentAccessState.Value.Add.Error?.Message : this.AgentAccessState.Value.Update.Error?.Message;
+
+    private bool SaveButtonDisabled => this.IsEdit ? this.Agent.Roles.SetEquals(this.InitialRoles) : this.Agent.IdentityProvider == KeycloakIdentityProvider.Unknown;
+
+    private MudForm Form { get; set; } = default!;
+
+    private IReadOnlySet<IdentityAccessRole> InitialRoles { get; set; } = ImmutableHashSet<IdentityAccessRole>.Empty;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        this.ActionSubscriber.SubscribeToAction<AgentAccessActions.AddSuccessAction>(this, _ => this.MudDialog.Close(true));
+        this.ActionSubscriber.SubscribeToAction<AgentAccessActions.UpdateSuccessAction>(this, _ => this.MudDialog.Close(true));
+        this.InitialRoles = new HashSet<IdentityAccessRole>(this.Agent.Roles);
+    }
+
+    private void HandleClickCancel()
+    {
+        this.MudDialog.Cancel();
+    }
+
+    private async Task HandleClickSaveAsync()
+    {
+        await this.Form.Validate().ConfigureAwait(true);
+        if (this.Form.IsValid)
+        {
+            if (this.IsEdit)
+            {
+                this.Dispatcher.Dispatch(new AgentAccessActions.UpdateAction(this.Agent));
+            }
+            else
+            {
+                this.Dispatcher.Dispatch(new AgentAccessActions.AddAction(this.Agent));
+            }
+        }
+    }
+
+    private void UpdateRoles(IEnumerable<IdentityAccessRole> roles)
+    {
+        this.Agent.Roles.Clear();
+        this.Agent.Roles.UnionWith(roles);
+    }
+}

--- a/Apps/Admin/Client/Pages/AgentAccessPage.razor
+++ b/Apps/Admin/Client/Pages/AgentAccessPage.razor
@@ -22,7 +22,7 @@
                          T="string"
                          Label="Query"
                          Required="@true"
-                         RequiredError="Search parameter is required"
+                         Validation="@ValidateQueryParameter"
                          @bind-Value="Query"
                          data-testid="query-input" />
         </MudItem>

--- a/Apps/Admin/Client/Pages/AgentAccessPage.razor.cs
+++ b/Apps/Admin/Client/Pages/AgentAccessPage.razor.cs
@@ -24,7 +24,6 @@ using Fluxor;
 using Fluxor.Blazor.Web.Components;
 using HealthGateway.Admin.Client.Components;
 using HealthGateway.Admin.Client.Store.AgentAccess;
-using HealthGateway.Admin.Client.Store.Broadcasts;
 using HealthGateway.Admin.Client.Utils;
 using HealthGateway.Admin.Common.Models;
 using HealthGateway.Common.Data.Utils;
@@ -36,6 +35,21 @@ using MudBlazor;
 /// </summary>
 public partial class AgentAccessPage : FluxorComponent
 {
+    private static Func<string, string?> ValidateQueryParameter => parameter =>
+    {
+        if (string.IsNullOrWhiteSpace(parameter))
+        {
+            return "Search parameter is required";
+        }
+
+        if (StringManipulator.StripWhitespace(parameter)?.Length < 3)
+        {
+            return "Query must contain at least 3 characters";
+        }
+
+        return null;
+    };
+
     [Inject]
     private IDispatcher Dispatcher { get; set; } = default!;
 
@@ -87,7 +101,7 @@ public partial class AgentAccessPage : FluxorComponent
 
     private void ResetState()
     {
-        this.Dispatcher.Dispatch(new BroadcastsActions.ResetStateAction());
+        this.Dispatcher.Dispatch(new AgentAccessActions.ResetStateAction());
     }
 
     private async Task SearchAsync()
@@ -141,8 +155,7 @@ public partial class AgentAccessPage : FluxorComponent
         DialogParameters parameters = new() { ["Agent"] = agent };
         DialogOptions options = new() { DisableBackdropClick = true };
 
-        // to do: swap BroadcastDialog for the new AgentAccessDialog
-        IDialogReference dialog = await this.Dialog.ShowAsync<BroadcastDialog>(title, parameters, options).ConfigureAwait(true);
+        IDialogReference dialog = await this.Dialog.ShowAsync<AgentAccessDialog>(title, parameters, options).ConfigureAwait(true);
 
         await dialog.Result.ConfigureAwait(true);
         this.IsModalShown = false;

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
@@ -95,7 +95,7 @@ public class AgentAccessEffects
         {
             RequestError error = StoreUtility.FormatRequestError(e);
             this.Logger.LogError("Error updating agent access, reason: {Exception}", e.ToString());
-            dispatcher.Dispatch(new AgentAccessActions.AddFailAction(error));
+            dispatcher.Dispatch(new AgentAccessActions.UpdateFailAction(error));
         }
     }
 

--- a/Apps/Admin/Client/Utils/AgentUtility.cs
+++ b/Apps/Admin/Client/Utils/AgentUtility.cs
@@ -1,4 +1,19 @@
-﻿namespace HealthGateway.Admin.Client.Utils
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Utils
 {
     using HealthGateway.Admin.Common.Constants;
 

--- a/Apps/Admin/Common/Models/AdminAgent.cs
+++ b/Apps/Admin/Common/Models/AdminAgent.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Common.Models
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using HealthGateway.Admin.Common.Constants;
 
     /// <summary>
@@ -26,9 +25,9 @@ namespace HealthGateway.Admin.Common.Models
     public class AdminAgent
     {
         /// <summary>
-        /// Gets or sets the agent's unique account identifier.
+        /// Gets the agent's unique account identifier.
         /// </summary>
-        public Guid Id { get; set; }
+        public Guid Id { get; init; }
 
         /// <summary>
         /// Gets or sets the agent's username.
@@ -41,8 +40,8 @@ namespace HealthGateway.Admin.Common.Models
         public KeycloakIdentityProvider IdentityProvider { get; set; } = KeycloakIdentityProvider.Unknown;
 
         /// <summary>
-        /// Gets or sets the roles assigned to the agent.
+        /// Gets the roles assigned to the agent.
         /// </summary>
-        public IEnumerable<IdentityAccessRole> Roles { get; set; } = Enumerable.Empty<IdentityAccessRole>();
+        public ISet<IdentityAccessRole> Roles { get; init; } = new HashSet<IdentityAccessRole>();
     }
 }


### PR DESCRIPTION
# Implements [AB#14641](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14641)

## Description

- Implements AgentAccessDialog
- Updates model to use a set instead of enumerable for roles
- Adds minor fixes related to agent provisioning

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-01-10-184413](https://user-images.githubusercontent.com/16570293/211706223-8abd83bf-ac1c-4260-a724-5c8840ccd989.png)
![localhost-2023-01-10-184429](https://user-images.githubusercontent.com/16570293/211706220-cf958fee-cd3f-401b-9328-d97e388a20ce.png)
![localhost-2023-01-10-184629](https://user-images.githubusercontent.com/16570293/211706221-2c2a9204-d1b3-41a6-882d-290ece80b73e.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
