### PR TITLE
Add and use configuration utility to check if datasets are enabled

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/FilterComponent.vue
@@ -144,7 +144,7 @@ export default class FilterComponent extends Vue {
         this.keywordInputText = this.activeFilter.keyword;
         this.startDate = this.activeFilter.startDate;
         this.endDate = this.activeFilter.endDate;
-        this.selectedEntryTypes = Array.from(this.activeEntryTypes);
+        this.selectedEntryTypes = [...this.activeEntryTypes];
     }
 
     private toggleMenu(): void {

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -28,9 +28,7 @@ const entryTypeMap = new Map<EntryType | undefined, EntryTypeDetails>();
 export function getEntryTypeByModule(
     module: string
 ): EntryTypeDetails | undefined {
-    return Array.from(entryTypeMap.values()).find(
-        (e) => e.moduleName === module
-    );
+    return [...entryTypeMap.values()].find((e) => e.moduleName === module);
 }
 
 entryTypeMap.set(EntryType.Immunization, {

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -9,7 +9,7 @@ export enum EntryType {
     LabResult = "LabResult",
     Medication = "Medication",
     Note = "Note",
-    SpecialAuthorityRequest = "SpecialAuthority",
+    SpecialAuthorityRequest = "SpecialAuthorityRequest",
 }
 
 export class EntryTypeDetails {

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -1,16 +1,15 @@
 import { CommentEntryType } from "@/constants/commentEntryType";
-import { FeatureToggleConfiguration } from "@/models/configData";
 
 export enum EntryType {
     ClinicalDocument = "ClinicalDocument",
-    Covid19TestResult = "Laboratory",
-    HealthVisit = "Encounter",
+    Covid19TestResult = "Covid19TestResult",
+    HealthVisit = "HealthVisit",
     HospitalVisit = "HospitalVisit",
     Immunization = "Immunization",
-    LabResult = "AllLaboratory",
+    LabResult = "LabResult",
     Medication = "Medication",
     Note = "Note",
-    SpecialAuthorityRequest = "MedicationRequest",
+    SpecialAuthorityRequest = "SpecialAuthority",
 }
 
 export class EntryTypeDetails {
@@ -21,19 +20,16 @@ export class EntryTypeDetails {
     component!: string;
     commentType!: CommentEntryType;
     eventName!: string;
-    enabled!: (config: FeatureToggleConfiguration) => boolean;
+    moduleName!: string;
 }
 
 const entryTypeMap = new Map<EntryType | undefined, EntryTypeDetails>();
 
-function isDatasetEnabled(
-    config: FeatureToggleConfiguration,
-    datasetName: string
-): boolean {
-    return (
-        config.datasets.find(
-            (ds) => ds.name.toLowerCase() == datasetName.toLowerCase()
-        )?.enabled ?? false
+export function getEntryTypeByModule(
+    module: string
+): EntryTypeDetails | undefined {
+    return Array.from(entryTypeMap.values()).find(
+        (e) => e.moduleName === module
     );
 }
 
@@ -46,7 +42,7 @@ entryTypeMap.set(EntryType.Immunization, {
     icon: "syringe",
     component: "ImmunizationTimelineComponent",
     eventName: "immunizations",
-    enabled: (config) => isDatasetEnabled(config, EntryType.Immunization),
+    moduleName: "Immunization",
 });
 
 entryTypeMap.set(EntryType.Medication, {
@@ -57,7 +53,7 @@ entryTypeMap.set(EntryType.Medication, {
     icon: "pills",
     component: "MedicationTimelineComponent",
     eventName: "medications",
-    enabled: (config) => isDatasetEnabled(config, EntryType.Medication),
+    moduleName: "Medication",
 });
 
 entryTypeMap.set(EntryType.LabResult, {
@@ -69,7 +65,7 @@ entryTypeMap.set(EntryType.LabResult, {
     icon: "microscope",
     component: "LaboratoryOrderTimelineComponent",
     eventName: "lab_results",
-    enabled: (config) => isDatasetEnabled(config, "LabResult"),
+    moduleName: "AllLaboratory",
 });
 
 entryTypeMap.set(EntryType.Covid19TestResult, {
@@ -81,7 +77,7 @@ entryTypeMap.set(EntryType.Covid19TestResult, {
     icon: "vial",
     component: "Covid19LaboratoryOrderTimelineComponent",
     eventName: "covid_test",
-    enabled: (config) => isDatasetEnabled(config, "Covid19TestResult"),
+    moduleName: "Laboratory",
 });
 
 entryTypeMap.set(EntryType.HealthVisit, {
@@ -93,7 +89,7 @@ entryTypeMap.set(EntryType.HealthVisit, {
     icon: "stethoscope",
     component: "EncounterTimelineComponent",
     eventName: "health_visits",
-    enabled: (config) => isDatasetEnabled(config, "HealthVisit"),
+    moduleName: "Encounter",
 });
 
 entryTypeMap.set(EntryType.Note, {
@@ -104,7 +100,7 @@ entryTypeMap.set(EntryType.Note, {
     icon: "edit",
     component: "NoteTimelineComponent",
     eventName: "my_notes",
-    enabled: (config) => isDatasetEnabled(config, EntryType.Note),
+    moduleName: "Note",
 });
 
 entryTypeMap.set(EntryType.SpecialAuthorityRequest, {
@@ -116,7 +112,7 @@ entryTypeMap.set(EntryType.SpecialAuthorityRequest, {
     icon: "file-medical",
     component: "MedicationRequestTimelineComponent",
     eventName: "special_authority",
-    enabled: (config) => isDatasetEnabled(config, "SpecialAuthority"),
+    moduleName: "MedicationRequest",
 });
 
 entryTypeMap.set(EntryType.ClinicalDocument, {
@@ -128,7 +124,7 @@ entryTypeMap.set(EntryType.ClinicalDocument, {
     icon: "file-waveform",
     component: "ClinicalDocumentTimelineComponent",
     eventName: "document",
-    enabled: (config) => isDatasetEnabled(config, EntryType.ClinicalDocument),
+    moduleName: "ClinicalDocument",
 });
 
 entryTypeMap.set(EntryType.HospitalVisit, {
@@ -140,7 +136,7 @@ entryTypeMap.set(EntryType.HospitalVisit, {
     icon: "house-medical",
     component: "HospitalVisitTimelineComponent",
     eventName: "hospital_visits",
-    enabled: (config) => isDatasetEnabled(config, EntryType.HospitalVisit),
+    moduleName: "HospitalVisit",
 });
 
 export { entryTypeMap };

--- a/Apps/WebClient/src/ClientApp/src/services/restClinicalDocumentService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restClinicalDocumentService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { ClinicalDocument } from "@/models/clinicalDocument";
@@ -14,6 +15,7 @@ import {
     IHttpDelegate,
     ILogger,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -30,7 +32,9 @@ export class RestClinicalDocumentService implements IClinicalDocumentService {
     ): void {
         this.baseUri = config.serviceEndpoints["ClinicalDocument"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["ClinicalDocument"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(
+            EntryType.ClinicalDocument
+        );
     }
 
     public getRecords(

--- a/Apps/WebClient/src/ClientApp/src/services/restEncounterService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restEncounterService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { ExternalConfiguration } from "@/models/configData";
@@ -13,6 +14,7 @@ import {
     IHttpDelegate,
     ILogger,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -29,7 +31,7 @@ export class RestEncounterService implements IEncounterService {
     ): void {
         this.baseUri = config.serviceEndpoints["Encounter"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["Encounter"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.HealthVisit);
     }
 
     public getPatientEncounters(

--- a/Apps/WebClient/src/ClientApp/src/services/restHospitalVisitService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restHospitalVisitService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { ExternalConfiguration } from "@/models/configData";
@@ -13,6 +14,7 @@ import {
     IHttpDelegate,
     ILogger,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -29,7 +31,7 @@ export class RestHospitalVisitService implements IHospitalVisitService {
     ): void {
         this.baseUri = config.serviceEndpoints["HospitalVisit"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["HospitalVisit"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.HospitalVisit);
     }
 
     public getHospitalVisits(

--- a/Apps/WebClient/src/ClientApp/src/services/restImmunizationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restImmunizationService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { ExternalConfiguration } from "@/models/configData";
@@ -13,6 +14,7 @@ import {
     IImmunizationService,
     ILogger,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -29,7 +31,7 @@ export class RestImmunizationService implements IImmunizationService {
     ): void {
         this.baseUri = config.serviceEndpoints["Immunization"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["Immunization"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.Immunization);
     }
 
     public getPatientImmunizations(

--- a/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { Dictionary } from "@/models/baseTypes";
@@ -19,6 +20,7 @@ import {
     ILaboratoryService,
     ILogger,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -37,8 +39,10 @@ export class RestLaboratoryService implements ILaboratoryService {
     ): void {
         this.baseUri = config.serviceEndpoints["Laboratory"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["AllLaboratory"];
-        this.isCovid19Enabled = config.webClient.modules["Laboratory"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.LabResult);
+        this.isCovid19Enabled = ConfigUtil.isDatasetEnabled(
+            EntryType.Covid19TestResult
+        );
     }
 
     getPublicCovid19Tests(

--- a/Apps/WebClient/src/ClientApp/src/services/restMedicationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restMedicationService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { Dictionary } from "@/models/baseTypes";
@@ -14,6 +15,7 @@ import {
     ILogger,
     IMedicationService,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -31,7 +33,7 @@ export class RestMedicationService implements IMedicationService {
     ): void {
         this.baseUri = config.serviceEndpoints["Medication"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["Medication"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.Medication);
     }
 
     public getPatientMedicationStatementHistory(

--- a/Apps/WebClient/src/ClientApp/src/services/restSpecialAuthorityService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restSpecialAuthorityService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { ExternalConfiguration } from "@/models/configData";
@@ -13,6 +14,7 @@ import {
     ILogger,
     ISpecialAuthorityService,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 @injectable()
@@ -29,7 +31,9 @@ export class RestSpecialAuthorityService implements ISpecialAuthorityService {
     ): void {
         this.baseUri = config.serviceEndpoints["SpecialAuthority"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["MedicationRequest"];
+        this.isEnabled = ConfigUtil.isDatasetEnabled(
+            EntryType.SpecialAuthorityRequest
+        );
     }
 
     public getPatientMedicationRequest(

--- a/Apps/WebClient/src/ClientApp/src/services/restUserNoteService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserNoteService.ts
@@ -1,5 +1,6 @@
 import { injectable } from "inversify";
 
+import { EntryType } from "@/constants/entryType";
 import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { Dictionary } from "@/models/baseTypes";
@@ -14,6 +15,7 @@ import {
     ILogger,
     IUserNoteService,
 } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 import RequestResultUtil from "@/utility/requestResultUtil";
 
@@ -29,9 +31,9 @@ export class RestUserNoteService implements IUserNoteService {
         config: ExternalConfiguration,
         http: IHttpDelegate
     ): void {
-        this.http = http;
-        this.isEnabled = config.webClient.modules["Note"];
         this.baseUri = config.serviceEndpoints["GatewayApi"];
+        this.http = http;
+        this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.Note);
     }
 
     public getNotes(hdid: string): Promise<RequestResult<UserNote[]>> {

--- a/Apps/WebClient/src/ClientApp/src/services/restVaccinationStatusService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restVaccinationStatusService.ts
@@ -34,7 +34,7 @@ export class RestVaccinationStatusService implements IVaccinationStatusService {
     ): void {
         this.baseUri = config.serviceEndpoints["Immunization"];
         this.http = http;
-        this.isEnabled = config.webClient.modules["Immunization"];
+        this.isEnabled = true;
     }
 
     public getPublicVaccineStatus(

--- a/Apps/WebClient/src/ClientApp/src/utility/configUtil.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/configUtil.ts
@@ -1,0 +1,46 @@
+import { EntryType } from "@/constants/entryType";
+import {
+    FeatureToggleConfiguration,
+    WebClientConfiguration,
+} from "@/models/configData";
+import container from "@/plugins/container";
+import { STORE_IDENTIFIER } from "@/plugins/inversify";
+import { IStoreProvider } from "@/services/interfaces";
+
+export default abstract class ConfigUtil {
+    private static storeWrapper = container.get<IStoreProvider>(
+        STORE_IDENTIFIER.StoreProvider
+    );
+
+    private static store = ConfigUtil.storeWrapper.getStore();
+
+    public static getWebClientConfiguration(): WebClientConfiguration {
+        return ConfigUtil.store.getters["config/webClient"];
+    }
+
+    public static getFeatureConfiguration(): FeatureToggleConfiguration {
+        return ConfigUtil.getWebClientConfiguration()
+            .featureToggleConfiguration;
+    }
+
+    public static isDatasetEnabled(datasetName: EntryType): boolean {
+        const config = ConfigUtil.getFeatureConfiguration();
+
+        return (
+            config.datasets.find(
+                (ds) => ds.name.toLowerCase() === datasetName.toLowerCase()
+            )?.enabled === true
+        );
+    }
+
+    public static isDependentDatasetEnabled(datasetName: EntryType): boolean {
+        const config = ConfigUtil.getFeatureConfiguration();
+
+        const disabledByOverride =
+            config.dependents.datasets.find(
+                (ds) => ds.name.toLowerCase() === datasetName.toLowerCase()
+            )?.enabled === false;
+
+        return ConfigUtil.isDatasetEnabled(datasetName) && !disabledByOverride;
+    }
+}

--- a/Apps/WebClient/src/ClientApp/src/utility/configUtil.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/configUtil.ts
@@ -8,14 +8,13 @@ import { STORE_IDENTIFIER } from "@/plugins/inversify";
 import { IStoreProvider } from "@/services/interfaces";
 
 export default abstract class ConfigUtil {
-    private static storeWrapper = container.get<IStoreProvider>(
-        STORE_IDENTIFIER.StoreProvider
-    );
-
-    private static store = ConfigUtil.storeWrapper.getStore();
-
     public static getWebClientConfiguration(): WebClientConfiguration {
-        return ConfigUtil.store.getters["config/webClient"];
+        const storeWrapper = container.get<IStoreProvider>(
+            STORE_IDENTIFIER.StoreProvider
+        );
+        const store = storeWrapper.getStore();
+
+        return store.getters["config/webClient"];
     }
 
     public static getFeatureConfiguration(): FeatureToggleConfiguration {

--- a/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/LandingView.vue
@@ -27,9 +27,6 @@ import { Getter } from "vuex-class";
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { RegistrationStatus } from "@/constants/registrationStatus";
 import type { WebClientConfiguration } from "@/models/configData";
-import container from "@/plugins/container";
-import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
-import { ILogger } from "@/services/interfaces";
 import ConfigUtil from "@/utility/configUtil";
 
 library.add(
@@ -84,30 +81,7 @@ export default class LandingView extends Vue {
     @Getter("patientRetrievalFailed", { namespace: "user" })
     patientRetrievalFailed!: boolean;
 
-    private get isVaccinationBannerEnabled(): boolean {
-        return false;
-    }
-
-    private get isPublicLaboratoryResultEnabled(): boolean {
-        return this.config.featureToggleConfiguration.covid19.publicCovid19
-            .enableTestResults;
-    }
-
-    private get isSidebarAvailable(): boolean {
-        return (
-            !this.isOffline &&
-            this.oidcIsAuthenticated &&
-            this.isValidIdentityProvider &&
-            this.userIsRegistered &&
-            this.userIsActive &&
-            !this.patientRetrievalFailed
-        );
-    }
-
-    private logger!: ILogger;
-    private selectedPreviewDevice = "laptop";
-
-    private entryTypes: EntryType[] = [
+    entryTypes: EntryType[] = [
         EntryType.Medication,
         EntryType.LabResult,
         EntryType.Covid19TestResult,
@@ -118,38 +92,34 @@ export default class LandingView extends Vue {
         EntryType.HospitalVisit,
     ];
 
-    private tiles: Tile[] = [];
+    selectedPreviewDevice = "laptop";
 
-    private get offlineMessage(): string {
-        if (this.isOffline) {
-            return this.config.offlineMode?.message || "";
-        } else {
-            return "";
-        }
+    get isVaccinationBannerEnabled(): boolean {
+        return false;
     }
 
-    private get activeTiles(): Tile[] {
-        return this.tiles.filter((tile) => tile.active);
+    get isPublicLaboratoryResultEnabled(): boolean {
+        return this.config.featureToggleConfiguration.covid19.publicCovid19
+            .enableTestResults;
     }
 
-    private get isOpenRegistration(): boolean {
-        return this.config.registrationStatus === RegistrationStatus.Open;
+    get isSidebarAvailable(): boolean {
+        return (
+            !this.isOffline &&
+            this.oidcIsAuthenticated &&
+            this.isValidIdentityProvider &&
+            this.userIsRegistered &&
+            this.userIsActive &&
+            !this.patientRetrievalFailed
+        );
     }
 
-    private created(): void {
-        this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+    get offlineMessage(): string {
+        return this.config.offlineMode?.message ?? "";
     }
 
-    private mounted(): void {
-        // Get core tiles from entry type constants
-        this.loadCoreTiles();
-
-        // Add Proof of Vaccination tile to tiles
-        this.addProofOfVaccinationTile();
-    }
-
-    private getProofOfVaccinationTile(): Tile {
-        const proofOfVaccinationTile: Tile = {
+    get proofOfVaccinationTile(): Tile {
+        return {
             type: "ProofOfVaccination",
             icon: "check-circle",
             name: "Proof of Vaccination",
@@ -157,17 +127,37 @@ export default class LandingView extends Vue {
             active: this.config.featureToggleConfiguration.covid19.publicCovid19
                 .showFederalProofOfVaccination,
         };
-
-        this.logger.debug(
-            `Proof of Vaccination Tile:  ${JSON.stringify(
-                proofOfVaccinationTile
-            )}`
-        );
-
-        return proofOfVaccinationTile;
     }
 
-    private getTile(entryType: EntryType): Tile | undefined {
+    get tiles(): Tile[] {
+        // Get core tiles from entry type constants
+        const tiles = this.entryTypes.map((type) => {
+            const details = entryTypeMap.get(type);
+            const tile: Tile = {
+                type,
+                icon: details?.icon ?? "",
+                name: details?.name ?? "",
+                description: details?.description ?? "",
+                active: ConfigUtil.isDatasetEnabled(type),
+            };
+            return tile;
+        });
+
+        // Add Proof of Vaccination tile
+        tiles.splice(2, 0, this.proofOfVaccinationTile);
+
+        return tiles;
+    }
+
+    get activeTiles(): Tile[] {
+        return this.tiles.filter((tile) => tile.active);
+    }
+
+    get isOpenRegistration(): boolean {
+        return this.config.registrationStatus === RegistrationStatus.Open;
+    }
+
+    getTile(entryType: EntryType): Tile | undefined {
         const entry = entryTypeMap.get(entryType);
         if (entry) {
             return {
@@ -181,30 +171,7 @@ export default class LandingView extends Vue {
         return undefined;
     }
 
-    private addProofOfVaccinationTile(): void {
-        this.tiles.splice(2, 0, this.getProofOfVaccinationTile());
-    }
-
-    private loadCoreTiles(): void {
-        // Get core tiles from entry type constants
-        this.tiles = this.entryTypes.map((type) => {
-            const details = entryTypeMap.get(type);
-            const tile: Tile = {
-                type,
-                icon: details?.icon ?? "",
-                name: details?.name ?? "",
-                description: details?.description ?? "",
-                active: ConfigUtil.isDatasetEnabled(type),
-            };
-            return tile;
-        });
-
-        this.tiles.forEach((tile) =>
-            this.logger.debug(`Core Tile:  ${JSON.stringify(tile)}`)
-        );
-    }
-
-    private selectPreviewDevice(deviceName: string): void {
+    selectPreviewDevice(deviceName: string): void {
         this.selectedPreviewDevice = deviceName;
         this.$root.$emit(
             "bv::hide::tooltip",

--- a/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ReportsView.vue
@@ -19,6 +19,7 @@ import MedicationHistoryReportComponent from "@/components/report/MedicationHist
 import MedicationRequestReportComponent from "@/components/report/MedicationRequestReportComponent.vue";
 import MSPVisitsReportComponent from "@/components/report/MSPVisitsReportComponent.vue";
 import NotesReportComponent from "@/components/report/NotesReportComponent.vue";
+import { EntryType } from "@/constants/entryType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
@@ -36,6 +37,7 @@ import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 import EventTracker from "@/utility/eventTracker";
 
 const medicationReport = "medication-report";
@@ -194,49 +196,49 @@ export default class ReportsView extends Vue {
     private created(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
-        if (this.config.modules["Medication"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.Medication)) {
             this.reportTypeOptions.push({
                 value: medicationReport,
                 text: "Medications",
             });
         }
-        if (this.config.modules["Encounter"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.HealthVisit)) {
             this.reportTypeOptions.push({
                 value: mspVisitReport,
                 text: "Health Visits",
             });
         }
-        if (this.config.modules["Laboratory"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.Covid19TestResult)) {
             this.reportTypeOptions.push({
                 value: covid19Report,
                 text: "COVID‑19 Test Results",
             });
         }
-        if (this.config.modules["Immunization"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.Immunization)) {
             this.reportTypeOptions.push({
                 value: immunizationReport,
                 text: "Immunizations",
             });
         }
-        if (this.config.modules["MedicationRequest"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.SpecialAuthorityRequest)) {
             this.reportTypeOptions.push({
                 value: medicationRequestReport,
                 text: "Special Authority Requests",
             });
         }
-        if (this.config.modules["Note"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.Note)) {
             this.reportTypeOptions.push({
                 value: noteReport,
                 text: "My Notes",
             });
         }
-        if (this.config.modules["AllLaboratory"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.LabResult)) {
             this.reportTypeOptions.push({
                 value: laboratoryReport,
                 text: "Laboratory Tests",
             });
         }
-        if (this.config.modules["HospitalVisit"]) {
+        if (ConfigUtil.isDatasetEnabled(EntryType.HospitalVisit)) {
             this.reportTypeOptions.push({
                 value: hospitalVisitReport,
                 text: "Hospital Visits",

--- a/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
@@ -22,13 +22,14 @@ import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
 import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
 import AddNoteButtonComponent from "@/components/timeline/AddNoteButtonComponent.vue";
 import TimelineComponent from "@/components/timeline/TimelineComponent.vue";
-import { EntryType } from "@/constants/entryType";
+import { EntryType, entryTypeMap } from "@/constants/entryType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
 import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
 
 library.add(
     faCheckCircle,
@@ -82,17 +83,9 @@ export default class UserTimelineView extends Vue {
     }
 
     get entryTypes(): EntryType[] {
-        return [
-            EntryType.ClinicalDocument,
-            EntryType.Covid19TestResult,
-            EntryType.HealthVisit,
-            EntryType.HospitalVisit,
-            EntryType.Immunization,
-            EntryType.LabResult,
-            EntryType.Medication,
-            EntryType.Note,
-            EntryType.SpecialAuthorityRequest,
-        ].filter((entryType) => this.config.modules[entryType]);
+        return [...entryTypeMap.values()]
+            .filter((d) => ConfigUtil.isDatasetEnabled(d.type))
+            .map((d) => d.type);
     }
 
     get notesAreEnabled(): boolean {

--- a/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/UserTimelineView.vue
@@ -89,7 +89,7 @@ export default class UserTimelineView extends Vue {
     }
 
     get notesAreEnabled(): boolean {
-        return this.config.modules["Note"];
+        return ConfigUtil.isDatasetEnabled(EntryType.Note);
     }
 
     created(): void {

--- a/Apps/WebClient/src/featuretoggleconfig.json
+++ b/Apps/WebClient/src/featuretoggleconfig.json
@@ -2,7 +2,7 @@
     "homepage": {
         "showFederalProofOfVaccination": true
     },
-    "waitingQueue":{
+    "waitingQueue": {
         "enabled": true
     },
     "notificationCentre": {
@@ -45,7 +45,7 @@
             "enabled": true
         },
         {
-            "name": "specialAuthority",
+            "name": "specialAuthorityRequest",
             "enabled": true
         }
     ],

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/encounter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/encounter.js
@@ -2,7 +2,14 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("MSP Visits", () => {
     beforeEach(() => {
-        cy.enableModules("Encounter");
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "healthVisit",
+                    enabled: true,
+                },
+            ],
+        });
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -12,7 +19,7 @@ describe("MSP Visits", () => {
     });
 
     it("Validate Encounter Card Details", () => {
-        cy.get("[data-testid=encounterTitle]").should("be.visible");
+        cy.get("[data-testid=healthvisitTitle]").should("be.visible");
         cy.get("[data-testid=entryCardDetailsTitle").first().click();
         cy.get("[data-testid=encounterClinicLabel").should("be.visible");
         cy.get("[data-testid=encounterClinicName").should("be.visible");
@@ -21,7 +28,14 @@ describe("MSP Visits", () => {
 
 describe("Hospital Visits", () => {
     beforeEach(() => {
-        cy.enableModules("HospitalVisit");
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "hospitalVisit",
+                    enabled: true,
+                },
+            ],
+        });
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
@@ -13,7 +13,14 @@ function verifyActiveFilters(filterLabels) {
 
 describe("Disabled Filters", () => {
     beforeEach(() => {
-        cy.enableModules("Medication");
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "medication",
+                    enabled: true,
+                },
+            ],
+        });
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -27,11 +34,13 @@ describe("Disabled Filters", () => {
         cy.get("[data-testid=filterDropdown]").click();
         cy.get("[data-testid=MedicationCount]").should("be.visible");
         cy.get("[data-testid=ImmunizationCount]").should("not.exist");
-        cy.get("[data-testid=EncounterCount]").should("not.exist");
+        cy.get("[data-testid=HealthVisitCount]").should("not.exist");
         cy.get("[data-testid=NoteCount]").should("not.exist");
-        cy.get("[data-testid=LaboratoryCount]").should("not.exist");
-        cy.get("[data-testid=AllLaboratoryCount]").should("not.exist");
-        cy.get("[data-testid=MedicationRequestCount]").should("not.exist");
+        cy.get("[data-testid=Covid19TestResultCount]").should("not.exist");
+        cy.get("[data-testid=LabResultCount]").should("not.exist");
+        cy.get("[data-testid=SpecialAuthorityRequestCount]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=ClinicalDocumentCount]").should("not.exist");
         cy.get("[data-testid=HospitalVisitCount]").should("not.exist");
         cy.get("[data-testid=btnFilterCancel]").click();
@@ -40,17 +49,46 @@ describe("Disabled Filters", () => {
 
 describe("Filters", () => {
     beforeEach(() => {
-        cy.enableModules([
-            "AllLaboratory",
-            "ClinicalDocument",
-            "Encounter",
-            "Immunization",
-            "Laboratory",
-            "Medication",
-            "MedicationRequest",
-            "Note",
-            "HospitalVisit",
-        ]);
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "clinicalDocument",
+                    enabled: true,
+                },
+                {
+                    name: "covid19TestResult",
+                    enabled: true,
+                },
+                {
+                    name: "healthVisit",
+                    enabled: true,
+                },
+                {
+                    name: "hospitalVisit",
+                    enabled: true,
+                },
+                {
+                    name: "immunization",
+                    enabled: true,
+                },
+                {
+                    name: "labResult",
+                    enabled: true,
+                },
+                {
+                    name: "medication",
+                    enabled: true,
+                },
+                {
+                    name: "note",
+                    enabled: true,
+                },
+                {
+                    name: "specialAuthorityRequest",
+                    enabled: true,
+                },
+            ],
+        });
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -68,19 +106,19 @@ describe("Filters", () => {
         cy.get("[data-testid=MedicationCount]")
             .should("be.visible")
             .contains(countRegex);
-        cy.get("[data-testid=AllLaboratoryCount]")
+        cy.get("[data-testid=LabResultCount]")
             .should("be.visible")
             .contains(countRegex);
-        cy.get("[data-testid=LaboratoryCount]")
+        cy.get("[data-testid=Covid19TestResultCount]")
             .should("be.visible")
             .contains(countRegex);
-        cy.get("[data-testid=EncounterCount]")
+        cy.get("[data-testid=HealthVisitCount]")
             .should("be.visible")
             .contains(countRegex);
         cy.get("[data-testid=NoteCount]")
             .should("be.visible")
             .contains(countRegex);
-        cy.get("[data-testid=MedicationRequestCount]")
+        cy.get("[data-testid=SpecialAuthorityRequestCount]")
             .should("be.visible")
             .contains(countRegex);
         cy.get("[data-testid=ClinicalDocumentCount]")
@@ -149,8 +187,10 @@ describe("Filters", () => {
         cy.get("[data-testid=Medication-filter]").should("not.to.be.checked");
         cy.get("[data-testid=Note-filter]").should("not.to.be.checked");
         cy.get("[data-testid=Immunization-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=Laboratory-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=Encounter-filter]").should("not.to.be.checked");
+        cy.get("[data-testid=Covid19TestResult-filter]").should(
+            "not.to.be.checked"
+        );
+        cy.get("[data-testid=HealthVisit-filter]").should("not.to.be.checked");
         cy.get("[data-testid=ClinicalDocument-filter]").should(
             "not.to.be.checked"
         );
@@ -167,12 +207,14 @@ describe("Filters", () => {
         cy.get("[data-testid=btnFilterApply]").click();
 
         cy.get("[data-testid=noteTitle]").should("not.exist");
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("be.visible");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["Immunization"]);
@@ -205,11 +247,13 @@ describe("Filters", () => {
 
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
         cy.get("[data-testid=noteTitle]").should("not.exist");
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
         cy.get("[data-testid=medicationTitle]").should("be.visible");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["Medication"]);
@@ -218,16 +262,18 @@ describe("Filters", () => {
     it("Filter Encounter", () => {
         cy.get("[data-testid=filterContainer]").should("not.exist");
         cy.get("[data-testid=filterDropdown]").click();
-        cy.get("[data-testid=Encounter-filter]").click({ force: true });
+        cy.get("[data-testid=HealthVisit-filter]").click({ force: true });
         cy.get("[data-testid=btnFilterApply]").click();
 
-        cy.get("[data-testid=encounterTitle]").should("be.visible");
+        cy.get("[data-testid=healthvisitTitle]").should("be.visible");
         cy.get("[data-testid=noteTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["Health Visits"]);
@@ -236,16 +282,18 @@ describe("Filters", () => {
     it("Filter COVID-19", () => {
         cy.get("[data-testid=filterContainer]").should("not.exist");
         cy.get("[data-testid=filterDropdown]").click();
-        cy.get("[data-testid=Laboratory-filter]").click({ force: true });
+        cy.get("[data-testid=Covid19TestResult-filter]").click({ force: true });
         cy.get("[data-testid=btnFilterApply]").click();
 
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
         cy.get("[data-testid=noteTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("be.visible");
+        cy.get("[data-testid=covid19testresultTitle]").should("be.visible");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["COVID‑19 Tests"]);
@@ -254,16 +302,18 @@ describe("Filters", () => {
     it("Filter Laboratory", () => {
         cy.get("[data-testid=filterContainer]").should("not.exist");
         cy.get("[data-testid=filterDropdown]").click();
-        cy.get("[data-testid=AllLaboratory-filter]").click({ force: true });
+        cy.get("[data-testid=LabResult-filter]").click({ force: true });
         cy.get("[data-testid=btnFilterApply]").click();
 
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
         cy.get("[data-testid=noteTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("be.visible");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("be.visible");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["Lab Results"]);
@@ -272,16 +322,20 @@ describe("Filters", () => {
     it("Filter Special Authority", () => {
         cy.get("[data-testid=filterContainer]").should("not.exist");
         cy.get("[data-testid=filterDropdown]").click();
-        cy.get("[data-testid=MedicationRequest-filter]").click({ force: true });
+        cy.get("[data-testid=SpecialAuthorityRequest-filter]").click({
+            force: true,
+        });
         cy.get("[data-testid=btnFilterApply]").click();
 
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
         cy.get("[data-testid=noteTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=medicationrequestTitle]").should("be.visible");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "be.visible"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["Special Authority"]);
@@ -293,13 +347,15 @@ describe("Filters", () => {
         cy.get("[data-testid=ClinicalDocument-filter]").click({ force: true });
         cy.get("[data-testid=btnFilterApply]").click();
 
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
         cy.get("[data-testid=noteTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("be.visible");
         cy.get("[data-testid=hospitalvisitTitle]").should("not.exist");
         verifyActiveFilters(["Clinical Documents"]);
@@ -311,13 +367,15 @@ describe("Filters", () => {
         cy.get("[data-testid=HospitalVisit-filter]").click({ force: true });
         cy.get("[data-testid=btnFilterApply]").click();
 
-        cy.get("[data-testid=encounterTitle]").should("not.exist");
+        cy.get("[data-testid=healthvisitTitle]").should("not.exist");
         cy.get("[data-testid=noteTitle]").should("not.exist");
         cy.get("[data-testid=immunizationTitle]").should("not.exist");
-        cy.get("[data-testid=laboratoryTitle]").should("not.exist");
-        cy.get("[data-testid=alllaboratoryTitle]").should("not.exist");
+        cy.get("[data-testid=covid19testresultTitle]").should("not.exist");
+        cy.get("[data-testid=labresultTitle]").should("not.exist");
         cy.get("[data-testid=medicationTitle]").should("not.exist");
-        cy.get("[data-testid=medicationrequestTitle]").should("not.exist");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=clinicaldocumentTitle]").should("not.exist");
         cy.get("[data-testid=hospitalvisitTitle]").should("be.visible");
         verifyActiveFilters(["Hospital Visits"]);
@@ -330,12 +388,12 @@ describe("Filters", () => {
         cy.get("[data-testid=Medication-filter]").should("not.to.be.checked");
         cy.get("[data-testid=Note-filter]").should("not.to.be.checked");
         cy.get("[data-testid=Immunization-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=Laboratory-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=AllLaboratory-filter]").should(
+        cy.get("[data-testid=Covid19TestResult-filter]").should(
             "not.to.be.checked"
         );
-        cy.get("[data-testid=Encounter-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=MedicationRequest-filter]").should(
+        cy.get("[data-testid=LabResult-filter]").should("not.to.be.checked");
+        cy.get("[data-testid=HealthVisit-filter]").should("not.to.be.checked");
+        cy.get("[data-testid=SpecialAuthorityRequest-filter]").should(
             "not.to.be.checked"
         );
         cy.get("[data-testid=ClinicalDocument-filter]").should(
@@ -351,20 +409,24 @@ describe("Filters", () => {
         cy.get("[data-testid=filterContainer]").should("be.visible");
         cy.get("[data-testid=Immunization-filter]").click({ force: true });
         cy.get("[data-testid=Medication-filter]").click({ force: true });
-        cy.get("[data-testid=Encounter-filter]").click({ force: true });
-        cy.get("[data-testid=Laboratory-filter]").click({ force: true });
-        cy.get("[data-testid=AllLaboratory-filter]").click({ force: true });
+        cy.get("[data-testid=HealthVisit-filter]").click({ force: true });
+        cy.get("[data-testid=Covid19TestResult-filter]").click({ force: true });
+        cy.get("[data-testid=LabResult-filter]").click({ force: true });
         cy.get("[data-testid=Note-filter]").click({ force: true });
-        cy.get("[data-testid=MedicationRequest-filter]").click({ force: true });
+        cy.get("[data-testid=SpecialAuthorityRequest-filter]").click({
+            force: true,
+        });
         cy.get("[data-testid=ClinicalDocument-filter]").click({ force: true });
         cy.get("[data-testid=HospitalVisit-filter]").click({ force: true });
         cy.get("[data-testid=Medication-filter]").should("be.checked");
         cy.get("[data-testid=Note-filter]").should("be.checked");
         cy.get("[data-testid=Immunization-filter]").should("be.checked");
-        cy.get("[data-testid=Laboratory-filter]").should("be.checked");
-        cy.get("[data-testid=AllLaboratory-filter]").should("be.checked");
-        cy.get("[data-testid=Encounter-filter]").should("be.checked");
-        cy.get("[data-testid=MedicationRequest-filter]").should("be.checked");
+        cy.get("[data-testid=Covid19TestResult-filter]").should("be.checked");
+        cy.get("[data-testid=LabResult-filter]").should("be.checked");
+        cy.get("[data-testid=HealthVisit-filter]").should("be.checked");
+        cy.get("[data-testid=SpecialAuthorityRequest-filter]").should(
+            "be.checked"
+        );
         cy.get("[data-testid=ClinicalDocument-filter]").should("be.checked");
         cy.get("[data-testid=HospitalVisit-filter]").should("be.checked");
         cy.get("[data-testid=btnFilterCancel]").click();
@@ -375,12 +437,12 @@ describe("Filters", () => {
         cy.get("[data-testid=Medication-filter]").should("not.to.be.checked");
         cy.get("[data-testid=Note-filter]").should("not.to.be.checked");
         cy.get("[data-testid=Immunization-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=Laboratory-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=AllLaboratory-filter]").should(
+        cy.get("[data-testid=Covid19TestResult-filter]").should(
             "not.to.be.checked"
         );
-        cy.get("[data-testid=Encounter-filter]").should("not.to.be.checked");
-        cy.get("[data-testid=MedicationRequest-filter]").should(
+        cy.get("[data-testid=LabResult-filter]").should("not.to.be.checked");
+        cy.get("[data-testid=HealthVisit-filter]").should("not.to.be.checked");
+        cy.get("[data-testid=SpecialAuthorityRequest-filter]").should(
             "not.to.be.checked"
         );
         cy.get("[data-testid=ClinicalDocument-filter]").should(

--- a/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
@@ -75,8 +75,8 @@ describe("Quick Links", () => {
         cy.get("[data-testid=filterContainer]").should("not.exist");
         cy.get("[data-testid=filterDropdown]").click();
         cy.get("[data-testid=filterContainer]").should("be.visible");
-        cy.get("[data-testid=Laboratory-filter]").should("be.checked");
-        cy.get("[data-testid=laboratoryTitle]").should("be.visible");
+        cy.get("[data-testid=Covid19TestResult-filter]").should("be.checked");
+        cy.get("[data-testid=covid19testresultTitle]").should("be.visible");
 
         cy.log("Returning to home page");
         cy.get("[data-testid=menu-btn-home-link]").should("be.visible").click();

--- a/Testing/functional/tests/cypress/integration/ui/pages/LandingPage.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/LandingPage.js
@@ -1,14 +1,11 @@
 describe("Landing Page", () => {
-    beforeEach(() => {
-        cy.logout();
-        cy.visit("/");
-    });
-
     it("Title", () => {
+        cy.visit("/");
         cy.title().should("eq", "Health Gateway");
     });
 
     it("Sign Up Button", () => {
+        cy.visit("/");
         cy.get("#btnStart")
             .should("be.visible")
             .should("have.attr", "href", "/registration")
@@ -16,6 +13,7 @@ describe("Landing Page", () => {
     });
 
     it("Login Button", () => {
+        cy.visit("/");
         cy.get("[data-testid=btnLogin]")
             .should("be.visible")
             .parent()
@@ -23,6 +21,7 @@ describe("Landing Page", () => {
     });
 
     it("Device Previews", () => {
+        cy.visit("/");
         cy.log("Laptop preview should be displayed by default");
         cy.get("[data-testid=preview-device-button-laptop]").should(
             "be.disabled"
@@ -118,15 +117,62 @@ describe("Landing Page", () => {
     });
 
     it("Validate clinical doc tile when module enabled", () => {
-        cy.enableModules(["ClinicalDocument"]);
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "clinicalDocument",
+                    enabled: true,
+                },
+            ],
+        });
+        cy.visit("/");
         cy.get("[data-testid=active-tile-ClinicalDocument]").should(
             "be.visible"
         );
     });
 
     it("Validate no clinical doc tile when module not enabled", () => {
-        cy.enableModules([]);
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "medication",
+                    enabled: true,
+                },
+            ],
+        });
+        cy.visit("/");
+        cy.get("[data-testid=active-tile-Medication]").should("be.visible");
         cy.get("[data-testid=active-tile-ClinicalDocument]").should(
+            "not.exist"
+        );
+    });
+
+    it("Validate proof of vaccination tile when setting enabled", () => {
+        cy.configureSettings({
+            covid19: {
+                publicCovid19: {
+                    showFederalProofOfVaccination: true,
+                },
+            },
+        });
+        cy.visit("/");
+        cy.get("[data-testid=active-tile-ProofOfVaccination]").should(
+            "be.visible"
+        );
+    });
+
+    it("Validate no proof of vaccination tile when setting not enabled", () => {
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "medication",
+                    enabled: true,
+                },
+            ],
+        });
+        cy.visit("/");
+        cy.get("[data-testid=active-tile-Medication]").should("be.visible");
+        cy.get("[data-testid=active-tile-ProofOfVaccination]").should(
             "not.exist"
         );
     });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -8,7 +8,18 @@ describe("Filters", () => {
         cy.intercept("GET", "**/Encounter/*", {
             fixture: "EncounterService/encounters.json",
         });
-        cy.enableModules(["Immunization", "Encounter"]);
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "healthVisit",
+                    enabled: true,
+                },
+                {
+                    name: "immunization",
+                    enabled: true,
+                },
+            ],
+        });
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -81,7 +92,7 @@ describe("Filters", () => {
         ).should("be.visible");
 
         cy.get("[data-testid=filterDropdown]").click();
-        cy.get("[data-testid=Encounter-filter]").click({ force: true });
+        cy.get("[data-testid=HealthVisit-filter]").click({ force: true });
         cy.get("[data-testid=btnFilterApply]").click();
 
         cy.get(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/medicationrequest.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/medicationrequest.js
@@ -2,7 +2,14 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Medication Request", () => {
     beforeEach(() => {
-        cy.enableModules("MedicationRequest");
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "specialAuthorityRequest",
+                    enabled: true,
+                },
+            ],
+        });
         cy.intercept("GET", "**/MedicationRequest/*", {
             fixture: "MedicationService/medicationRequest.json",
         });
@@ -15,7 +22,9 @@ describe("Medication Request", () => {
     });
 
     it("Validate Card Details", () => {
-        cy.get("[data-testid=medicationrequestTitle]").should("be.visible");
+        cy.get("[data-testid=specialauthorityrequestTitle]").should(
+            "be.visible"
+        );
         cy.get("[data-testid=medicationPractitioner]").should("not.be.visible");
         cy.get("[data-testid=entryCardDetailsTitle]").first().click();
         cy.get("[data-testid=medicationPractitioner]").should("be.visible");

--- a/Testing/functional/tests/cypress/support/index.d.ts
+++ b/Testing/functional/tests/cypress/support/index.d.ts
@@ -11,6 +11,7 @@ declare namespace Cypress {
         readConfig(): Chainable<any>;
         checkTimelineHasLoaded(): void;
         enableModules(modules: string[]): Chainable<any>;
+        configureSettings(settings: any, modules?: string[]): Chainable<any>;
         setupDownloads(): void;
         restoreAuthCookies(): void;
         /**


### PR DESCRIPTION
# Implements [AB#14989](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14989) [AB#14948](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14948) [AB#14950](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14950) [AB#14949](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14949) [AB#14991](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14991)

## Description

- Adds config utility to check if dataset is enabled [AB#14989](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14989)
- Updates quick links to use utility to check dataset is enabled [AB#14948](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14948)
   - Renames SpecialAuthority dataset to SpecialAuthorityRequest
- Updates landing page to use utility to check dataset is enabled [AB#14950](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14950)
   - Refactors landing page to generate tiles within getters
- Updates timeline to use utility to check dataset is enabled [AB#14949](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14949)
- Updates services to use utility to check dataset is enabled
- Updates functional tests for timeline filters [AB#14991](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14991)
- Update remaining places to use utility to check dataset is enabled

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
