### PR TITLE
Fix test failure on observer loop error by ignoring in Cypress

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -10,7 +10,7 @@
 require("cy-verify-downloads").addCustomCommand();
 
 const openIdConnectClientId = "hg-admin-blazor";
-const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
+const resizeObserverLoopErr = "ResizeObserver loop limit exceeded";
 
 function generateRandomString(length) {
     var text = "";
@@ -32,7 +32,7 @@ function logout(config) {
 
 Cypress.on("uncaught:exception", (err) => {
     /* returning false here prevents Cypress from failing the test */
-    if (resizeObserverLoopErrRe.test(err.message)) {
+    if (err.message.includes(resizeObserverLoopErr)) {
         return false;
     }
 });

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -10,6 +10,7 @@
 require("cy-verify-downloads").addCustomCommand();
 
 const openIdConnectClientId = "hg-admin-blazor";
+const resizeObserverLoopErrRe = /^[^(ResizeObserver loop limit exceeded)]/;
 
 function generateRandomString(length) {
     var text = "";
@@ -28,6 +29,13 @@ function logout(config) {
         failOnStatusCode: false,
     });
 }
+
+Cypress.on("uncaught:exception", (err) => {
+    /* returning false here prevents Cypress from failing the test */
+    if (resizeObserverLoopErrRe.test(err.message)) {
+        return false;
+    }
+});
 
 Cypress.Commands.add("logout", () => {
     cy.readConfig().then((config) => logout(config));


### PR DESCRIPTION
# Fixes [AB#14721](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14721)

## Fix functional test failure
- added code to Cypress commands.js that ignores observer loop errors preventing test failures
- https://stackoverflow.com/questions/49384120/resizeobserver-loop-limit-exceeded/63519375#63519375

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
