### PR TITLE
fixed compile warning as error to address AB#14705

### DIFF
--- a/Apps/Medication/src/Delegates/RestMedStatementDelegate.cs
+++ b/Apps/Medication/src/Delegates/RestMedStatementDelegate.cs
@@ -34,7 +34,7 @@ namespace HealthGateway.Medication.Delegates
     using HealthGateway.Medication.Models.ODR;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
-    using ApiException = Refit.ApiException;
+    using Refit;
 
     /// <summary>
     /// ODR Implementation for Rest Medication Statements.
@@ -151,7 +151,7 @@ namespace HealthGateway.Medication.Delegates
                     this.logger.LogDebug("Attempting to fetch Protective Word from Cache");
                     using (Source.StartActivity("GetCacheObject"))
                     {
-                        cacheHash = this.cacheProvider.GetItem<HmacHash>($"{ProtectiveWordCacheDomain}:{hdid}");
+                        cacheHash = await this.cacheProvider.GetItemAsync<HmacHash>($"{ProtectiveWordCacheDomain}:{hdid}").ConfigureAwait(true);
                     }
                 }
 


### PR DESCRIPTION
# Fixes or Implements [AB#14705](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14705)

[Bug 14705](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/14705): Medication Service compile failed with warnings

## Description

Compilation error fix


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
