### PR TITLE
refactored hospital visits to handle no null results properly to resolve AB#14803

### DIFF
--- a/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
+++ b/Apps/AdminWebClient/src/Server/Delegates/RestImmunizationAdminDelegate.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Admin.Delegates
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
-    using System.Globalization;
     using System.Net.Http;
     using System.Threading.Tasks;
     using AutoMapper;
@@ -190,7 +189,7 @@ namespace HealthGateway.Admin.Delegates
                     retVal.ResultStatus = ResultType.Success;
                     retVal.ResourcePayload!.Result = response.Result;
                     retVal.TotalResultCount = 1;
-                    retVal.PageSize = int.Parse(this.phsaConfig.FetchSize, CultureInfo.InvariantCulture);
+                    retVal.PageSize = this.phsaConfig.FetchSize;
                 }
                 catch (Exception e) when (e is ApiException or HttpRequestException)
                 {

--- a/Apps/Common/src/Models/PHSA/PHSAConfig.cs
+++ b/Apps/Common/src/Models/PHSA/PHSAConfig.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.Common.Models.PHSA
         /// <summary>
         /// Gets or sets the total number of records to retrieve in one call.
         /// </summary>
-        public string FetchSize { get; set; } = string.Empty;
+        public int? FetchSize { get; set; }
 
         /// <summary>
         /// Gets or sets the default time to wait for a new request.

--- a/Apps/Encounter/src/Api/IHospitalVisitApi.cs
+++ b/Apps/Encounter/src/Api/IHospitalVisitApi.cs
@@ -37,6 +37,6 @@ namespace HealthGateway.Encounter.Api
         /// the subject id in the query.
         /// </returns>
         [Get("/api/v1/HospitalVisits?subjectHdid={subjectHdid}&limit={limit}")]
-        Task<PhsaResult<IEnumerable<HospitalVisit>>> GetHospitalVisitsAsync(string subjectHdid, string limit, [Authorize] string token);
+        Task<PhsaResult<IEnumerable<HospitalVisit>>> GetHospitalVisitsAsync(string subjectHdid, int? limit, [Authorize] string token);
     }
 }

--- a/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
+++ b/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.EncounterTests.Delegates
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(AccessToken);
             Mock<IHospitalVisitApi> mockHospitalVisitApi = new();
-            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken)).ReturnsAsync(phsaResponse);
+            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken)).ReturnsAsync(phsaResponse);
             IHospitalVisitDelegate hospitalVisitDelegate = new RestHospitalVisitDelegate(
                 mockAuthDelegate.Object,
                 mockHospitalVisitApi.Object,
@@ -102,7 +102,7 @@ namespace HealthGateway.EncounterTests.Delegates
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(AccessToken);
             Mock<IHospitalVisitApi> mockHospitalVisitApi = new();
-            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken)).ThrowsAsync(mockException);
+            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken)).ThrowsAsync(mockException);
             IHospitalVisitDelegate hospitalVisitDelegate = new RestHospitalVisitDelegate(
                 mockAuthDelegate.Object,
                 mockHospitalVisitApi.Object,
@@ -115,8 +115,8 @@ namespace HealthGateway.EncounterTests.Delegates
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(ExpectedExceptionMessage, actualResult.ResultError?.ResultMessage);
-            Assert.Equal(0, actualResult.TotalResultCount);
-            Assert.Equal(int.Parse(ConfigFetchSize, CultureInfo.InvariantCulture), actualResult.PageSize);
+            Assert.Null(actualResult.TotalResultCount);
+            Assert.Null(actualResult.PageSize);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace HealthGateway.EncounterTests.Delegates
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.FetchAuthenticatedUserToken()).Returns(AccessToken);
             Mock<IHospitalVisitApi> mockHospitalVisitApi = new();
-            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken)).ThrowsAsync(mockException);
+            mockHospitalVisitApi.Setup(s => s.GetHospitalVisitsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken)).ThrowsAsync(mockException);
             IHospitalVisitDelegate hospitalVisitDelegate = new RestHospitalVisitDelegate(
                 mockAuthDelegate.Object,
                 mockHospitalVisitApi.Object,
@@ -144,8 +144,8 @@ namespace HealthGateway.EncounterTests.Delegates
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(ExpectedExceptionMessage, actualResult.ResultError?.ResultMessage);
-            Assert.Equal(0, actualResult.TotalResultCount);
-            Assert.Equal(int.Parse(ConfigFetchSize, CultureInfo.InvariantCulture), actualResult.PageSize);
+            Assert.Null(actualResult.TotalResultCount);
+            Assert.Null(actualResult.PageSize);
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Immunization/src/Api/IImmunizationApi.cs
+++ b/Apps/Immunization/src/Api/IImmunizationApi.cs
@@ -43,7 +43,7 @@ public interface IImmunizationApi
     /// A PhsaResult containing the immunizations and recommendations of a given patient.
     /// </returns>
     [Get("/api/v1/Immunizations?subjectHdid={subjectHdid}&limit={limit}")]
-    Task<PhsaResult<ImmunizationResponse>> GetImmunizationsAsync(string subjectHdid, string limit, [Authorize] string token);
+    Task<PhsaResult<ImmunizationResponse>> GetImmunizationsAsync(string subjectHdid, int? limit, [Authorize] string token);
 
     /// <summary>
     /// Retrieves a PhsaResult containing the vaccine status of a given patient.

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -209,14 +209,14 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             Mock<IImmunizationApi> mockImmunizationApi = new();
             if (!throwException)
             {
-                mockImmunizationApi.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken))
+                mockImmunizationApi.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken))
                     .ReturnsAsync(response);
             }
             else
             {
                 mockImmunizationApi.Setup(
                         s =>
-                            s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<string>(), AccessToken))
+                            s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken))
                     .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
             }
 


### PR DESCRIPTION
# Fixes or Implements [AB#14803](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14803)

[Bug 14803](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/14803): Error when no hospital visits are returned from PHSA

## Description

Changed PhsaConfig fetch size to int and refactored RestHospitalVisitsDelegate to handle null return values correctly


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
