### PR TITLE
Add phone number validators AB#14983

### DIFF
--- a/Apps/Common/src/Delegates/PHSA/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestNotificationSettingsDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Delegates.PHSA
 {
     using System;
     using System.Diagnostics;
+    using System.Net;
     using System.Net.Http;
     using System.Threading.Tasks;
     using HealthGateway.Common.Api;
@@ -74,10 +75,16 @@ namespace HealthGateway.Common.Delegates.PHSA
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
+                string errorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.Phsa);
+                if (e is ApiException { StatusCode: HttpStatusCode.UnprocessableEntity })
+                {
+                    errorCode = ErrorTranslator.ServiceError(ErrorType.SmsInvalid, ServiceType.Phsa);
+                }
+
                 retVal.ResultError = new RequestResultError
                 {
                     ResultMessage = "Error while sending notification settings to PHSA",
-                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.Phsa),
+                    ErrorCode = errorCode,
                 };
                 this.logger.LogError("Unexpected exception in SetNotificationSettings {Exception}", e);
             }

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -391,10 +391,10 @@ namespace HealthGateway.GatewayApi.Controllers
         }
 
         /// <summary>
-        /// Test US phone number validation required by the GatewayAPI and PHSA.
+        /// Test phone number validation required by the GatewayAPI and PHSA.
         /// </summary>
         /// <param name="phoneNumber">Phone number stripped of any masked characters.</param>
-        /// <returns>True if the submitted phone number conforms to US standards.</returns>
+        /// <returns>True if the submitted phone number conforms to the appropriate standards.</returns>
         /// <response code="200">Returns the result of the validation attempt.</response>
         [HttpGet]
         [Route("IsValidPhoneNumber/{phoneNumber}")]

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -294,6 +294,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <param name="smsNumber">The new sms number.</param>
         /// <returns>True if the action was successful.</returns>
         /// <response code="200">Returns true if the call was successful.</response>
+        /// <response code="400">the client must ensure sms number is valid.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
         /// The client does not have access rights to the content; that is, it is unauthorized, so the server
@@ -387,6 +388,20 @@ namespace HealthGateway.GatewayApi.Controllers
             this.AddUserPreferences(result.ResourcePayload);
 
             return result;
+        }
+
+        /// <summary>
+        /// Test US phone number validation required by the GatewayAPI and PHSA.
+        /// </summary>
+        /// <param name="phoneNumber">Phone number stripped of any masked characters.</param>
+        /// <returns>True if the submitted phone number conforms to US standards.</returns>
+        /// <response code="200">Returns the result of the validation attempt</response>
+        [HttpGet]
+        [Route("IsValidPhoneNumber/{phoneNumber}")]
+        [Authorize]
+        public ActionResult<bool> IsValidPhoneNumber(string phoneNumber)
+        {
+            return this.userProfileService.IsPhoneNumberValid(phoneNumber);
         }
 
         private void AddUserPreferences(UserProfileModel? profile)

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -395,7 +395,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <param name="phoneNumber">Phone number stripped of any masked characters.</param>
         /// <returns>True if the submitted phone number conforms to US standards.</returns>
-        /// <response code="200">Returns the result of the validation attempt</response>
+        /// <response code="200">Returns the result of the validation attempt.</response>
         [HttpGet]
         [Route("IsValidPhoneNumber/{phoneNumber}")]
         [Authorize]

--- a/Apps/GatewayApi/src/GatewayApi.csproj
+++ b/Apps/GatewayApi/src/GatewayApi.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
     <PropertyGroup Condition=" '$(RunConfiguration)' == 'GatewayApi' " />
     <ItemGroup>
+        <PackageReference Include="libphonenumber-csharp" Version="8.13.6" />
         <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.9" />
         <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     </ItemGroup>

--- a/Apps/GatewayApi/src/Services/IUserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileService.cs
@@ -99,5 +99,12 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="termsOfServiceId">The terms of service id accepted.</param>
         /// <returns>A user profile model wrapped in a RequestResult.</returns>
         RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, Guid termsOfServiceId);
+
+        /// <summary>
+        /// Validates a phone number against the system wide accepted number validation logic.
+        /// </summary>
+        /// <param name="phoneNumber">This should be a phone number without a mask.</param>
+        /// <returns>True if the phone number is valid.</returns>
+        bool IsPhoneNumberValid(string phoneNumber);
     }
 }

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -490,7 +490,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.Error<UserProfileModel>(ErrorType.SmsInvalid, "Profile values entered are invalid");
             }
 
