### PR TITLE
Dependent Endpoint for PHSA - unit tests

### DIFF
--- a/Apps/GatewayApi/src/Controllers/PhsaController.cs
+++ b/Apps/GatewayApi/src/Controllers/PhsaController.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.GatewayApi.Controllers
     using System;
     using System.Collections.Generic;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
+    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Services;
     using Microsoft.AspNetCore.Authorization;
@@ -58,9 +59,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Authorize(Policy = UserProfilePolicy.Read)]
         [Route("dependents/{hdid}")]
-        public ActionResult<IEnumerable<DependentModel>> GetAll(string hdid)
+        public ActionResult<RequestResult<IEnumerable<DependentModel>>> GetAll(string hdid)
         {
-            return this.Ok(this.dependentService.GetDependents(hdid));
+            return this.dependentService.GetDependents(hdid);
         }
 
         /// <summary>
@@ -80,13 +81,13 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Authorize(Policy = UserProfilePolicy.Read)]
         [Route("dependents")]
-        public ActionResult<IEnumerable<GetDependentResponse>> GetAll(
+        public ActionResult<RequestResult<IEnumerable<GetDependentResponse>>> GetAll(
             [FromQuery] DateTime fromDateUtc,
             [FromQuery] DateTime? toDateUtc,
             [FromQuery] int page = 0,
             [FromQuery] int pageSize = 5000)
         {
-            return this.Ok(this.dependentService.GetDependents(fromDateUtc, toDateUtc, page, pageSize));
+            return this.dependentService.GetDependents(fromDateUtc, toDateUtc, page, pageSize);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
@@ -1,0 +1,129 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApiTests.Controllers.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using DeepEqual.Syntax;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.GatewayApi.Controllers;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Services;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// PhsaController's Unit Tests.
+    /// </summary>
+    public class PhsaControllerTests
+    {
+        private readonly string hdid = "mockedHdId";
+        private readonly DateTime fromDate = DateTime.UtcNow.AddDays(-1);
+        private readonly DateTime toDate = DateTime.UtcNow.AddDays(1);
+
+        /// <summary>
+        /// GetDependents by hdid - Happy path scenario.
+        /// </summary>
+        [Fact]
+        public void ShouldGetDependentsByHdid()
+        {
+            Mock<IDependentService> dependentServiceMock = new();
+            IEnumerable<DependentModel> expectedDependents = GetMockDependentModels();
+            RequestResult<IEnumerable<DependentModel>> expectedResult = new()
+            {
+                ResourcePayload = expectedDependents,
+                ResultStatus = ResultType.Success,
+            };
+            dependentServiceMock.Setup(s => s.GetDependents(this.hdid, 0, 500)).Returns(expectedResult);
+
+            PhsaController phsaController = new(
+                dependentServiceMock.Object);
+            ActionResult<RequestResult<IEnumerable<DependentModel>>> actualResult = phsaController.GetAll(this.hdid);
+
+            RequestResult<IEnumerable<DependentModel>>? actualRequestResult = actualResult.Value;
+            expectedResult.ShouldDeepEqual(actualRequestResult);
+        }
+
+        /// <summary>
+        /// GetDependents by date - Happy path scenario.
+        /// </summary>
+        [Fact]
+        public void ShouldGetDependentsByDate()
+        {
+            Mock<IDependentService> dependentServiceMock = new();
+            IEnumerable<GetDependentResponse> expectedDependents = GetMockDependentResponses();
+            RequestResult<IEnumerable<GetDependentResponse>> expectedResult = new()
+            {
+                ResourcePayload = expectedDependents,
+                ResultStatus = ResultType.Success,
+            };
+            dependentServiceMock.Setup(s => s.GetDependents(this.fromDate, this.toDate, 0, 5000)).Returns(expectedResult);
+
+            PhsaController phsaController = new(
+                dependentServiceMock.Object);
+            ActionResult<RequestResult<IEnumerable<GetDependentResponse>>> actualResult = phsaController.GetAll(this.fromDate, this.toDate);
+
+            RequestResult<IEnumerable<GetDependentResponse>>? actualRequestResult = actualResult.Value;
+            expectedResult.ShouldDeepEqual(actualRequestResult);
+        }
+
+        private static IEnumerable<GetDependentResponse> GetMockDependentResponses()
+        {
+            List<GetDependentResponse> dependentResponses = new();
+
+            for (int i = 0; i < 10; i++)
+            {
+                dependentResponses.Add(
+                    new GetDependentResponse
+                    {
+                        OwnerId = $"OWNER00{i}",
+                        DelegateId = $"DELEGATE00{i}",
+                        CreationDateTime = DateTime.UtcNow.AddMinutes(i),
+                    });
+            }
+
+            return dependentResponses;
+        }
+
+        private static IEnumerable<DependentModel> GetMockDependentModels()
+        {
+            List<DependentModel> dependentModels = new();
+
+            for (int i = 0; i < 10; i++)
+            {
+                dependentModels.Add(
+                    new DependentModel
+                    {
+                        OwnerId = $"OWNER00{i}",
+                        DelegateId = $"DELEGATE00{i}",
+                        Version = (uint)i,
+                        DependentInformation = new DependentInformation
+                        {
+                            Phn = $"{dependentModels}-{i}",
+                            DateOfBirth = new DateTime(1980 + i, 1, 1),
+                            Gender = "Female",
+                            FirstName = "first",
+                            LastName = "last-{i}",
+                        },
+                    });
+            }
+
+            return dependentModels;
+        }
+    }
+}


### PR DESCRIPTION
# Implements [AB#14741](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14741)

## Dependent Endpoint for PHSA - unit tests

- Added PhsaControllerTests.cs and new test to DependentServiceTests.cs
- Changed the PhsaController method returns to have the RequestResult included and only return the service method result so that I could create the PhsaController unit tests.  This matches the pattern in CommentController. Discuss.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

![Screenshot 2023-01-27 at 2 20 11 PM](https://user-images.githubusercontent.com/5408101/215216639-426a08d4-1e3b-4a61-9ce3-5ec47b166c50.png)

![Screenshot 2023-01-27 at 2 20 29 PM](https://user-images.githubusercontent.com/5408101/215216646-24130fea-f9a4-4614-82e4-e4daaf2accba.png)

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
