### PR TITLE
AdminWebClient Support Lookup Broken

### DIFF
--- a/Apps/AdminWebClient/src/Server/Constants/UserQueryType.cs
+++ b/Apps/AdminWebClient/src/Server/Constants/UserQueryType.cs
@@ -39,5 +39,10 @@ namespace HealthGateway.Admin.Constants
         /// Query by Health-Directed identifier.
         /// </summary>
         Hdid,
+
+        /// <summary>
+        /// Query by dependent Personal Health Number.
+        /// </summary>
+        Dependent,
     }
 }

--- a/Apps/AdminWebClient/src/Server/Controllers/SupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/SupportController.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Controllers
 {
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Services;
     using Microsoft.AspNetCore.Authorization;
@@ -55,9 +56,9 @@ namespace HealthGateway.Admin.Controllers
         /// </response>
         [HttpGet]
         [Route("Users")]
-        public IActionResult GetSupportUsers([FromQuery] UserQueryType queryType, [FromQuery] string queryString)
+        public async Task<IActionResult> GetSupportUsers([FromQuery] UserQueryType queryType, [FromQuery] string queryString)
         {
-            return new JsonResult(this.supportService.GetUsers(queryType, queryString));
+            return new JsonResult(await this.supportService.GetUsers(queryType, queryString).ConfigureAwait(true));
         }
 
         /// <summary>

--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -104,6 +104,7 @@ namespace HealthGateway.Admin
             services.AddTransient<IVaccineProofDelegate, VaccineProofDelegate>();
             services.AddTransient<IAdminUserProfileDelegate, DbAdminUserProfileDelegate>();
             services.AddTransient<IAuthenticationDelegate, AuthenticationDelegate>();
+            services.AddTransient<IResourceDelegateDelegate, DbResourceDelegateDelegate>();
 
             // Configure SPA
             services.AddControllersWithViews();
@@ -161,7 +162,6 @@ namespace HealthGateway.Admin
                         endpoints.MapToVueCliProxy(
                             "{*path}",
                             new SpaOptions { SourcePath = "ClientApp" },
-                            "serve",
                             regex: "Compiled successfully",
                             forceKill: true);
                     }


### PR DESCRIPTION
# Fixes [AB#14841](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14841)

## AdminWebClient Support Lookup Broken

- added IResourceDelegateDelegate to Startup.cs for SupportService.cs changes
- added Dependent to UserQueryType.cs to match back end
- changed GetSupportUsers to an async task in the SupportController.cs to match change to GetUsers in SupportService.cs

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
