### PR TITLE
Address section should only exist for hdid and phn query for AB#14891

### DIFF
--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -100,7 +100,7 @@
                     </MudTd>
                 </RowTemplate>
                 <ChildRowContent>
-                    @if (!context.IsSameAddress)
+                    @if (!context.IsSameAddress && SelectedQueryType is UserQueryType.Phn or UserQueryType.Hdid)
                     {
                         <div Class="mx-4 my-3">
                             <MudText Typo="Typo.subtitle1">
@@ -118,21 +118,24 @@
                             </MudText>
                         </div>
                     }
-                    <div Class="mx-4 my-3">
-                        <MudText Typo="Typo.subtitle1">
-                            @context.PostalAddressLabel
-                        </MudText>
-                        <MudText Typo="Typo.body2" data-testid=@($"postal-address-{context.Hdid}")>
-                            @if (context.IsPostalAddressShown)
-                            {
-                                @context.PostalAddress
-                            }
-                            else
-                            {
-                                @SupportUserRow.NoAddressMessage
-                            }
-                        </MudText>
-                    </div>
+                    @if (SelectedQueryType is UserQueryType.Phn or UserQueryType.Hdid)
+                    {
+                        <div Class="mx-4 my-3">
+                            <MudText Typo="Typo.subtitle1">
+                                @context.PostalAddressLabel
+                            </MudText>
+                            <MudText Typo="Typo.body2" data-testid=@($"postal-address-{context.Hdid}")>
+                                @if (context.IsPostalAddressShown)
+                                {
+                                    @context.PostalAddress
+                                }
+                                else
+                                {
+                                    @SupportUserRow.NoAddressMessage
+                                }
+                            </MudText>
+                        </div>
+                    }
                     @if (context.IsExpanded)
                     {
                         <MessageVerificationTable Data="@GetMessagingVerificationModels(context.Hdid)" IsLoading="@MessagingVerificationsLoading" />

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
@@ -29,6 +29,8 @@ function verifyUserTableResults(queryType, personlHealthNumber) {
         cy.get(`[data-testid=postal-address-${hdid}]`).contains(postalAddress);
     } else {
         cy.get(`[data-testid=user-table-phn-${hdid}]`).should("be.empty");
+        cy.get(`[data-testid=physical-address-${hdid}]`).should("not.exist");
+        cy.get(`[data-testid=postal-address-${hdid}]`).should("not.exist");
     }
 }
 


### PR DESCRIPTION
# Fixes [AB#14891](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14891)

## Description

- Physical and Postal Address section should only display for PHN and HDID queries as only those queries make calls to Patient
- Updated functional test

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

**Functional Tests:**

<img width="1224" alt="Screenshot 2023-02-08 at 4 03 51 PM" src="https://user-images.githubusercontent.com/58790456/217682401-16de9ffd-df3f-40d5-b867-c843a0ecafc5.png">

**HDID:**

<img width="1520" alt="Screenshot 2023-02-08 at 4 26 32 PM" src="https://user-images.githubusercontent.com/58790456/217682837-9f842a6f-be5b-4d3d-84eb-3b01f1f0165a.png">


**PHN:**

<img width="1975" alt="Screenshot 2023-02-08 at 4 03 03 PM" src="https://user-images.githubusercontent.com/58790456/217682554-0698e253-c913-41de-be6c-3214d26b32cf.png">

**Email:**

<img width="1412" alt="Screenshot 2023-02-08 at 3 59 41 PM" src="https://user-images.githubusercontent.com/58790456/217682620-754cae6d-fab4-4d57-8ca5-b1c7e40270ef.png">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
