### PR TITLE
Add dependent timeline page AB#14548

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -690,6 +690,7 @@ export default class TimelineComponent extends Vue {
                         :entry="entry"
                         :index="index"
                         :hdid="hdid"
+                        :comments-are-enabled="commentsAreEnabled"
                         data-testid="timelineCard"
                     />
                 </div>
@@ -748,7 +749,10 @@ export default class TimelineComponent extends Vue {
             <content-placeholders-text :lines="3" />
         </content-placeholders>
         <ProtectiveWordComponent :hdid="hdid" />
-        <EntryDetailsComponent :hdid="hdid" />
+        <EntryDetailsComponent
+            :hdid="hdid"
+            :comments-are-enabled="commentsAreEnabled"
+        />
     </div>
 </template>
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/ClinicalDocumentTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/ClinicalDocumentTimelineComponent.vue
@@ -43,6 +43,9 @@ export default class ClinicalDocumentTimelineComponent extends Vue {
     @Prop()
     isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     @Action("getFile", { namespace: "clinicalDocument" })
     getFile!: (params: {
         fileId: string;
@@ -109,6 +112,7 @@ export default class ClinicalDocumentTimelineComponent extends Vue {
         :subtitle="entry.documentType"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="commentsAreEnabled"
         has-attachment
     >
         <div slot="details-body">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/Covid19LaboratoryOrderTimelineComponent.vue
@@ -48,6 +48,9 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
     @Prop()
     isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
 
@@ -147,6 +150,7 @@ export default class Covid19LaboratoryOrderTimelineComponent extends Vue {
         :title="entry.summaryTitle"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="commentsAreEnabled"
         :has-attachment="reportAvailable"
     >
         <div v-if="entry.tests.length === 1" slot="header-description">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EncounterTimelineComponent.vue
@@ -25,6 +25,9 @@ export default class EncounterTimelineComponent extends Vue {
     @Prop() datekey!: string;
     @Prop() isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     private get entryIcon(): string | undefined {
         return entryTypeMap.get(EntryType.HealthVisit)?.icon;
     }
@@ -43,6 +46,7 @@ export default class EncounterTimelineComponent extends Vue {
         :subtitle="entry.practitionerName"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="commentsAreEnabled"
     >
         <b-row slot="details-body">
             <b-col>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
@@ -43,6 +43,9 @@ export default class EntryDetailsComponent extends Vue {
     @Prop({ required: true })
     hdid!: string;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     @Action("setHeaderState", { namespace: "navbar" })
     setHeaderState!: (isOpen: boolean) => void;
 
@@ -168,6 +171,7 @@ export default class EntryDetailsComponent extends Vue {
             :index="1"
             :is-mobile-details="true"
             :hdid="hdid"
+            :comments-are-enabled="commentsAreEnabled"
             data-testid="entryDetailsCard"
         />
     </b-modal>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -33,7 +33,7 @@ export default class EntrycardTimelineComponent extends Vue {
     @Prop() subtitle!: string;
     @Prop() entryIcon: string | undefined;
     @Prop() iconClass!: string;
-    @Prop({ default: true }) allowComment!: boolean;
+    @Prop({ default: false }) allowComment!: boolean;
     @Prop({ default: true }) canShowDetails!: boolean;
     @Prop({ default: false }) isMobileDetails!: boolean;
     @Prop({ default: false }) hasAttachment!: boolean;
@@ -72,10 +72,6 @@ export default class EntrycardTimelineComponent extends Vue {
 
     private get dateString(): string {
         return this.entry.date.format();
-    }
-
-    private get isCommentEnabled(): boolean {
-        return this.config.featureToggleConfiguration.timeline.comment;
     }
 
     private get commentCount(): number {
@@ -188,7 +184,7 @@ export default class EntrycardTimelineComponent extends Vue {
                         <slot name="details-body" />
                     </b-col>
                 </b-row>
-                <b-row v-if="allowComment && isCommentEnabled">
+                <b-row v-if="allowComment">
                     <b-col class="leftPane d-none d-md-block" />
                     <b-col class="pb-1 pt-1 px-3">
                         <CommentSectionComponent

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/HospitalVisitTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/HospitalVisitTimelineComponent.vue
@@ -36,6 +36,9 @@ export default class HospitalVisitTimelineComponent extends Vue {
     @Prop()
     isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     @Getter("user", { namespace: "user" })
     user!: User;
 
@@ -66,6 +69,7 @@ export default class HospitalVisitTimelineComponent extends Vue {
         :subtitle="entry.visitType"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="commentsAreEnabled"
     >
         <div slot="details-body">
             <div class="my-2">

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/ImmunizationTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/ImmunizationTimelineComponent.vue
@@ -21,6 +21,9 @@ export default class ImmunizationTimelineComponent extends Vue {
     @Prop() datekey!: string;
     @Prop() isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     private get isCovidImmunization(): boolean {
         return (
             this.entry.immunization.valid &&

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/LaboratoryOrderTimelineComponent.vue
@@ -46,6 +46,9 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
     @Prop()
     isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
 
@@ -136,6 +139,7 @@ export default class LaboratoryOrderTimelineComponent extends Vue {
         :entry="entry"
         :is-mobile-details="isMobileDetails"
         :has-attachment="entry.reportAvailable"
+        :allow-comment="commentsAreEnabled"
     >
         <div slot="header-description">
             <span>Order Status: </span>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationRequestTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationRequestTimelineComponent.vue
@@ -23,6 +23,9 @@ export default class MedicationRequestTimelineComponent extends Vue {
     @Prop() datekey!: string;
     @Prop() isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     private get entryIcon(): string | undefined {
         return entryTypeMap.get(EntryType.SpecialAuthorityRequest)?.icon;
     }
@@ -41,6 +44,7 @@ export default class MedicationRequestTimelineComponent extends Vue {
         :subtitle="'Status: ' + entry.requestStatus"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="commentsAreEnabled"
     >
         <b-row slot="details-body" class="justify-content-between">
             <b-col>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/MedicationTimelineComponent.vue
@@ -22,6 +22,9 @@ export default class MedicationTimelineComponent extends Vue {
     @Prop() datekey!: string;
     @Prop() isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     private get entryIcon(): string | undefined {
         return entryTypeMap.get(EntryType.Medication)?.icon;
     }
@@ -40,6 +43,7 @@ export default class MedicationTimelineComponent extends Vue {
         :subtitle="entry.medication.genericName"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="commentsAreEnabled"
     >
         <b-row slot="details-body" class="justify-content-between">
             <b-col>

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/NoteTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/NoteTimelineComponent.vue
@@ -34,6 +34,9 @@ export default class NoteTimelineComponent extends Vue {
     @Prop()
     isMobileDetails!: boolean;
 
+    @Prop({ default: false })
+    commentsAreEnabled!: boolean;
+
     @Action("addError", { namespace: "errorBanner" })
     addError!: (params: {
         errorType: ErrorType;
@@ -94,9 +97,9 @@ export default class NoteTimelineComponent extends Vue {
         :title="entry.title"
         :subtitle="entry.textSummary"
         :entry="entry"
-        :allow-comment="false"
         :can-show-details="canShowDetails"
         :is-mobile-details="isMobileDetails"
+        :allow-comment="false"
     >
         <b-navbar-nav slot="header-menu">
             <b-nav-item-dropdown

--- a/Apps/WebClient/src/ClientApp/src/models/configData.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/configData.ts
@@ -114,6 +114,7 @@ export interface ProofOfVaccinationSettings {
 
 export interface DependentsSettings {
     enabled: boolean;
+    timelineEnabled: boolean;
     datasets: DatasetSettings[];
 }
 

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -87,6 +87,10 @@ const ContactUsView = () =>
     import(/* webpackChunkName: "contactUs" */ "@/views/ContactUsView.vue");
 const DependentsView = () =>
     import(/* webpackChunkName: "dependents" */ "@/views/DependentsView.vue");
+const DependentTimelineView = () =>
+    import(
+        /* webpackChunkName: "dependents" */ "@/views/DependentTimelineView.vue"
+    );
 const FAQView = () =>
     import(/* webpackChunkName: "faq" */ "@/views/FaqView.vue");
 const PcrTestView = () =>
@@ -266,6 +270,21 @@ const routes = [
             validStates: [UserState.registered],
             requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>
                 config.dependents.enabled,
+            requiresProcessedWaitlistTicket: true,
+        },
+    },
+    {
+        path: "/dependents/:id",
+        redirect: "/dependents/:id/timeline",
+    },
+    {
+        path: "/dependents/:id/timeline",
+        component: DependentTimelineView,
+        props: true,
+        meta: {
+            validStates: [UserState.registered],
+            requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>
+                config.dependents.enabled && config.dependents.timelineEnabled,
             requiresProcessedWaitlistTicket: true,
         },
     },

--- a/Apps/WebClient/src/ClientApp/src/store/modules/dependent/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/dependent/actions.ts
@@ -1,0 +1,92 @@
+import { ErrorSourceType, ErrorType } from "@/constants/errorType";
+import { DateWrapper } from "@/models/dateWrapper";
+import { ResultError } from "@/models/errors";
+import { LoadStatus } from "@/models/storeOperations";
+import container from "@/plugins/container";
+import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
+import { IDependentService, ILogger } from "@/services/interfaces";
+
+import { DependentActions } from "./types";
+
+export const actions: DependentActions = {
+    retrieveDependents(
+        context,
+        params: { hdid: string; bypassCache: boolean }
+    ): Promise<void> {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        const dependentService = container.get<IDependentService>(
+            SERVICE_IDENTIFIER.DependentService
+        );
+
+        return new Promise((resolve, reject) => {
+            if (
+                context.state.status === LoadStatus.LOADED &&
+                !params.bypassCache
+            ) {
+                logger.debug("Dependents found stored, not querying!");
+                resolve();
+            } else {
+                logger.debug("Retrieving dependents");
+                context.commit("setDependentsRequested");
+                dependentService
+                    .getAll(params.hdid)
+                    .then((result) => {
+                        result.sort((a, b) => {
+                            const firstDate = new DateWrapper(
+                                a.dependentInformation.dateOfBirth
+                            );
+                            const secondDate = new DateWrapper(
+                                b.dependentInformation.dateOfBirth
+                            );
+
+                            if (firstDate.isBefore(secondDate)) {
+                                return 1;
+                            }
+
+                            if (firstDate.isAfter(secondDate)) {
+                                return -1;
+                            }
+
+                            return 0;
+                        });
+                        context.commit("setDependents", result);
+                        resolve();
+                    })
+                    .catch((error: ResultError) => {
+                        context.dispatch("handleDependentsError", {
+                            error,
+                            errorType: ErrorType.Retrieve,
+                        });
+                        reject(error);
+                    });
+            }
+        });
+    },
+    handleDependentsError(
+        context,
+        params: { error: ResultError; errorType: ErrorType }
+    ) {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+
+        logger.error(`ERROR: ${JSON.stringify(params.error)}`);
+        context.commit("setDependentsError", params.error);
+
+        if (params.error.statusCode === 429) {
+            let action = "errorBanner/setTooManyRequestsError";
+            if (params.errorType === ErrorType.Retrieve) {
+                action = "errorBanner/setTooManyRequestsWarning";
+            }
+            context.dispatch(action, { key: "page" }, { root: true });
+        } else {
+            context.dispatch(
+                "errorBanner/addError",
+                {
+                    errorType: params.errorType,
+                    source: ErrorSourceType.Dependent,
+                    traceId: params.error.traceId,
+                },
+                { root: true }
+            );
+        }
+    },
+};

--- a/Apps/WebClient/src/ClientApp/src/store/modules/dependent/dependent.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/dependent/dependent.ts
@@ -1,0 +1,23 @@
+import { LoadStatus } from "@/models/storeOperations";
+
+import { actions } from "./actions";
+import { getters } from "./getters";
+import { mutations } from "./mutations";
+import { DependentModule, DependentState } from "./types";
+
+const state: DependentState = {
+    dependents: [],
+    status: LoadStatus.NONE,
+    statusMessage: "",
+    error: undefined,
+};
+
+const namespaced = true;
+
+export const dependent: DependentModule = {
+    namespaced,
+    state,
+    getters,
+    actions,
+    mutations,
+};

--- a/Apps/WebClient/src/ClientApp/src/store/modules/dependent/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/dependent/getters.ts
@@ -1,0 +1,13 @@
+import { Dependent } from "@/models/dependent";
+import { LoadStatus } from "@/models/storeOperations";
+
+import { DependentGetters, DependentState } from "./types";
+
+export const getters: DependentGetters = {
+    dependents(state: DependentState): Dependent[] {
+        return state.dependents;
+    },
+    dependentsAreLoading(state: DependentState): boolean {
+        return state.status === LoadStatus.REQUESTED;
+    },
+};

--- a/Apps/WebClient/src/ClientApp/src/store/modules/dependent/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/dependent/mutations.ts
@@ -1,0 +1,21 @@
+import { Dependent } from "@/models/dependent";
+import { ResultError } from "@/models/errors";
+import { LoadStatus } from "@/models/storeOperations";
+
+import { DependentMutations, DependentState } from "./types";
+
+export const mutations: DependentMutations = {
+    setDependentsRequested(state: DependentState) {
+        state.status = LoadStatus.REQUESTED;
+    },
+    setDependents(state: DependentState, dependents: Dependent[]) {
+        state.dependents = dependents;
+        state.error = undefined;
+        state.status = LoadStatus.LOADED;
+    },
+    setDependentsError(state: DependentState, error: ResultError) {
+        state.error = error;
+        state.statusMessage = error.resultMessage;
+        state.status = LoadStatus.ERROR;
+    },
+};

--- a/Apps/WebClient/src/ClientApp/src/store/modules/dependent/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/dependent/types.ts
@@ -1,0 +1,52 @@
+import {
+    ActionContext,
+    ActionTree,
+    GetterTree,
+    Module,
+    MutationTree,
+} from "vuex";
+
+import { ErrorType } from "@/constants/errorType";
+import { Dependent } from "@/models/dependent";
+import { ResultError } from "@/models/errors";
+import { LoadStatus } from "@/models/storeOperations";
+import { RootState } from "@/store/types";
+
+export interface DependentState {
+    dependents: Dependent[];
+    status: LoadStatus;
+    statusMessage: string;
+    error?: ResultError;
+}
+
+export interface DependentGetters
+    extends GetterTree<DependentState, RootState> {
+    dependents(state: DependentState): Dependent[];
+    dependentsAreLoading(state: DependentState): boolean;
+}
+
+type StoreContext = ActionContext<DependentState, RootState>;
+export interface DependentActions
+    extends ActionTree<DependentState, RootState> {
+    retrieveDependents(
+        context: StoreContext,
+        params: { hdid: string }
+    ): Promise<void>;
+    handleDependentsError(
+        context: StoreContext,
+        params: { error: ResultError; errorType: ErrorType }
+    ): void;
+}
+
+export interface DependentMutations extends MutationTree<DependentState> {
+    setDependentsRequested(state: DependentState): void;
+    setDependents(state: DependentState, dependents: Dependent[]): void;
+    setDependentsError(state: DependentState, error: ResultError): void;
+}
+
+export interface DependentModule extends Module<DependentState, RootState> {
+    state: DependentState;
+    getters: DependentGetters;
+    actions: DependentActions;
+    mutations: DependentMutations;
+}

--- a/Apps/WebClient/src/ClientApp/src/store/options.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/options.ts
@@ -8,6 +8,7 @@ import { auth } from "./modules/auth/auth";
 import { clinicalDocument } from "./modules/clinicalDocument/clinicalDocument";
 import { comment } from "./modules/comment/comment";
 import { config } from "./modules/config/config";
+import { dependent } from "./modules/dependent/dependent";
 import { encounter } from "./modules/encounter/encounter";
 import { errorBanner } from "./modules/error/errorBanner";
 import { idle } from "./modules/idle/idle";
@@ -66,6 +67,7 @@ export class StoreOptions implements GatewayStoreOptions {
         auth,
         config,
         user,
+        dependent,
         medication,
         laboratory,
         comment,

--- a/Apps/WebClient/src/ClientApp/src/store/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/types.ts
@@ -6,6 +6,7 @@ import { AuthModule } from "./modules/auth/types";
 import { ClinicalDocumentModule } from "./modules/clinicalDocument/types";
 import { CommentModule } from "./modules/comment/types";
 import { ConfigModule } from "./modules/config/types";
+import { DependentModule } from "./modules/dependent/types";
 import { EncounterModule } from "./modules/encounter/types";
 import { ErrorBannerModule } from "./modules/error/types";
 import { IdleModule } from "./modules/idle/types";
@@ -49,6 +50,7 @@ export interface GatewayStoreOptions extends StoreOptions<RootState> {
         auth: AuthModule;
         config: ConfigModule;
         user: UserModule;
+        dependent: DependentModule;
         medication: MedicationModule;
         laboratory: LaboratoryModule;
         comment: CommentModule;

--- a/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
@@ -1,0 +1,149 @@
+<script lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import {
+    faCheckCircle,
+    faEdit,
+    faFileMedical,
+    faFileWaveform,
+    faHouseMedical,
+    faMicroscope,
+    faPills,
+    faQuestion,
+    faSearch,
+    faStethoscope,
+    faSyringe,
+    faVial,
+} from "@fortawesome/free-solid-svg-icons";
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+import { Action, Getter } from "vuex-class";
+
+import LoadingComponent from "@/components/LoadingComponent.vue";
+import NoteEditComponent from "@/components/modal/NoteEditComponent.vue";
+import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
+import AddNoteButtonComponent from "@/components/timeline/AddNoteButtonComponent.vue";
+import TimelineComponent from "@/components/timeline/TimelineComponent.vue";
+import { EntryType, entryTypeMap } from "@/constants/entryType";
+import BreadcrumbItem from "@/models/breadcrumbItem";
+import type { WebClientConfiguration } from "@/models/configData";
+import { Dependent, DependentInformation } from "@/models/dependent";
+import User from "@/models/user";
+import container from "@/plugins/container";
+import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
+import { ILogger } from "@/services/interfaces";
+import ConfigUtil from "@/utility/configUtil";
+
+library.add(
+    faCheckCircle,
+    faEdit,
+    faFileMedical,
+    faFileWaveform,
+    faHouseMedical,
+    faMicroscope,
+    faPills,
+    faQuestion,
+    faSearch,
+    faStethoscope,
+    faSyringe,
+    faVial
+);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const options: any = {
+    components: {
+        AddNoteButtonComponent,
+        BreadcrumbComponent,
+        LoadingComponent,
+        NoteEditComponent,
+        TimelineComponent,
+    },
+};
+
+@Component(options)
+export default class DependentTimelineView extends Vue {
+    @Prop({ required: true })
+    id!: string;
+
+    @Action("retrieveDependents", { namespace: "dependent" })
+    retrieveDependents!: (params: {
+        hdid: string;
+        bypassCache: boolean;
+    }) => Promise<void>;
+
+    @Getter("webClient", { namespace: "config" })
+    config!: WebClientConfiguration;
+
+    @Getter("dependents", { namespace: "dependent" })
+    dependents!: Dependent[];
+
+    @Getter("dependentsAreLoading", { namespace: "dependent" })
+    dependentsAreLoading!: boolean;
+
+    @Getter("user", { namespace: "user" })
+    user!: User;
+
+    logger!: ILogger;
+
+    get breadcrumbItems(): BreadcrumbItem[] {
+        return [
+            {
+                text: "Dependents",
+                to: "/dependents",
+                active: false,
+                dataTestId: "breadcrumb-dependents",
+            },
+            {
+                text: `${this.formattedName} Timeline`,
+                active: true,
+                dataTestId: "breadcrumb-dependent-name",
+            },
+        ];
+    }
+
+    get entryTypes(): EntryType[] {
+        return [...entryTypeMap.values()]
+            .filter((d) => ConfigUtil.isDependentDatasetEnabled(d.type))
+            .map((d) => d.type);
+    }
+
+    get dependent(): Dependent | undefined {
+        return this.dependents.find((d) => d.ownerId === this.hdid);
+    }
+
+    get dependentInfo(): DependentInformation | undefined {
+        return this.dependent?.dependentInformation;
+    }
+
+    get formattedName(): string {
+        const firstName = this.dependentInfo?.firstname;
+        const lastInitial = this.dependentInfo?.lastname?.slice(0, 1);
+        return [firstName, lastInitial].filter((s) => Boolean(s)).join(" ");
+    }
+
+    get hdid(): string {
+        return this.id;
+    }
+
+    get title(): string {
+        return [this.formattedName, "Timeline"]
+            .filter((s) => Boolean(s))
+            .join(" ");
+    }
+
+    created(): void {
+        this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        this.retrieveDependents({ hdid: this.user.hdid, bypassCache: false });
+    }
+}
+</script>
+
+<template>
+    <div>
+        <LoadingComponent :is-loading="dependentsAreLoading" />
+        <div v-if="!dependentsAreLoading">
+            <BreadcrumbComponent :items="breadcrumbItems" />
+            <page-title :title="title" />
+            <TimelineComponent :hdid="hdid" :entry-types="entryTypes" />
+        </div>
+    </div>
+</template>

--- a/Apps/WebClient/src/Server/Models/FeatureToggleConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/FeatureToggleConfiguration.cs
@@ -104,9 +104,11 @@ namespace HealthGateway.WebClient.Server.Models
     /// Settings for dependents features.
     /// </summary>
     /// <param name="Enabled">Toggles dependents features.</param>
+    /// <param name="TimelineEnabled">Toggles dependent timeline.</param>
     /// <param name="Datasets">Settings for dependents data sets.</param>
     public record DependentsSettings(
         bool Enabled,
+        bool TimelineEnabled,
         DatasetSettings[] Datasets);
 
 #pragma warning restore CA1819

--- a/Apps/WebClient/src/featuretoggleconfig.json
+++ b/Apps/WebClient/src/featuretoggleconfig.json
@@ -61,6 +61,7 @@
     },
     "dependents": {
         "enabled": true,
+        "timelineEnabled": true,
         "datasets": [
             {
                 "name": "clinicalDocument",

--- a/Apps/WebClient/src/featuretoggleconfig.json
+++ b/Apps/WebClient/src/featuretoggleconfig.json
@@ -64,19 +64,11 @@
         "timelineEnabled": true,
         "datasets": [
             {
-                "name": "clinicalDocument",
-                "enabled": false
-            },
-            {
                 "name": "healthVisit",
                 "enabled": false
             },
             {
                 "name": "hospitalVisit",
-                "enabled": false
-            },
-            {
-                "name": "labResult",
                 "enabled": false
             },
             {
@@ -88,7 +80,7 @@
                 "enabled": false
             },
             {
-                "name": "specialAuthority",
+                "name": "specialAuthorityRequest",
                 "enabled": false
             }
         ]


### PR DESCRIPTION
# Implements [AB#14548](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14548)

## Description

- adds configuration setting for dependent timeline [AB#14957](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14957)
- adds store for dependents [AB#15011](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15011)
- updates enabled dependent datasets in local environment
- adds dependent timeline view [AB#14954](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14954)
   - fixes comments appearing on dependent timeline [AB#15010](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15010)
   - redirects to unauthorized page if dependent is not recognized

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

/dependents/162346565465464564565463257/timeline

![localhost-2023-02-24-174619](https://user-images.githubusercontent.com/16570293/221329732-76a572ce-64ce-4837-9593-1b189dc09188.png)
![localhost-2023-02-24-174558](https://user-images.githubusercontent.com/16570293/221329735-cadaad98-27be-48ae-a69b-2ff3c0b9f0fe.png)

/dependents/badhdid/timeline

![localhost-2023-02-24-174533](https://user-images.githubusercontent.com/16570293/221329764-8386659e-15cc-4d86-80b4-43bb6182d89f.png)

## Notes

Functional tests still remain ([AB#14747](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14747)) and can be merged to dev seperately.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
