### PR TITLE
Fix URL path combining for ODR API AB#14812

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/OdrConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/OdrConfiguration.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                 ? "/pgw/patientGateway"
                 : "/odr";
 
-            return new(new(odrEndpoint), pathPrefix);
+            return new(odrEndpoint.TrimEnd('/') + pathPrefix);
         }
     }
 }


### PR DESCRIPTION
# Fixes [AB#14812](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14812)

## Description

Resolves an issue where path information contained in the base endpoint would be ignored.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
