### PR TITLE
Display custom error when provisioning pre-existing user AB#14704

### DIFF
--- a/Apps/Admin/Client/Components/AgentAccessDialog.razor
+++ b/Apps/Admin/Client/Components/AgentAccessDialog.razor
@@ -7,14 +7,16 @@
         <HgBannerFeedback
             Severity="@Severity.Error"
             IsEnabled="@HasAddError"
-            TResetAction="@BroadcastsActions.AddAction">
-            @ErrorMessage
+            TResetAction="@BroadcastsActions.AddAction"
+            DataTestId="add-error-alert">
+            @AddErrorMessage
         </HgBannerFeedback>
         <HgBannerFeedback
             Severity="@Severity.Error"
             IsEnabled="@HasUpdateError"
-            TResetAction="@BroadcastsActions.UpdateAction">
-            @ErrorMessage
+            TResetAction="@BroadcastsActions.UpdateAction"
+            DataTestId="update-error-alert">
+            @UpdateErrorMessage
         </HgBannerFeedback>
         <MudForm @ref="Form" data-testid="broadcast-dialog-modal-text">
             <MudGrid Spacing="0">

--- a/Apps/Admin/Client/Components/AgentAccessDialog.razor.cs
+++ b/Apps/Admin/Client/Components/AgentAccessDialog.razor.cs
@@ -71,7 +71,9 @@ public partial class AgentAccessDialog : FluxorComponent
 
     private bool HasUpdateError => this.AgentAccessState.Value.Update.Error is { Message.Length: > 0 };
 
-    private string? ErrorMessage => this.HasAddError ? this.AgentAccessState.Value.Add.Error?.Message : this.AgentAccessState.Value.Update.Error?.Message;
+    private string? AddErrorMessage => this.AgentAccessState.Value.Add.Error?.Message;
+
+    private string? UpdateErrorMessage => this.AgentAccessState.Value.Update.Error?.Message;
 
     private bool SaveButtonDisabled => this.IsEdit ? this.Agent.Roles.SetEquals(this.InitialRoles) : this.Agent.IdentityProvider == KeycloakIdentityProvider.Unknown;
 

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.Admin.Client.Store.AgentAccess;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Fluxor;
@@ -54,6 +55,12 @@ public class AgentAccessEffects
             AdminAgent response = await this.Api.ProvisionAgentAccessAsync(action.Agent).ConfigureAwait(true);
             this.Logger.LogInformation("Agent added successfully");
             dispatcher.Dispatch(new AgentAccessActions.AddSuccessAction(response));
+        }
+        catch (ApiException e) when (e.StatusCode == HttpStatusCode.Conflict)
+        {
+            RequestError error = new() { Message = "User already exists" };
+            this.Logger.LogInformation("Agent already exists");
+            dispatcher.Dispatch(new AgentAccessActions.AddFailAction(error));
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {

--- a/Apps/Admin/Client/Utils/StoreUtility.cs
+++ b/Apps/Admin/Client/Utils/StoreUtility.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.Admin.Client.Utils
             return FormatRequestError(null, resultError);
         }
 
-    /// <summary>
+        /// <summary>
         /// Formats errors returned from external requests.
         /// </summary>
         /// <param name="exception">An exception returned by Refit.</param>


### PR DESCRIPTION
# Fixes [AB#14704](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14704)

## Description

Replaces the generic error message with "User already exists" when a 409 (Conflict) status code is returned from the call to provision user access.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://user-images.githubusercontent.com/16570293/212766958-5b36651e-c435-4bf1-9ef1-d21bbab55323.png)

![image](https://user-images.githubusercontent.com/16570293/212767093-daba0d93-b070-42fd-bdd4-311217106de8.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
