### PR TITLE
Refactor cypress  configureSettings command for AB#14975.

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
@@ -6,13 +6,6 @@ const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 describe("Notification Centre", () => {
     beforeEach(() => {
         cy.configureSettings({
-            datasets: {
-                name: "medication",
-                enabled: true,
-            },
-            notificationCentre: {
-                enabled: true,
-            },
             waitingQueue: {
                 enabled: false,
             },

--- a/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
@@ -6,8 +6,8 @@ const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 describe("Notification Centre", () => {
     beforeEach(() => {
         cy.configureSettings({
-            waitingQueue: {
-                enabled: false,
+            notificationCentre: {
+                enabled: true,
             },
         });
 


### PR DESCRIPTION
# Implements [AB#14975](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14975)

## Description

Refactor cypress command 'configureSettings' so that base configuration values returned from initial configuration call are not overwritten @ytqsl 

- When using 'configurationSettings', all configuration will be defaulted to false
- The default configuration values will be overwritten by the configuration values passed in.
- Notification Center functional test has been updated with 'notificationCentre' setting value set to true 

**Functional Test:**

<img width="1174" alt="Screenshot 2023-02-21 at 5 52 17 PM" src="https://user-images.githubusercontent.com/58790456/220501527-8ffe636a-0229-4296-a1b8-ba632d7ebcbb.png">


**Config Settings:**

<img width="2007" alt="Screenshot 2023-02-21 at 5 44 00 PM" src="https://user-images.githubusercontent.com/58790456/220501516-71ba7db5-dfb3-4cf9-acbf-e2d29c032a0b.png">



## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
