### PR TITLE
Refactor timeline view and component AB#14745

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/ProtectiveWordComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/ProtectiveWordComponent.vue
@@ -6,29 +6,29 @@ import { Action, Getter } from "vuex-class";
 import { ResultError } from "@/models/errors";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
 import RequestResult from "@/models/requestResult";
-import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
 
 @Component
 export default class ProtectiveWordComponent extends Vue {
+    @Prop({ required: true })
+    hdid!: string;
+
     @Action("retrieveMedications", { namespace: "medication" })
     retrieveMedications!: (params: {
         hdid: string;
         protectiveWord?: string;
     }) => Promise<RequestResult<MedicationStatementHistory[]>>;
 
+    @Getter("medicationsAreLoading", { namespace: "medication" })
+    medicationsAreLoading!: (hdid: string) => boolean;
+
     @Getter("medicationsAreProtected", { namespace: "medication" })
     medicationsAreProtected!: (hdid: string) => boolean;
 
     @Getter("protectiveWordAttempts", { namespace: "medication" })
     protectiveWordAttempts!: (hdid: string) => number;
-
-    @Getter("user", { namespace: "user" })
-    user!: User;
-
-    @Prop({ default: false }) isLoading!: boolean;
 
     private protectiveWord = "";
     private isDismissed = false;
@@ -37,8 +37,8 @@ export default class ProtectiveWordComponent extends Vue {
 
     private get isVisible(): boolean {
         return (
-            this.medicationsAreProtected(this.user.hdid) &&
-            !this.isLoading &&
+            this.medicationsAreProtected(this.hdid) &&
+            !this.medicationsAreLoading &&
             !this.isDismissed
         );
     }
@@ -48,7 +48,7 @@ export default class ProtectiveWordComponent extends Vue {
     }
 
     private get error(): boolean {
-        return this.protectiveWordAttempts(this.user.hdid) > 1;
+        return this.protectiveWordAttempts(this.hdid) > 1;
     }
 
     private created(): void {
@@ -63,7 +63,7 @@ export default class ProtectiveWordComponent extends Vue {
 
     private fetchMedications(): void {
         this.retrieveMedications({
-            hdid: this.user.hdid,
+            hdid: this.hdid,
             protectiveWord: this.protectiveWord,
         }).catch((err: ResultError) =>
             this.logger.error(

--- a/Apps/WebClient/src/ClientApp/src/components/report/MedicationHistoryReportComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/MedicationHistoryReportComponent.vue
@@ -216,10 +216,7 @@ export default class MedicationHistoryReportComponent extends Vue {
                 </template>
             </b-table>
         </section>
-        <ProtectiveWordComponent
-            ref="protectiveWordModal"
-            :is-loading="isLoading"
-        />
+        <ProtectiveWordComponent ref="protectiveWordModal" :hdid="user.hdid" />
     </div>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
@@ -181,21 +181,21 @@ export default class FilterComponent extends Vue {
         switch (entryType) {
             case EntryType.ClinicalDocument:
                 return this.clinicalDocumentsCount(this.hdid);
-            case EntryType.Covid19LaboratoryOrder:
+            case EntryType.Covid19TestResult:
                 return this.covid19LaboratoryOrdersCount(this.hdid);
-            case EntryType.Encounter:
+            case EntryType.HealthVisit:
                 return this.healthVisitsCount(this.hdid);
             case EntryType.HospitalVisit:
                 return this.hospitalVisitsCount(this.hdid);
             case EntryType.Immunization:
                 return this.immunizationsCount(this.hdid);
-            case EntryType.LaboratoryOrder:
+            case EntryType.LabResult:
                 return this.laboratoryOrdersCount(this.hdid);
             case EntryType.Medication:
                 return this.medicationsCount(this.hdid);
             case EntryType.Note:
                 return this.notesCount;
-            case EntryType.MedicationRequest:
+            case EntryType.SpecialAuthorityRequest:
                 return this.specialAuthorityRequestsCount(this.hdid);
             default:
                 return undefined;

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
@@ -299,7 +299,6 @@ export default class FilterComponent extends Vue {
             placement="bottom"
             fallback-placement="clockwise"
             boundary="viewport"
-            menu-class="z-index-large w-100"
         >
             <div class="px-1">
                 <b-row class="mt-2">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -52,19 +52,18 @@ enum FilterLabelType {
 const options: any = {
     components: {
         BToast,
-        ProtectiveWordComponent,
+        ClinicalDocumentTimelineComponent,
+        Covid19LaboratoryOrderTimelineComponent,
+        EncounterTimelineComponent,
         EntryDetailsComponent,
         FilterComponent,
-        MedicationRequestComponent: MedicationRequestTimelineComponent,
-        MedicationComponent: MedicationTimelineComponent,
-        ImmunizationComponent: ImmunizationTimelineComponent,
-        Covid19LaboratoryOrderComponent:
-            Covid19LaboratoryOrderTimelineComponent,
-        LaboratoryOrderComponent: LaboratoryOrderTimelineComponent,
-        EncounterComponent: EncounterTimelineComponent,
-        NoteComponent: NoteTimelineComponent,
-        ClinicalDocumentComponent: ClinicalDocumentTimelineComponent,
-        HospitalVisitComponent: HospitalVisitTimelineComponent,
+        HospitalVisitTimelineComponent,
+        ImmunizationTimelineComponent,
+        LaboratoryOrderTimelineComponent,
+        MedicationRequestTimelineComponent,
+        MedicationTimelineComponent,
+        NoteTimelineComponent,
+        ProtectiveWordComponent,
     },
 };
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -479,21 +479,21 @@ export default class LinearTimelineComponent extends Vue {
         switch (entryType) {
             case EntryType.ClinicalDocument:
                 return this.clinicalDocumentsAreLoading(this.hdid);
-            case EntryType.Covid19LaboratoryOrder:
+            case EntryType.Covid19TestResult:
                 return this.covid19LaboratoryOrdersAreLoading(this.hdid);
-            case EntryType.Encounter:
+            case EntryType.HealthVisit:
                 return this.healthVisitsAreLoading(this.hdid);
             case EntryType.HospitalVisit:
                 return this.hospitalVisitsAreLoading(this.hdid);
             case EntryType.Immunization:
                 return this.immunizationsAreLoading(this.hdid);
-            case EntryType.LaboratoryOrder:
+            case EntryType.LabResult:
                 return this.laboratoryOrdersAreLoading(this.hdid);
             case EntryType.Medication:
                 return this.medicationsAreLoading(this.hdid);
             case EntryType.Note:
                 return this.notesAreLoading;
-            case EntryType.MedicationRequest:
+            case EntryType.SpecialAuthorityRequest:
                 return this.specialAuthorityRequestsAreLoading(this.hdid);
             default:
                 throw new Error(`Unknown dataset "${entryType}"`);
@@ -504,23 +504,23 @@ export default class LinearTimelineComponent extends Vue {
         switch (entryType) {
             case EntryType.ClinicalDocument:
                 return this.retrieveClinicalDocuments({ hdid: this.hdid });
-            case EntryType.Covid19LaboratoryOrder:
+            case EntryType.Covid19TestResult:
                 return this.retrieveCovid19LaboratoryOrders({
                     hdid: this.hdid,
                 });
-            case EntryType.Encounter:
+            case EntryType.HealthVisit:
                 return this.retrieveHealthVisits({ hdid: this.hdid });
             case EntryType.HospitalVisit:
                 return this.retrieveHospitalVisits({ hdid: this.hdid });
             case EntryType.Immunization:
                 return this.retrieveImmunizations({ hdid: this.hdid });
-            case EntryType.LaboratoryOrder:
+            case EntryType.LabResult:
                 return this.retrieveLaboratoryOrders({ hdid: this.hdid });
             case EntryType.Medication:
                 return this.retrieveMedications({ hdid: this.hdid });
             case EntryType.Note:
                 return this.retrieveNotes({ hdid: this.hdid });
-            case EntryType.MedicationRequest:
+            case EntryType.SpecialAuthorityRequest:
                 return this.retrieveSpecialAuthorityRequests({
                     hdid: this.hdid,
                 });

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/LinearTimelineComponent.vue
@@ -1,13 +1,34 @@
 <script lang="ts">
+import { BToast } from "bootstrap-vue";
 import Vue from "vue";
-import { Component, Prop, Watch } from "vue-property-decorator";
+import { Component, Watch } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
+import ProtectiveWordComponent from "@/components/modal/ProtectiveWordComponent.vue";
+import EntryDetailsComponent from "@/components/timeline/entryCard/EntryDetailsComponent.vue";
+import FilterComponent from "@/components/timeline/FilterComponent.vue";
 import { EntryType, entryTypeMap } from "@/constants/entryType";
+import { ClinicalDocument } from "@/models/clinicalDocument";
+import ClinicalDocumentTimelineEntry from "@/models/clinicalDocumentTimelineEntry";
+import Covid19LaboratoryOrderTimelineEntry from "@/models/covid19LaboratoryOrderTimelineEntry";
 import { DateWrapper } from "@/models/dateWrapper";
+import { Encounter, HospitalVisit } from "@/models/encounter";
+import EncounterTimelineEntry from "@/models/encounterTimelineEntry";
+import HospitalVisitTimelineEntry from "@/models/hospitalVisitTimelineEntry";
+import { ImmunizationEvent } from "@/models/immunizationModel";
+import ImmunizationTimelineEntry from "@/models/immunizationTimelineEntry";
+import { Covid19LaboratoryOrder, LaboratoryOrder } from "@/models/laboratory";
+import LaboratoryOrderTimelineEntry from "@/models/laboratoryOrderTimelineEntry";
+import MedicationRequest from "@/models/medicationRequest";
+import MedicationRequestTimelineEntry from "@/models/medicationRequestTimelineEntry";
+import MedicationStatementHistory from "@/models/medicationStatementHistory";
+import MedicationTimelineEntry from "@/models/medicationTimelineEntry";
+import NoteTimelineEntry from "@/models/noteTimelineEntry";
 import TimelineEntry, { DateGroup } from "@/models/timelineEntry";
-import TimelineFilter from "@/models/timelineFilter";
+import TimelineFilter, { TimelineFilterBuilder } from "@/models/timelineFilter";
 import User from "@/models/user";
+import { UserComment } from "@/models/userComment";
+import UserNote from "@/models/userNote";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
@@ -22,9 +43,19 @@ import MedicationRequestTimelineComponent from "./entryCard/MedicationRequestTim
 import MedicationTimelineComponent from "./entryCard/MedicationTimelineComponent.vue";
 import NoteTimelineComponent from "./entryCard/NoteTimelineComponent.vue";
 
+enum FilterLabelType {
+    Keyword = "Keyword",
+    Type = "Record Type",
+    Date = "Date",
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
     components: {
+        BToast,
+        ProtectiveWordComponent,
+        EntryDetailsComponent,
+        Filters: FilterComponent,
         MedicationRequestComponent: MedicationRequestTimelineComponent,
         MedicationComponent: MedicationTimelineComponent,
         ImmunizationComponent: ImmunizationTimelineComponent,
@@ -40,8 +71,126 @@ const options: any = {
 
 @Component(options)
 export default class LinearTimelineComponent extends Vue {
+    @Action("retrieveComments", { namespace: "comment" })
+    retrieveComments!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveClinicalDocuments", { namespace: "clinicalDocument" })
+    retrieveClinicalDocuments!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveHealthVisits", { namespace: "encounter" })
+    retrieveHealthVisits!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveHospitalVisits", { namespace: "encounter" })
+    retrieveHospitalVisits!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveImmunizations", { namespace: "immunization" })
+    retrieveImmunizations!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveCovid19LaboratoryOrders", { namespace: "laboratory" })
+    retrieveCovid19LaboratoryOrders!: (params: {
+        hdid: string;
+    }) => Promise<void>;
+
+    @Action("retrieveLaboratoryOrders", { namespace: "laboratory" })
+    retrieveLaboratoryOrders!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveNotes", { namespace: "note" })
+    retrieveNotes!: (params: { hdid: string }) => Promise<void>;
+
+    @Action("retrieveMedications", { namespace: "medication" })
+    retrieveMedications!: (params: {
+        hdid: string;
+        protectiveWord?: string;
+    }) => Promise<void>;
+
+    @Action("retrieveSpecialAuthorityRequests", { namespace: "medication" })
+    retrieveSpecialAuthorityRequests!: (params: {
+        hdid: string;
+    }) => Promise<void>;
+
+    @Action("setFilter", { namespace: "timeline" })
+    setFilter!: (filterBuilder: TimelineFilterBuilder) => void;
+
     @Action("setLinearDate", { namespace: "timeline" })
     setLinearDate!: (linearDate: DateWrapper) => void;
+
+    @Getter("clinicalDocuments", { namespace: "clinicalDocument" })
+    clinicalDocuments!: (hdid: string) => ClinicalDocument[];
+
+    @Getter("clinicalDocumentsAreLoading", { namespace: "clinicalDocument" })
+    clinicalDocumentsAreLoading!: (hdid: string) => boolean;
+
+    @Getter("getEntryComments", { namespace: "comment" })
+    getEntryComments!: (entyId: string) => UserComment[] | null;
+
+    @Getter("commentsAreLoading", { namespace: "comment" })
+    commentsAreLoading!: boolean;
+
+    @Getter("healthVisits", { namespace: "encounter" })
+    healthVisits!: (hdid: string) => Encounter[];
+
+    @Getter("healthVisitsAreLoading", { namespace: "encounter" })
+    healthVisitsAreLoading!: (hdid: string) => boolean;
+
+    @Getter("hospitalVisits", { namespace: "encounter" })
+    hospitalVisits!: (hdid: string) => HospitalVisit[];
+
+    @Getter("hospitalVisitsAreLoading", { namespace: "encounter" })
+    hospitalVisitsAreLoading!: (hdid: string) => boolean;
+
+    @Getter("immunizations", { namespace: "immunization" })
+    patientImmunizations!: (hdid: string) => ImmunizationEvent[];
+
+    @Getter("immunizationsAreLoading", { namespace: "immunization" })
+    immunizationsAreLoading!: (hdid: string) => boolean;
+
+    @Getter("immunizationsAreDeferred", { namespace: "immunization" })
+    immunizationsAreDeferred!: (hdid: string) => boolean;
+
+    @Getter("covid19LaboratoryOrders", { namespace: "laboratory" })
+    covid19LaboratoryOrders!: (hdid: string) => Covid19LaboratoryOrder[];
+
+    @Getter("covid19LaboratoryOrdersAreLoading", { namespace: "laboratory" })
+    covid19LaboratoryOrdersAreLoading!: (hdid: string) => boolean;
+
+    @Getter("laboratoryOrders", { namespace: "laboratory" })
+    laboratoryOrders!: (hdid: string) => LaboratoryOrder[];
+
+    @Getter("laboratoryOrdersAreLoading", { namespace: "laboratory" })
+    laboratoryOrdersAreLoading!: (hdid: string) => boolean;
+
+    @Getter("laboratoryOrdersAreQueued", { namespace: "laboratory" })
+    laboratoryOrdersAreQueued!: (hdid: string) => boolean;
+
+    @Getter("medications", { namespace: "medication" })
+    medications!: (hdid: string) => MedicationStatementHistory[];
+
+    @Getter("medicationsAreLoading", { namespace: "medication" })
+    medicationsAreLoading!: (hdid: string) => boolean;
+
+    @Getter("specialAuthorityRequests", { namespace: "medication" })
+    specialAuthorityRequests!: (hdid: string) => MedicationRequest[];
+
+    @Getter("specialAuthorityRequestsAreLoading", { namespace: "medication" })
+    specialAuthorityRequestsAreLoading!: (hdid: string) => boolean;
+
+    @Getter("isHeaderShown", { namespace: "navbar" })
+    isHeaderShown!: boolean;
+
+    @Getter("notes", { namespace: "note" })
+    userNotes!: UserNote[];
+
+    @Getter("notesAreLoading", { namespace: "note" })
+    notesAreLoading!: boolean;
+
+    @Getter("entryTypes", { namespace: "timeline" })
+    entryTypes!: Set<EntryType>;
+
+    @Getter("filter", { namespace: "timeline" })
+    filter!: TimelineFilter;
+
+    @Getter("hasActiveFilter", { namespace: "timeline" })
+    hasActiveFilter!: boolean;
 
     @Getter("linearDate", { namespace: "timeline" })
     linearDate!: DateWrapper;
@@ -49,101 +198,76 @@ export default class LinearTimelineComponent extends Vue {
     @Getter("selectedDate", { namespace: "timeline" })
     selectedDate!: DateWrapper | null;
 
-    @Getter("isHeaderShown", { namespace: "navbar" })
-    isHeaderShown!: boolean;
-
-    @Getter("filter", { namespace: "timeline" })
-    filter!: TimelineFilter;
-
-    @Getter("entryTypes", { namespace: "timeline" })
-    entryTypes!: Set<EntryType>;
-
-    @Getter("hasActiveFilter", { namespace: "timeline" })
-    hasActiveFilter!: boolean;
-
-    @Getter("medicationsAreLoading", { namespace: "medication" })
-    medicationsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("specialAuthorityRequestsAreLoading", { namespace: "medication" })
-    specialAuthorityRequestsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("commentsAreLoading", { namespace: "comment" })
-    commentsAreLoading!: boolean;
-
-    @Getter("covid19LaboratoryOrdersAreLoading", { namespace: "laboratory" })
-    covid19LaboratoryOrdersAreLoading!: (hdid: string) => boolean;
-
-    @Getter("laboratoryOrdersAreLoading", { namespace: "laboratory" })
-    laboratoryOrdersAreLoading!: (hdid: string) => boolean;
-
-    @Getter("healthVisitsAreLoading", { namespace: "encounter" })
-    healthVisitsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("hospitalVisitsAreLoading", { namespace: "encounter" })
-    hospitalVisitsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("immunizationsAreLoading", { namespace: "immunization" })
-    immunizationsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("notesAreLoading", { namespace: "note" })
-    notesAreLoading!: boolean;
-
-    @Getter("clinicalDocumentsAreLoading", { namespace: "clinicalDocument" })
-    clinicalDocumentsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("immunizationsAreDeferred", { namespace: "immunization" })
-    immunizationsAreDeferred!: (hdid: string) => boolean;
-
     @Getter("user", { namespace: "user" })
     user!: User;
 
-    @Prop()
-    private timelineEntries!: TimelineEntry[];
+    currentPage = 1;
 
-    private currentPage = 1;
+    readonly pageSize = 25;
 
-    private readonly pageSize = 25;
+    logger!: ILogger;
 
-    private logger!: ILogger;
+    get dateGroups(): DateGroup[] {
+        if (this.timelineIsEmpty) {
+            return [];
+        }
 
-    private get isFullyLoaded(): boolean {
-        const fullyLoaded =
-            !this.immunizationsAreLoading(this.user.hdid) &&
-            !this.immunizationsAreDeferred(this.user.hdid) &&
-            !this.specialAuthorityRequestsAreLoading(this.user.hdid) &&
-            !this.medicationsAreLoading(this.user.hdid) &&
-            !this.covid19LaboratoryOrdersAreLoading(this.user.hdid) &&
-            !this.laboratoryOrdersAreLoading(this.user.hdid) &&
-            !this.healthVisitsAreLoading(this.user.hdid) &&
-            !this.hospitalVisitsAreLoading(this.user.hdid) &&
-            !this.clinicalDocumentsAreLoading(this.user.hdid) &&
-            !this.notesAreLoading &&
-            !this.commentsAreLoading;
-        this.logger.debug(`Linear Timeline is fully loaded: ${fullyLoaded}`);
-        return fullyLoaded;
+        let newGroupArray = DateGroup.createGroups(this.visibleTimelineEntries);
+        return DateGroup.sortGroups(newGroupArray);
     }
 
-    private get isFilterLoading(): boolean {
+    get filterLabels(): [string, string][] {
+        const labels: [string, string][] = [];
+
+        if (this.filter.keyword) {
+            labels.push([FilterLabelType.Keyword, `"${this.filter.keyword}"`]);
+        }
+
+        this.entryTypes.forEach((entryType) => {
+            const label = entryTypeMap.get(entryType)?.name;
+            if (label) {
+                labels.push([FilterLabelType.Type, label]);
+            }
+        });
+
+        const startDate = this.filter.startDate
+            ? `From ${new DateWrapper(this.filter.startDate).format()}`
+            : "";
+        const endDate = this.filter.endDate
+            ? `To ${new DateWrapper(this.filter.endDate).format()}`
+            : "";
+        if (startDate && endDate) {
+            labels.push([FilterLabelType.Date, `${startDate} ${endDate}`]);
+        } else if (startDate) {
+            labels.push([FilterLabelType.Date, startDate]);
+        } else if (endDate) {
+            labels.push([FilterLabelType.Date, endDate]);
+        }
+
+        return labels;
+    }
+
+    get filteredTimelineEntries(): TimelineEntry[] {
+        let filteredEntries = [];
+
+        if (this.filter.hasActiveFilter()) {
+            filteredEntries = this.timelineEntries.filter((entry) =>
+                entry.filterApplies(this.filter)
+            );
+        } else {
+            filteredEntries = this.timelineEntries;
+        }
+
+        return filteredEntries;
+    }
+
+    get isFilterLoading(): boolean {
         const filtersLoaded = [];
 
         filtersLoaded.push(
             this.isSelectedFilterModuleLoading(
-                EntryType.MedicationRequest,
-                this.specialAuthorityRequestsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Medication,
-                this.medicationsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Immunization,
-                this.immunizationsAreLoading(this.user.hdid)
+                EntryType.ClinicalDocument,
+                this.clinicalDocumentsAreLoading(this.user.hdid)
             )
         );
 
@@ -156,15 +280,15 @@ export default class LinearTimelineComponent extends Vue {
 
         filtersLoaded.push(
             this.isSelectedFilterModuleLoading(
-                EntryType.LaboratoryOrder,
-                this.laboratoryOrdersAreLoading(this.user.hdid)
+                EntryType.Encounter,
+                this.healthVisitsAreLoading(this.user.hdid)
             )
         );
 
         filtersLoaded.push(
             this.isSelectedFilterModuleLoading(
-                EntryType.Encounter,
-                this.healthVisitsAreLoading(this.user.hdid)
+                EntryType.Immunization,
+                this.immunizationsAreLoading(this.user.hdid)
             )
         );
 
@@ -177,8 +301,15 @@ export default class LinearTimelineComponent extends Vue {
 
         filtersLoaded.push(
             this.isSelectedFilterModuleLoading(
-                EntryType.ClinicalDocument,
-                this.clinicalDocumentsAreLoading(this.user.hdid)
+                EntryType.LaboratoryOrder,
+                this.laboratoryOrdersAreLoading(this.user.hdid)
+            )
+        );
+
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.Medication,
+                this.medicationsAreLoading(this.user.hdid)
             )
         );
 
@@ -189,35 +320,168 @@ export default class LinearTimelineComponent extends Vue {
             )
         );
 
-        const filterLoading = filtersLoaded.includes(true);
-        this.logger.debug(`Timeline filter loading: ${filterLoading}`);
+        filtersLoaded.push(
+            this.isSelectedFilterModuleLoading(
+                EntryType.MedicationRequest,
+                this.specialAuthorityRequestsAreLoading(this.user.hdid)
+            )
+        );
 
-        return filterLoading;
+        return filtersLoaded.includes(true);
     }
 
-    private get isOnlyImmunizationSelected(): boolean {
+    get isFilterModuleSelected(): boolean {
+        const entryTypes = Array.from(this.entryTypes);
+        this.logger.debug(
+            `Number of imeline filter modules selected: ${entryTypes.length}`
+        );
+        return entryTypes.length > 0;
+    }
+
+    get isFullyLoaded(): boolean {
+        return (
+            !this.clinicalDocumentsAreLoading(this.user.hdid) &&
+            !this.commentsAreLoading &&
+            !this.covid19LaboratoryOrdersAreLoading(this.user.hdid) &&
+            !this.healthVisitsAreLoading(this.user.hdid) &&
+            !this.hospitalVisitsAreLoading(this.user.hdid) &&
+            !this.immunizationsAreDeferred(this.user.hdid) &&
+            !this.immunizationsAreLoading(this.user.hdid) &&
+            !this.laboratoryOrdersAreLoading(this.user.hdid) &&
+            !this.medicationsAreLoading(this.user.hdid) &&
+            !this.notesAreLoading &&
+            !this.specialAuthorityRequestsAreLoading(this.user.hdid)
+        );
+    }
+
+    get isLaboratoryQueued(): boolean {
+        return this.laboratoryOrdersAreQueued(this.user.hdid);
+    }
+
+    get isOnlyImmunizationSelected(): boolean {
         return (
             this.entryTypes.size === 1 &&
             this.entryTypes.has(EntryType.Immunization)
         );
     }
 
-    private get numberOfPages(): number {
+    get numberOfPages(): number {
         let pageCount = 1;
-        if (this.timelineEntries.length > this.pageSize) {
-            pageCount = Math.ceil(this.timelineEntries.length / this.pageSize);
+        if (this.filteredTimelineEntries.length > this.pageSize) {
+            pageCount = Math.ceil(
+                this.filteredTimelineEntries.length / this.pageSize
+            );
         }
         return pageCount;
     }
 
-    private get timelineIsEmpty(): boolean {
-        this.logger.debug(
-            `Linear Timeline Entries length: ${this.timelineEntries.length}`
-        );
-        return this.timelineEntries.length === 0;
+    get showContentPlaceholders(): boolean {
+        if (this.isFilterModuleSelected) {
+            return this.isFilterLoading;
+        }
+        return !this.isFullyLoaded && this.filteredTimelineEntries.length === 0;
     }
 
-    private get visibleTimelineEntries(): TimelineEntry[] {
+    get showDisplayCount(): boolean {
+        return this.visibleTimelineEntries.length > 0;
+    }
+    get showEmptyState(): boolean {
+        return this.timelineIsEmpty && !this.isFilterLoading;
+    }
+
+    get showTimelineEntries(): boolean {
+        return this.timelineEntries.length > 0 || this.isFullyLoaded;
+    }
+
+    get timelineEntries(): TimelineEntry[] {
+        this.logger.debug("Updating timeline Entries");
+
+        let timelineEntries = [];
+
+        // Add the Special Authority request entries to the timeline list
+        for (const request of this.specialAuthorityRequests(this.user.hdid)) {
+            timelineEntries.push(
+                new MedicationRequestTimelineEntry(
+                    request,
+                    this.getEntryComments
+                )
+            );
+        }
+
+        // Add the medication entries to the timeline list
+        for (const medication of this.medications(this.user.hdid)) {
+            timelineEntries.push(
+                new MedicationTimelineEntry(medication, this.getEntryComments)
+            );
+        }
+
+        // Add the COVID-19 laboratory entries to the timeline list
+        for (const order of this.covid19LaboratoryOrders(this.user.hdid)) {
+            timelineEntries.push(
+                new Covid19LaboratoryOrderTimelineEntry(
+                    order,
+                    this.getEntryComments
+                )
+            );
+        }
+
+        // Add the laboratory entries to the timeline list
+        for (const order of this.laboratoryOrders(this.user.hdid)) {
+            timelineEntries.push(
+                new LaboratoryOrderTimelineEntry(order, this.getEntryComments)
+            );
+        }
+
+        // Add the health visit entries to the timeline list
+        for (const healthVisit of this.healthVisits(this.user.hdid)) {
+            timelineEntries.push(
+                new EncounterTimelineEntry(healthVisit, this.getEntryComments)
+            );
+        }
+
+        // Add the hospital visit entries to the timeline list
+        for (const visit of this.hospitalVisits(this.user.hdid)) {
+            timelineEntries.push(
+                new HospitalVisitTimelineEntry(visit, this.getEntryComments)
+            );
+        }
+
+        // Add the clinical document entries to the timeline list
+        for (const clinicalDocument of this.clinicalDocuments(this.user.hdid)) {
+            timelineEntries.push(
+                new ClinicalDocumentTimelineEntry(
+                    clinicalDocument,
+                    this.getEntryComments
+                )
+            );
+        }
+
+        // Add the Note entries to the timeline list
+        for (const note of this.userNotes) {
+            timelineEntries.push(new NoteTimelineEntry(note));
+        }
+
+        // Add the immunization entries to the timeline list
+        for (const immunization of this.patientImmunizations(this.user.hdid)) {
+            timelineEntries.push(new ImmunizationTimelineEntry(immunization));
+        }
+
+        timelineEntries = this.sortEntries(timelineEntries);
+        return timelineEntries;
+    }
+
+    get timelineIsEmpty(): boolean {
+        this.logger.debug(
+            `Linear Timeline Entries length: ${this.filteredTimelineEntries.length}`
+        );
+        return this.filteredTimelineEntries.length === 0;
+    }
+
+    get timelineEntryCount(): number {
+        return this.filteredTimelineEntries.length;
+    }
+
+    get visibleTimelineEntries(): TimelineEntry[] {
         if (this.timelineIsEmpty) {
             return [];
         }
@@ -231,22 +495,17 @@ export default class LinearTimelineComponent extends Vue {
         let lowerIndex = (this.currentPage - 1) * this.pageSize;
         let upperIndex = Math.min(
             this.currentPage * this.pageSize,
-            this.timelineEntries.length
+            this.filteredTimelineEntries.length
         );
-        return this.timelineEntries.slice(lowerIndex, upperIndex);
+        return this.filteredTimelineEntries.slice(lowerIndex, upperIndex);
     }
 
-    private get dateGroups(): DateGroup[] {
-        if (this.timelineIsEmpty) {
-            return [];
-        }
-
-        let newGroupArray = DateGroup.createGroups(this.visibleTimelineEntries);
-        return DateGroup.sortGroups(newGroupArray);
+    get visibleTimelineEntryCount(): number {
+        return this.visibleTimelineEntries.length;
     }
 
     @Watch("currentPage")
-    private onCurrentPage(): void {
+    onCurrentPage(): void {
         if (this.visibleTimelineEntries.length > 0) {
             // Update the store
             this.setLinearDate(this.visibleTimelineEntries[0].date);
@@ -254,7 +513,7 @@ export default class LinearTimelineComponent extends Vue {
     }
 
     @Watch("selectedDate")
-    private onSelectedDate(): void {
+    onSelectedDate(): void {
         if (
             this.selectedDate !== null &&
             this.setPageFromDate(this.selectedDate)
@@ -266,36 +525,104 @@ export default class LinearTimelineComponent extends Vue {
         }
     }
 
-    private linkGen(pageNum: number): string {
-        return `?page=${pageNum}`;
-    }
-
-    private created(): void {
+    created(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        this.fetchTimelineData();
     }
 
-    private mounted(): void {
+    mounted(): void {
         this.setPageFromDate(this.linearDate);
     }
 
-    private get showDisplayCount(): boolean {
-        return this.visibleTimelineEntries.length > 0;
+    clearFilter(label: string, value: string | undefined): void {
+        let keyword = this.filter.keyword;
+        let startDate = this.filter.startDate;
+        let endDate = this.filter.endDate;
+        let entryTypes = [...this.entryTypes];
+
+        switch (label) {
+            case FilterLabelType.Keyword:
+                keyword = "";
+                break;
+            case FilterLabelType.Date:
+                startDate = "";
+                endDate = "";
+                break;
+            case FilterLabelType.Type:
+                entryTypes = entryTypes.filter(
+                    (e) => entryTypeMap.get(e)?.name !== value
+                );
+                break;
+        }
+
+        const builder = TimelineFilterBuilder.create()
+            .withKeyword(keyword)
+            .withStartDate(startDate)
+            .withEndDate(endDate)
+            .withEntryTypes(entryTypes);
+
+        this.setFilter(builder);
     }
 
-    private get showEmptyState(): boolean {
-        return this.timelineIsEmpty && !this.isFilterLoading;
+    clearFilters(): void {
+        const builder = TimelineFilterBuilder.create();
+        this.setFilter(builder);
     }
 
-    private get timelineEntryCount(): number {
-        return this.timelineEntries.length;
+    fetchTimelineData(): void {
+        Promise.all([
+            this.retrieveMedications({ hdid: this.user.hdid }),
+            this.retrieveSpecialAuthorityRequests({ hdid: this.user.hdid }),
+            this.retrieveImmunizations({ hdid: this.user.hdid }),
+            this.retrieveCovid19LaboratoryOrders({ hdid: this.user.hdid }),
+            this.retrieveLaboratoryOrders({ hdid: this.user.hdid }),
+            this.retrieveHealthVisits({ hdid: this.user.hdid }),
+            this.retrieveHospitalVisits({ hdid: this.user.hdid }),
+            this.retrieveClinicalDocuments({ hdid: this.user.hdid }),
+            this.retrieveNotes({ hdid: this.user.hdid }),
+            this.retrieveComments({ hdid: this.user.hdid }),
+        ]).catch((err) =>
+            this.logger.error(`Error loading timeline data: ${err}`)
+        );
     }
 
-    private get visibleTimelineEntryCount(): number {
-        return this.visibleTimelineEntries.length;
+    focusOnDate(date: DateWrapper): void {
+        const dateEpoch = date.fromEpoch();
+        const container = this.$refs[dateEpoch] as HTMLElement[];
+        container[0].querySelector("button")?.focus();
     }
 
-    private setPageFromDate(eventDate: DateWrapper): boolean {
-        let index = this.timelineEntries.findIndex((entry) => {
+    getComponentForEntry(entryType: EntryType): string {
+        return entryTypeMap.get(entryType)?.component ?? "";
+    }
+
+    isFilterApplied(entryType: EntryType): boolean {
+        const entryTypes = Array.from(this.entryTypes);
+        const filterApplied = !!entryTypes.includes(entryType);
+        this.logger.debug(
+            `Timeline filter entry type: ${entryType} applied: ${filterApplied}`
+        );
+        return filterApplied;
+    }
+
+    isSelectedFilterModuleLoading(
+        entryType: EntryType,
+        loading: boolean
+    ): boolean {
+        const filterApplied = this.isFilterApplied(entryType);
+        const isLoading = filterApplied && loading;
+        this.logger.debug(
+            `Timeline filter entry type: ${entryType} applied: ${filterApplied} - filter loading: ${loading} and filter isLoading: ${isLoading}`
+        );
+        return isLoading;
+    }
+
+    linkGen(pageNum: number): string {
+        return `?page=${pageNum}`;
+    }
+
+    setPageFromDate(eventDate: DateWrapper): boolean {
+        let index = this.filteredTimelineEntries.findIndex((entry) => {
             entry.date.isSame(eventDate);
         });
 
@@ -307,126 +634,197 @@ export default class LinearTimelineComponent extends Vue {
         }
     }
 
-    private focusOnDate(date: DateWrapper): void {
-        const dateEpoch = date.fromEpoch();
-        const container = this.$refs[dateEpoch] as HTMLElement[];
-        container[0].querySelector("button")?.focus();
-    }
-
-    private getComponentForEntry(entryType: EntryType): string {
-        return entryTypeMap.get(entryType)?.component ?? "";
-    }
-
-    private isSelectedFilterModuleLoading(
-        entryType: EntryType,
-        loading: boolean
-    ): boolean {
-        const filterApplied = this.entryTypes.has(entryType);
-        const isLoading = filterApplied && loading;
-        this.logger.debug(
-            `Timeline filter entry type: ${entryType} applied: ${filterApplied} - filter loading: ${loading} and filter isLoading: ${isLoading}`
-        );
-        return isLoading;
+    sortEntries(timelineEntries: TimelineEntry[]): TimelineEntry[] {
+        return timelineEntries.sort((a, b) => {
+            if (a.date.isBefore(b.date)) {
+                return 1;
+            }
+            if (a.date.isAfter(b.date)) {
+                return -1;
+            }
+            return 0;
+        });
     }
 }
 </script>
 
 <template>
     <div>
-        <b-row
-            v-if="showDisplayCount"
-            id="listControls"
-            class="no-print"
-            data-testid="displayCountText"
+        <b-toast
+            v-if="!isFullyLoaded"
+            id="loading-toast"
+            visible
+            toaster="b-toaster-top-center"
+            variant="info"
+            solid
+            no-auto-hide
+            no-close-button
+            is-status
+            data-testid="loading-toast"
         >
-            <b-col class="py-2" data-testid="timeline-record-count">
-                Displaying {{ visibleTimelineEntryCount }} out of
-                {{ timelineEntryCount }} records
-            </b-col>
-        </b-row>
+            <div class="text-center">Retrieving your health records</div>
+        </b-toast>
         <div
-            v-show="isOnlyImmunizationSelected"
-            id="linear-timeline-immunization-disclaimer"
-            class="pb-2"
+            v-if="!isFullyLoaded"
+            v-show="false"
+            data-testid="loading-in-progress"
+        />
+        <b-alert
+            v-if="isLaboratoryQueued"
+            show
+            dismissible
+            variant="info"
+            class="no-print"
+            data-testid="laboratory-orders-queued-alert-message"
         >
-            <b-alert
-                show
-                variant="info"
-                class="mt-0 mb-1"
-                data-testid="linear-timeline-immunization-disclaimer-alert"
+            <span>
+                We are getting your lab results. It may take up to 48 hours
+                until you can see them.
+            </span>
+        </b-alert>
+        <div
+            v-if="showTimelineEntries"
+            class="sticky-top sticky-offset"
+            :class="{ 'header-offset': isHeaderShown }"
+        >
+            <b-row
+                class="no-print justify-content-between py-2"
+                align-v="start"
             >
-                <span>
-                    If any of your immunizations are missing or incorrect,
-                    <a
-                        href="https://www.immunizationrecord.gov.bc.ca/"
-                        target="_blank"
-                        rel="noopener"
-                        >fill in this online form</a
-                    >.
-                </span>
-            </b-alert>
+                <b-col class="col-auto">
+                    <Filters class="my-1" />
+                </b-col>
+                <b-col class="mx-2">
+                    <b-form-tag
+                        v-for="[label, value] in filterLabels"
+                        :key="`${label}-${value}`"
+                        variant="light"
+                        class="filter-label p-1 mr-2 my-1"
+                        :title="`${label} Filter`"
+                        data-testid="filter-label"
+                        @remove="clearFilter(label, value)"
+                        >{{ value }}</b-form-tag
+                    >
+                    <hg-button
+                        v-if="filterLabels.length > 0"
+                        class="p-1 mt-n1"
+                        data-testid="clear-filters-button"
+                        variant="link"
+                        @click="clearFilters"
+                    >
+                        Clear All
+                    </hg-button>
+                </b-col>
+            </b-row>
         </div>
-        <div id="timeData" data-testid="linearTimelineData">
+        <div v-show="showTimelineEntries">
+            <b-row
+                v-if="showDisplayCount"
+                id="listControls"
+                class="no-print"
+                data-testid="displayCountText"
+            >
+                <b-col class="py-2" data-testid="timeline-record-count">
+                    Displaying {{ visibleTimelineEntryCount }} out of
+                    {{ timelineEntryCount }} records
+                </b-col>
+            </b-row>
             <div
-                v-for="dateGroup in dateGroups"
-                :key="dateGroup.key"
-                :ref="dateGroup.key"
+                v-show="isOnlyImmunizationSelected"
+                id="linear-timeline-immunization-disclaimer"
+                class="pb-2"
             >
-                <component
-                    :is="getComponentForEntry(entry.type)"
-                    v-for="(entry, index) in dateGroup.entries"
-                    :key="entry.type + '-' + entry.id"
-                    :datekey="dateGroup.key"
-                    :entry="entry"
-                    :index="index"
-                    data-testid="timelineCard"
-                />
+                <b-alert
+                    show
+                    variant="info"
+                    class="mt-0 mb-1"
+                    data-testid="linear-timeline-immunization-disclaimer-alert"
+                >
+                    <span>
+                        If any of your immunizations are missing or incorrect,
+                        <a
+                            href="https://www.immunizationrecord.gov.bc.ca/"
+                            target="_blank"
+                            rel="noopener"
+                            >fill in this online form</a
+                        >.
+                    </span>
+                </b-alert>
             </div>
-        </div>
-        <b-row align-h="center">
-            <b-col cols="auto">
-                <b-pagination-nav
-                    v-if="!timelineIsEmpty"
-                    v-model="currentPage"
-                    :link-gen="linkGen"
-                    :number-of-pages="numberOfPages"
-                    data-testid="pagination"
-                    limit="4"
-                    first-number
-                    last-number
-                    next-text="Next"
-                    prev-text="Prev"
-                    use-router
-                    class="mt-3"
-                />
-            </b-col>
-        </b-row>
-        <div v-if="showEmptyState" class="text-center pt-2">
-            <b-row>
-                <b-col>
-                    <img
-                        class="mx-auto d-block"
-                        src="@/assets/images/timeline/empty-state.png"
-                        width="200"
-                        height="auto"
-                        alt="..."
+            <div id="timeData" data-testid="linearTimelineData">
+                <div
+                    v-for="dateGroup in dateGroups"
+                    :key="dateGroup.key"
+                    :ref="dateGroup.key"
+                >
+                    <component
+                        :is="getComponentForEntry(entry.type)"
+                        v-for="(entry, index) in dateGroup.entries"
+                        :key="entry.type + '-' + entry.id"
+                        :datekey="dateGroup.key"
+                        :entry="entry"
+                        :index="index"
+                        data-testid="timelineCard"
+                    />
+                </div>
+            </div>
+            <b-row align-h="center">
+                <b-col cols="auto">
+                    <b-pagination-nav
+                        v-if="!timelineIsEmpty"
+                        v-model="currentPage"
+                        :link-gen="linkGen"
+                        :number-of-pages="numberOfPages"
+                        data-testid="pagination"
+                        limit="4"
+                        first-number
+                        last-number
+                        next-text="Next"
+                        prev-text="Prev"
+                        use-router
+                        class="mt-3"
                     />
                 </b-col>
             </b-row>
-            <b-row>
-                <b-col>
-                    <p
-                        class="text-center pt-2 noTimelineEntriesText"
-                        data-testid="noTimelineEntriesText"
-                    >
-                        <span v-if="hasActiveFilter"
-                            >No records found with the selected filters</span
+            <div v-if="showEmptyState" class="text-center pt-2">
+                <b-row>
+                    <b-col>
+                        <img
+                            class="mx-auto d-block"
+                            src="@/assets/images/timeline/empty-state.png"
+                            width="200"
+                            height="auto"
+                            alt="..."
+                        />
+                    </b-col>
+                </b-row>
+                <b-row>
+                    <b-col>
+                        <p
+                            class="text-center pt-2 noTimelineEntriesText"
+                            data-testid="noTimelineEntriesText"
                         >
-                        <span v-else>No records found</span>
-                    </p>
-                </b-col>
-            </b-row>
+                            <span v-if="hasActiveFilter"
+                                >No records found with the selected
+                                filters</span
+                            >
+                            <span v-else>No records found</span>
+                        </p>
+                    </b-col>
+                </b-row>
+            </div>
         </div>
+        <content-placeholders
+            v-if="showContentPlaceholders"
+            data-testid="content-placeholders"
+        >
+            <content-placeholders-heading :img="true" />
+            <content-placeholders-text :lines="3" />
+        </content-placeholders>
+        <ProtectiveWordComponent
+            :is-loading="medicationsAreLoading(user.hdid)"
+        />
+        <EntryDetailsComponent />
     </div>
 </template>
 
@@ -443,13 +841,31 @@ export default class LinearTimelineComponent extends Vue {
     padding: 0px;
 }
 
+.form-group {
+    margin-bottom: 0px;
+}
+
 .sticky-top {
     transition: all 0.3s;
+    z-index: 49 !important;
+}
+
+.sticky-offset {
+    background-color: white;
+    z-index: 2;
+
+    &.header-offset {
+        top: $header-height;
+    }
 }
 
 .noTimelineEntriesText {
     font-size: 1.5rem;
     color: #6c757d;
+}
+
+.filter-label {
+    font-size: 1rem;
 }
 </style>
 <style lang="scss">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -322,8 +322,6 @@ export default class TimelineComponent extends Vue {
     }
 
     get unfilteredTimelineEntries(): TimelineEntry[] {
-        this.logger.debug("Updating timeline entries");
-
         const getComments = this.getEntryComments;
         let entries = [];
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -68,7 +68,7 @@ const options: any = {
 };
 
 @Component(options)
-export default class LinearTimelineComponent extends Vue {
+export default class TimelineComponent extends Vue {
     @Prop({ required: true })
     hdid!: string;
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -748,7 +748,7 @@ export default class TimelineComponent extends Vue {
             <content-placeholders-text :lines="3" />
         </content-placeholders>
         <ProtectiveWordComponent :hdid="hdid" />
-        <EntryDetailsComponent />
+        <EntryDetailsComponent :hdid="hdid" />
     </div>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/ClinicalDocumentTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/ClinicalDocumentTimelineComponent.vue
@@ -11,7 +11,6 @@ import { ClinicalDocumentFile } from "@/models/clinicalDocument";
 import ClinicalDocumentTimelineEntry from "@/models/clinicalDocumentTimelineEntry";
 import EncodedMedia from "@/models/encodedMedia";
 import { LoadStatus } from "@/models/storeOperations";
-import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
@@ -29,6 +28,9 @@ const options: any = {
 
 @Component(options)
 export default class ClinicalDocumentTimelineComponent extends Vue {
+    @Prop({ required: true })
+    hdid!: string;
+
     @Prop()
     entry!: ClinicalDocumentTimelineEntry;
 
@@ -49,9 +51,6 @@ export default class ClinicalDocumentTimelineComponent extends Vue {
 
     @Getter("files", { namespace: "clinicalDocument" })
     files!: Dictionary<ClinicalDocumentFile>;
-
-    @Getter("user", { namespace: "user" })
-    user!: User;
 
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
@@ -86,7 +85,7 @@ export default class ClinicalDocumentTimelineComponent extends Vue {
             text: "document",
         });
 
-        this.getFile({ fileId: this.entry.fileId, hdid: this.user.hdid })
+        this.getFile({ fileId: this.entry.fileId, hdid: this.hdid })
             .then((result: EncodedMedia) => {
                 const dateString = this.entry.date.format("yyyy_MM_dd-HH_mm");
                 fetch(

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
@@ -67,7 +67,7 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
     private logger!: ILogger;
 
     private get entryIcon(): string | undefined {
-        return entryTypeMap.get(EntryType.Covid19LaboratoryOrder)?.icon;
+        return entryTypeMap.get(EntryType.Covid19TestResult)?.icon;
     }
 
     private get reportAvailable(): boolean {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
@@ -4,7 +4,7 @@ import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { saveAs } from "file-saver";
 import Vue from "vue";
 import { Component, Prop, Ref } from "vue-property-decorator";
-import { Action, Getter } from "vuex-class";
+import { Action } from "vuex-class";
 
 import Covid19LaboratoryTestDescriptionComponent from "@/components/laboratory/Covid19LaboratoryTestDescriptionComponent.vue";
 import MessageModalComponent from "@/components/modal/MessageModalComponent.vue";
@@ -13,7 +13,6 @@ import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import Covid19LaboratoryOrderTimelineEntry from "@/models/covid19LaboratoryOrderTimelineEntry";
 import { DateWrapper } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";
-import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILaboratoryService, ILogger } from "@/services/interfaces";
@@ -34,11 +33,20 @@ const options: any = {
 
 @Component(options)
 export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
-    @Prop() entry!: Covid19LaboratoryOrderTimelineEntry;
-    @Prop() index!: number;
-    @Prop() datekey!: string;
-    @Prop() isMobileDetails!: boolean;
-    @Getter("user", { namespace: "user" }) user!: User;
+    @Prop({ required: true })
+    hdid!: string;
+
+    @Prop()
+    entry!: Covid19LaboratoryOrderTimelineEntry;
+
+    @Prop()
+    index!: number;
+
+    @Prop()
+    datekey!: string;
+
+    @Prop()
+    isMobileDetails!: boolean;
 
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
@@ -100,7 +108,7 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
 
         this.isLoadingDocument = true;
         this.laboratoryService
-            .getReportDocument(this.entry.id, this.user.hdid, true)
+            .getReportDocument(this.entry.id, this.hdid, true)
             .then((result) => {
                 const dateString =
                     this.entry.displayDate.format("yyyy_MM_dd-HH_mm");

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -26,7 +26,7 @@ export default class EncounterTimelineComponent extends Vue {
     @Prop() isMobileDetails!: boolean;
 
     private get entryIcon(): string | undefined {
-        return entryTypeMap.get(EntryType.Encounter)?.icon;
+        return entryTypeMap.get(EntryType.HealthVisit)?.icon;
     }
 
     private get showEncounterRolloffAlert(): boolean {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
@@ -26,16 +26,15 @@ library.add(faArrowLeft);
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
     components: {
-        MedicationRequestComponent: MedicationRequestTimelineComponent,
-        MedicationComponent: MedicationTimelineComponent,
-        ImmunizationComponent: ImmunizationTimelineComponent,
-        Covid19LaboratoryOrderComponent:
-            Covid19LaboratoryOrderTimelineComponent,
-        LaboratoryOrderComponent: LaboratoryOrderTimelineComponent,
-        EncounterComponent: EncounterTimelineComponent,
-        NoteComponent: NoteTimelineComponent,
-        ClinicalDocumentComponent: ClinicalDocumentTimelineComponent,
-        HospitalVisitComponent: HospitalVisitTimelineComponent,
+        ClinicalDocumentTimelineComponent,
+        Covid19LaboratoryOrderTimelineComponent,
+        EncounterTimelineComponent,
+        HospitalVisitTimelineComponent,
+        ImmunizationTimelineComponent,
+        LaboratoryOrderTimelineComponent,
+        MedicationRequestTimelineComponent,
+        MedicationTimelineComponent,
+        NoteTimelineComponent,
     },
 };
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
@@ -2,7 +2,7 @@
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import Vue from "vue";
-import { Component, Watch } from "vue-property-decorator";
+import { Component, Prop, Watch } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
 import { entryTypeMap } from "@/constants/entryType";
@@ -40,6 +40,9 @@ const options: any = {
 
 @Component(options)
 export default class EntryDetailsComponent extends Vue {
+    @Prop({ required: true })
+    hdid!: string;
+
     @Action("setHeaderState", { namespace: "navbar" })
     setHeaderState!: (isOpen: boolean) => void;
 
@@ -164,6 +167,7 @@ export default class EntryDetailsComponent extends Vue {
             :entry="entry"
             :index="1"
             :is-mobile-details="true"
+            :hdid="hdid"
             data-testid="entryDetailsCard"
         />
     </b-modal>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -64,7 +64,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
     }
 
     private get entryIcon(): string | undefined {
-        return entryTypeMap.get(EntryType.LaboratoryOrder)?.icon;
+        return entryTypeMap.get(EntryType.LabResult)?.icon;
     }
 
     private formatDate(date: DateWrapper): string {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -4,7 +4,7 @@ import { faDownload } from "@fortawesome/free-solid-svg-icons";
 import { saveAs } from "file-saver";
 import Vue from "vue";
 import { Component, Prop, Ref } from "vue-property-decorator";
-import { Action, Getter } from "vuex-class";
+import { Action } from "vuex-class";
 
 import MessageModalComponent from "@/components/modal/MessageModalComponent.vue";
 import { EntryType, entryTypeMap } from "@/constants/entryType";
@@ -12,7 +12,6 @@ import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { DateWrapper } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";
 import LaboratoryOrderTimelineEntry from "@/models/laboratoryOrderTimelineEntry";
-import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILaboratoryService, ILogger } from "@/services/interfaces";
@@ -32,11 +31,20 @@ const options: any = {
 
 @Component(options)
 export default class LaboratoryOrderTimelineComponent extends Vue {
-    @Prop() entry!: LaboratoryOrderTimelineEntry;
-    @Prop() index!: number;
-    @Prop() datekey!: string;
-    @Prop() isMobileDetails!: boolean;
-    @Getter("user", { namespace: "user" }) user!: User;
+    @Prop({ required: true })
+    hdid!: string;
+
+    @Prop()
+    entry!: LaboratoryOrderTimelineEntry;
+
+    @Prop()
+    index!: number;
+
+    @Prop()
+    datekey!: string;
+
+    @Prop()
+    isMobileDetails!: boolean;
 
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
@@ -88,7 +96,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
 
         this.isLoadingDocument = true;
         this.laboratoryService
-            .getReportDocument(this.entry.id, this.user.hdid, false)
+            .getReportDocument(this.entry.id, this.hdid, false)
             .then((result) => {
                 const dateString =
                     this.entry.timelineDateTime.format("yyyy_MM_dd-HH_mm");

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationRequestTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationRequestTimelineComponent.vue
@@ -24,7 +24,7 @@ export default class MedicationRequestTimelineComponent extends Vue {
     @Prop() isMobileDetails!: boolean;
 
     private get entryIcon(): string | undefined {
-        return entryTypeMap.get(EntryType.MedicationRequest)?.icon;
+        return entryTypeMap.get(EntryType.SpecialAuthorityRequest)?.icon;
     }
 
     private formatDate(dateValue: string): string {

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/NoteTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/NoteTimelineComponent.vue
@@ -3,14 +3,13 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faEllipsisV } from "@fortawesome/free-solid-svg-icons";
 import Vue from "vue";
 import { Component, Prop } from "vue-property-decorator";
-import { Action, Getter } from "vuex-class";
+import { Action } from "vuex-class";
 
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import EventBus, { EventMessageName } from "@/eventbus";
 import { ResultError } from "@/models/errors";
 import NoteTimelineEntry from "@/models/noteTimelineEntry";
-import User from "@/models/user";
 import UserNote from "@/models/userNote";
 
 import EntrycardTimelineComponent from "./EntrycardTimelineComponent.vue";
@@ -26,6 +25,15 @@ const options: any = {
 
 @Component(options)
 export default class NoteTimelineComponent extends Vue {
+    @Prop({ required: true })
+    hdid!: string;
+
+    @Prop()
+    entry!: NoteTimelineEntry;
+
+    @Prop()
+    isMobileDetails!: boolean;
+
     @Action("addError", { namespace: "errorBanner" })
     addError!: (params: {
         errorType: ErrorType;
@@ -35,11 +43,6 @@ export default class NoteTimelineComponent extends Vue {
 
     @Action("deleteNote", { namespace: "note" })
     deleteNote!: (params: { hdid: string; note: UserNote }) => Promise<void>;
-
-    @Getter("user", { namespace: "user" }) user!: User;
-
-    @Prop() entry!: NoteTimelineEntry;
-    @Prop() isMobileDetails!: boolean;
 
     private isSaving = false;
     private eventBus = EventBus;
@@ -59,7 +62,7 @@ export default class NoteTimelineComponent extends Vue {
         if (confirm("Are you sure you want to delete this note?")) {
             this.isSaving = true;
             this.deleteNote({
-                hdid: this.user.hdid,
+                hdid: this.hdid,
                 note: this.entry.toModel(),
             })
                 .catch((err: ResultError) => {

--- a/Apps/WebClient/src/ClientApp/src/constants/commentEntryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/commentEntryType.ts
@@ -1,11 +1,11 @@
 export const enum CommentEntryType {
     None = "NA",
-    MedicationRequest = "SAR",
-    Medication = "Med",
-    Immunization = "Imm",
-    Covid19LaboratoryOrder = "Lab",
-    LaboratoryOrder = "ALO",
-    Encounter = "Enc",
     ClinicalDocument = "CDO",
+    Covid19TestResult = "Lab",
+    HealthVisit = "Enc",
     HospitalVisit = "Hos",
+    Immunization = "Imm",
+    LabResult = "ALO",
+    Medication = "Med",
+    SpecialAuthorityRequest = "SAR",
 }

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -1,15 +1,15 @@
 import { CommentEntryType } from "@/constants/commentEntryType";
 
 export enum EntryType {
-    MedicationRequest = "MedicationRequest",
-    Medication = "Medication",
-    Immunization = "Immunization",
-    Covid19LaboratoryOrder = "Laboratory",
-    LaboratoryOrder = "AllLaboratory",
-    Encounter = "Encounter",
-    Note = "Note",
     ClinicalDocument = "ClinicalDocument",
+    Covid19TestResult = "Laboratory",
+    HealthVisit = "Encounter",
     HospitalVisit = "HospitalVisit",
+    Immunization = "Immunization",
+    LabResult = "AllLaboratory",
+    Medication = "Medication",
+    Note = "Note",
+    SpecialAuthorityRequest = "MedicationRequest",
 }
 
 export class EntryTypeDetails {
@@ -45,9 +45,9 @@ entryTypeMap.set(EntryType.Medication, {
     eventName: "medications",
 });
 
-entryTypeMap.set(EntryType.LaboratoryOrder, {
-    type: EntryType.LaboratoryOrder,
-    commentType: CommentEntryType.LaboratoryOrder,
+entryTypeMap.set(EntryType.LabResult, {
+    type: EntryType.LabResult,
+    commentType: CommentEntryType.LabResult,
     name: "Lab Results",
     description:
         "Find out your lab results within about 48 hours of taking a test",
@@ -56,9 +56,9 @@ entryTypeMap.set(EntryType.LaboratoryOrder, {
     eventName: "lab_results",
 });
 
-entryTypeMap.set(EntryType.Covid19LaboratoryOrder, {
-    type: EntryType.Covid19LaboratoryOrder,
-    commentType: CommentEntryType.Covid19LaboratoryOrder,
+entryTypeMap.set(EntryType.Covid19TestResult, {
+    type: EntryType.Covid19TestResult,
+    commentType: CommentEntryType.Covid19TestResult,
     name: "COVID‑19 Tests",
     description:
         "View and download your COVID‑19 test results as soon as they are available",
@@ -67,9 +67,9 @@ entryTypeMap.set(EntryType.Covid19LaboratoryOrder, {
     eventName: "covid_test",
 });
 
-entryTypeMap.set(EntryType.Encounter, {
-    type: EntryType.Encounter,
-    commentType: CommentEntryType.Encounter,
+entryTypeMap.set(EntryType.HealthVisit, {
+    type: EntryType.HealthVisit,
+    commentType: CommentEntryType.HealthVisit,
     name: "Health Visits",
     description:
         "See the last seven years of your health visits billed to the BC Medical Services Plan",
@@ -88,9 +88,9 @@ entryTypeMap.set(EntryType.Note, {
     eventName: "my_notes",
 });
 
-entryTypeMap.set(EntryType.MedicationRequest, {
-    type: EntryType.MedicationRequest,
-    commentType: CommentEntryType.MedicationRequest,
+entryTypeMap.set(EntryType.SpecialAuthorityRequest, {
+    type: EntryType.SpecialAuthorityRequest,
+    commentType: CommentEntryType.SpecialAuthorityRequest,
     name: "Special Authority",
     description:
         "Check the status of your Special Authority Requests since March 2021",

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -31,7 +31,7 @@ entryTypeMap.set(EntryType.Immunization, {
     description:
         "View immunizations you received from public health and community pharmacies",
     icon: "syringe",
-    component: "ImmunizationComponent",
+    component: "ImmunizationTimelineComponent",
     eventName: "immunizations",
 });
 
@@ -41,7 +41,7 @@ entryTypeMap.set(EntryType.Medication, {
     name: "Medications",
     description: "See your medication history dating back to 1995",
     icon: "pills",
-    component: "MedicationComponent",
+    component: "MedicationTimelineComponent",
     eventName: "medications",
 });
 
@@ -52,7 +52,7 @@ entryTypeMap.set(EntryType.LabResult, {
     description:
         "Find out your lab results within about 48 hours of taking a test",
     icon: "microscope",
-    component: "LaboratoryOrderComponent",
+    component: "LaboratoryOrderTimelineComponent",
     eventName: "lab_results",
 });
 
@@ -63,7 +63,7 @@ entryTypeMap.set(EntryType.Covid19TestResult, {
     description:
         "View and download your COVID‑19 test results as soon as they are available",
     icon: "vial",
-    component: "Covid19LaboratoryOrderComponent",
+    component: "Covid19LaboratoryOrderTimelineComponent",
     eventName: "covid_test",
 });
 
@@ -74,7 +74,7 @@ entryTypeMap.set(EntryType.HealthVisit, {
     description:
         "See the last seven years of your health visits billed to the BC Medical Services Plan",
     icon: "stethoscope",
-    component: "EncounterComponent",
+    component: "EncounterTimelineComponent",
     eventName: "health_visits",
 });
 
@@ -84,7 +84,7 @@ entryTypeMap.set(EntryType.Note, {
     name: "My Notes",
     description: "Create and edit your own notes on your health records",
     icon: "edit",
-    component: "NoteComponent",
+    component: "NoteTimelineComponent",
     eventName: "my_notes",
 });
 
@@ -95,7 +95,7 @@ entryTypeMap.set(EntryType.SpecialAuthorityRequest, {
     description:
         "Check the status of your Special Authority Requests since March 2021",
     icon: "file-medical",
-    component: "MedicationRequestComponent",
+    component: "MedicationRequestTimelineComponent",
     eventName: "special_authority",
 });
 
@@ -106,7 +106,7 @@ entryTypeMap.set(EntryType.ClinicalDocument, {
     description:
         "View documents shared by your care providers. You can get consultation notes, hospital discharge summaries, outpatient clinic notes and more.",
     icon: "file-waveform",
-    component: "ClinicalDocumentComponent",
+    component: "ClinicalDocumentTimelineComponent",
     eventName: "document",
 });
 
@@ -117,7 +117,7 @@ entryTypeMap.set(EntryType.HospitalVisit, {
     description:
         "View a list of your hospital visits. You can get the admission and discharge dates, location and provider for each visit.",
     icon: "house-medical",
-    component: "HospitalVisitComponent",
+    component: "HospitalVisitTimelineComponent",
     eventName: "hospital_visits",
 });
 

--- a/Apps/WebClient/src/ClientApp/src/models/covid19LaboratoryOrderTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/covid19LaboratoryOrderTimelineEntry.ts
@@ -32,7 +32,7 @@ export default class Covid19LaboratoryOrderTimelineEntry extends TimelineEntry {
     ) {
         super(
             model.id,
-            EntryType.Covid19LaboratoryOrder,
+            EntryType.Covid19TestResult,
             new DateWrapper(model.labResults[0].collectedDateTime, {
                 hasTime: true,
             })

--- a/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/encounterTimelineEntry.ts
@@ -20,7 +20,7 @@ export default class EncounterTimelineEntry extends TimelineEntry {
     ) {
         super(
             model.id,
-            EntryType.Encounter,
+            EntryType.HealthVisit,
             new DateWrapper(model.encounterDate)
         );
         this.practitionerName =

--- a/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/laboratoryOrderTimelineEntry.ts
@@ -29,7 +29,7 @@ export default class LaboratoryOrderTimelineEntry extends TimelineEntry {
     ) {
         super(
             model.labPdfId,
-            EntryType.LaboratoryOrder,
+            EntryType.LabResult,
             new DateWrapper(model.timelineDateTime, {
                 hasTime: true,
             })

--- a/Apps/WebClient/src/ClientApp/src/models/medicationRequestTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/medicationRequestTimelineEntry.ts
@@ -23,7 +23,7 @@ export default class MedicationRequestTimelineEntry extends TimelineEntry {
     ) {
         super(
             model.referenceNumber,
-            EntryType.MedicationRequest,
+            EntryType.SpecialAuthorityRequest,
             new DateWrapper(model.requestedDate)
         );
 

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -60,8 +60,8 @@ const RegistrationView = () =>
     );
 const HomeView = () =>
     import(/* webpackChunkName: "home" */ "@/views/HomeView.vue");
-const TimelineView = () =>
-    import(/* webpackChunkName: "timeline" */ "@/views/TimelineView.vue");
+const UserTimelineView = () =>
+    import(/* webpackChunkName: "timeline" */ "@/views/UserTimelineView.vue");
 const Covid19View = () =>
     import(/* webpackChunkName: "covid19" */ "@/views/Covid19View.vue");
 const ValidateEmailView = () =>
@@ -254,7 +254,7 @@ const routes = [
     },
     {
         path: TIMELINE_PATH,
-        component: TimelineView,
+        component: UserTimelineView,
         meta: {
             validStates: [UserState.registered],
             requiresProcessedWaitlistTicket: true,

--- a/Apps/WebClient/src/ClientApp/src/store/modules/encounter/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/encounter/actions.ts
@@ -61,7 +61,7 @@ export const actions: EncounterActions = {
                             reject(result.resultError);
                         } else {
                             EventTracker.loadData(
-                                EntryType.Encounter,
+                                EntryType.HealthVisit,
                                 result.resourcePayload.length
                             );
                             context.commit("setHealthVisits", {

--- a/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/laboratory/actions.ts
@@ -64,7 +64,7 @@ export const actions: LaboratoryActions = {
                         const payload = result.resourcePayload;
                         if (result.resultStatus === ResultType.Success) {
                             EventTracker.loadData(
-                                EntryType.Covid19LaboratoryOrder,
+                                EntryType.Covid19TestResult,
                                 result.totalResultCount
                             );
                             context.commit("setCovid19LaboratoryOrders", {
@@ -159,7 +159,7 @@ export const actions: LaboratoryActions = {
                             payload.loaded
                         ) {
                             EventTracker.loadData(
-                                EntryType.LaboratoryOrder,
+                                EntryType.LabResult,
                                 result.totalResultCount
                             );
                             logger.info("Laboratory Orders loaded.");

--- a/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/request/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/medication/modules/request/actions.ts
@@ -61,7 +61,7 @@ export const actions: MedicationRequestActions = {
                             reject(result.resultError);
                         } else {
                             EventTracker.loadData(
-                                EntryType.MedicationRequest,
+                                EntryType.SpecialAuthorityRequest,
                                 result.resourcePayload.length
                             );
                             context.commit("setSpecialAuthorityRequests", {

--- a/Apps/WebClient/src/ClientApp/src/store/modules/timeline/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/timeline/getters.ts
@@ -42,7 +42,7 @@ export const getters: TimelineGetters = {
         return new DateWrapper(state.linearDate);
     },
 
-    entryTypes(state: TimelineState): Set<EntryType> {
+    selectedEntryTypes(state: TimelineState): Set<EntryType> {
         if (
             state.filter instanceof TimelineFilter &&
             state.filter.entryTypes instanceof Set<EntryType>

--- a/Apps/WebClient/src/ClientApp/src/store/modules/timeline/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/timeline/types.ts
@@ -24,7 +24,7 @@ export interface TimelineGetters extends GetterTree<TimelineState, RootState> {
     keyword(state: TimelineState): string;
     linearDate(state: TimelineState): DateWrapper;
     selectedDate(state: TimelineState): DateWrapper | null;
-    entryTypes(state: TimelineState): Set<EntryType>;
+    selectedEntryTypes(state: TimelineState): Set<EntryType>;
 }
 
 type StoreContext = ActionContext<TimelineState, RootState>;

--- a/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
@@ -107,11 +107,11 @@ export default class LandingView extends Vue {
 
     private entryTypes: EntryType[] = [
         EntryType.Medication,
-        EntryType.LaboratoryOrder,
-        EntryType.Covid19LaboratoryOrder,
-        EntryType.Encounter,
+        EntryType.LabResult,
+        EntryType.Covid19TestResult,
+        EntryType.HealthVisit,
         EntryType.Immunization,
-        EntryType.MedicationRequest,
+        EntryType.SpecialAuthorityRequest,
         EntryType.ClinicalDocument,
         EntryType.HospitalVisit,
     ];

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -14,42 +14,17 @@ import {
     faSyringe,
     faVial,
 } from "@fortawesome/free-solid-svg-icons";
-import { BToast } from "bootstrap-vue";
 import Vue from "vue";
 import { Component } from "vue-property-decorator";
-import { Action, Getter } from "vuex-class";
+import { Getter } from "vuex-class";
 
 import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
-import ProtectiveWordComponent from "@/components/modal/ProtectiveWordComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
 import AddNoteButtonComponent from "@/components/timeline/AddNoteButtonComponent.vue";
-import EntryDetailsComponent from "@/components/timeline/entryCard/EntryDetailsComponent.vue";
-import FilterComponent from "@/components/timeline/FilterComponent.vue";
 import LinearTimelineComponent from "@/components/timeline/LinearTimelineComponent.vue";
-import { EntryType, entryTypeMap } from "@/constants/entryType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
-import { ClinicalDocument } from "@/models/clinicalDocument";
-import ClinicalDocumentTimelineEntry from "@/models/clinicalDocumentTimelineEntry";
 import type { WebClientConfiguration } from "@/models/configData";
-import Covid19LaboratoryOrderTimelineEntry from "@/models/covid19LaboratoryOrderTimelineEntry";
-import { DateWrapper } from "@/models/dateWrapper";
-import { Encounter, HospitalVisit } from "@/models/encounter";
-import EncounterTimelineEntry from "@/models/encounterTimelineEntry";
-import HospitalVisitTimelineEntry from "@/models/hospitalVisitTimelineEntry";
-import { ImmunizationEvent } from "@/models/immunizationModel";
-import ImmunizationTimelineEntry from "@/models/immunizationTimelineEntry";
-import { Covid19LaboratoryOrder, LaboratoryOrder } from "@/models/laboratory";
-import LaboratoryOrderTimelineEntry from "@/models/laboratoryOrderTimelineEntry";
-import MedicationRequest from "@/models/medicationRequest";
-import MedicationRequestTimelineEntry from "@/models/medicationRequestTimelineEntry";
-import MedicationStatementHistory from "@/models/medicationStatementHistory";
-import MedicationTimelineEntry from "@/models/medicationTimelineEntry";
-import NoteTimelineEntry from "@/models/noteTimelineEntry";
-import TimelineEntry from "@/models/timelineEntry";
-import TimelineFilter, { TimelineFilterBuilder } from "@/models/timelineFilter";
 import User from "@/models/user";
-import { UserComment } from "@/models/userComment";
-import UserNote from "@/models/userNote";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
@@ -69,22 +44,12 @@ library.add(
     faVial
 );
 
-enum FilterLabelType {
-    Keyword = "Keyword",
-    Type = "Record Type",
-    Date = "Date",
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
     components: {
-        BToast,
         BreadcrumbComponent,
-        ProtectiveWordComponent,
         NoteEditComponent,
-        EntryDetailsComponent,
         LinearTimeline: LinearTimelineComponent,
-        Filters: FilterComponent,
         "add-note-button": AddNoteButtonComponent,
     },
 };
@@ -94,125 +59,15 @@ export default class TimelineView extends Vue {
     @Getter("webClient", { namespace: "config" })
     config!: WebClientConfiguration;
 
-    @Action("retrieveImmunizations", { namespace: "immunization" })
-    retrieveImmunizations!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("retrieveHealthVisits", { namespace: "encounter" })
-    retrieveHealthVisits!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("retrieveHospitalVisits", { namespace: "encounter" })
-    retrieveHospitalVisits!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("retrieveNotes", { namespace: "note" })
-    retrieveNotes!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("retrieveCovid19LaboratoryOrders", { namespace: "laboratory" })
-    retrieveCovid19LaboratoryOrders!: (params: {
-        hdid: string;
-    }) => Promise<void>;
-
-    @Action("retrieveLaboratoryOrders", { namespace: "laboratory" })
-    retrieveLaboratoryOrders!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("retrieveMedications", { namespace: "medication" })
-    retrieveMedications!: (params: {
-        hdid: string;
-        protectiveWord?: string;
-    }) => Promise<void>;
-
-    @Action("retrieveSpecialAuthorityRequests", { namespace: "medication" })
-    retrieveSpecialAuthorityRequests!: (params: {
-        hdid: string;
-    }) => Promise<void>;
-
-    @Action("retrieveClinicalDocuments", { namespace: "clinicalDocument" })
-    retrieveClinicalDocuments!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("retrieveComments", { namespace: "comment" })
-    retrieveComments!: (params: { hdid: string }) => Promise<void>;
-
-    @Action("setFilter", { namespace: "timeline" })
-    setFilter!: (filterBuilder: TimelineFilterBuilder) => void;
-
-    @Getter("medicationsAreLoading", { namespace: "medication" })
-    medicationsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("specialAuthorityRequestsAreLoading", { namespace: "medication" })
-    specialAuthorityRequestsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("commentsAreLoading", { namespace: "comment" })
-    commentsAreLoading!: boolean;
-
-    @Getter("covid19LaboratoryOrdersAreLoading", { namespace: "laboratory" })
-    covid19LaboratoryOrdersAreLoading!: (hdid: string) => boolean;
-
-    @Getter("laboratoryOrdersAreQueued", { namespace: "laboratory" })
-    laboratoryOrdersAreQueued!: (hdid: string) => boolean;
-
-    @Getter("laboratoryOrdersAreLoading", { namespace: "laboratory" })
-    laboratoryOrdersAreLoading!: (hdid: string) => boolean;
-
-    @Getter("healthVisitsAreLoading", { namespace: "encounter" })
-    healthVisitsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("hospitalVisitsAreLoading", { namespace: "encounter" })
-    hospitalVisitsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("immunizationsAreLoading", { namespace: "immunization" })
-    immunizationsAreLoading!: (hdid: string) => boolean;
-
-    @Getter("immunizationsAreDeferred", { namespace: "immunization" })
-    immunizationsAreDeferred!: (hdid: string) => boolean;
-
     @Getter("notesAreLoading", { namespace: "note" })
     notesAreLoading!: boolean;
 
-    @Getter("clinicalDocumentsAreLoading", { namespace: "clinicalDocument" })
-    clinicalDocumentsAreLoading!: (hdid: string) => boolean;
+    @Getter("user", { namespace: "user" })
+    user!: User;
 
-    @Getter("immunizations", { namespace: "immunization" })
-    patientImmunizations!: (hdid: string) => ImmunizationEvent[];
+    logger!: ILogger;
 
-    @Getter("healthVisits", { namespace: "encounter" })
-    healthVisits!: (hdid: string) => Encounter[];
-
-    @Getter("hospitalVisits", { namespace: "encounter" })
-    hospitalVisits!: (hdid: string) => HospitalVisit[];
-
-    @Getter("medications", { namespace: "medication" })
-    medications!: (hdid: string) => MedicationStatementHistory[];
-
-    @Getter("specialAuthorityRequests", { namespace: "medication" })
-    specialAuthorityRequests!: (hdid: string) => MedicationRequest[];
-
-    @Getter("covid19LaboratoryOrders", { namespace: "laboratory" })
-    covid19LaboratoryOrders!: (hdid: string) => Covid19LaboratoryOrder[];
-
-    @Getter("laboratoryOrders", { namespace: "laboratory" })
-    laboratoryOrders!: (hdid: string) => LaboratoryOrder[];
-
-    @Getter("clinicalDocuments", { namespace: "clinicalDocument" })
-    clinicalDocuments!: (hdid: string) => ClinicalDocument[];
-
-    @Getter("notes", { namespace: "note" })
-    userNotes!: UserNote[];
-
-    @Getter("getEntryComments", { namespace: "comment" })
-    getEntryComments!: (entyId: string) => UserComment[] | null;
-
-    @Getter("filter", { namespace: "timeline" })
-    filter!: TimelineFilter;
-
-    @Getter("entryTypes", { namespace: "timeline" })
-    entryTypes!: Set<EntryType>;
-
-    @Getter("user", { namespace: "user" }) user!: User;
-
-    @Getter("isHeaderShown", { namespace: "navbar" }) isHeaderShown!: boolean;
-
-    private logger!: ILogger;
-
-    private breadcrumbItems: BreadcrumbItem[] = [
+    breadcrumbItems: BreadcrumbItem[] = [
         {
             text: "Timeline",
             to: "/timeline",
@@ -221,473 +76,25 @@ export default class TimelineView extends Vue {
         },
     ];
 
-    private get isLaboratoryQueued(): boolean {
-        return this.laboratoryOrdersAreQueued(this.user.hdid);
-    }
-
-    private get timelineEntries(): TimelineEntry[] {
-        this.logger.debug("Updating timeline Entries");
-
-        let timelineEntries = [];
-
-        // Add the Special Authority request entries to the timeline list
-        for (const request of this.specialAuthorityRequests(this.user.hdid)) {
-            timelineEntries.push(
-                new MedicationRequestTimelineEntry(
-                    request,
-                    this.getEntryComments
-                )
-            );
-        }
-
-        // Add the medication entries to the timeline list
-        for (const medication of this.medications(this.user.hdid)) {
-            timelineEntries.push(
-                new MedicationTimelineEntry(medication, this.getEntryComments)
-            );
-        }
-
-        // Add the COVID-19 laboratory entries to the timeline list
-        for (const order of this.covid19LaboratoryOrders(this.user.hdid)) {
-            timelineEntries.push(
-                new Covid19LaboratoryOrderTimelineEntry(
-                    order,
-                    this.getEntryComments
-                )
-            );
-        }
-
-        // Add the laboratory entries to the timeline list
-        for (const order of this.laboratoryOrders(this.user.hdid)) {
-            timelineEntries.push(
-                new LaboratoryOrderTimelineEntry(order, this.getEntryComments)
-            );
-        }
-
-        // Add the health visit entries to the timeline list
-        for (const healthVisit of this.healthVisits(this.user.hdid)) {
-            timelineEntries.push(
-                new EncounterTimelineEntry(healthVisit, this.getEntryComments)
-            );
-        }
-
-        // Add the hospital visit entries to the timeline list
-        for (const visit of this.hospitalVisits(this.user.hdid)) {
-            timelineEntries.push(
-                new HospitalVisitTimelineEntry(visit, this.getEntryComments)
-            );
-        }
-
-        // Add the clinical document entries to the timeline list
-        for (const clinicalDocument of this.clinicalDocuments(this.user.hdid)) {
-            timelineEntries.push(
-                new ClinicalDocumentTimelineEntry(
-                    clinicalDocument,
-                    this.getEntryComments
-                )
-            );
-        }
-
-        // Add the Note entries to the timeline list
-        for (const note of this.userNotes) {
-            timelineEntries.push(new NoteTimelineEntry(note));
-        }
-
-        // Add the immunization entries to the timeline list
-        for (const immunization of this.patientImmunizations(this.user.hdid)) {
-            timelineEntries.push(new ImmunizationTimelineEntry(immunization));
-        }
-
-        timelineEntries = this.sortEntries(timelineEntries);
-        return timelineEntries;
-    }
-
-    public get filteredTimelineEntries(): TimelineEntry[] {
-        let filteredEntries = [];
-
-        if (this.filter.hasActiveFilter()) {
-            filteredEntries = this.timelineEntries.filter((entry) =>
-                entry.filterApplies(this.filter)
-            );
-        } else {
-            filteredEntries = this.timelineEntries;
-        }
-
-        return filteredEntries;
-    }
-
-    private get isFullyLoaded(): boolean {
-        return (
-            !this.specialAuthorityRequestsAreLoading(this.user.hdid) &&
-            !this.medicationsAreLoading(this.user.hdid) &&
-            !this.covid19LaboratoryOrdersAreLoading(this.user.hdid) &&
-            !this.laboratoryOrdersAreLoading(this.user.hdid) &&
-            !this.immunizationsAreLoading(this.user.hdid) &&
-            !this.immunizationsAreDeferred(this.user.hdid) &&
-            !this.healthVisitsAreLoading(this.user.hdid) &&
-            !this.hospitalVisitsAreLoading(this.user.hdid) &&
-            !this.clinicalDocumentsAreLoading(this.user.hdid) &&
-            !this.notesAreLoading &&
-            !this.commentsAreLoading
-        );
-    }
-
-    private get isFilterLoading(): boolean {
-        const filtersLoaded = [];
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.MedicationRequest,
-                this.specialAuthorityRequestsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Medication,
-                this.medicationsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Immunization,
-                this.immunizationsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Covid19LaboratoryOrder,
-                this.covid19LaboratoryOrdersAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.LaboratoryOrder,
-                this.laboratoryOrdersAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Encounter,
-                this.healthVisitsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.HospitalVisit,
-                this.hospitalVisitsAreLoading(this.user.hdid)
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.Note,
-                this.notesAreLoading
-            )
-        );
-
-        filtersLoaded.push(
-            this.isSelectedFilterModuleLoading(
-                EntryType.ClinicalDocument,
-                this.clinicalDocumentsAreLoading(this.user.hdid)
-            )
-        );
-
-        const filterLoading = filtersLoaded.includes(true);
-        this.logger.debug(`Timeline filter loading: ${filterLoading}`);
-
-        return filterLoading;
-    }
-
-    private get isFilterModuleSelected(): boolean {
-        const entryTypes = Array.from(this.entryTypes);
-        this.logger.debug(
-            `Number of imeline filter modules selected: ${entryTypes.length}`
-        );
-        return entryTypes.length > 0;
-    }
-
-    private get showContentPlaceholders(): boolean {
-        if (this.isFilterModuleSelected) {
-            return this.isFilterLoading;
-        }
-        return !this.isFullyLoaded && this.filteredTimelineEntries.length === 0;
-    }
-
-    private get showTimelineEntries(): boolean {
-        return this.timelineEntries.length > 0 || this.isFullyLoaded;
-    }
-
-    private get isNoteEnabled(): boolean {
+    get isNoteEnabled(): boolean {
         return this.config.modules["Note"];
     }
 
-    private get filterLabels(): [string, string][] {
-        const labels: [string, string][] = [];
-
-        if (this.filter.keyword) {
-            labels.push([FilterLabelType.Keyword, `"${this.filter.keyword}"`]);
-        }
-
-        this.entryTypes.forEach((entryType) => {
-            const label = entryTypeMap.get(entryType)?.name;
-            if (label) {
-                labels.push([FilterLabelType.Type, label]);
-            }
-        });
-
-        const startDate = this.filter.startDate
-            ? `From ${new DateWrapper(this.filter.startDate).format()}`
-            : "";
-        const endDate = this.filter.endDate
-            ? `To ${new DateWrapper(this.filter.endDate).format()}`
-            : "";
-        if (startDate && endDate) {
-            labels.push([FilterLabelType.Date, `${startDate} ${endDate}`]);
-        } else if (startDate) {
-            labels.push([FilterLabelType.Date, startDate]);
-        } else if (endDate) {
-            labels.push([FilterLabelType.Date, endDate]);
-        }
-
-        return labels;
-    }
-
-    private created(): void {
+    created(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-        this.fetchTimelineData();
-    }
-
-    private fetchTimelineData(): void {
-        Promise.all([
-            this.retrieveMedications({ hdid: this.user.hdid }),
-            this.retrieveSpecialAuthorityRequests({ hdid: this.user.hdid }),
-            this.retrieveImmunizations({ hdid: this.user.hdid }),
-            this.retrieveCovid19LaboratoryOrders({ hdid: this.user.hdid }),
-            this.retrieveLaboratoryOrders({ hdid: this.user.hdid }),
-            this.retrieveHealthVisits({ hdid: this.user.hdid }),
-            this.retrieveHospitalVisits({ hdid: this.user.hdid }),
-            this.retrieveClinicalDocuments({ hdid: this.user.hdid }),
-            this.retrieveNotes({ hdid: this.user.hdid }),
-            this.retrieveComments({ hdid: this.user.hdid }),
-        ]).catch((err) =>
-            this.logger.error(`Error loading timeline data: ${err}`)
-        );
-    }
-
-    private isFilterApplied(entryType: EntryType): boolean {
-        const entryTypes = Array.from(this.entryTypes);
-        const filterApplied = !!entryTypes.includes(entryType);
-        this.logger.debug(
-            `Timeline filter entry type: ${entryType} applied: ${filterApplied}`
-        );
-        return filterApplied;
-    }
-
-    private isSelectedFilterModuleLoading(
-        entryType: EntryType,
-        loading: boolean
-    ): boolean {
-        const filterApplied = this.isFilterApplied(entryType);
-        const isLoading = filterApplied && loading;
-        this.logger.debug(
-            `Timeline filter entry type: ${entryType} applied: ${filterApplied} - filter loading: ${loading} and filter isLoading: ${isLoading}`
-        );
-        return isLoading;
-    }
-
-    private sortEntries(timelineEntries: TimelineEntry[]): TimelineEntry[] {
-        return timelineEntries.sort((a, b) => {
-            if (a.date.isBefore(b.date)) {
-                return 1;
-            }
-            if (a.date.isAfter(b.date)) {
-                return -1;
-            }
-            return 0;
-        });
-    }
-
-    private clearFilter(label: string, value: string | undefined): void {
-        let keyword = this.filter.keyword;
-        let startDate = this.filter.startDate;
-        let endDate = this.filter.endDate;
-        let entryTypes = [...this.entryTypes];
-
-        switch (label) {
-            case FilterLabelType.Keyword:
-                keyword = "";
-                break;
-            case FilterLabelType.Date:
-                startDate = "";
-                endDate = "";
-                break;
-            case FilterLabelType.Type:
-                entryTypes = entryTypes.filter(
-                    (e) => entryTypeMap.get(e)?.name !== value
-                );
-                break;
-        }
-
-        const builder = TimelineFilterBuilder.create()
-            .withKeyword(keyword)
-            .withStartDate(startDate)
-            .withEndDate(endDate)
-            .withEntryTypes(entryTypes);
-
-        this.setFilter(builder);
-    }
-
-    private clearFilters(): void {
-        const builder = TimelineFilterBuilder.create();
-        this.setFilter(builder);
     }
 }
 </script>
 
 <template>
     <div>
-        <b-toast
-            v-if="!isFullyLoaded"
-            id="loading-toast"
-            visible
-            toaster="b-toaster-top-center"
-            variant="info"
-            solid
-            no-auto-hide
-            no-close-button
-            is-status
-            data-testid="loading-toast"
-        >
-            <div class="text-center">Retrieving your health records</div>
-        </b-toast>
-        <div
-            v-if="!isFullyLoaded"
-            v-show="false"
-            data-testid="loading-in-progress"
-        />
         <BreadcrumbComponent :items="breadcrumbItems" />
-        <b-alert
-            v-if="isLaboratoryQueued"
-            show
-            dismissible
-            variant="info"
-            class="no-print"
-            data-testid="laboratory-orders-queued-alert-message"
-        >
-            <span>
-                We are getting your lab results. It may take up to 48 hours
-                until you can see them.
-            </span>
-        </b-alert>
         <page-title title="Timeline">
             <div class="float-right">
                 <add-note-button v-if="isNoteEnabled && !notesAreLoading" />
             </div>
         </page-title>
-        <div
-            v-if="showTimelineEntries"
-            class="sticky-top sticky-offset"
-            :class="{ 'header-offset': isHeaderShown }"
-        >
-            <b-row
-                class="no-print justify-content-between py-2"
-                align-v="start"
-            >
-                <b-col class="col-auto">
-                    <Filters class="my-1" />
-                </b-col>
-                <b-col class="mx-2">
-                    <b-form-tag
-                        v-for="[label, value] in filterLabels"
-                        :key="`${label}-${value}`"
-                        variant="light"
-                        class="filter-label p-1 mr-2 my-1"
-                        :title="`${label} Filter`"
-                        data-testid="filter-label"
-                        @remove="clearFilter(label, value)"
-                        >{{ value }}</b-form-tag
-                    >
-                    <hg-button
-                        v-if="filterLabels.length > 0"
-                        class="p-1 mt-n1"
-                        data-testid="clear-filters-button"
-                        variant="link"
-                        @click="clearFilters"
-                    >
-                        Clear All
-                    </hg-button>
-                </b-col>
-            </b-row>
-        </div>
-        <LinearTimeline
-            v-show="showTimelineEntries"
-            :timeline-entries="filteredTimelineEntries"
-        />
-        <content-placeholders
-            v-if="showContentPlaceholders"
-            data-testid="content-placeholders"
-        >
-            <content-placeholders-heading :img="true" />
-            <content-placeholders-text :lines="3" />
-        </content-placeholders>
-        <ProtectiveWordComponent
-            :is-loading="medicationsAreLoading(user.hdid)"
-        />
+        <LinearTimeline />
         <NoteEditComponent :is-loading="notesAreLoading" />
-        <EntryDetailsComponent />
     </div>
 </template>
-
-<style lang="scss" scoped>
-@import "@/assets/scss/_variables.scss";
-
-.row {
-    margin: 0px;
-    padding: 0px;
-}
-
-.col {
-    margin: 0px;
-    padding: 0px;
-}
-
-.sticky-top {
-    transition: all 0.3s;
-    z-index: 49 !important;
-}
-
-hr {
-    border-top: 2px solid $primary;
-}
-
-.form-group {
-    margin-bottom: 0px;
-}
-
-.sticky-offset {
-    background-color: white;
-    z-index: 2;
-
-    &.header-offset {
-        top: $header-height;
-    }
-}
-
-.btn-light {
-    border-color: $primary;
-    color: $primary;
-}
-
-.z-index-large {
-    z-index: 50;
-}
-
-.filter-label {
-    font-size: 1rem;
-}
-</style>

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -22,6 +22,7 @@ import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
 import AddNoteButtonComponent from "@/components/timeline/AddNoteButtonComponent.vue";
 import LinearTimelineComponent from "@/components/timeline/LinearTimelineComponent.vue";
+import { EntryType } from "@/constants/entryType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
 import User from "@/models/user";
@@ -47,10 +48,10 @@ library.add(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const options: any = {
     components: {
+        AddNoteButtonComponent,
         BreadcrumbComponent,
+        LinearTimelineComponent,
         NoteEditComponent,
-        LinearTimeline: LinearTimelineComponent,
-        "add-note-button": AddNoteButtonComponent,
     },
 };
 
@@ -76,7 +77,25 @@ export default class TimelineView extends Vue {
         },
     ];
 
-    get isNoteEnabled(): boolean {
+    get commentsAreEnabled(): boolean {
+        return this.config.modules["Comment"];
+    }
+
+    get entryTypes(): EntryType[] {
+        return [
+            EntryType.ClinicalDocument,
+            EntryType.Covid19LaboratoryOrder,
+            EntryType.Encounter,
+            EntryType.HospitalVisit,
+            EntryType.Immunization,
+            EntryType.LaboratoryOrder,
+            EntryType.Medication,
+            EntryType.Note,
+            EntryType.MedicationRequest,
+        ].filter((entryType) => this.config.modules[entryType]);
+    }
+
+    get notesAreEnabled(): boolean {
         return this.config.modules["Note"];
     }
 
@@ -91,10 +110,16 @@ export default class TimelineView extends Vue {
         <BreadcrumbComponent :items="breadcrumbItems" />
         <page-title title="Timeline">
             <div class="float-right">
-                <add-note-button v-if="isNoteEnabled && !notesAreLoading" />
+                <AddNoteButtonComponent
+                    v-if="notesAreEnabled && !notesAreLoading"
+                />
             </div>
         </page-title>
-        <LinearTimeline />
+        <LinearTimelineComponent
+            :hdid="user.hdid"
+            :entry-types="entryTypes"
+            :comments-are-enabled="commentsAreEnabled"
+        />
         <NoteEditComponent :is-loading="notesAreLoading" />
     </div>
 </template>

--- a/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/TimelineView.vue
@@ -84,14 +84,14 @@ export default class TimelineView extends Vue {
     get entryTypes(): EntryType[] {
         return [
             EntryType.ClinicalDocument,
-            EntryType.Covid19LaboratoryOrder,
-            EntryType.Encounter,
+            EntryType.Covid19TestResult,
+            EntryType.HealthVisit,
             EntryType.HospitalVisit,
             EntryType.Immunization,
-            EntryType.LaboratoryOrder,
+            EntryType.LabResult,
             EntryType.Medication,
             EntryType.Note,
-            EntryType.MedicationRequest,
+            EntryType.SpecialAuthorityRequest,
         ].filter((entryType) => this.config.modules[entryType]);
     }
 

--- a/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
@@ -56,7 +56,7 @@ const options: any = {
 };
 
 @Component(options)
-export default class TimelineView extends Vue {
+export default class UserTimelineView extends Vue {
     @Getter("webClient", { namespace: "config" })
     config!: WebClientConfiguration;
 

--- a/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
@@ -21,7 +21,7 @@ import { Getter } from "vuex-class";
 import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
 import AddNoteButtonComponent from "@/components/timeline/AddNoteButtonComponent.vue";
-import LinearTimelineComponent from "@/components/timeline/LinearTimelineComponent.vue";
+import TimelineComponent from "@/components/timeline/TimelineComponent.vue";
 import { EntryType } from "@/constants/entryType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
@@ -50,8 +50,8 @@ const options: any = {
     components: {
         AddNoteButtonComponent,
         BreadcrumbComponent,
-        LinearTimelineComponent,
         NoteEditComponent,
+        TimelineComponent,
     },
 };
 
@@ -115,7 +115,7 @@ export default class UserTimelineView extends Vue {
                 />
             </div>
         </page-title>
-        <LinearTimelineComponent
+        <TimelineComponent
             :hdid="user.hdid"
             :entry-types="entryTypes"
             :comments-are-enabled="commentsAreEnabled"


### PR DESCRIPTION
# Implements [AB#14745](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14745)

## Description

- moves dataset handling out of TimelineView (and into the component)
- refactors timeline component to support HDID and datasets passed as props
  - passes HDID from the view to the component and then to the timeline entry components for each dataset
  - removes noisy logging
  - consolidates and eliminates some getters and functions
    - the component is still quite large and may benefit from splitting some parts off into smaller components in the future
- standardizes names of entry types and comment entry types
- removes custom names for timeline entry components
- renames TimelineView to UserTimelineView
- renames LinearTimelineComponent to TimelineComponent

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
