### PR TITLE
Fix aria tags for dependent tables AB#14443

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/DependentCardComponent.vue
@@ -1167,7 +1167,11 @@ export default class DependentCardComponent extends Vue {
                             </hg-button>
                         </div>
                         <b-spinner v-if="isLoading" class="mt-3" />
-                        <h4 v-if="!isLoading" class="pt-3">
+                        <h4
+                            v-if="!isLoading"
+                            :id="`covid19-table-header-${dependent.ownerId}`"
+                            class="pt-3"
+                        >
                             COVID-19 Test Results
                         </h4>
                         <div
@@ -1184,7 +1188,7 @@ export default class DependentCardComponent extends Vue {
                         borderless
                         :items="testRows"
                         class="w-100 mb-0"
-                        aria-describedby="COVID-19 Test Results"
+                        :aria-labelledby="`covid19-table-header-${dependent.ownerId}`"
                         :data-testid="`covid19-table-${dependent.ownerId}`"
                     >
                         <b-thead>
@@ -1412,7 +1416,7 @@ export default class DependentCardComponent extends Vue {
                                             borderless
                                             :items="immunizationItems"
                                             class="w-100 mb-0"
-                                            aria-describedby="Immunization History"
+                                            aria-label="Immunization History"
                                             :data-testid="`immunization-history-table-${dependent.ownerId}`"
                                         >
                                             <b-thead>
@@ -1579,7 +1583,7 @@ export default class DependentCardComponent extends Vue {
                                         striped
                                         borderless
                                         class="w-100 mb-0"
-                                        aria-describedby="Immunization Forecast"
+                                        aria-label="Immunization Forecasts"
                                         :data-testid="`immunization-forecast-table-${dependent.ownerId}`"
                                     >
                                         <b-thead>
@@ -1738,6 +1742,7 @@ export default class DependentCardComponent extends Vue {
                 >
                     <template #title>
                         <div
+                            :id="`clinical-document-tab-title-${dependent.ownerId}`"
                             :data-testid="`clinical-document-tab-title-${dependent.ownerId}`"
                         >
                             Clinical Docs
@@ -1762,7 +1767,7 @@ export default class DependentCardComponent extends Vue {
                         borderless
                         :items="clinicalDocuments"
                         class="w-100 mb-0"
-                        aria-describedby="Clinical Docs Results"
+                        :aria-labelledby="`clinical-document-tab-title-${dependent.ownerId}`"
                         :data-testid="`clinical-document-table-${dependent.ownerId}`"
                     >
                         <b-thead>


### PR DESCRIPTION
# Fixes AB#14443

## Description

Corrects invalid aria tags for the tables on the COVID-19, Immunization, and Clinical Docs tabs on the Dependents page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
