### PR TITLE
Add skeletons for new dependent components AB#14959

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/dependent/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependent/DependentCardComponent.vue
@@ -1,0 +1,33 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+import DependentDashboardTabComponent from "@/components/dependent/tabs/DependentDashboardTabComponent.vue";
+import type { Dependent } from "@/models/dependent";
+import DependentUtil from "@/utility/dependentUtil";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const options: any = {
+    components: {
+        DependentDashboardTabComponent,
+    },
+};
+
+@Component(options)
+export default class DependentCardComponent extends Vue {
+    @Prop({ required: true })
+    private dependent!: Dependent;
+
+    private get formattedName(): string {
+        return DependentUtil.formatName(this.dependent.dependentInformation);
+    }
+}
+</script>
+<template>
+    <div>
+        <div>
+            {{ formattedName }}
+        </div>
+        <DependentDashboardTabComponent :dependent="dependent" />
+    </div>
+</template>

--- a/Apps/WebClient/src/ClientApp/src/components/dependent/DependentViewSelectorComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependent/DependentViewSelectorComponent.vue
@@ -1,0 +1,32 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import { Getter } from "vuex-class";
+
+import type { WebClientConfiguration } from "@/models/configData";
+import DependentManagementView from "@/views/DependentManagementView.vue";
+import DependentsView from "@/views/DependentsView.vue";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const options: any = {
+    components: {
+        DependentManagementView,
+        DependentsView,
+    },
+};
+
+@Component(options)
+export default class DependentViewSelectorComponent extends Vue {
+    @Getter("webClient", { namespace: "config" })
+    private config!: WebClientConfiguration;
+
+    private get timelineEnabled(): boolean {
+        return this.config.featureToggleConfiguration.dependents
+            .timelineEnabled;
+    }
+}
+</script>
+<template>
+    <DependentManagementView v-if="timelineEnabled" />
+    <DependentsView v-else />
+</template>

--- a/Apps/WebClient/src/ClientApp/src/components/dependent/tabs/DependentDashboardTabComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependent/tabs/DependentDashboardTabComponent.vue
@@ -1,0 +1,20 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+import type { Dependent } from "@/models/dependent";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const options: any = {
+    components: {},
+};
+
+@Component(options)
+export default class DependentDashboardTabComponent extends Vue {
+    @Prop({ required: true })
+    private dependent!: Dependent;
+}
+</script>
+<template>
+    <div>Dashboard Tab Content</div>
+</template>

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -85,8 +85,10 @@ const ReleaseNotesView = () =>
     );
 const ContactUsView = () =>
     import(/* webpackChunkName: "contactUs" */ "@/views/ContactUsView.vue");
