### PR TITLE
Prevent leaking dev credentials on functional test failure AB#14886

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/services/webClient/phsa.js
+++ b/Testing/functional/tests/cypress/integration/e2e/services/webClient/phsa.js
@@ -1,4 +1,5 @@
 function getPhsaTokens(config) {
+    cy.log("Requesting access token");
     return cy
         .request({
             method: "POST",
@@ -9,6 +10,11 @@ function getPhsaTokens(config) {
                 client_id: Cypress.env("keycloak.phsa.client"),
                 client_secret: Cypress.env("keycloak.phsa.secret"),
             },
+            failOnStatusCode: false, // prevent leaking credentials on failures
+        })
+        .should((response) => {
+            expect(response.status).to.eq(200);
+            expect(response.body?.access_token).to.exist;
         })
         .its("body");
 }


### PR DESCRIPTION
# Fixes [AB#14886](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14886)

## Description

Changes the functional test requests to retrieve an access token for PHSA to assert that the response is successful instead of relying on the command's default behaviour (where a non-successful response fails the test and may output sensitive information in the log).

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
