### PR TITLE
Use dev endpoints locally for Encounter and Medication AB#14815

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/constants/serviceCodes.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/serviceCodes.ts
@@ -4,6 +4,7 @@ export const enum ServiceCode {
     ODR = "ODR",
     HealthGatewayUser = "HGU",
     Medication = "MED",
+    SpecialAuthority = "SPA",
     Laboratory = "LAB",
     Immunization = "IMZ",
     Encounter = "ENC",

--- a/Apps/WebClient/src/ClientApp/src/constants/serviceCodes.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/serviceCodes.ts
@@ -8,6 +8,7 @@ export const enum ServiceCode {
     Laboratory = "LAB",
     Immunization = "IMZ",
     Encounter = "ENC",
+    HospitalVisit = "HOS",
     Patient = "PAT",
     PHSA = "PHSA",
     Report = "REP",

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -58,6 +58,7 @@ import {
     IConfigService,
     IDependentService,
     IEncounterService,
+    IHospitalVisitService,
     IHttpDelegate,
     IImmunizationService,
     ILaboratoryService,
@@ -144,6 +145,9 @@ configService
         const encounterService = container.get<IEncounterService>(
             SERVICE_IDENTIFIER.EncounterService
         );
+        const hospitalVisitService = container.get<IHospitalVisitService>(
+            SERVICE_IDENTIFIER.HospitalVisitService
+        );
         const clinicalDocumentService = container.get<IClinicalDocumentService>(
             SERVICE_IDENTIFIER.ClinicalDocumentService
         );
@@ -199,6 +203,7 @@ configService
         specialAuthorityService.initialize(config, httpDelegate);
         laboratoryService.initialize(config, httpDelegate);
         encounterService.initialize(config, httpDelegate);
+        hospitalVisitService.initialize(config, httpDelegate);
         clinicalDocumentService.initialize(config, httpDelegate);
         userProfileService.initialize(config, httpDelegate);
         userFeedbackService.initialize(config, httpDelegate);

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -67,6 +67,7 @@ import {
     IPatientService,
     IPcrTestService,
     IReportService,
+    ISpecialAuthorityService,
     IStoreProvider,
     ITicketService,
     IUserCommentService,
@@ -134,6 +135,9 @@ configService
         const medicationService = container.get<IMedicationService>(
             SERVICE_IDENTIFIER.MedicationService
         );
+        const specialAuthorityService = container.get<ISpecialAuthorityService>(
+            SERVICE_IDENTIFIER.SpecialAuthorityService
+        );
         const laboratoryService = container.get<ILaboratoryService>(
             SERVICE_IDENTIFIER.LaboratoryService
         );
@@ -192,6 +196,7 @@ configService
         immunizationService.initialize(config, httpDelegate);
         patientService.initialize(config, httpDelegate);
         medicationService.initialize(config, httpDelegate);
+        specialAuthorityService.initialize(config, httpDelegate);
         laboratoryService.initialize(config, httpDelegate);
         encounterService.initialize(config, httpDelegate);
         clinicalDocumentService.initialize(config, httpDelegate);

--- a/Apps/WebClient/src/ClientApp/src/plugins/inversify.config.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/inversify.config.ts
@@ -24,6 +24,7 @@ import {
     IPatientService,
     IPcrTestService,
     IReportService,
+    ISpecialAuthorityService,
     IStoreProvider,
     ITicketService,
     IUserCommentService,
@@ -44,6 +45,7 @@ import { RestLaboratoryService } from "@/services/restLaboratoryService";
 import { RestMedicationService } from "@/services/restMedicationService";
 import { RestNotificationService } from "@/services/restNotificationService";
 import { RestPatientService } from "@/services/restPatientService";
+import { RestSpecialAuthorityService } from "@/services/restSpecialAuthorityService";
 import { RestUserCommentService } from "@/services/restUserCommentService";
 import { RestUserFeedbackService } from "@/services/restUserFeedback";
 import { RestUserNoteService } from "@/services/restUserNoteService";
@@ -82,6 +84,10 @@ container
 container
     .bind<IMedicationService>(SERVICE_IDENTIFIER.MedicationService)
     .to(RestMedicationService)
+    .inSingletonScope();
+container
+    .bind<ISpecialAuthorityService>(SERVICE_IDENTIFIER.SpecialAuthorityService)
+    .to(RestSpecialAuthorityService)
     .inSingletonScope();
 container
     .bind<IEncounterService>(SERVICE_IDENTIFIER.EncounterService)

--- a/Apps/WebClient/src/ClientApp/src/plugins/inversify.config.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/inversify.config.ts
@@ -15,6 +15,7 @@ import {
     IConfigService,
     IDependentService,
     IEncounterService,
+    IHospitalVisitService,
     IHttpDelegate,
     IImmunizationService,
     ILaboratoryService,
@@ -40,6 +41,7 @@ import { RestCommunicationService } from "@/services/restCommunicationService";
 import { RestConfigService } from "@/services/restConfigService";
 import { RestDependentService } from "@/services/restDependentService";
 import { RestEncounterService } from "@/services/restEncounterService";
+import { RestHospitalVisitService } from "@/services/restHospitalVisitService";
 import { RestImmunizationService } from "@/services/restImmunizationService";
 import { RestLaboratoryService } from "@/services/restLaboratoryService";
 import { RestMedicationService } from "@/services/restMedicationService";
@@ -92,6 +94,10 @@ container
 container
     .bind<IEncounterService>(SERVICE_IDENTIFIER.EncounterService)
     .to(RestEncounterService)
+    .inSingletonScope();
+container
+    .bind<IHospitalVisitService>(SERVICE_IDENTIFIER.HospitalVisitService)
+    .to(RestHospitalVisitService)
     .inSingletonScope();
 container
     .bind<ILaboratoryService>(SERVICE_IDENTIFIER.LaboratoryService)

--- a/Apps/WebClient/src/ClientApp/src/plugins/inversify.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/inversify.ts
@@ -7,6 +7,7 @@ export const SERVICE_IDENTIFIER = {
     MedicationService: Symbol.for("MedicationService"),
     SpecialAuthorityService: Symbol.for("SpecialAuthorityService"),
     EncounterService: Symbol.for("EncounterService"),
+    HospitalVisitService: Symbol.for("HospitalVisitService"),
     LaboratoryService: Symbol.for("LaboratoryService"),
     ClinicalDocumentService: Symbol.for("ClinicalDocumentService"),
     UserProfileService: Symbol.for("UserProfileService"),

--- a/Apps/WebClient/src/ClientApp/src/plugins/inversify.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/inversify.ts
@@ -5,6 +5,7 @@ export const SERVICE_IDENTIFIER = {
     ImmunizationService: Symbol.for("ImmunizationService"),
     PatientService: Symbol.for("PatientService"),
     MedicationService: Symbol.for("MedicationService"),
+    SpecialAuthorityService: Symbol.for("SpecialAuthorityService"),
     EncounterService: Symbol.for("EncounterService"),
     LaboratoryService: Symbol.for("LaboratoryService"),
     ClinicalDocumentService: Symbol.for("ClinicalDocumentService"),

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -103,6 +103,10 @@ export interface ISpecialAuthorityService {
 export interface IEncounterService {
     initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
     getPatientEncounters(hdid: string): Promise<RequestResult<Encounter[]>>;
+}
+
+export interface IHospitalVisitService {
+    initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
     getHospitalVisits(
         hdid: string
     ): Promise<RequestResult<HospitalVisitResult>>;

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -91,6 +91,10 @@ export interface IMedicationService {
         hdid: string,
         protectiveWord?: string
     ): Promise<RequestResult<MedicationStatementHistory[]>>;
+}
+
+export interface ISpecialAuthorityService {
+    initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
     getPatientMedicationRequest(
         hdid: string
     ): Promise<RequestResult<MedicationRequest[]>>;

--- a/Apps/WebClient/src/ClientApp/src/services/restEncounterService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restEncounterService.ts
@@ -21,6 +21,7 @@ export class RestEncounterService implements IEncounterService {
     private logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
     private readonly ENCOUNTER_BASE_URI: string = "Encounter";
     private baseUri = "";
+    private hospitalVisitBaseUri = "";
     private http!: IHttpDelegate;
     private isEncounterEnabled = false;
     private isHospitalVisitEnabled = false;
@@ -30,6 +31,7 @@ export class RestEncounterService implements IEncounterService {
         http: IHttpDelegate
     ): void {
         this.baseUri = config.serviceEndpoints["Encounter"];
+        this.hospitalVisitBaseUri = config.serviceEndpoints["HospitalVisit"];
         this.http = http;
         this.isEncounterEnabled = config.webClient.modules["Encounter"];
         this.isHospitalVisitEnabled = config.webClient.modules["HospitalVisit"];
@@ -89,7 +91,7 @@ export class RestEncounterService implements IEncounterService {
             }
             this.http
                 .getWithCors<RequestResult<HospitalVisitResult>>(
-                    `${this.baseUri}${this.ENCOUNTER_BASE_URI}/HospitalVisit/${hdid}`
+                    `${this.hospitalVisitBaseUri}${this.ENCOUNTER_BASE_URI}/HospitalVisit/${hdid}`
                 )
                 .then((requestResult) => resolve(requestResult))
                 .catch((err: HttpError) => {

--- a/Apps/WebClient/src/ClientApp/src/services/restMedicationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restMedicationService.ts
@@ -24,6 +24,7 @@ export class RestMedicationService implements IMedicationService {
         "MedicationStatement";
     private readonly MEDICATION_REQUEST_BASE_URI: string = "MedicationRequest";
     private baseUri = "";
+    private specialAuthorityBaseUri = "";
     private http!: IHttpDelegate;
     private isMedicationEnabled = false;
     private isMedicationRequestEnabled = false;
@@ -33,6 +34,8 @@ export class RestMedicationService implements IMedicationService {
         http: IHttpDelegate
     ): void {
         this.baseUri = config.serviceEndpoints["Medication"];
+        this.specialAuthorityBaseUri =
+            config.serviceEndpoints["SpecialAuthority"];
         this.http = http;
         this.isMedicationEnabled = config.webClient.modules["Medication"];
         this.isMedicationRequestEnabled =
@@ -94,7 +97,7 @@ export class RestMedicationService implements IMedicationService {
             }
             this.http
                 .get<RequestResult<MedicationRequest[]>>(
-                    `${this.baseUri}${this.MEDICATION_REQUEST_BASE_URI}/${hdid}`
+                    `${this.specialAuthorityBaseUri}${this.MEDICATION_REQUEST_BASE_URI}/${hdid}`
                 )
                 .then((requestResult) => resolve(requestResult))
                 .catch((err: HttpError) => {

--- a/Apps/WebClient/src/ClientApp/src/services/restSpecialAuthorityService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restSpecialAuthorityService.ts
@@ -2,25 +2,23 @@ import { injectable } from "inversify";
 
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
-import { Dictionary } from "@/models/baseTypes";
 import { ExternalConfiguration } from "@/models/configData";
 import { HttpError } from "@/models/errors";
-import MedicationStatementHistory from "@/models/medicationStatementHistory";
+import MedicationRequest from "@/models/MedicationRequest";
 import RequestResult from "@/models/requestResult";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import {
     IHttpDelegate,
     ILogger,
-    IMedicationService,
+    ISpecialAuthorityService,
 } from "@/services/interfaces";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
-export class RestMedicationService implements IMedicationService {
+export class RestSpecialAuthorityService implements ISpecialAuthorityService {
     private logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-    private readonly MEDICATION_STATEMENT_BASE_URI: string =
-        "MedicationStatement";
+    private readonly SPECIAL_AUTHORITY_BASE_URI: string = "MedicationRequest";
     private baseUri = "";
     private http!: IHttpDelegate;
     private isEnabled = false;
@@ -29,19 +27,14 @@ export class RestMedicationService implements IMedicationService {
         config: ExternalConfiguration,
         http: IHttpDelegate
     ): void {
-        this.baseUri = config.serviceEndpoints["Medication"];
+        this.baseUri = config.serviceEndpoints["SpecialAuthority"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["Medication"];
+        this.isEnabled = config.webClient.modules["MedicationRequest"];
     }
 
-    public getPatientMedicationStatementHistory(
-        hdid: string,
-        protectiveWord?: string
-    ): Promise<RequestResult<MedicationStatementHistory[]>> {
-        const headers: Dictionary<string> = {};
-        if (protectiveWord) {
-            headers["protectiveWord"] = protectiveWord;
-        }
+    public getPatientMedicationRequest(
+        hdid: string
+    ): Promise<RequestResult<MedicationRequest[]>> {
         return new Promise((resolve, reject) => {
             if (!this.isEnabled) {
                 resolve({
@@ -54,19 +47,18 @@ export class RestMedicationService implements IMedicationService {
                 return;
             }
             this.http
-                .get<RequestResult<MedicationStatementHistory[]>>(
-                    `${this.baseUri}${this.MEDICATION_STATEMENT_BASE_URI}/${hdid}`,
-                    headers
+                .get<RequestResult<MedicationRequest[]>>(
+                    `${this.baseUri}${this.SPECIAL_AUTHORITY_BASE_URI}/${hdid}`
                 )
                 .then((requestResult) => resolve(requestResult))
                 .catch((err: HttpError) => {
                     this.logger.error(
-                        `Error in RestMedicationService.getPatientMedicationStatementHistory()`
+                        `Error in RestSpecialAuthorityService.getPatientMedicationRequest()`
                     );
                     reject(
                         ErrorTranslator.internalNetworkError(
                             err,
-                            ServiceCode.Medication
+                            ServiceCode.SpecialAuthority
                         )
                     );
                 });

--- a/Apps/WebClient/src/ClientApp/src/store/modules/encounter/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/encounter/actions.ts
@@ -9,7 +9,11 @@ import RequestResult from "@/models/requestResult";
 import { LoadStatus } from "@/models/storeOperations";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
-import { IEncounterService, ILogger } from "@/services/interfaces";
+import {
+    IEncounterService,
+    IHospitalVisitService,
+    ILogger,
+} from "@/services/interfaces";
 import EventTracker from "@/utility/eventTracker";
 
 import { EncounterActions } from "./types";
@@ -77,8 +81,8 @@ export const actions: EncounterActions = {
         params: { hdid: string }
     ): Promise<RequestResult<HospitalVisitResult>> {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-        const encounterService = container.get<IEncounterService>(
-            SERVICE_IDENTIFIER.EncounterService
+        const hospitalVisitService = container.get<IHospitalVisitService>(
+            SERVICE_IDENTIFIER.HospitalVisitService
         );
 
         return new Promise((resolve, reject) => {
@@ -102,7 +106,7 @@ export const actions: EncounterActions = {
             } else {
                 logger.debug(`Retrieving Hospital Visits`);
                 context.commit("setHospitalVisitsRequested");
-                encounterService
+                hospitalVisitService
                     .getHospitalVisits(params.hdid)
                     .then((result) => {
                         const payload = result.resourcePayload;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/request/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/request/actions.ts
@@ -7,7 +7,7 @@ import RequestResult from "@/models/requestResult";
 import { LoadStatus } from "@/models/storeOperations";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
-import { ILogger, IMedicationService } from "@/services/interfaces";
+import { ILogger, ISpecialAuthorityService } from "@/services/interfaces";
 import EventTracker from "@/utility/eventTracker";
 
 import { MedicationRequestActions } from "./types";
@@ -18,8 +18,8 @@ export const actions: MedicationRequestActions = {
         params: { hdid: string }
     ): Promise<RequestResult<MedicationRequest[]>> {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-        const medicationService = container.get<IMedicationService>(
-            SERVICE_IDENTIFIER.MedicationService
+        const specialAuthorityService = container.get<ISpecialAuthorityService>(
+            SERVICE_IDENTIFIER.SpecialAuthorityService
         );
 
         return new Promise((resolve, reject) => {
@@ -40,7 +40,7 @@ export const actions: MedicationRequestActions = {
             } else {
                 logger.debug("Retrieving Medication Requests");
                 context.commit("setMedicationRequestRequested");
-                return medicationService
+                return specialAuthorityService
                     .getPatientMedicationRequest(params.hdid)
                     .then((result) => {
                         if (result.resultStatus === ResultType.Error) {

--- a/Apps/WebClient/src/appsettings.Development.json
+++ b/Apps/WebClient/src/appsettings.Development.json
@@ -43,11 +43,13 @@
     },
     "ServiceEndpoints": {
         "ClinicalDocument": "http://localhost:3006/",
-        "Encounter": "http://localhost:3005/",
+        "Encounter": "https://hg-dev.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "http://localhost:3005/",
         "GatewayApi": "http://localhost:3000/",
         "Immunization": "http://localhost:3001/",
         "Laboratory": "http://localhost:3004/",
-        "Medication": "http://localhost:3003/",
+        "Medication": "https://hg-dev.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "http://localhost:3003/",
         "Patient": "http://localhost:3002/",
         "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },

--- a/Apps/WebClient/src/appsettings.hgdev.json
+++ b/Apps/WebClient/src/appsettings.hgdev.json
@@ -53,10 +53,12 @@
     "ServiceEndpoints": {
         "ClinicalDocument": "https://hg-dev.api.gov.bc.ca/api/clinicaldocumentservice/",
         "Encounter": "https://hg-dev.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg-dev.api.gov.bc.ca/api/encounterservice/",
         "GatewayApi": "https://hg-dev.api.gov.bc.ca/api/gatewayapiservice/",
         "Immunization": "https://hg-dev.api.gov.bc.ca/api/immunizationservice/",
         "Laboratory": "https://hg-dev.api.gov.bc.ca/api/laboratoryservice/",
         "Medication": "https://hg-dev.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg-dev.api.gov.bc.ca/api/medicationservice/",
         "Patient": "https://hg-dev.api.gov.bc.ca/api/patientservice/",
         "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },

--- a/Apps/WebClient/src/appsettings.hgmock.json
+++ b/Apps/WebClient/src/appsettings.hgmock.json
@@ -45,10 +45,12 @@
     "ServiceEndpoints": {
         "ClinicalDocument": "https://hg-mock.api.gov.bc.ca/api/clinicaldocumentservice/",
         "Encounter": "https://hg-mock.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg-mock.api.gov.bc.ca/api/encounterservice/",
         "GatewayApi": "https://hg-mock.api.gov.bc.ca/api/gatewayapiservice/",
         "Immunization": "https://hg-mock.api.gov.bc.ca/api/immunizationservice/",
         "Laboratory": "https://hg-mock.api.gov.bc.ca/api/laboratoryservice/",
         "Medication": "https://hg-mock.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg-mock.api.gov.bc.ca/api/medicationservice/",
         "Patient": "https://hg-mock.api.gov.bc.ca/api/patientservice/"
     },
     "ContentSecurityPolicy": {

--- a/Apps/WebClient/src/appsettings.hgpoc.json
+++ b/Apps/WebClient/src/appsettings.hgpoc.json
@@ -45,10 +45,12 @@
     "ServiceEndpoints": {
         "ClinicalDocument": "https://poc.healthgateway.gov.bc.ca/api/clinicaldocumentservice/",
         "Encounter": "https://poc.healthgateway.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://poc.healthgateway.gov.bc.ca/api/encounterservice/",
         "GatewayApi": "https://dev.healthgateway.gov.bc.ca/api/gatewayapiservice/",
         "Immunization": "https://dev.healthgateway.gov.bc.ca/api/immunizationservice/",
         "Laboratory": "https://poc.healthgateway.gov.bc.ca/api/laboratoryservice/",
         "Medication": "https://poc.healthgateway.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://poc.healthgateway.gov.bc.ca/api/medicationservice/",
         "Patient": "https://poc.healthgateway.gov.bc.ca/api/patientservice/"
     },
     "ContentSecurityPolicy": {

--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -19,10 +19,12 @@
     "ServiceEndpoints": {
         "ClinicalDocument": "https://hg-test.api.gov.bc.ca/api/clinicaldocumentservice/",
         "Encounter": "https://hg-test.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg-test.api.gov.bc.ca/api/encounterservice/",
         "GatewayApi": "https://hg-test.api.gov.bc.ca/api/gatewayapiservice/",
         "Immunization": "https://hg-test.api.gov.bc.ca/api/immunizationservice/",
         "Laboratory": "https://hg-test.api.gov.bc.ca/api/laboratoryservice/",
         "Medication": "https://hg-test.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg-test.api.gov.bc.ca/api/medicationservice/",
         "Patient": "https://hg-test.api.gov.bc.ca/api/patientservice/",
         "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -93,8 +93,10 @@
         "Immunization": "https://hg-prod.api.gov.bc.ca/api/immunizationservice/",
         "Patient": "https://hg-prod.api.gov.bc.ca/api/patientservice/",
         "Medication": "https://hg-prod.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg-prod.api.gov.bc.ca/api/medicationservice/",
         "Laboratory": "https://hg-prod.api.gov.bc.ca/api/laboratoryservice/",
         "Encounter": "https://hg-prod.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg-prod.api.gov.bc.ca/api/encounterservice/",
         "Ticket": "https://tickets.healthgateway.gov.bc.ca/"
     },
     "AvailabilityFilter": {


### PR DESCRIPTION
# Implements [AB#14815](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14815)

## Description

- introduces separate service endpoints for Special Authority and Hospital Visit
    - they share the same values as Medication and Encounter in every environment except local development
- updates the Encounter and Medication endpoints for local development from localhost to the dev endpoints, since those services can only be accessed from OpenShift
- splits Medication and Special Authority into separate services
- splits Encounter and Hospital Visit into separate services

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