-            return null!;
+            return null;
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.GatewayApi.Services
     using System.Linq;
     using System.Threading.Tasks;
     using AutoMapper;
+    using FluentValidation.Results;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
@@ -39,6 +40,7 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.GatewayApi.Constants;
     using HealthGateway.GatewayApi.MapUtils;
     using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Validations;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -212,19 +214,13 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.Error<UserProfileModel>(ErrorType.InvalidState, "Registration is closed");
             }
 
-            // Validate registration age
-            string hdid = createProfileRequest.Profile.HdId;
-            RequestResult<bool> isMinimumAgeResult = await this.ValidateMinimumAge(hdid).ConfigureAwait(true);
-            if (isMinimumAgeResult.ResultStatus != ResultType.Success)
+            RequestResult<UserProfileModel>? validationResult = await this.ValidateUserProfile(createProfileRequest).ConfigureAwait(true);
+            if (validationResult != null)
             {
-                return RequestResultFactory.Error<UserProfileModel>(isMinimumAgeResult.ResultError);
+                return validationResult;
             }
 
-            if (!isMinimumAgeResult.ResourcePayload)
-            {
-                this.logger.LogWarning("Patient under minimum age... {Hdid}", createProfileRequest.Profile.HdId);
-                return RequestResultFactory.Error<UserProfileModel>(ErrorType.InvalidState, "Patient under minimum age");
-            }
+            string hdid = createProfileRequest.Profile.HdId;
 
             RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid).ConfigureAwait(true);
             DateTime? birthDate = patientResult.ResourcePayload?.Birthdate;
@@ -452,6 +448,12 @@ namespace HealthGateway.GatewayApi.Services
             return RequestResultFactory.Success(UserProfileMapUtils.CreateFromDbModel(profileResult.Payload, termsOfServiceResult.ResourcePayload?.Id, this.autoMapper));
         }
 
