### PR TITLE
Fix Blazor Admin logout/login for AB#14712 and obsolete SignOutSessionStateManager for AB#14344

### DIFF
--- a/Apps/Admin/Client/Layouts/MainLayout.razor
+++ b/Apps/Admin/Client/Layouts/MainLayout.razor
@@ -24,7 +24,7 @@
                                 @(context.User.Identity?.Name ?? "Unknown")
                             </MudNavLink>
                         </AuthorizeView>
-                        <MudNavLink Icon="@Icons.Material.Outlined.Logout" OnClick="@LogOutAsync" data-testid="logout-text-link">Log Out</MudNavLink>
+                        <MudNavLink Icon="@Icons.Material.Outlined.Logout" OnClick="@LogOut" data-testid="logout-text-link">Log Out</MudNavLink>
                     </ChildContent>
                 </MudMenu>
             </Authorized>

--- a/Apps/Admin/Client/Layouts/MainLayout.razor.cs
+++ b/Apps/Admin/Client/Layouts/MainLayout.razor.cs
@@ -66,11 +66,6 @@ namespace HealthGateway.Admin.Client.Layouts
         private NavigationManager NavigationManager { get; set; } = default!;
 
         [Inject]
-#pragma warning disable CS0618
-        private SignOutSessionStateManager SignOutManager { get; set; } = default!;
-#pragma warning restore CS0618
-
-        [Inject]
         private IState<ConfigurationState> ConfigurationState { get; set; } = default!;
 
         private bool UserInfoDisabled => !this.ConfigurationState.Value.Result?.Features["UserInfo"] ?? true;
@@ -177,7 +172,7 @@ namespace HealthGateway.Admin.Client.Layouts
             if (!activityDetected)
             {
                 // sign out
-                await this.LogOutAsync().ConfigureAwait(true);
+                this.LogOut();
                 return;
             }
 
@@ -216,10 +211,9 @@ namespace HealthGateway.Admin.Client.Layouts
             this.DrawerOpen = !this.DrawerOpen;
         }
 
-        private async Task LogOutAsync()
+        private void LogOut()
         {
-            await this.SignOutManager.SetSignOutState().ConfigureAwait(true);
-            this.NavigationManager.NavigateTo("authentication/logout", replace: true);
+            this.NavigationManager.NavigateToLogout("authentication/logout");
         }
     }
 }

--- a/Apps/Admin/Client/Pages/AuthenticationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/AuthenticationPage.razor.cs
@@ -16,7 +16,9 @@
 
 namespace HealthGateway.Admin.Client.Pages;
 
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
 using Microsoft.Extensions.Options;
 
@@ -32,10 +34,24 @@ public partial class AuthenticationPage : ComponentBase
     public string? Action { get; set; }
 
     [Inject]
+    private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
+
+    [Inject]
     private NavigationManager NavigationManager { get; set; } = default!;
 
     [Inject]
     private IOptionsSnapshot<RemoteAuthenticationOptions<ApiAuthorizationProviderOptions>> OptionsSnapshot { get; set; } = default!;
+
+    /// <inheritdoc/>
+    protected override async Task OnParametersSetAsync()
+    {
+        AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync().ConfigureAwait(true);
+        if (this.Action == "logout-callback" && authState.User.Identity is { IsAuthenticated: true })
+        {
+            string loginPath = this.OptionsSnapshot.Get(Options.DefaultName).AuthenticationPaths.LogInPath;
+            this.NavigationManager.NavigateTo(loginPath ?? "/", replace: true);
+        }
+    }
 
     private void RedirectToLoginPage()
     {

--- a/Apps/Admin/Client/Pages/UnauthorizedPage.razor
+++ b/Apps/Admin/Client/Pages/UnauthorizedPage.razor
@@ -7,6 +7,6 @@
     You are unauthorized to access this application. Please contact your administrator to get access to Health Gateway Admin.
 </MudText>
 
-<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@LogOutAsync" Size="Size.Large" FullWidth="true" data-testid="log-out-button">
+<MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="@LogOut" Size="Size.Large" FullWidth="true" data-testid="log-out-button">
     Log Out
 </MudButton>

--- a/Apps/Admin/Client/Pages/UnauthorizedPage.razor.cs
+++ b/Apps/Admin/Client/Pages/UnauthorizedPage.razor.cs
@@ -32,11 +32,6 @@ public partial class UnauthorizedPage : ComponentBase
     [Inject]
     private NavigationManager NavigationManager { get; set; } = default!;
 
-    [Inject]
-    #pragma warning disable CS0618
-    private SignOutSessionStateManager SignOutManager { get; set; } = default!;
-    #pragma warning restore CS0618
-
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()
     {
@@ -47,9 +42,8 @@ public partial class UnauthorizedPage : ComponentBase
         }
     }
 
-    private async Task LogOutAsync()
+    private void LogOut()
     {
-        await this.SignOutManager.SetSignOutState().ConfigureAwait(true);
-        this.NavigationManager.NavigateTo("authentication/logout", replace: true);
+        this.NavigationManager.NavigateToLogout("authentication/logout");
     }
 }


### PR DESCRIPTION
# Fixes [AB#14712](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14712) and Fixes [AB#14344](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14344)

## Description

- Fix Blazor Admin logout/login issue - after user logs out and attempts to login again, user is stuck on 'Processing logout callback' page.
- Removed obsolete SignOutSessionStateManager code

**Test Video:**

https://user-images.githubusercontent.com/58790456/212800666-783fa702-fd30-40fc-929b-4c2c109b43ba.mp4

**Functional Tests:**

<img width="1197" alt="Screenshot 2023-01-16 at 7 34 10 PM" src="https://user-images.githubusercontent.com/58790456/212804232-5223313f-9483-46f3-a585-0ea349ab5f9e.png">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
