### PR TITLE
Revamp Config - Covid19 for AB#14885

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -94,10 +94,7 @@ export default class AddQuickLinkComponent extends Vue {
     private get showVaccineCard(): boolean {
         const preference =
             this.user.preferences[UserPreferenceType.HideVaccineCardQuickLink];
-        return (
-            preference?.value === "true" &&
-            this.webClientConfig.modules["VaccinationStatus"]
-        );
+        return preference?.value === "true";
     }
 
     private get showImmunizationRecord(): boolean {

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
@@ -184,10 +184,6 @@ export default class SidebarComponent extends Vue {
         return this.$route.path == "/covid19";
     }
 
-    private get isVaccinationStatusEnabled(): boolean {
-        return this.config.modules["VaccinationStatus"];
-    }
-
     private get isTermsOfService(): boolean {
         return this.$route.path == "/profile/termsOfService";
     }
@@ -269,7 +265,7 @@ export default class SidebarComponent extends Vue {
                     </hg-button>
                     <!-- COVID-19 button -->
                     <hg-button
-                        v-show="isVaccinationStatusEnabled && userIsActive"
+                        v-show="userIsActive"
                         id="menuBtnCovid19"
                         data-testid="menu-btn-covid19-link"
                         to="/covid19"

--- a/Apps/WebClient/src/ClientApp/src/views/Covid19View.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/Covid19View.vue
@@ -186,16 +186,15 @@ export default class Covid19View extends Vue {
 
     private get downloadButtonShown(): boolean {
         return (
-            this.config.modules["VaccinationStatusPdf"] &&
-            (this.vaccinationStatus?.state ===
+            this.vaccinationStatus?.state ===
                 VaccinationState.PartiallyVaccinated ||
-                this.vaccinationStatus?.state ===
-                    VaccinationState.FullyVaccinated)
+            this.vaccinationStatus?.state === VaccinationState.FullyVaccinated
         );
     }
 
     private get saveExportPdfShown(): boolean {
-        return this.config.modules["VaccinationExportPdf"];
+        return this.config.featureToggleConfiguration.covid19.proofOfVaccination
+            .exportPdf;
     }
 
     private get isVaccineCardLoading(): boolean {

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -214,10 +214,6 @@ export default class HomeView extends Vue {
         return this.config.modules["FederalCardButton"];
     }
 
-    private get vaccinationStatusModuleEnabled(): boolean {
-        return this.config.modules["VaccinationStatus"];
-    }
-
     private get preferenceVaccineCardHidden(): boolean {
         const preferenceName = UserPreferenceType.HideVaccineCardQuickLink;
         const preference = this.user.preferences[preferenceName];
@@ -232,10 +228,7 @@ export default class HomeView extends Vue {
     }
 
     private get showVaccineCardButton(): boolean {
-        return (
-            !this.preferenceVaccineCardHidden &&
-            this.vaccinationStatusModuleEnabled
-        );
+        return !this.preferenceVaccineCardHidden;
     }
 
     private get showImmunizationRecordButton(): boolean {
@@ -286,8 +279,7 @@ export default class HomeView extends Vue {
                     ) === undefined
             ).length === 0 &&
             !this.preferenceImmunizationRecordHidden &&
-            (!this.vaccinationStatusModuleEnabled ||
-                !this.preferenceVaccineCardHidden)
+            !this.preferenceVaccineCardHidden
         );
     }
 

--- a/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/PublicVaccineCardView.vue
@@ -153,9 +153,8 @@ export default class PublicVaccineCardView extends Vue {
 
     private get downloadButtonShown(): boolean {
         return (
-            this.config.modules["VaccinationStatusPdf"] &&
-            (this.status?.state === VaccinationState.PartiallyVaccinated ||
-                this.status?.state === VaccinationState.FullyVaccinated)
+            this.status?.state === VaccinationState.PartiallyVaccinated ||
+            this.status?.state === VaccinationState.FullyVaccinated
         );
     }
 
@@ -213,7 +212,8 @@ export default class PublicVaccineCardView extends Vue {
     }
 
     private get saveExportPdfShown(): boolean {
-        return this.config.modules["PublicVaccineDownloadPdf"];
+        return this.config.featureToggleConfiguration.covid19.publicCovid19
+            .showFederalProofOfVaccination;
     }
 
     private download(): void {

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -262,11 +262,7 @@ export default class RegistrationView extends Vue {
                 },
             });
 
-            const path = this.webClientConfig.modules["VaccinationStatus"]
-                ? "/home"
-                : "/timeline";
-
-            await this.$router.push({ path });
+            await this.$router.push("/home");
         } catch {
             this.logger.error("Error while registering.");
         } finally {

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/authenticatedVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/authenticatedVaccineCard.js
@@ -7,7 +7,7 @@ describe("Authenticated Vaccine Card", () => {
             "getVaccinationStatus"
         );
 
-        cy.enableModules(["Immunization", "VaccinationStatus"]);
+        cy.enableModules(["Immunization"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -69,7 +69,7 @@ describe("Authenticated Vaccine Card", () => {
             "getVaccinationStatus"
         );
 
-        cy.enableModules(["Immunization", "VaccinationStatus"]);
+        cy.enableModules(["Immunization"]);
         cy.login(
             Cypress.env("keycloak.notfound.username"),
             Cypress.env("keycloak.password"),
@@ -95,12 +95,7 @@ describe("Authenticated Vaccine Card", () => {
             "getVaccineProof"
         );
 
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-            "VaccinationExportPdf",
-        ]);
+        cy.enableModules(["Immunization", "VaccinationExportPdf"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/publicVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/publicVaccineCard.js
@@ -42,11 +42,7 @@ describe("Public Vaccine Card Result", () => {
         const dovMonth = "July";
         const dovDay = "4";
 
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-        ]);
+        cy.enableModules(["Immunization"]);
         cy.logout();
         cy.visit(vaccineCardUrl);
 
@@ -66,11 +62,7 @@ describe("Public Vaccine Card Result", () => {
     });
 
     it("Fully Vaccinated", () => {
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-        ]);
+        cy.enableModules(["Immunization"]);
         cy.logout();
         cy.visit(vaccineCardUrl);
 
@@ -91,12 +83,7 @@ describe("Public Vaccine Card Result", () => {
 
 describe("Public Vaccine Card Downloads", () => {
     beforeEach(() => {
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-            "PublicVaccineDownloadPdf",
-        ]);
+        cy.enableModules(["Immunization", "PublicVaccineDownloadPdf"]);
         cy.logout();
         cy.visit(vaccineCardUrl);
 

--- a/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
@@ -29,7 +29,6 @@ describe("Registration Page", () => {
     });
 
     it("Registering leads to home page", () => {
-        cy.enableModules(["VaccinationStatus"]);
         cy.login(
             Cypress.env("keycloak.unregistered.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
@@ -10,7 +10,7 @@ function testPageBreadcrumb(url, dataTestId) {
 
 describe("Breadcrumbs", () => {
     it("Breadcrumbs present when logged in", () => {
-        cy.enableModules(["Dependent", "VaccinationStatus"]);
+        cy.enableModules(["Dependent"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
@@ -12,7 +12,6 @@ const vaccineCardAddQuickLinkCheckboxSelector =
 
 describe("Vaccine Card Quick Link", () => {
     it("Remove and Add Vaccine Card Quick Link", () => {
-        cy.enableModules(["VaccinationStatus"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -51,11 +50,6 @@ describe("Vaccine Card Quick Link", () => {
             .should("be.visible")
             .should("be.enabled")
             .click();
-
-        cy.log("Verifying add quick link button is disabled");
-        cy.get(addQuickLinkButtonSelector)
-            .should("be.visible")
-            .should("not.be.enabled");
 
         cy.log("Verifying vaccine quick link card is present");
         cy.get(vaccineCardQuickLinkCardSelector).should(

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedVaccineCard.js
@@ -10,11 +10,7 @@ describe("Authenticated Vaccine Card Downloads", () => {
     });
 
     it("Save Image", () => {
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-        ]);
+        cy.enableModules(["Immunization"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -51,12 +47,7 @@ describe("Authenticated Vaccine Card Downloads", () => {
                 isLoading = !isLoading;
             }
         );
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-            "VaccinationExportPdf",
-        ]);
+        cy.enableModules(["Immunization", "VaccinationExportPdf"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicVaccineCard.js
@@ -18,7 +18,6 @@ const feedbackPhnIsRequiredSelector = "[data-testid=feedbackPhnIsRequired]";
 const feedbackDobIsRequiredSelector = "[data-testid=feedbackDobIsRequired]";
 const feedbackDovIsRequiredSelector = "[data-testid=feedbackDovIsRequired]";
 
-const vaccinationStatusModule = "VaccinationStatus";
 const vaccineCardUrl = "/vaccinecard";
 
 const dummyYear = "2021";
@@ -46,7 +45,7 @@ function clickVaccineCardEnterButton() {
 
 describe("Public Vaccine Card Form", () => {
     beforeEach(() => {
-        cy.enableModules(["Immunization", "VaccinationStatus"]);
+        cy.enableModules(["Immunization"]);
         cy.logout();
         cy.visit(vaccineCardUrl);
     });
@@ -216,12 +215,7 @@ describe("Public Vaccine Card Form", () => {
 
 describe("Public Vaccine Card Downloads", () => {
     beforeEach(() => {
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-            "PublicVaccineDownloadPdf",
-        ]);
+        cy.enableModules(["Immunization", "PublicVaccineDownloadPdf"]);
         cy.logout();
         cy.intercept("GET", "**/PublicVaccineStatus", {
             fixture: "ImmunizationService/publicVaccineStatusLoaded.json",
@@ -305,11 +299,7 @@ describe("Public Vaccine Card Downloads", () => {
 
 describe("Public Vaccine Card Downloads When PublicVaccineDownloadPdf Disabled", () => {
     it("Save Image When PublicVaccineDownloadPdf Disabled", () => {
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-        ]);
+        cy.enableModules(["Immunization"]);
         cy.logout();
         cy.intercept("GET", "**/PublicVaccineStatus", {
             fixture: "ImmunizationService/publicVaccineStatusLoaded.json",

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -233,7 +233,6 @@ function testRemoveQuickLinkError(statusCode = serverErrorStatusCode) {
 }
 
 function testHideVaccineCardQuickLinkError(statusCode = serverErrorStatusCode) {
-    cy.enableModules(["VaccinationStatus"]);
     cy.intercept("PUT", "**/UserProfile/*/preference", {
         statusCode,
     });

--- a/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
@@ -48,7 +48,7 @@ describe("Authenticated Vaccine Card Downloads", () => {
         cy.intercept("GET", "**/AuthenticatedVaccineStatus?hdid=*", {
             statusCode: 429,
         });
-        cy.enableModules(["Immunization", "VaccinationStatus"]);
+        cy.enableModules(["Immunization"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -63,12 +63,7 @@ describe("Authenticated Vaccine Card Downloads", () => {
         cy.intercept("GET", "**/AuthenticatedVaccineStatus/pdf?hdid=*", {
             statusCode: 429,
         });
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-            "VaccinationExportPdf",
-        ]);
+        cy.enableModules(["Immunization", "VaccinationExportPdf"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -115,7 +110,7 @@ describe("Public Vaccine Card Form", () => {
         cy.intercept("GET", "**/PublicVaccineStatus", {
             statusCode: 429,
         });
-        cy.enableModules(["Immunization", "VaccinationStatus"]);
+        cy.enableModules(["Immunization"]);
         cy.logout();
         cy.visit(vaccineCardUrl);
 
@@ -140,12 +135,7 @@ describe("Public Vaccine Card Downloads", () => {
         cy.intercept("GET", "**/PublicVaccineStatus/pdf", {
             statusCode: 429,
         });
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-            "PublicVaccineDownloadPdf",
-        ]);
+        cy.enableModules(["Immunization", "PublicVaccineDownloadPdf"]);
         cy.logout();
         cy.visit(vaccineCardUrl);
 

--- a/Testing/functional/tests/cypress/integration/ui/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/home.js
@@ -5,7 +5,6 @@ const timelineUrl = "/timeline";
 
 describe("Authenticated User - Home Page", () => {
     it("Home Page exists", () => {
-        cy.enableModules("VaccinationStatus");
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -31,7 +30,6 @@ describe("Authenticated User - Home Page", () => {
     });
 
     it("Home - Link to COVID-19 page", () => {
-        cy.enableModules(["VaccinationStatus"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/ui/pages/publicRoute.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/publicRoute.js
@@ -3,11 +3,7 @@ const covidTestPath = "/covidTest";
 
 describe("Public Route", () => {
     it("Redirect to Public Vaccine Card", () => {
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-        ]);
+        cy.enableModules(["Immunization"]);
         cy.logout();
         cy.visit(vaccineCardPath);
         cy.get("[data-testid=loginBtn]").should("not.exist");

--- a/Testing/functional/tests/cypress/integration/ui/pages/vaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/vaccineCard.js
@@ -1,6 +1,5 @@
 const homeUrl = "/";
 const vaccineCardUrl = "/vaccinecard";
-const vaccinationStatusModule = "VaccinationStatus";
 
 describe("Vaccine Card Page", () => {
     it("Landing Page - Vaccine Card Button does not exist - Vaccine Status module disabled", () => {
@@ -18,13 +17,11 @@ describe("Vaccine Card Page", () => {
     });
 
     it("Landing Page - Vaccine Card Button Exists - Vaccine Status module enabled", () => {
-        cy.enableModules(vaccinationStatusModule);
         cy.logout();
         cy.visit(homeUrl);
     });
 
     it("Landing Page - Vaccination Card - unauthenticated user", () => {
-        cy.enableModules(vaccinationStatusModule);
         cy.logout();
         cy.visit(vaccineCardUrl);
 

--- a/Testing/functional/tests/cypress/integration/ui/timeline/immunization.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/immunization.js
@@ -15,11 +15,7 @@ describe("Immunization - With Refresh", () => {
             }
             isLoading = !isLoading;
         });
-        cy.enableModules([
-            "Immunization",
-            "VaccinationStatus",
-            "VaccinationStatusPdf",
-        ]);
+        cy.enableModules(["Immunization"]);
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),


### PR DESCRIPTION
# Fixes or Implements [AB#14885](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14885)

## Revamp Config - Refactor COVID-19 feature toggles

- eliminate code paths that that trigger when "VaccinationStatus" is false - it is now permanently enabled
- eliminate code paths that that trigger when "VaccinationStatusPdf" is false - it is now permanently enabled
- update these settings in code and functional tests
-     PublicVaccineDownloadPdf
-         now covid19.publicCovid19.showFederalProofOfVaccination
-     VaccinationStatusPdf
-         now covid19.proofOfVaccination.exportPdf
- these settings can be ignored since they will be updated in [#14917](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14917) 
-     PublicLaboratoryResult
-         now covid19.publicCovid19.enableTestResults
-     PcrTest
-         now covid19.pcrTestEnabled
- not all functional test changes were completed since some are related to router and data set changes

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