+        /// <inheritdoc/>
+        public bool IsPhoneNumberValid(string phoneNumber)
+        {
+            return PhoneNumberValidator.IsValid(phoneNumber);
+        }
+
         private void QueueEmail(string toEmail, string templateName)
         {
             string activationHost = this.httpContextAccessor.HttpContext!.Request
@@ -462,6 +464,33 @@ namespace HealthGateway.GatewayApi.Services
 
             Dictionary<string, string> keyValues = new() { [EmailTemplateVariable.Host] = hostUrl };
             this.emailQueueService.QueueNewEmail(toEmail, templateName, keyValues);
+        }
+
+        private async Task<RequestResult<UserProfileModel>?> ValidateUserProfile(CreateUserRequest createProfileRequest)
+        {
+            // Validate registration age
+            string hdid = createProfileRequest.Profile.HdId;
+            RequestResult<bool> isMinimumAgeResult = await this.ValidateMinimumAge(hdid).ConfigureAwait(true);
+            if (isMinimumAgeResult.ResultStatus != ResultType.Success)
+            {
+                return RequestResultFactory.Error<UserProfileModel>(isMinimumAgeResult.ResultError);
+            }
+
+            if (!isMinimumAgeResult.ResourcePayload)
+            {
+                this.logger.LogWarning("Patient under minimum age... {Hdid}", createProfileRequest.Profile.HdId);
+                return RequestResultFactory.Error<UserProfileModel>(ErrorType.InvalidState, "Patient under minimum age");
+            }
+
+            // Validate UserProfile inputs
+            ValidationResult profileValidationResult = new UserProfileValidator().Validate(createProfileRequest.Profile);
+            if (!profileValidationResult.IsValid)
+            {
+                this.logger.LogWarning("Profile inputs have failed validation for {Hdid}", createProfileRequest.Profile.HdId);
+                return RequestResultFactory.Error<UserProfileModel>(ErrorType.SmsInvalid, "Profile values entered are invalid");
+            }
+
+            return null!;
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -17,14 +17,17 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System;
     using System.Globalization;
+    using System.Net;
     using System.Security.Cryptography;
     using System.Text.RegularExpressions;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
+    using HealthGateway.GatewayApi.Validations;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
@@ -118,6 +121,16 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Removing user sms number {Hdid}", hdid);
             string sanitizedSms = this.SanitizeSms(sms);
+            if (!PhoneNumberValidator.IsValid(sanitizedSms))
+            {
+                this.logger.LogWarning("Proposed sms number is not valid {SmsNumber}", sanitizedSms);
+                throw new ProblemDetailsException(
+                    ExceptionUtility.CreateProblemDetails(
+                        $"Proposed sms number is not valid {sanitizedSms}",
+                        HttpStatusCode.BadRequest,
+                        nameof(UserSmsService)));
+            }
+
             UserProfile userProfile = this.profileDelegate.GetUserProfile(hdid).Payload;
             userProfile.SmsNumber = null;
             this.profileDelegate.Update(userProfile);

--- a/Apps/GatewayApi/src/Validations/PhoneNumberValidator.cs
+++ b/Apps/GatewayApi/src/Validations/PhoneNumberValidator.cs
@@ -28,7 +28,7 @@ namespace HealthGateway.GatewayApi.Validations
         /// Initializes a new instance of the <see cref="PhoneNumberValidator"/> class.
         /// </summary>
         /// <param name="region">The region that the phone number should be validated against.</param>
-        public PhoneNumberValidator(string region = "CA")
+        public PhoneNumberValidator(string region = "US")
         {
             PhoneNumberUtil util = PhoneNumberUtil.GetInstance();
             this.RuleFor(number => number)
@@ -52,9 +52,9 @@ namespace HealthGateway.GatewayApi.Validations
         /// Validate a phone number against a desired region (default: US).
         /// </summary>
         /// <param name="phoneNumber">Phone number for validation.</param>
-        /// <param name="region">defaults to the "CA" region.</param>
+        /// <param name="region">defaults to the "US" region.</param>
         /// <returns>True if phone number passes the validation for the current region.</returns>
-        public static bool IsValid(string? phoneNumber, string region = "CA")
+        public static bool IsValid(string? phoneNumber, string region = "US")
         {
             return !string.IsNullOrEmpty(phoneNumber) && new PhoneNumberValidator(region).Validate(phoneNumber).IsValid;
         }

--- a/Apps/GatewayApi/src/Validations/PhoneNumberValidator.cs
+++ b/Apps/GatewayApi/src/Validations/PhoneNumberValidator.cs
@@ -1,0 +1,62 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Validations
+{
+    using System;
+    using FluentValidation;
+    using PhoneNumbers;
+
+    /// <summary>
+    /// Class encapsulating validation phone numbers leveraging Google's libphonenumber library.
+    /// </summary>
+    public class PhoneNumberValidator : AbstractValidator<string>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PhoneNumberValidator"/> class.
+        /// </summary>
+        /// <param name="region">The region that the phone number should be validated against.</param>
+        public PhoneNumberValidator(string region = "CA")
+        {
+            PhoneNumberUtil util = PhoneNumberUtil.GetInstance();
+            this.RuleFor(number => number)
+                .NotNull()
+                .Must(
+                    number =>
+                    {
+                        try
+                        {
+                            PhoneNumber? phoneNumber = util.Parse(number, region);
+                            return util.IsValidNumber(phoneNumber);
+                        }
+                        catch (Exception e) when (e is NumberParseException)
+                        {
+                            return false;
+                        }
+                    });
+        }
+
+        /// <summary>
+        /// Validate a phone number against a desired region (default: US).
+        /// </summary>
+        /// <param name="phoneNumber">Phone number for validation.</param>
+        /// <param name="region">defaults to the "CA" region.</param>
+        /// <returns>True if phone number passes the validation for the current region.</returns>
+        public static bool IsValid(string? phoneNumber, string region = "CA")
+        {
+            return !string.IsNullOrEmpty(phoneNumber) && new PhoneNumberValidator(region).Validate(phoneNumber).IsValid;
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Validations/UserProfileValidator.cs
+++ b/Apps/GatewayApi/src/Validations/UserProfileValidator.cs
@@ -1,0 +1,35 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Validations
+{
+    using FluentValidation;
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// Validates <see cref="UserProfile"/> instances.
+    /// </summary>
+    public class UserProfileValidator : AbstractValidator<UserProfile>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserProfileValidator"/> class.
+        /// </summary>
+        public UserProfileValidator()
+        {
+            this.RuleFor(profile => profile.SmsNumber)
+                .Must(smsNumber => string.IsNullOrEmpty(smsNumber) || PhoneNumberValidator.IsValid(smsNumber));
+        }
+    }
+}

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -117,7 +117,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [Fact]
         public void ShouldValidateUpdate()
         {
-            string sms = "2501234567";
+            string sms = "2508801234";
             MessagingVerification expectedResult = new()
             {
                 UserProfileId = HdIdMock,

--- a/Apps/GatewayApi/test/unit/Validations/PhoneNumberValidatorTests.cs
+++ b/Apps/GatewayApi/test/unit/Validations/PhoneNumberValidatorTests.cs
@@ -1,0 +1,58 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApiTests.Validations
+{
+    using HealthGateway.GatewayApi.Validations;
+    using Xunit;
+
+    /// <summary>
+    /// PhoneNumberValidator unit tests.
+    /// </summary>
+    public class PhoneNumberValidatorTests
+    {
+        /// <summary>
+        /// Test range of valid phone numbers.
+        /// </summary>
+        /// <param name="phoneNumber">Valid phone number.</param>
+        [Theory]
+        [InlineData("3345678901")]
+        [InlineData("4345678901")]
+        [InlineData("5345678901")]
+        [InlineData("7345678901")]
+        [InlineData("2507001000")]
+        public void ShouldBeValid(string? phoneNumber)
+        {
+            Assert.True(PhoneNumberValidator.IsValid(phoneNumber));
+        }
+
+        /// <summary>
+        /// Test range of invalid phone numbers.
+        /// </summary>
+        /// <param name="phoneNumber">Invalid phone numbers.</param>
+        /// <param name="reason">Reason that the phone number should be rejected.</param>
+        [Theory]
+        [InlineData("1031231234", "Begins with 1")]
+        [InlineData("0000000000", "All zeros is invalid format")]
+        [InlineData("6345678901", "Not a valid Area code")]
+        [InlineData("2031231234", "Not a valid Area code")]
+        [InlineData("", "Empty string is not a phone number")]
+        [InlineData(null, "null is not a phone number")]
+        public void ShouldNotBeValid(string? phoneNumber, string reason)
+        {
+            Assert.False(PhoneNumberValidator.IsValid(phoneNumber), reason);
+        }
+    }
+}

--- a/Apps/JobScheduler/src/Jobs/NotificationSettingsJob.cs
+++ b/Apps/JobScheduler/src/Jobs/NotificationSettingsJob.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.JobScheduler.Jobs
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Delegates.PHSA;
+    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.Jobs;
     using HealthGateway.Common.Models;
     using HealthGateway.Database.Delegates;
@@ -102,7 +103,10 @@ namespace HealthGateway.JobScheduler.Jobs
                         if (retVal.ResultStatus != ResultType.Success)
                         {
                             this.logger.LogError("Unable to send Notification Settings to PHSA, Error:\n{ResultMessage}", retVal.ResultError?.ResultMessage);
-                            throw new FormatException($"Unable to send Notification Settings to PHSA, Error:\n{retVal.ResultError?.ResultMessage}");
+                            if (!string.Equals(retVal.ResultError?.ErrorCode, ErrorTranslator.ServiceError(ErrorType.SmsInvalid, ServiceType.Phsa), StringComparison.OrdinalIgnoreCase))
+                            {
+                                throw new FormatException($"Unable to send Notification Settings to PHSA, Error:\n{retVal.ResultError?.ResultMessage}");
+                            }
                         }
                     }
                 }

--- a/Apps/WebClient/src/ClientApp/src/constants/validationRegEx.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/validationRegEx.ts
@@ -1,0 +1,3 @@
+﻿export default abstract class ValidationRegEx {
+    public static PhoneNumberMasked = /^\D?(\d{3})\D?\D?(\d{3})\D?(\d{4})$/;
+}

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -170,6 +170,7 @@ export interface IUserProfileService {
         hdid: string,
         termsOfServiceId: string
     ): Promise<UserProfile>;
+    isPhoneNumberValid(phoneNumber: string): Promise<boolean>;
 }
 
 export interface IUserFeedbackService {

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
@@ -421,4 +421,30 @@ export class RestUserProfileService implements IUserProfileService {
                 })
         );
     }
