### PR TITLE
Dependent Timeline Navigation - Added back arrow button to return to dependents page

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
@@ -9,6 +9,10 @@ export default class PageTitleComponent extends Vue {
     private get hasSlot(): boolean {
         return this.$slots.default !== undefined;
     }
+
+    private get hasPrependSlot(): boolean {
+        return this.$slots.prepend !== undefined;
+    }
 }
 </script>
 
@@ -16,7 +20,9 @@ export default class PageTitleComponent extends Vue {
     <div id="pageTitle">
         <b-row no-gutters class="justify-content-between">
             <b-col cols="auto" sm>
-                <h1 id="subject">{{ title }}</h1>
+                <h1 id="subject">
+                    <slot v-if="hasPrependSlot" name="prepend" /> {{ title }}
+                </h1>
             </b-col>
             <b-col v-if="hasSlot" class="mb-2 ml-2">
                 <slot />

--- a/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
@@ -1,6 +1,7 @@
 <script lang="ts">
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
+    faArrowLeft,
     faCheckCircle,
     faEdit,
     faFileMedical,
@@ -34,6 +35,7 @@ import { ILogger } from "@/services/interfaces";
 import ConfigUtil from "@/utility/configUtil";
 
 library.add(
+    faArrowLeft,
     faCheckCircle,
     faEdit,
     faFileMedical,
@@ -140,6 +142,10 @@ export default class DependentTimelineView extends Vue {
             await this.$router.push({ path: "/unauthorized" });
         }
     }
+
+    handleBack(): void {
+        this.$router.push({ path: "/dependents" });
+    }
 }
 </script>
 
@@ -148,8 +154,31 @@ export default class DependentTimelineView extends Vue {
         <LoadingComponent :is-loading="dependentsAreLoading" />
         <div v-if="!dependentsAreLoading && dependent !== undefined">
             <BreadcrumbComponent :items="breadcrumbItems" />
-            <page-title :title="title" />
+            <b-row class="w-100 h-100">
+                <b-col cols="auto">
+                    <b-button
+                        data-testid="backBtn"
+                        variant="link"
+                        size="sm"
+                        class="back-button-icon mt-2 p-2"
+                        @click="handleBack"
+                    >
+                        <hg-icon icon="arrow-left" size="large" />
+                    </b-button>
+                </b-col>
+                <b-col>
+                    <page-title :title="title" />
+                </b-col>
+            </b-row>
             <TimelineComponent :hdid="hdid" :entry-types="entryTypes" />
         </div>
     </div>
 </template>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/_variables.scss";
+
+.back-button-icon {
+    color: grey;
+}
+</style>

--- a/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
@@ -142,10 +142,6 @@ export default class DependentTimelineView extends Vue {
             await this.$router.push({ path: "/unauthorized" });
         }
     }
-
-    handleBack(): void {
-        this.$router.push({ path: "/dependents" });
-    }
 }
 </script>
 
@@ -154,22 +150,19 @@ export default class DependentTimelineView extends Vue {
         <LoadingComponent :is-loading="dependentsAreLoading" />
         <div v-if="!dependentsAreLoading && dependent !== undefined">
             <BreadcrumbComponent :items="breadcrumbItems" />
-            <b-row class="w-100 h-100">
-                <b-col cols="auto">
+            <page-title :title="title">
+                <template #prepend>
                     <b-button
+                        to="/dependents"
                         data-testid="backBtn"
                         variant="link"
                         size="sm"
-                        class="back-button-icon mt-2 p-2"
-                        @click="handleBack"
+                        class="back-button-icon p-1"
                     >
-                        <hg-icon icon="arrow-left" size="large" />
+                        <hg-icon icon="arrow-left" size="large" square />
                     </b-button>
-                </b-col>
-                <b-col>
-                    <page-title :title="title" />
-                </b-col>
-            </b-row>
+                </template>
+            </page-title>
             <TimelineComponent :hdid="hdid" :entry-types="entryTypes" />
         </div>
     </div>


### PR DESCRIPTION
# Fixes or Implements [AB#14963](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14963)

## Dependent Timeline Navigation

- added back arrow button to return to /dependents page
- used same button as EntryDetailsComponent

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-02-28-154850](https://user-images.githubusercontent.com/16570293/222009241-3fd25366-ff71-4cfb-9b9c-6d2266ac2bb3.png)

![localhost-2023-02-28-155017](https://user-images.githubusercontent.com/16570293/222009402-9a690d4e-6308-4235-b699-ec81960c9922.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