-const DependentsView = () =>
-    import(/* webpackChunkName: "dependents" */ "@/views/DependentsView.vue");
+const DependentViewSelectorComponent = () =>
+    import(
+        /* webpackChunkName: "dependents" */ "@/components/dependent/DependentViewSelectorComponent.vue"
+    );
 const DependentTimelineView = () =>
     import(
         /* webpackChunkName: "dependents" */ "@/views/DependentTimelineView.vue"
@@ -267,7 +269,7 @@ const routes = [
     },
     {
         path: "/dependents",
-        component: DependentsView,
+        component: DependentViewSelectorComponent,
         meta: {
             validStates: [UserState.registered],
             requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>

--- a/Apps/WebClient/src/ClientApp/src/utility/dependentUtil.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/dependentUtil.ts
@@ -1,0 +1,11 @@
+import { DependentInformation } from "@/models/dependent";
+
+export default abstract class DependentUtil {
+    public static formatName(
+        dependentInfo: DependentInformation | undefined
+    ): string {
+        const firstName = dependentInfo?.firstname;
+        const lastInitial = dependentInfo?.lastname?.slice(0, 1);
+        return [firstName, lastInitial].filter((s) => Boolean(s)).join(" ");
+    }
+}

--- a/Apps/WebClient/src/ClientApp/src/views/DependentManagementView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentManagementView.vue
@@ -1,0 +1,71 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component } from "vue-property-decorator";
+import { Action, Getter } from "vuex-class";
+
+import DependentCardComponent from "@/components/dependent/DependentCardComponent.vue";
+import LoadingComponent from "@/components/LoadingComponent.vue";
+import BreadcrumbComponent from "@/components/navmenu/BreadcrumbComponent.vue";
+import BreadcrumbItem from "@/models/breadcrumbItem";
+import { Dependent } from "@/models/dependent";
+import User from "@/models/user";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const options: any = {
+    components: {
+        BreadcrumbComponent,
+        DependentCardComponent,
+        LoadingComponent,
+    },
+};
+
+@Component(options)
+export default class DependentManagementView extends Vue {
+    @Action("retrieveDependents", { namespace: "dependent" })
+    private retrieveDependents!: (params: {
+        hdid: string;
+        bypassCache: boolean;
+    }) => Promise<void>;
+
+    @Getter("dependents", { namespace: "dependent" })
+    private dependents!: Dependent[];
+
+    @Getter("dependentsAreLoading", { namespace: "dependent" })
+    private dependentsAreLoading!: boolean;
+
+    @Getter("user", { namespace: "user" })
+    private user!: User;
+
+    private breadcrumbItems: BreadcrumbItem[] = [
+        {
+            text: "Dependents",
+            to: "/dependents",
+            active: true,
+            dataTestId: "breadcrumb-dependents",
+        },
+    ];
+
+    private get isLoading(): boolean {
+        return this.dependentsAreLoading;
+    }
+
+    private async created(): Promise<void> {
+        await this.retrieveDependents({
+            hdid: this.user.hdid,
+            bypassCache: false,
+        });
+    }
+}
+</script>
+<template>
+    <div>
+        <BreadcrumbComponent :items="breadcrumbItems" />
+        <LoadingComponent :is-loading="isLoading" />
+        <page-title title="Dependents" />
+        <DependentCardComponent
+            v-for="dependent in dependents"
+            :key="dependent.ownerId"
+            :dependent="dependent"
+        />
+    </div>
+</template>

--- a/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
@@ -26,12 +26,13 @@ import TimelineComponent from "@/components/timeline/TimelineComponent.vue";
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
-import { Dependent, DependentInformation } from "@/models/dependent";
+import { Dependent } from "@/models/dependent";
 import User from "@/models/user";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
 import ConfigUtil from "@/utility/configUtil";
+import DependentUtil from "@/utility/dependentUtil";
 
 library.add(
     faCheckCircle,
@@ -104,10 +105,6 @@ export default class DependentTimelineView extends Vue {
         return this.dependents.find((d) => d.ownerId === this.hdid);
     }
 
-    get dependentInfo(): DependentInformation | undefined {
-        return this.dependent?.dependentInformation;
-    }
-
     get entryTypes(): EntryType[] {
         return [...entryTypeMap.values()]
             .filter((d) => ConfigUtil.isDependentDatasetEnabled(d.type))
@@ -115,9 +112,7 @@ export default class DependentTimelineView extends Vue {
     }
 
     get formattedName(): string {
-        const firstName = this.dependentInfo?.firstname;
-        const lastInitial = this.dependentInfo?.lastname?.slice(0, 1);
-        return [firstName, lastInitial].filter((s) => Boolean(s)).join(" ");
+        return DependentUtil.formatName(this.dependent?.dependentInformation);
     }
 
     get hdid(): string {


### PR DESCRIPTION
# Implements [AB#14959](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14959)

## Description

- adds skeletons for:
   - views/DependentManagementView
   - components/dependent/DependentCardComponent
   - components/dependent/tabs/DependentDashboardTabComponent
- introduces DependentViewSelectorComponent to determine whether to render the new or old page at the /dependents route
   - can be removed once old page is retired
- introduces DependentUtil to handle common functions used by multiple dependent components

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
