### PR TITLE
Updated route to protect endpoints in PhsaController for AB#14740

### DIFF
--- a/Tools/Kong/routes-gatewayapi.tmpl
+++ b/Tools/Kong/routes-gatewayapi.tmpl
@@ -89,6 +89,7 @@
         paths:
           # starting in Kong v3.0.x, regex paths will need to be prefixed with ~
           - /api/gatewayapiservice/UserProfile/\w+/Dependent
+          - /api/gatewayapiservice/Phsa
         strip_path: false
         plugins:
           - name: jwt-keycloak


### PR DESCRIPTION
# Implements [AB#14740](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14740)

## Updated route to protect endpoints in PhsaController

- update route "gatewayapi-$KONG_NAMESPACE-phsa" in routes-gatewayapi.tmpl to protect all endpoints in the new PHSA controller

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