+
+    public isPhoneNumberValid(phoneNumber: string): Promise<boolean> {
+        return new Promise<boolean>((resolve, reject) => {
+            this.http
+                .get<boolean>(
+                    `${this.baseUri}${this.USER_PROFILE_BASE_URI}/IsValidPhoneNumber/${phoneNumber}`
+                )
+                .then((result: boolean) => {
+                    this.logger.verbose(
+                        `Validate phone number format result: ${result}`
+                    );
+                    resolve(result);
+                })
+                .catch((err: HttpError) => {
+                    this.logger.error(
+                        `Error in RestUserProfileService.isPhoneNumberValid()`
+                    );
+                    reject(
+                        ErrorTranslator.internalNetworkError(
+                            err,
+                            ServiceCode.HealthGatewayUser
+                        )
+                    );
+                });
+        });
+    }
 }

--- a/Apps/WebClient/src/ClientApp/src/utility/phoneUtil.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/phoneUtil.ts
@@ -1,8 +1,13 @@
 export default abstract class PhoneUtil {
     public static formatPhone(phone: string): string {
-        phone = phone || "";
-        return phone
-            .replace(/\D/g, "")
-            .replace(/(\d{3})(\d{3})(\d{4})/, "($1) $2-$3");
+        return PhoneUtil.stripPhoneMask(phone).replace(
+            /(\d{3})(\d{3})(\d{4})/,
+            "($1) $2-$3"
+        );
+    }
+
+    public static stripPhoneMask(phoneNumber: string): string {
+        phoneNumber = phoneNumber || "";
+        return phoneNumber.replace(/\D/g, "");
     }
 }

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -3,7 +3,7 @@ import { library } from "@fortawesome/fontawesome-svg-core";
 import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
 import Vue from "vue";
 import { Component, Prop, Ref } from "vue-property-decorator";
