### PR TITLE
added missing mapping of loadstate to resolve AB#14708

### DIFF
--- a/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
+++ b/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
@@ -89,7 +89,8 @@ namespace HealthGateway.Encounter.Delegates
                 PhsaResult<IEnumerable<HospitalVisit>> response =
                     await this.hospitalVisitApi.GetHospitalVisitsAsync(hdid, this.phsaConfig.FetchSize, accessToken).ConfigureAwait(true);
                 requestResult.ResultStatus = ResultType.Success;
-                requestResult.ResourcePayload!.Result = response.Result;
+                requestResult.ResourcePayload.Result = response.Result;
+                requestResult.ResourcePayload.LoadState = response.LoadState;
                 requestResult.TotalResultCount = requestResult.ResourcePayload.Result.Count();
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)

--- a/Apps/Encounter/src/Services/EncounterService.cs
+++ b/Apps/Encounter/src/Services/EncounterService.cs
@@ -153,8 +153,6 @@ namespace HealthGateway.Encounter.Services
                     result.ResultStatus = ResultType.Success;
                     result.TotalResultCount = hospitalVisitResult.TotalResultCount;
                     result.ResourcePayload.HospitalVisits = this.autoMapper.Map<IList<HospitalVisitModel>>(hospitalVisitResult.ResourcePayload.Result);
-                    result.ResourcePayload.Loaded = true;
-                    result.ResourcePayload.Queued = false;
                     result.PageIndex = hospitalVisitResult.PageIndex;
                     result.PageSize = hospitalVisitResult.PageSize;
                 }


### PR DESCRIPTION
# Fixes or Implements [AB#14708](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14708)

[Bug 14708](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/14708): Implement Retry Logic on Hospital Visits

## Description

added missing mapping of loadstate

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
