### PR TITLE
Resolve error alert issues with dialogs AB#14718 AB#14719

### DIFF
--- a/Apps/Admin/Client/Components/AgentAccessDialog.razor
+++ b/Apps/Admin/Client/Components/AgentAccessDialog.razor
@@ -1,4 +1,4 @@
-@using HealthGateway.Admin.Client.Store.Broadcasts
+@using HealthGateway.Admin.Client.Store.AgentAccess
 @using HealthGateway.Admin.Common.Constants
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
@@ -7,14 +7,14 @@
         <HgBannerFeedback
             Severity="@Severity.Error"
             IsEnabled="@HasAddError"
-            TResetAction="@BroadcastsActions.AddAction"
+            TResetAction="@AgentAccessActions.AddAction"
             DataTestId="add-error-alert">
             @AddErrorMessage
         </HgBannerFeedback>
         <HgBannerFeedback
             Severity="@Severity.Error"
             IsEnabled="@HasUpdateError"
-            TResetAction="@BroadcastsActions.UpdateAction"
+            TResetAction="@AgentAccessActions.UpdateAction"
             DataTestId="update-error-alert">
             @UpdateErrorMessage
         </HgBannerFeedback>

--- a/Apps/Admin/Client/Components/AgentAccessDialog.razor.cs
+++ b/Apps/Admin/Client/Components/AgentAccessDialog.razor.cs
@@ -92,6 +92,8 @@ public partial class AgentAccessDialog : FluxorComponent
 
     private void HandleClickCancel()
     {
+        this.Dispatcher.Dispatch(new AgentAccessActions.ClearAddErrorAction());
+        this.Dispatcher.Dispatch(new AgentAccessActions.ClearUpdateErrorAction());
         this.MudDialog.Cancel();
     }
 

--- a/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
@@ -149,6 +149,8 @@ public partial class BroadcastDialog : FluxorComponent
 
     private void HandleClickCancel()
     {
+        this.Dispatcher.Dispatch(new BroadcastsActions.ClearAddErrorAction());
+        this.Dispatcher.Dispatch(new BroadcastsActions.ClearUpdateErrorAction());
         this.MudDialog.Cancel();
     }
 

--- a/Apps/Admin/Client/Components/CommunicationDialog.razor
+++ b/Apps/Admin/Client/Components/CommunicationDialog.razor
@@ -5,7 +5,16 @@
 
 <MudDialog>
     <DialogContent>
-        <HgBannerFeedback Severity="@Severity.Error" IsEnabled="@(HasAddError || HasUpdateError)" TResetAction="@CommunicationsActions.ResetStateAction">
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasAddError"
+            TResetAction="@CommunicationsActions.AddAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasUpdateError"
+            TResetAction="@CommunicationsActions.UpdateAction">
             @ErrorMessage
         </HgBannerFeedback>
         <MudForm @ref="Form" data-testid="communication-dialog-modal-text">

--- a/Apps/Admin/Client/Components/CommunicationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/CommunicationDialog.razor.cs
@@ -122,6 +122,8 @@ public partial class CommunicationDialog : FluxorComponent
 
     private void HandleClickCancel()
     {
+        this.Dispatcher.Dispatch(new CommunicationsActions.ClearAddErrorAction());
+        this.Dispatcher.Dispatch(new CommunicationsActions.ClearUpdateErrorAction());
         this.MudDialog.Cancel();
     }
 

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessActions.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessActions.cs
@@ -227,6 +227,20 @@ public static class AgentAccessActions
     }
 
     /// <summary>
+    /// The action that clears any error encountered during an add.
+    /// </summary>
+    public class ClearAddErrorAction
+    {
+    }
+
+    /// <summary>
+    /// The action that clears any error encountered during an update.
+    /// </summary>
+    public class ClearUpdateErrorAction
+    {
+    }
+
+    /// <summary>
     /// The action that clears the state.
     /// </summary>
     public class ResetStateAction

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessReducers.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessReducers.cs
@@ -203,6 +203,30 @@ public static class AgentAccessReducers
         };
     }
 
+    [ReducerMethod(typeof(AgentAccessActions.ClearAddErrorAction))]
+    public static AgentAccessState ReduceClearAddErrorAction(AgentAccessState state)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                Error = null,
+            },
+        };
+    }
+
+    [ReducerMethod(typeof(AgentAccessActions.ClearUpdateErrorAction))]
+    public static AgentAccessState ReduceClearUpdateErrorAction(AgentAccessState state)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                Error = null,
+            },
+        };
+    }
+
     [ReducerMethod(typeof(AgentAccessActions.ResetStateAction))]
     public static AgentAccessState ReduceResetStateAction(AgentAccessState state)
     {

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsActions.cs
@@ -221,6 +221,20 @@ public static class BroadcastsActions
     }
 
     /// <summary>
+    /// The action that clears any error encountered during an add.
+    /// </summary>
+    public class ClearAddErrorAction
+    {
+    }
+
+    /// <summary>
+    /// The action that clears any error encountered during an update.
+    /// </summary>
+    public class ClearUpdateErrorAction
+    {
+    }
+
+    /// <summary>
     /// The action that clears the state.
     /// </summary>
     public class ResetStateAction

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -203,6 +203,30 @@ public static class BroadcastsReducers
         };
     }
 
+    [ReducerMethod(typeof(BroadcastsActions.ClearAddErrorAction))]
+    public static BroadcastsState ReduceClearAddErrorAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                Error = null,
+            },
+        };
+    }
+
+    [ReducerMethod(typeof(BroadcastsActions.ClearUpdateErrorAction))]
+    public static BroadcastsState ReduceClearUpdateErrorAction(BroadcastsState state)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                Error = null,
+            },
+        };
+    }
+
     /// <summary>
     /// The reducer for the delete fail action.
     /// </summary>

--- a/Apps/Admin/Client/Store/Communications/CommunicationsActions.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsActions.cs
@@ -221,6 +221,20 @@ public static class CommunicationsActions
     }
 
     /// <summary>
+    /// The action that clears any error encountered during an add.
+    /// </summary>
+    public class ClearAddErrorAction
+    {
+    }
+
+    /// <summary>
+    /// The action that clears any error encountered during an update.
+    /// </summary>
+    public class ClearUpdateErrorAction
+    {
+    }
+
+    /// <summary>
     /// The action that clears the state.
     /// </summary>
     public class ResetStateAction

--- a/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
@@ -259,6 +259,30 @@ public static class CommunicationsReducers
         };
     }
 
+    [ReducerMethod(typeof(CommunicationsActions.ClearAddErrorAction))]
+    public static CommunicationsState ReduceClearAddErrorAction(CommunicationsState state)
+    {
+        return state with
+        {
+            Add = state.Add with
+            {
+                Error = null,
+            },
+        };
+    }
+
+    [ReducerMethod(typeof(CommunicationsActions.ClearUpdateErrorAction))]
+    public static CommunicationsState ReduceClearUpdateErrorAction(CommunicationsState state)
+    {
+        return state with
+        {
+            Update = state.Update with
+            {
+                Error = null,
+            },
+        };
+    }
+
     /// <summary>
     /// The reducer for the reset state action.
     /// </summary>


### PR DESCRIPTION
# Fixes [AB#14718](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14718) annd Fixes [AB#14719](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14719)

## Description

- fixes agent dialog error alerts not returning after dismissal [AB#14719](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14719)
- fixes agent dialog error alerts persisting after reopening dialog [AB#14718](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14718)
- fixes communication dialog error alerts not returning after dismissal
- fixes communication dialog error alerts persisting after reopening dialog
- fixes broadcast dialog error alerts persisting after reopening dialog

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
