### PR TITLE
Fix action URLs not showing in dialog after saving AB#14904

### DIFF
--- a/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/BroadcastDialog.razor.cs
@@ -52,7 +52,10 @@ public partial class BroadcastDialog : FluxorComponent
             {
                 case BroadcastActionType.InternalLink:
                 case BroadcastActionType.ExternalLink:
-                    return urlString.StartsWith("https://", StringComparison.OrdinalIgnoreCase) ? null : "URL is invalid";
+                    return urlString.StartsWith("https://", StringComparison.InvariantCultureIgnoreCase)
+                           && Uri.TryCreate(this.ActionUrlString, UriKind.Absolute, out Uri? _)
+                        ? null
+                        : "URL is invalid";
                 case BroadcastActionType.None:
                 default:
                     return urlString.Length == 0 ? null : "Selected Action Type does not support Action URL";
@@ -120,6 +123,7 @@ public partial class BroadcastDialog : FluxorComponent
             this.EffectiveTime = now.TimeOfDay;
             this.ExpiryDate = tomorrow.Date;
             this.ExpiryTime = tomorrow.TimeOfDay;
+            this.ActionUrlString = string.Empty;
         }
         else
         {
@@ -127,6 +131,7 @@ public partial class BroadcastDialog : FluxorComponent
             this.EffectiveTime = this.Broadcast.ScheduledDateUtc.ToLocalTime().TimeOfDay;
             this.ExpiryDate = this.Broadcast.ExpirationDateUtc?.ToLocalTime().Date;
             this.ExpiryTime = this.Broadcast.ExpirationDateUtc?.ToLocalTime().TimeOfDay;
+            this.ActionUrlString = this.Broadcast.ActionUrl?.ToString() ?? string.Empty;
         }
     }
 


### PR DESCRIPTION
# Fixes [AB#14904](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14904)

## Description

Corrects the action URL field not being populated when editing an existing notification.  Also updates the URL validation to ensure it matches the logic used when the value is saved.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
