### PR TITLE
Disable CS1591 and SA1600 warnings for AB#14204

### DIFF
--- a/Apps/Admin/Client/Store/Analytics/AnalyticsEffects.cs
+++ b/Apps/Admin/Client/Store/Analytics/AnalyticsEffects.cs
@@ -22,16 +22,9 @@ using HealthGateway.Admin.Client.Api;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public class AnalyticsEffects
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="AnalyticsEffects"/> class.
-    /// </summary>
-    /// <param name="logger">The injected logger.</param>
-    /// <param name="analyticsApi">the injected api to query the analytics service. </param>
     public AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi analyticsApi)
     {
         this.Logger = logger;
@@ -44,12 +37,6 @@ public class AnalyticsEffects
     [Inject]
     private IAnalyticsApi AnalyticsApi { get; set; }
 
-    /// <summary>
-    /// Handler that calls the user profiles service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadUserProfilesAction action, IDispatcher dispatcher)
     {
@@ -72,12 +59,6 @@ public class AnalyticsEffects
         dispatcher.Dispatch(new AnalyticsActions.LoadFailAction(error));
     }
 
-    /// <summary>
-    /// Handler that calls the comments service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadCommentsAction action, IDispatcher dispatcher)
     {
@@ -100,12 +81,6 @@ public class AnalyticsEffects
         dispatcher.Dispatch(new AnalyticsActions.LoadFailAction(error));
     }
 
-    /// <summary>
-    /// Handler that calls the notes service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadNotesAction action, IDispatcher dispatcher)
     {
@@ -128,12 +103,6 @@ public class AnalyticsEffects
         dispatcher.Dispatch(new AnalyticsActions.LoadFailAction(error));
     }
 
-    /// <summary>
-    /// Handler that calls the ratings service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadRatingsAction action, IDispatcher dispatcher)
     {
@@ -156,12 +125,6 @@ public class AnalyticsEffects
         dispatcher.Dispatch(new AnalyticsActions.LoadFailAction(error));
     }
 
-    /// <summary>
-    /// Handler that calls the inactive users service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadInactiveUsersAction action, IDispatcher dispatcher)
     {
@@ -184,12 +147,6 @@ public class AnalyticsEffects
         dispatcher.Dispatch(new AnalyticsActions.LoadFailAction(error));
     }
 
-    /// <summary>
-    /// Handler that calls the user feedback service and dispatches the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadUserFeedbackAction action, IDispatcher dispatcher)
     {
@@ -212,12 +169,6 @@ public class AnalyticsEffects
         dispatcher.Dispatch(new AnalyticsActions.LoadFailAction(error));
     }
 
-    /// <summary>
-    /// Handler that calls the year of birth counts service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(AnalyticsActions.LoadYearOfBirthCountsAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/Analytics/AnalyticsReducers.cs
+++ b/Apps/Admin/Client/Store/Analytics/AnalyticsReducers.cs
@@ -17,16 +17,9 @@ namespace HealthGateway.Admin.Client.Store.Analytics;
 
 using Fluxor;
 
-/// <summary>
-/// The set of reducers for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public static class AnalyticsReducers
 {
-    /// <summary>
-    /// The Reducer for the load user profiles action.
-    /// </summary>
-    /// <param name="state">The user profiles state.</param>
-    /// <returns>The new user profiles state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadUserProfilesAction))]
     public static AnalyticsState ReduceLoadUserProfilesAction(AnalyticsState state)
     {
@@ -36,11 +29,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load comments action.
-    /// </summary>
-    /// <param name="state">The comments state.</param>
-    /// <returns>The new comments state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadCommentsAction))]
     public static AnalyticsState ReduceLoadCommentsAction(AnalyticsState state)
     {
@@ -50,11 +38,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load notes action.
-    /// </summary>
-    /// <param name="state">The notes state.</param>
-    /// <returns>The new notes state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadNotesAction))]
     public static AnalyticsState ReduceLoadNotesAction(AnalyticsState state)
     {
@@ -64,11 +47,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load ratings action.
-    /// </summary>
-    /// <param name="state">The ratings state.</param>
-    /// <returns>The new ratings state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadRatingsAction))]
     public static AnalyticsState ReduceLoadRatingsAction(AnalyticsState state)
     {
@@ -78,11 +56,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load inactive users action.
-    /// </summary>
-    /// <param name="state">The inactive users state.</param>
-    /// <returns>The new inactive users state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadInactiveUsersAction))]
     public static AnalyticsState ReduceLoadInactiveUsersAction(AnalyticsState state)
     {
@@ -92,11 +65,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load user feedback action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <returns>The new user feedback state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadUserFeedbackAction))]
     public static AnalyticsState ReduceLoadUserFeedbackAction(AnalyticsState state)
     {
@@ -106,11 +74,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load year of birth counts action.
-    /// </summary>
-    /// <param name="state">The year of birth counts state.</param>
-    /// <returns>The new year of birth counts state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.LoadYearOfBirthCountsAction))]
     public static AnalyticsState ReduceYearOfBirthCountsAction(AnalyticsState state)
     {
@@ -120,12 +83,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The analytics state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new analytics state.</returns>
     [ReducerMethod]
     public static AnalyticsState ReduceLoadSuccessAction(AnalyticsState state, AnalyticsActions.LoadSuccessAction action)
     {
@@ -137,12 +94,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the analytics load fail action.
-    /// </summary>
-    /// <param name="state">The analytics state.</param>
-    /// <param name="action">The load fail action.</param>
-    /// <returns>The new analytics state.</returns>
     [ReducerMethod]
     public static AnalyticsState ReduceLoadFailAction(AnalyticsState state, AnalyticsActions.LoadFailAction action)
     {
@@ -154,11 +105,6 @@ public static class AnalyticsReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the reset inactive users state action.
-    /// </summary>
-    /// <param name="state">The inactive users state.</param>
-    /// <returns>The empty state.</returns>
     [ReducerMethod(typeof(AnalyticsActions.ResetStateAction))]
     public static AnalyticsState ReduceResetAction(AnalyticsState state)
     {

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
@@ -30,16 +30,9 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public class BroadcastsEffects
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="BroadcastsEffects"/> class.
-    /// </summary>
-    /// <param name="logger">The injected logger.</param>
-    /// <param name="api">The injected API.</param>
     public BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi api)
     {
         this.Logger = logger;
@@ -52,12 +45,6 @@ public class BroadcastsEffects
     [Inject]
     private IBroadcastsApi Api { get; set; }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleAddAction(BroadcastsActions.AddAction action, IDispatcher dispatcher)
     {
@@ -84,11 +71,6 @@ public class BroadcastsEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod(typeof(BroadcastsActions.LoadAction))]
     public async Task HandleLoadAction(IDispatcher dispatcher)
     {
@@ -115,12 +97,6 @@ public class BroadcastsEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleUpdateAction(BroadcastsActions.UpdateAction action, IDispatcher dispatcher)
     {
@@ -147,12 +123,6 @@ public class BroadcastsEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleDeleteAction(BroadcastsActions.DeleteAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -23,16 +23,9 @@ using Fluxor;
 using HealthGateway.Admin.Client.Models;
 using HealthGateway.Common.Data.Models;
 
-/// <summary>
-/// The set of reducers for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public static class BroadcastsReducers
 {
-    /// <summary>
-    /// The reducer for loading broadcasts.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(BroadcastsActions.LoadAction))]
     public static BroadcastsState ReduceLoadAction(BroadcastsState state)
     {
@@ -46,12 +39,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static BroadcastsState ReduceLoadSuccessAction(BroadcastsState state, BroadcastsActions.LoadSuccessAction action)
     {
@@ -69,12 +56,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <param name="action">The load fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static BroadcastsState ReduceLoadFailAction(BroadcastsState state, BroadcastsActions.LoadFailAction action)
     {
@@ -90,11 +71,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for adding broadcasts.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(BroadcastsActions.AddAction))]
     public static BroadcastsState ReduceAddAction(BroadcastsState state)
     {
@@ -108,12 +84,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the add success action.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <param name="action">The add success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static BroadcastsState ReduceAddSuccessAction(BroadcastsState state, BroadcastsActions.AddSuccessAction action)
     {
@@ -139,12 +109,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the add fail action.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <param name="action">The add fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static BroadcastsState ReduceAddFailAction(BroadcastsState state, BroadcastsActions.AddFailAction action)
     {
@@ -160,11 +124,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for updating broadcasts.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(BroadcastsActions.UpdateAction))]
     public static BroadcastsState ReduceUpdateAction(BroadcastsState state)
     {
@@ -178,12 +137,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the update success action.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <param name="action">The update success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static BroadcastsState ReduceUpdateSuccessAction(BroadcastsState state, BroadcastsActions.UpdateSuccessAction action)
     {
@@ -209,12 +162,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the update fail action.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <param name="action">The update fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static BroadcastsState ReduceUpdateFailAction(BroadcastsState state, BroadcastsActions.UpdateFailAction action)
     {
@@ -230,11 +177,6 @@ public static class BroadcastsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for deleting broadcasts.
-    /// </summary>
-    /// <param name="state">The broadcasts state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(BroadcastsActions.DeleteAction))]
     public static BroadcastsState ReduceDeleteAction(BroadcastsState state)
     {

--- a/Apps/Admin/Client/Store/Communications/CommunicationsEffects.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsEffects.cs
@@ -30,16 +30,9 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public class CommunicationsEffects
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="CommunicationsEffects"/> class.
-    /// </summary>
-    /// <param name="logger">The injected logger.</param>
-    /// <param name="api">The injected API.</param>
     public CommunicationsEffects(ILogger<CommunicationsEffects> logger, ICommunicationsApi api)
     {
         this.Logger = logger;
@@ -52,12 +45,6 @@ public class CommunicationsEffects
     [Inject]
     private ICommunicationsApi Api { get; set; }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleAddAction(CommunicationsActions.AddAction action, IDispatcher dispatcher)
     {
@@ -87,11 +74,6 @@ public class CommunicationsEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod(typeof(CommunicationsActions.LoadAction))]
     public async Task HandleLoadAction(IDispatcher dispatcher)
     {
@@ -121,12 +103,6 @@ public class CommunicationsEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleUpdateAction(CommunicationsActions.UpdateAction action, IDispatcher dispatcher)
     {
@@ -156,12 +132,6 @@ public class CommunicationsEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleDeleteAction(CommunicationsActions.DeleteAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
@@ -21,16 +21,9 @@ using Fluxor;
 using HealthGateway.Admin.Client.Models;
 using HealthGateway.Admin.Common.Models;
 
-/// <summary>
-/// The set of reducers for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public static class CommunicationsReducers
 {
-    /// <summary>
-    /// The reducer for loading communications.
-    /// </summary>
-    /// <param name="state">The communications state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(CommunicationsActions.LoadAction))]
     public static CommunicationsState ReduceLoadAction(CommunicationsState state)
     {
@@ -44,12 +37,6 @@ public static class CommunicationsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The communications state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static CommunicationsState ReduceLoadSuccessAction(CommunicationsState state, CommunicationsActions.LoadSuccessAction action)
     {
@@ -67,12 +54,6 @@ public static class CommunicationsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The communications state.</param>
-    /// <param name="action">The load fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static CommunicationsState ReduceLoadFailAction(CommunicationsState state, CommunicationsActions.LoadFailAction action)
     {
@@ -88,11 +69,6 @@ public static class CommunicationsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for adding communications.
-    /// </summary>
-    /// <param name="state">The communications state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(CommunicationsActions.AddAction))]
     public static CommunicationsState ReduceAddAction(CommunicationsState state)
     {
@@ -106,12 +82,6 @@ public static class CommunicationsReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the add success action.
-    /// </summary>
-    /// <param name="state">The communications state.</param>
-    /// <param name="action">The add success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static CommunicationsState ReduceAddSuccessAction(CommunicationsState state, CommunicationsActions.AddSuccessAction action)
     {

--- a/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
+++ b/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
@@ -24,16 +24,9 @@ namespace HealthGateway.Admin.Client.Store.Configuration
     using Microsoft.Extensions.Logging;
     using Refit;
 
-    /// <summary>
-    /// The effects for the feature.
-    /// </summary>
+#pragma warning disable CS1591, SA1600
     public class ConfigurationEffects
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="ConfigurationEffects"/> class.
-        /// </summary>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="configApi">the injected api to query the configuration. </param>
         public ConfigurationEffects(ILogger<ConfigurationEffects> logger, IConfigurationApi configApi)
         {
             this.Logger = logger;
@@ -46,11 +39,6 @@ namespace HealthGateway.Admin.Client.Store.Configuration
         [Inject]
         private IConfigurationApi ConfigApi { get; set; }
 
-        /// <summary>
-        /// Handler that calls the service and dispatch the actions.
-        /// </summary>
-        /// <param name="dispatcher">Dispatch the actions.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         [EffectMethod(typeof(ConfigurationActions.LoadAction))]
         public async Task HandleLoadAction(IDispatcher dispatcher)
         {

--- a/Apps/Admin/Client/Store/Configuration/ConfigurationReducers.cs
+++ b/Apps/Admin/Client/Store/Configuration/ConfigurationReducers.cs
@@ -17,16 +17,9 @@ namespace HealthGateway.Admin.Client.Store.Configuration
 {
     using Fluxor;
 
-    /// <summary>
-    /// The set of reducers for the feature.
-    /// </summary>
+#pragma warning disable CS1591, SA1600
     public static class ConfigurationReducers
     {
-        /// <summary>
-        /// The Reducer for loading the configuration.
-        /// </summary>
-        /// <param name="state">The configuration state.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod(typeof(ConfigurationActions.LoadAction))]
         public static ConfigurationState ReduceLoadAction(ConfigurationState state)
         {
@@ -36,12 +29,6 @@ namespace HealthGateway.Admin.Client.Store.Configuration
             };
         }
 
-        /// <summary>
-        /// The Reducer for the load success action.
-        /// </summary>
-        /// <param name="state">The configuration state.</param>
-        /// <param name="action">The load success action.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod]
         public static ConfigurationState ReduceLoadSuccessAction(ConfigurationState state, ConfigurationActions.LoadSuccessAction action)
         {
@@ -53,12 +40,6 @@ namespace HealthGateway.Admin.Client.Store.Configuration
             };
         }
 
-        /// <summary>
-        /// The Reducer for the fail action.
-        /// </summary>
-        /// <param name="state">The configuration state.</param>
-        /// <param name="action">The load fail action.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod]
         public static ConfigurationState ReduceLoadFailAction(ConfigurationState state, ConfigurationActions.LoadFailAction action)
         {

--- a/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
@@ -26,16 +26,9 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public class DashboardEffects
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="DashboardEffects"/> class.
-    /// </summary>
-    /// <param name="logger">The injected logger.</param>
-    /// <param name="dashboardApi">the injected api to query the dashboard service. </param>
     public DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi dashboardApi)
     {
         this.Logger = logger;
@@ -48,12 +41,6 @@ public class DashboardEffects
     [Inject]
     private IDashboardApi DashboardApi { get; set; }
 
-    /// <summary>
-    /// Handler that calls the dashboard service and dispatch the actions.
-    /// </summary>
-    /// <param name="action">Load the initial action.</param>
-    /// <param name="dispatcher">Dispatch the actions.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleLoadAction(DashboardActions.LoadRegisteredUsersAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -17,16 +17,9 @@ namespace HealthGateway.Admin.Client.Store.Dashboard;
 
 using Fluxor;
 
-/// <summary>
-/// The set of reducers for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public static class DashboardReducers
 {
-    /// <summary>
-    /// The Reducer for the load registered users action.
-    /// </summary>
-    /// <param name="state">The users state.</param>
-    /// <returns>The new users  state.</returns>
     [ReducerMethod(typeof(DashboardActions.LoadRegisteredUsersAction))]
     public static DashboardState ReduceRegisteredUsersAction(DashboardState state)
     {
@@ -36,12 +29,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The registered user state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new registered user state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceLoadRegisteredUsersSuccessAction(DashboardState state, DashboardActions.RegisteredUsersSuccessAction action)
     {
@@ -56,12 +43,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The registered user state.</param>
-    /// <param name="action">The load fail action.</param>
-    /// <returns>The new registered user state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceRegisteredUserFailAction(DashboardState state, DashboardActions.RegisteredUsersFailAction action)
     {
@@ -76,11 +57,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load logged in users action.
-    /// </summary>
-    /// <param name="state">The users state.</param>
-    /// <returns>The new users  state.</returns>
     [ReducerMethod(typeof(DashboardActions.LoadLoggedInUsersAction))]
     public static DashboardState ReduceLoggedInUsersAction(DashboardState state)
     {
@@ -90,12 +66,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The logged in user state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new logged in user state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceLoggedInUsersSuccessAction(DashboardState state, DashboardActions.LoggedInUsersSuccessAction action)
     {
@@ -110,12 +80,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The logged in user state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new logged in user state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceLoggedInUserFailAction(DashboardState state, DashboardActions.LoggedInUsersFailAction action)
     {
@@ -130,11 +94,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load dependents action.
-    /// </summary>
-    /// <param name="state">The dependents state.</param>
-    /// <returns>The new dependents  state.</returns>
     [ReducerMethod(typeof(DashboardActions.LoadDependentsAction))]
     public static DashboardState ReduceDependentsAction(DashboardState state)
     {
@@ -144,12 +103,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The logged in user state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new logged in user state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceDependentsSuccessAction(DashboardState state, DashboardActions.DependentsSuccessAction action)
     {
@@ -164,12 +117,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The logged in dependents state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new dependents state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceDependentsFailAction(DashboardState state, DashboardActions.DependentsFailAction action)
     {
@@ -184,11 +131,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load recurring users action.
-    /// </summary>
-    /// <param name="state">The recurring users state.</param>
-    /// <returns>The new recurring users  state.</returns>
     [ReducerMethod(typeof(DashboardActions.LoadRecurringUsersAction))]
     public static DashboardState ReduceRecurringUsersAction(DashboardState state)
     {
@@ -198,12 +140,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The recurring users state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new recurring users state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceRecurringUsersSuccessAction(DashboardState state, DashboardActions.RecurringUsersSuccessAction action)
     {
@@ -218,12 +154,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The recurring users state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new recurring users state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceRecurringUsersFailAction(DashboardState state, DashboardActions.RecurringUsersFailAction action)
     {
@@ -238,11 +168,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load rating users action.
-    /// </summary>
-    /// <param name="state">The rating summary state.</param>
-    /// <returns>The new rating summary  state.</returns>
     [ReducerMethod(typeof(DashboardActions.LoadRatingSummaryAction))]
     public static DashboardState ReduceRatingSummaryAction(DashboardState state)
     {
@@ -252,12 +177,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The rating summary state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new rating summary state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceRatingSummarySuccessAction(DashboardState state, DashboardActions.RatingSummarySuccessAction action)
     {
@@ -272,12 +191,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The Reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The logged in rating summary state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new ratings summary state.</returns>
     [ReducerMethod]
     public static DashboardState ReduceRatingSummaryFailAction(DashboardState state, DashboardActions.RatingSummaryFailAction action)
     {
@@ -292,11 +205,6 @@ public static class DashboardReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the reset state action.
-    /// </summary>
-    /// <param name="state">The dashboard state.</param>
-    /// <returns>The default state.</returns>
     [ReducerMethod(typeof(DashboardActions.ResetStateAction))]
     public static DashboardState ReduceResetStateAction(DashboardState state)
     {

--- a/Apps/Admin/Client/Store/MessageVerification/MessageVerificationEffects.cs
+++ b/Apps/Admin/Client/Store/MessageVerification/MessageVerificationEffects.cs
@@ -29,16 +29,9 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
     using Microsoft.Extensions.Logging;
     using Refit;
 
-    /// <summary>
-    /// The effects for the feature.
-    /// </summary>
+#pragma warning disable CS1591, SA1600
     public class MessageVerificationEffects
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MessageVerificationEffects"/> class.
-        /// </summary>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="supportApi">the injected api to query the support. </param>
         public MessageVerificationEffects(ILogger<MessageVerificationEffects> logger, ISupportApi supportApi)
         {
             this.Logger = logger;
@@ -51,12 +44,6 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
         [Inject]
         private ISupportApi SupportApi { get; set; }
 
-        /// <summary>
-        /// Handler that calls the service and dispatch the actions.
-        /// </summary>
-        /// <param name="action">Load the initial action.</param>
-        /// <param name="dispatcher">Dispatch the actions.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         [EffectMethod]
         public async Task HandleLoadAction(MessageVerificationActions.LoadAction action, IDispatcher dispatcher)
         {

--- a/Apps/Admin/Client/Store/MessageVerification/MessageVerificationReducers.cs
+++ b/Apps/Admin/Client/Store/MessageVerification/MessageVerificationReducers.cs
@@ -20,16 +20,9 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
     using Fluxor;
     using HealthGateway.Common.Data.ViewModels;
 
-    /// <summary>
-    /// The set of reducers for the feature.
-    /// </summary>
+#pragma warning disable CS1591, SA1600
     public static class MessageVerificationReducers
     {
-        /// <summary>
-        /// The Reducer for loading the message verification.
-        /// </summary>
-        /// <param name="state">The message verification state.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod(typeof(MessageVerificationActions.LoadAction))]
         public static MessageVerificationState ReduceLoadAction(MessageVerificationState state)
         {
@@ -39,12 +32,6 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
             };
         }
 
-        /// <summary>
-        /// The Reducer for the load success action.
-        /// </summary>
-        /// <param name="state">The message verification state.</param>
-        /// <param name="action">The load success action.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod]
         public static MessageVerificationState ReduceLoadSuccessAction(MessageVerificationState state, MessageVerificationActions.LoadSuccessAction action)
         {
@@ -65,12 +52,6 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
             };
         }
 
-        /// <summary>
-        /// The Reducer for the fail action.
-        /// </summary>
-        /// <param name="state">The message verification state.</param>
-        /// <param name="action">The load fail action.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod]
         public static MessageVerificationState ReduceLoadFailAction(MessageVerificationState state, MessageVerificationActions.LoadFailAction action)
         {
@@ -81,11 +62,6 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
             };
         }
 
-        /// <summary>
-        /// The Reducer for the reset state action.
-        /// </summary>
-        /// <param name="state">The message verification state.</param>
-        /// <returns>The empty state.</returns>
         [ReducerMethod(typeof(MessageVerificationActions.ResetStateAction))]
         public static MessageVerificationState ReduceResetStateAction(MessageVerificationState state)
         {

--- a/Apps/Admin/Client/Store/SupportUser/SupportUserEffects.cs
+++ b/Apps/Admin/Client/Store/SupportUser/SupportUserEffects.cs
@@ -29,16 +29,9 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     using Microsoft.Extensions.Logging;
     using Refit;
 
-    /// <summary>
-    /// The effects for the feature.
-    /// </summary>
+#pragma warning disable CS1591, SA1600
     public class SupportUserEffects
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="SupportUserEffects"/> class.
-        /// </summary>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="supportApi">the injected api to query the support. </param>
         public SupportUserEffects(ILogger<SupportUserEffects> logger, ISupportApi supportApi)
         {
             this.Logger = logger;
@@ -51,12 +44,6 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
         [Inject]
         private ISupportApi SupportApi { get; set; }
 
-        /// <summary>
-        /// Handler that calls the service and dispatch the actions.
-        /// </summary>
-        /// <param name="action">Load the initial action.</param>
-        /// <param name="dispatcher">Dispatch the actions.</param>
-        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         [EffectMethod]
         public async Task HandleLoadAction(SupportUserActions.LoadAction action, IDispatcher dispatcher)
         {

--- a/Apps/Admin/Client/Store/SupportUser/SupportUserReducers.cs
+++ b/Apps/Admin/Client/Store/SupportUser/SupportUserReducers.cs
@@ -20,16 +20,9 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     using Fluxor;
     using HealthGateway.Admin.Client.Models;
 
-    /// <summary>
-    /// The set of reducers for the feature.
-    /// </summary>
+#pragma warning disable CS1591, SA1600
     public static class SupportUserReducers
     {
-        /// <summary>
-        /// The Reducer for loading the support user.
-        /// </summary>
-        /// <param name="state">The support user state.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod(typeof(SupportUserActions.LoadAction))]
         public static SupportUserState ReduceLoadAction(SupportUserState state)
         {
@@ -39,12 +32,6 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             };
         }
 
-        /// <summary>
-        /// The Reducer for the load success action.
-        /// </summary>
-        /// <param name="state">The support user state.</param>
-        /// <param name="action">The load success action.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod]
         public static SupportUserState ReduceLoadSuccessAction(SupportUserState state, SupportUserActions.LoadSuccessAction action)
         {
@@ -58,12 +45,6 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             };
         }
 
-        /// <summary>
-        /// The Reducer for the fail action.
-        /// </summary>
-        /// <param name="state">The message verification state.</param>
-        /// <param name="action">The load fail action.</param>
-        /// <returns>The new state.</returns>
         [ReducerMethod]
         public static SupportUserState ReduceLoadFailAction(SupportUserState state, SupportUserActions.LoadFailAction action)
         {
@@ -74,11 +55,6 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             };
         }
 
-        /// <summary>
-        /// The Reducer for the reset state action.
-        /// </summary>
-        /// <param name="state">The support user state.</param>
-        /// <returns>The empty state.</returns>
         [ReducerMethod(typeof(SupportUserActions.ResetStateAction))]
         public static SupportUserState ReduceResetStateAction(SupportUserState state)
         {
@@ -92,12 +68,6 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             };
         }
 
-        /// <summary>
-        /// The reducer for the toggle IsExpanded action.
-        /// </summary>
-        /// <param name="state">The user state.</param>
-        /// <param name="action">The toggle IsExpanded action.</param>
-        /// <returns>The default state.</returns>
         [ReducerMethod]
         public static SupportUserState ReduceToggleIsExpandedAction(SupportUserState state, SupportUserActions.ToggleIsExpandedAction action)
         {

--- a/Apps/Admin/Client/Store/Tag/TagEffects.cs
+++ b/Apps/Admin/Client/Store/Tag/TagEffects.cs
@@ -29,16 +29,9 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public class TagEffects
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="TagEffects"/> class.
-    /// </summary>
-    /// <param name="logger">The injected logger.</param>
-    /// <param name="api">The injected API.</param>
     public TagEffects(ILogger<TagEffects> logger, ITagApi api)
     {
         this.Logger = logger;
@@ -51,12 +44,6 @@ public class TagEffects
     [Inject]
     private ITagApi Api { get; set; }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleAddAction(TagActions.AddAction action, IDispatcher dispatcher)
     {
@@ -76,11 +63,6 @@ public class TagEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod(typeof(TagActions.LoadAction))]
     public async Task HandleLoadAction(IDispatcher dispatcher)
     {
@@ -100,12 +82,6 @@ public class TagEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleDeleteAction(TagActions.DeleteAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/Tag/TagReducers.cs
+++ b/Apps/Admin/Client/Store/Tag/TagReducers.cs
@@ -21,16 +21,9 @@ using System.Collections.Immutable;
 using Fluxor;
 using HealthGateway.Admin.Common.Models;
 
-/// <summary>
-/// The set of reducers for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public static class TagReducers
 {
-    /// <summary>
-    /// The reducer for loading Tag.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(TagActions.LoadAction))]
     public static TagState ReduceLoadAction(TagState state)
     {
@@ -43,12 +36,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static TagState ReduceLoadSuccessAction(TagState state, TagActions.LoadSuccessAction action)
     {
@@ -64,12 +51,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <param name="action">The load fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static TagState ReduceLoadFailAction(TagState state, TagActions.LoadFailAction action)
     {
@@ -83,11 +64,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for adding Tag.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(TagActions.AddAction))]
     public static TagState ReduceAddAction(TagState state)
     {
@@ -100,12 +76,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the add success action.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <param name="action">The add success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static TagState ReduceAddSuccessAction(TagState state, TagActions.AddSuccessAction action)
     {
@@ -129,12 +99,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the add fail action.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <param name="action">The add fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static TagState ReduceAddFailAction(TagState state, TagActions.AddFailAction action)
     {
@@ -148,11 +112,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for deleting Tag.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(TagActions.DeleteAction))]
     public static TagState ReduceDeleteAction(TagState state)
     {
@@ -165,12 +124,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the delete success action.
-    /// </summary>
-    /// <param name="state">The tag state.</param>
-    /// <param name="action">The delete success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static TagState ReduceDeleteSuccessAction(TagState state, TagActions.DeleteSuccessAction action)
     {
@@ -194,12 +147,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the delete fail action.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <param name="action">The delete fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static TagState ReduceDeleteFailAction(TagState state, TagActions.DeleteFailAction action)
     {
@@ -213,11 +160,6 @@ public static class TagReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the reset state action.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <returns>The default state.</returns>
     [ReducerMethod(typeof(TagActions.ResetStateAction))]
     public static TagState ReduceResetStateAction(TagState state)
     {

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackEffects.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackEffects.cs
@@ -29,16 +29,9 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public class UserFeedbackEffects
 {
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UserFeedbackEffects"/> class.
-    /// </summary>
-    /// <param name="logger">The injected logger.</param>
-    /// <param name="api">The injected user feedback API.</param>
     public UserFeedbackEffects(ILogger<UserFeedbackEffects> logger, IUserFeedbackApi api)
     {
         this.Logger = logger;
@@ -51,11 +44,6 @@ public class UserFeedbackEffects
     [Inject]
     private IUserFeedbackApi Api { get; set; }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod(typeof(UserFeedbackActions.LoadAction))]
     public async Task HandleLoadAction(IDispatcher dispatcher)
     {
@@ -83,12 +71,6 @@ public class UserFeedbackEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleUpdateAction(UserFeedbackActions.UpdateAction action, IDispatcher dispatcher)
     {
@@ -116,12 +98,6 @@ public class UserFeedbackEffects
         }
     }
 
-    /// <summary>
-    /// Handler that calls the service and dispatches resulting actions.
-    /// </summary>
-    /// <param name="action">The triggering action.</param>
-    /// <param name="dispatcher">The injected dispatcher.</param>
-    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
     [EffectMethod]
     public async Task HandleAssociateTagsAction(UserFeedbackActions.AssociateTagsAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackReducers.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackReducers.cs
@@ -21,16 +21,9 @@ using System.Collections.Immutable;
 using Fluxor;
 using HealthGateway.Admin.Common.Models;
 
-/// <summary>
-/// The effects for the feature.
-/// </summary>
+#pragma warning disable CS1591, SA1600
 public static class UserFeedbackReducers
 {
-    /// <summary>
-    /// The reducer for loading user feedback.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(UserFeedbackActions.LoadAction))]
     public static UserFeedbackState ReduceLoadAction(UserFeedbackState state)
     {
@@ -43,12 +36,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load success action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static UserFeedbackState ReduceLoadSuccessAction(UserFeedbackState state, UserFeedbackActions.LoadSuccessAction action)
     {
@@ -64,12 +51,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the load fail action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The load fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static UserFeedbackState ReduceLoadFailAction(UserFeedbackState state, UserFeedbackActions.LoadFailAction action)
     {
@@ -83,11 +64,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for updating user feedback.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(UserFeedbackActions.UpdateAction))]
     public static UserFeedbackState ReduceUpdateAction(UserFeedbackState state)
     {
@@ -100,12 +76,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the update success action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The update success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static UserFeedbackState ReduceUpdateSuccessAction(UserFeedbackState state, UserFeedbackActions.UpdateSuccessAction action)
     {
@@ -129,12 +99,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the update fail action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The update fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static UserFeedbackState ReduceUpdateFailAction(UserFeedbackState state, UserFeedbackActions.UpdateFailAction action)
     {
@@ -148,11 +112,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for initiating the association of tags to user feedback.
-    /// </summary>
-    /// <param name="state">The Tag state.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod(typeof(UserFeedbackActions.AssociateTagsAction))]
     public static UserFeedbackState ReduceAssociateTagsAction(UserFeedbackState state)
     {
@@ -165,12 +124,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the successful association of tags to user feedback.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The load success action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static UserFeedbackState ReduceAssociateTagsSuccessAction(UserFeedbackState state, UserFeedbackActions.AssociateTagsSuccessAction action)
     {
@@ -194,12 +147,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the failed association of tags to user feedback.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <param name="action">The add fail action.</param>
-    /// <returns>The new state.</returns>
     [ReducerMethod]
     public static UserFeedbackState ReduceAssociateTagsFailAction(UserFeedbackState state, UserFeedbackActions.AssociateTagsFailAction action)
     {
@@ -213,11 +160,6 @@ public static class UserFeedbackReducers
         };
     }
 
-    /// <summary>
-    /// The reducer for the reset state action.
-    /// </summary>
-    /// <param name="state">The user feedback state.</param>
-    /// <returns>The default state.</returns>
     [ReducerMethod(typeof(UserFeedbackActions.ResetStateAction))]
     public static UserFeedbackState ReduceResetStateAction(UserFeedbackState state)
     {

--- a/Apps/Admin/Tests/Converters/DateOutputConverterTests.cs
+++ b/Apps/Admin/Tests/Converters/DateOutputConverterTests.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.Admin.Tests.Converters
             string expected = "2022-12-31 5:00 PM";
 
             // Act
-            object? actual = converter.ConvertToString(dateTime, null, null);
+            object actual = converter.ConvertToString(dateTime, null, null);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -90,7 +90,7 @@ namespace HealthGateway.Admin.Tests.Converters
             string expected = string.Empty;
 
             // Act
-            object? actual = converter.ConvertToString(dateTime, null, null);
+            object actual = converter.ConvertToString(dateTime, null, null);
 
             // Assert
             Assert.Equal(expected, actual);


### PR DESCRIPTION
# Fixes [AB#14204](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14204)

## Description

- Removed comments from *Reducers and *Effects file
- Added **#pragma warning disable CS1591, SA1600** to suppress CS1591 and SA1600
- [SuppressMessage] can only be used for SA1600.  It cannot be used for CS1591. As a result, #pragma was used.  [Suppress Message Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/tree/master/documentation) - for consistency used **#pragma** for both CS1591 and SA1600
- Updated unit test to remove warning

**Warnings:**

<img width="1660" alt="Screenshot 2023-01-13 at 12 43 57 PM" src="https://user-images.githubusercontent.com/58790456/212416394-b18e61fa-336b-4ae7-a735-b0606cb94f4d.png">


**Unit Tests:**

<img width="1288" alt="Screenshot 2023-01-13 at 12 42 55 PM" src="https://user-images.githubusercontent.com/58790456/212416388-06652f07-cef3-4c7d-a827-3c9407803155.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
