### PR TITLE
Update card appearance on dependent dashboard tab AB#15052

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/dependent/tabs/DependentDashboardTabComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependent/tabs/DependentDashboardTabComponent.vue
@@ -218,6 +218,7 @@ export default class DependentDashboardTabComponent extends Vue {
             <b-col v-for="entry in entryTypes" :key="entry.type" class="p-3">
                 <hg-card-button
                     :title="entry.name"
+                    dense
                     has-chevron
                     :data-testid="`dependent-entry-type-${dependent.ownerId}`"
                     @click="handleClickEntryType(entry.type)"
@@ -235,6 +236,7 @@ export default class DependentDashboardTabComponent extends Vue {
             <b-col v-if="showFederalProofOfVaccination" class="p-3">
                 <hg-card-button
                     title="Proof of Vaccination"
+                    dense
                     :data-testid="`proof-vaccination-card-btn-${dependent.ownerId}`"
                     @click="showSensitiveDocumentDownloadModal()"
                 >

--- a/Apps/WebClient/src/ClientApp/src/components/shared/HgCardButtonComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/HgCardButtonComponent.vue
@@ -4,9 +4,14 @@ import { Component, Prop } from "vue-property-decorator";
 
 @Component
 export default class HgCardButtonComponent extends Vue {
-    @Prop({ required: true }) title!: string;
+    @Prop({ required: true })
+    title!: string;
 
-    @Prop({ required: false, default: false }) hasChevron!: boolean;
+    @Prop({ required: false, default: false })
+    dense!: boolean;
+
+    @Prop({ required: false, default: false })
+    hasChevron!: boolean;
 
     private get hasIconSlot(): boolean {
         return this.$slots.icon !== undefined;
@@ -24,7 +29,8 @@ export default class HgCardButtonComponent extends Vue {
 
 <template>
     <b-button
-        class="hg-card-button h-100 w-100 p-4 d-flex flex-column align-content-start text-left rounded shadow"
+        class="hg-card-button h-100 w-100 d-flex flex-column align-content-start text-left rounded shadow"
+        :class="{ 'p-3': dense, 'p-4': !dense }"
         v-bind="$attrs"
         v-on="$listeners"
     >
@@ -45,6 +51,7 @@ export default class HgCardButtonComponent extends Vue {
             <b-col
                 data-testid="card-button-title"
                 class="hg-card-button-title mt-3"
+                :class="{ dense: dense }"
             >
                 {{ title }}
             </b-col>
@@ -86,8 +93,10 @@ export default class HgCardButtonComponent extends Vue {
         outline-color 0.15s ease-in-out;
 
     .hg-card-button-title {
-        font-size: 1.2rem;
-        font-weight: bold;
+        &:not(.dense) {
+            font-size: 1.2rem;
+            font-weight: bold;
+        }
 
         // add text-decoration-color to transition
         transition: text-decoration-color 0.15s ease-in-out;


### PR DESCRIPTION
# Implements [AB#15052](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15052)

## Description

Adds a `dense` prop for the card component that reduces padding and the size and weight of the font used in the title.  Updates the dependent dashboard tab to use the dense version for its cards.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-03-02-122226](https://user-images.githubusercontent.com/16570293/222544070-76e3b99d-c173-40cc-ae08-495165e7318c.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
