### PR TITLE
Add and populate total delegate count in DependentModel AB#15029

### DIFF
--- a/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
@@ -133,6 +133,24 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
+        public async Task<DbResult<Dictionary<string, int>>> GetTotalDelegateCountsAsync(IEnumerable<string> dependentHdids)
+        {
+            this.logger.LogTrace("Getting total delegate counts from DB...");
+            string[] dependentArray = dependentHdids.ToArray();
+            DbResult<Dictionary<string, int>> result = new()
+            {
+                Payload = await this.dbContext.ResourceDelegate
+                    .Where(d => dependentArray.Contains(d.ResourceOwnerHdid))
+                    .GroupBy(d => d.ResourceOwnerHdid)
+                    .ToDictionaryAsync(g => g.Key, g => g.Count())
+                    .ConfigureAwait(true),
+                Status = DbStatusCode.Read,
+            };
+            this.logger.LogTrace("Finished getting total delegate counts from DB");
+            return result;
+        }
+
+        /// <inheritdoc/>
         public DbResult<ResourceDelegate> Delete(ResourceDelegate resourceDelegate, bool commit)
         {
             this.logger.LogTrace("Deleting resourceDelegate from DB...");

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -66,6 +66,13 @@ namespace HealthGateway.Database.Delegates
         IDictionary<DateTime, int> GetDailyDependentCount(TimeSpan offset);
 
         /// <summary>
+        /// Gets the total number of delegates associated with each specified dependent from the database.
+        /// </summary>
+        /// <param name="dependentHdids">The HDIDs corresponding to the dependents whose total delegate counts should be retrieved.</param>
+        /// <returns>A dictionary that associates dependent HDIDs with their total number of delegates, wrapped in a DBResult.</returns>
+        Task<DbResult<Dictionary<string, int>>> GetTotalDelegateCountsAsync(IEnumerable<string> dependentHdids);
+
+        /// <summary>
         /// Deletes a Resource Delegate record in the database.
         /// </summary>
         /// <param name="resourceDelegate">The model to be deleted.</param>

--- a/Apps/Database/src/Models/ResourceDelegate.cs
+++ b/Apps/Database/src/Models/ResourceDelegate.cs
@@ -26,19 +26,19 @@ namespace HealthGateway.Database.Models
     public class ResourceDelegate : AuditableEntity
     {
         /// <summary>
-        /// Gets or sets the owner of the hdid.
+        /// Gets or sets the HDID corresponding to the resource owner (the dependent).
         /// </summary>
         [MaxLength(52)]
         public string ResourceOwnerHdid { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets the hdid which has delegated access to the owner Id.
+        /// Gets or sets the HDID corresponding to the user with delegated access to the resources (the delegate).
         /// </summary>
         [MaxLength(52)]
         public string ProfileHdid { get; set; } = null!;
 
         /// <summary>
-        /// Gets or sets reason code for the resource delegate.
+        /// Gets or sets the reason code for the delegation.
         /// </summary>
         [Required]
         [MaxLength(10)]

--- a/Apps/GatewayApi/src/Controllers/DependentController.cs
+++ b/Apps/GatewayApi/src/Controllers/DependentController.cs
@@ -17,7 +17,9 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using System.Collections.Generic;
     using System.Security.Claims;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Services;
@@ -69,9 +71,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Authorize(Policy = UserProfilePolicy.Read)]
         [Route("{hdid}/[controller]")]
-        public RequestResult<IEnumerable<DependentModel>> GetAll(string hdid)
+        public async Task<RequestResult<IEnumerable<DependentModel>>> GetAll(string hdid)
         {
-            return this.dependentService.GetDependents(hdid);
+            return await this.dependentService.GetDependentsAsync(hdid).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -89,13 +91,13 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPost]
         [Authorize(Policy = UserProfilePolicy.Write)]
         [Route("{hdid}/[controller]")]
-        public RequestResult<DependentModel> AddDependent([FromBody] AddDependentRequest addDependentRequest)
+        public async Task<RequestResult<DependentModel>> AddDependent([FromBody] AddDependentRequest addDependentRequest)
         {
             ClaimsPrincipal? user = this.httpContextAccessor.HttpContext?.User;
-            var delegateHdId = user?.FindFirst("hdid")?.Value ?? string.Empty;
-            var result = this.dependentService.AddDependent(delegateHdId, addDependentRequest);
+            string delegateHdId = user?.FindFirst("hdid")?.Value ?? string.Empty;
+            RequestResult<DependentModel> result = await this.dependentService.AddDependentAsync(delegateHdId, addDependentRequest).ConfigureAwait(true);
 
-            if (result.ResultStatus == Common.Data.Constants.ResultType.Error)
+            if (result.ResultStatus == ResultType.Error)
             {
                 this.logger.LogError("Error adding a dependent: {Error}", result.ResultError);
             }

--- a/Apps/GatewayApi/src/Controllers/PhsaController.cs
+++ b/Apps/GatewayApi/src/Controllers/PhsaController.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
@@ -59,9 +60,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Authorize(Policy = SystemDelegatedPatientPolicy.Read)]
         [Route("dependents/{hdid}")]
-        public ActionResult<RequestResult<IEnumerable<DependentModel>>> GetAll(string hdid)
+        public async Task<ActionResult<RequestResult<IEnumerable<DependentModel>>>> GetAll(string hdid)
         {
-            return this.dependentService.GetDependents(hdid);
+            return await this.dependentService.GetDependentsAsync(hdid).ConfigureAwait(true);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/MapUtils/DependentMapUtils.cs
+++ b/Apps/GatewayApi/src/MapUtils/DependentMapUtils.cs
@@ -1,0 +1,46 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+
+namespace HealthGateway.GatewayApi.MapUtils
+{
+    using AutoMapper;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Database.Models;
+    using HealthGateway.GatewayApi.Models;
+
+    /// <summary>
+    /// Static Helper classes for conversion of model objects.
+    /// </summary>
+    public static class DependentMapUtils
+    {
+        /// <summary>
+        /// Converts a ResourceDelegate and PatientModel to a DependentModel.
+        /// </summary>
+        /// <param name="resourceDelegate">The DB model for the resource delegate.</param>
+        /// <param name="patientModel">The DB model for the dependent's patient information.</param>
+        /// <param name="totalDelegateCount">The total number of delegates with access to the dependent.</param>
+        /// <param name="autoMapper">The automapper to use.</param>
+        /// <returns>A DependentModel.</returns>
+        public static DependentModel CreateFromDbModels(ResourceDelegate resourceDelegate, PatientModel patientModel, int totalDelegateCount, IMapper autoMapper)
+        {
+            DependentModel dependent = autoMapper.Map<ResourceDelegate, DependentModel>(resourceDelegate);
+            dependent.DependentInformation = autoMapper.Map<PatientModel, DependentInformation>(patientModel);
+            dependent.TotalDelegateCount = totalDelegateCount;
+
+            return dependent;
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Models/DependentModel.cs
+++ b/Apps/GatewayApi/src/Models/DependentModel.cs
@@ -38,6 +38,11 @@ namespace HealthGateway.GatewayApi.Models
         public string DelegateId { get; set; } = null!;
 
         /// <summary>
+        /// Gets or sets the total number of users that have delegated access to this dependent.
+        /// </summary>
+        public int TotalDelegateCount { get; set; }
+
+        /// <summary>
         /// Gets or sets the delegate reason code.
         /// </summary>
         public ResourceDelegateReason ReasonCode { get; set; }

--- a/Apps/GatewayApi/src/Services/IDependentService.cs
+++ b/Apps/GatewayApi/src/Services/IDependentService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
 
@@ -32,7 +33,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="page">The page of data to fetch indexed from 0.</param>
         /// <param name="pageSize">The amount of records per page.</param>
         /// <returns>A List of dependents wrapped in a RequestResult.</returns>
-        RequestResult<IEnumerable<DependentModel>> GetDependents(string hdId, int page = 0, int pageSize = 500);
+        Task<RequestResult<IEnumerable<DependentModel>>> GetDependentsAsync(string hdId, int page = 0, int pageSize = 500);
 
         /// <summary>
         /// Gets all the dependents for the given date range.
@@ -50,7 +51,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="delegateHdId">The HdId of the Delegate (parent or guardian).</param>
         /// <param name="addDependentRequest">The request to create a User Delegate model.</param>
         /// <returns>A dependent model wrapped in a RequestResult.</returns>
-        RequestResult<DependentModel> AddDependent(string delegateHdId, AddDependentRequest addDependentRequest);
+        Task<RequestResult<DependentModel>> AddDependentAsync(string delegateHdId, AddDependentRequest addDependentRequest);
 
         /// <summary>
         /// Removes a dependent delegate relation.

--- a/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
     using System;
     using System.Collections.Generic;
     using System.Security.Claims;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -44,39 +45,41 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         private readonly string lastname = "DependentName";
 
         /// <summary>
-        /// GetDependents - Happy path scenario.
+        /// GetDependentsAsync - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetDependents()
+        public async Task ShouldGetDependents()
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
             Mock<IDependentService> dependentServiceMock = new();
-            IEnumerable<DependentModel> expectedDependends = GetMockDependends();
+            IEnumerable<DependentModel> expectedDependents = GetMockDependents();
             RequestResult<IEnumerable<DependentModel>> expectedResult = new()
             {
-                ResourcePayload = expectedDependends,
+                ResourcePayload = expectedDependents,
                 ResultStatus = ResultType.Success,
             };
-            dependentServiceMock.Setup(s => s.GetDependents(this.hdid, 0, 500)).Returns(expectedResult);
+            dependentServiceMock.Setup(s => s.GetDependentsAsync(this.hdid, 0, 500)).ReturnsAsync(expectedResult);
 
             DependentController dependentController = new(
                 new Mock<ILogger<DependentController>>().Object,
                 dependentServiceMock.Object,
                 httpContextAccessorMock.Object);
-            RequestResult<IEnumerable<DependentModel>> actualResult = dependentController.GetAll(this.hdid);
+            RequestResult<IEnumerable<DependentModel>> actualResult = await dependentController.GetAll(this.hdid).ConfigureAwait(true);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
 
         /// <summary>
-        /// AddDependent - Happy path scenario.
+        /// AddDependentAsync - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldAddDependent()
+        public async Task ShouldAddDependent()
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
             Mock<IDependentService> dependentServiceMock = new();
-            DependentModel expectedDependend = new()
+            DependentModel expectedDependent = new()
             {
                 OwnerId = "OWNER",
                 DelegateId = "DELEGATER",
@@ -91,16 +94,16 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
             RequestResult<DependentModel> expectedResult = new()
             {
-                ResourcePayload = expectedDependend,
+                ResourcePayload = expectedDependent,
                 ResultStatus = ResultType.Success,
             };
-            dependentServiceMock.Setup(s => s.AddDependent(this.hdid, It.IsAny<AddDependentRequest>())).Returns(expectedResult);
+            dependentServiceMock.Setup(s => s.AddDependentAsync(this.hdid, It.IsAny<AddDependentRequest>())).ReturnsAsync(expectedResult);
 
             DependentController dependentController = new(
                 new Mock<ILogger<DependentController>>().Object,
                 dependentServiceMock.Object,
                 httpContextAccessorMock.Object);
-            RequestResult<DependentModel> actualResult = dependentController.AddDependent(new AddDependentRequest());
+            RequestResult<DependentModel> actualResult = await dependentController.AddDependent(new AddDependentRequest()).ConfigureAwait(true);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -165,7 +168,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
 
-        private static IEnumerable<DependentModel> GetMockDependends()
+        private static IEnumerable<DependentModel> GetMockDependents()
         {
             List<DependentModel> dependentModels = new();
 

--- a/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -37,10 +38,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         private readonly DateTime toDate = DateTime.UtcNow.AddDays(1);
 
         /// <summary>
-        /// GetDependents by hdid - Happy path scenario.
+        /// GetDependentsAsync by hdid - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetDependentsByHdid()
+        public async Task ShouldGetDependentsByHdid()
         {
             Mock<IDependentService> dependentServiceMock = new();
             IEnumerable<DependentModel> expectedDependents = GetMockDependentModels();
@@ -49,11 +51,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 ResourcePayload = expectedDependents,
                 ResultStatus = ResultType.Success,
             };
-            dependentServiceMock.Setup(s => s.GetDependents(this.hdid, 0, 500)).Returns(expectedResult);
+            dependentServiceMock.Setup(s => s.GetDependentsAsync(this.hdid, 0, 500)).ReturnsAsync(expectedResult);
 
             PhsaController phsaController = new(
                 dependentServiceMock.Object);
-            ActionResult<RequestResult<IEnumerable<DependentModel>>> actualResult = phsaController.GetAll(this.hdid);
+            ActionResult<RequestResult<IEnumerable<DependentModel>>> actualResult = await phsaController.GetAll(this.hdid).ConfigureAwait(true);
 
             RequestResult<IEnumerable<DependentModel>>? actualRequestResult = actualResult.Value;
             expectedResult.ShouldDeepEqual(actualRequestResult);


### PR DESCRIPTION
# Implements [AB#15029](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15029)

## Description

- adds new DB delegate method for retrieving total delegate counts
- updates DependentService when adding and retrieving dependents to call new DB delegate method to populate a corresponding property added to DependentModel
- updates unit tests

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