-import { email, helpers, requiredIf, sameAs } from "vuelidate/lib/validators";
+import { email, requiredIf, sameAs } from "vuelidate/lib/validators";
 import { Validation } from "vuelidate/vuelidate";
 import { Action, Getter } from "vuex-class";
 
@@ -11,6 +11,7 @@ import HtmlTextAreaComponent from "@/components/HtmlTextAreaComponent.vue";
 import LoadingComponent from "@/components/LoadingComponent.vue";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { RegistrationStatus } from "@/constants/registrationStatus";
+import ValidationRegEx from "@/constants/validationRegEx";
 import type { WebClientConfiguration } from "@/models/configData";
 import { ResultError } from "@/models/errors";
 import { TermsOfService } from "@/models/termsOfService";
@@ -19,6 +20,7 @@ import { CreateUserRequest } from "@/models/userProfile";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger, IUserProfileService } from "@/services/interfaces";
+import PhoneUtil from "@/utility/phoneUtil";
 
 library.add(faExclamationTriangle);
 
@@ -122,6 +124,10 @@ export default class RegistrationView extends Vue {
         return false;
     }
 
+    private get termsOfServiceLoaded(): boolean {
+        return !this.isLoading && Boolean(this.termsOfService?.content);
+    }
+
     private mounted(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
         this.minimumAge = this.webClientConfig.minPatientAge;
@@ -182,11 +188,19 @@ export default class RegistrationView extends Vue {
     }
 
     private validations(): unknown {
-        const sms = helpers.regex("sms", /^\D?(\d{3})\D?\D?(\d{3})\D?(\d{4})$/);
+        const validPhoneNumberFormat = async (rawInputSmsNumber: string) => {
+            if (!ValidationRegEx.PhoneNumberMasked.test(rawInputSmsNumber)) {
+                return false;
+            }
+            const phoneNumber = PhoneUtil.stripPhoneMask(rawInputSmsNumber);
+            return await this.userProfileService.isPhoneNumberValid(
+                phoneNumber
+            );
+        };
         return {
             smsNumber: {
                 required: requiredIf(() => this.isSMSNumberChecked),
-                sms,
+                sms: validPhoneNumberFormat,
             },
             email: {
                 required: requiredIf(() => this.isEmailChecked),
@@ -282,10 +296,6 @@ export default class RegistrationView extends Vue {
             this.smsNumber = "";
         }
     }
-
-    private get termsOfServiceLoaded(): boolean {
-        return !this.isLoading && Boolean(this.termsOfService?.content);
-    }
 }
 </script>
 
@@ -327,11 +337,11 @@ export default class RegistrationView extends Vue {
                         <b-form-input
                             id="emailInput"
                             v-model="$v.email.$model"
-                            data-testid="emailInput"
-                            type="email"
-                            placeholder="Your email address"
                             :disabled="isPredefinedEmail || !isEmailChecked"
                             :state="isValid($v.email)"
+                            data-testid="emailInput"
+                            placeholder="Your email address"
+                            type="email"
                         />
                         <b-form-invalid-feedback :state="isValid($v.email)">
                             Valid email is required
@@ -341,11 +351,11 @@ export default class RegistrationView extends Vue {
                         <b-form-input
                             id="emailConfirmationInput"
                             v-model="$v.emailConfirmation.$model"
-                            data-testid="emailConfirmationInput"
-                            type="email"
-                            placeholder="Confirm your email address"
                             :disabled="!isEmailChecked"
                             :state="isValid($v.emailConfirmation)"
+                            data-testid="emailConfirmationInput"
+                            placeholder="Confirm your email address"
+                            type="email"
                         />
                         <b-form-invalid-feedback
                             :state="$v.emailConfirmation.sameAsEmail"
@@ -371,12 +381,12 @@ export default class RegistrationView extends Vue {
                             id="smsNumberInput"
                             v-model="$v.smsNumber.$model"
                             v-mask="'(###) ###-####'"
-                            type="tel"
-                            data-testid="smsNumberInput"
-                            class="d-flex"
-                            placeholder="Your phone number"
-                            :state="isValid($v.smsNumber)"
                             :disabled="!isSMSNumberChecked"
+                            :state="isValid($v.smsNumber)"
+                            class="d-flex"
+                            data-testid="smsNumberInput"
+                            placeholder="Your phone number"
+                            type="tel"
                         >
                         </b-form-input>
                         <b-form-invalid-feedback :state="isValid($v.smsNumber)">
@@ -388,10 +398,10 @@ export default class RegistrationView extends Vue {
                         class="font-weight-bold text-primary"
                     >
                         <hg-icon
-                            icon="exclamation-triangle"
-                            size="medium"
                             aria-hidden="true"
                             class="mr-2"
+                            icon="exclamation-triangle"
+                            size="medium"
                         />
                         <span
                             >You won't receive notifications from the Health
@@ -401,16 +411,16 @@ export default class RegistrationView extends Vue {
                     </div>
                     <h4 class="subheading mt-4">Terms of Service</h4>
                     <HtmlTextAreaComponent
-                        class="termsOfService mb-3"
                         :input="termsOfService.content"
+                        class="termsOfService mb-3"
                     />
                     <div class="mb-3">
                         <b-form-checkbox
                             id="accept"
                             v-model="accepted"
-                            data-testid="acceptCheckbox"
-                            class="accept"
                             :state="isValid($v.accepted)"
+                            class="accept"
+                            data-testid="acceptCheckbox"
                         >
                             I agree to the terms of service above
                         </b-form-checkbox>
@@ -420,13 +430,13 @@ export default class RegistrationView extends Vue {
                     </div>
                     <div class="mb-3 text-right">
                         <hg-button
-                            class="px-5"
-                            type="submit"
-                            data-testid="registerButton"
-                            variant="primary"
                             :disabled="!accepted"
-                            >Register</hg-button
-                        >
+                            class="px-5"
+                            data-testid="registerButton"
+                            type="submit"
+                            variant="primary"
+                            >Register
+                        </hg-button>
                     </div>
                 </b-form>
                 <div v-else-if="isValidAge === false">


### PR DESCRIPTION
# Fixes or Implements [AB#14983](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14983)

## Description

1. Add validation endpoint for phone number
2. Add `google-libphonenumber` for consistency
3. Add check for 422 errors on JobScheduler
4. Add Unit tests for PhoneNumberValidator

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
Not visible, but vuelidators updated to use debounced (1s) validation to validation endpoint.

## Notes
Was not sure about ideal method of sharing validators in the `vuelidate` style. This lead to the duplication between registration and profile. guidance on this would be appreciated.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
