### PR TITLE
Refactor PatientModel to include legal and common name objects AB#15020

### DIFF
--- a/Apps/Patient/src/Controllers/PatientController.cs
+++ b/Apps/Patient/src/Controllers/PatientController.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.Patient.Controllers
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
+    using HealthGateway.Patient.Models;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -89,7 +90,7 @@ namespace HealthGateway.Patient.Controllers
         /// <response code="502">Unable to get response from client registry.</response>
         [HttpGet]
         [Produces("application/json")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApiResult<PatientModel>))]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApiResult<PatientModelV2>))]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]

--- a/Apps/Patient/src/Delegates/IClientRegistriesDelegate.cs
+++ b/Apps/Patient/src/Delegates/IClientRegistriesDelegate.cs
@@ -18,7 +18,7 @@ namespace HealthGateway.Patient.Delegates
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
+    using HealthGateway.Patient.Models;
 
     /// <summary>
     /// The Patient data service.
@@ -32,6 +32,6 @@ namespace HealthGateway.Patient.Delegates
         /// <param name="identifier">The associated oid type's identifier to retrieve the patient demographics information.</param>
         /// <param name="disableIdValidation">Disables the validation on HDID/PHN when true.</param>
         /// <returns>The patient model wrapped in an api result object.</returns>
-        Task<ApiResult<PatientModel>> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false);
+        Task<ApiResult<PatientModelV2>> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false);
     }
 }

--- a/Apps/Patient/src/Models/Name.cs
+++ b/Apps/Patient/src/Models/Name.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Patient.Models
+{
+    /// <summary>
+    ///  Represents the name of a person.
+    /// </summary>
+    public class Name
+    {
+        /// <summary>
+        /// Gets or sets the given name of a person.
+        /// </summary>
+        public string GivenName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the surname of a person.
+        /// </summary>
+        public string Surname { get; set; } = string.Empty;
+    }
+}

--- a/Apps/Patient/src/Models/PatientModelV2.cs
+++ b/Apps/Patient/src/Models/PatientModelV2.cs
@@ -41,19 +41,19 @@ namespace HealthGateway.Patient.Models
         /// Gets or sets the patient's common name.
         /// </summary>
         [JsonPropertyName("commonName")]
-        public Name? CommonName { get; set; } = new();
+        public Name? CommonName { get; set; }
 
         /// <summary>
         /// Gets or sets the patient's legal name.
         /// </summary>
         [JsonPropertyName("legalName")]
-        public Name LegalName { get; set; } = null!;
+        public Name? LegalName { get; set; }
 
         /// <summary>
         /// Gets the patient's preferred name.
         /// </summary>
         [JsonPropertyName("preferredName")]
-        public Name PreferredName => this.CommonName ?? this.LegalName;
+        public Name PreferredName => this.CommonName ?? this.LegalName!;
 
         /// <summary>
         /// Gets or sets the patient's date of birth.

--- a/Apps/Patient/src/Models/PatientModelV2.cs
+++ b/Apps/Patient/src/Models/PatientModelV2.cs
@@ -1,0 +1,85 @@
+﻿//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Patient.Models
+{
+    using System;
+    using System.Text.Json.Serialization;
+    using HealthGateway.Common.Models;
+
+    /// <summary>
+    /// The patient data model.
+    /// </summary>
+    public class PatientModelV2
+    {
+        /// <summary>
+        /// Gets or sets the health directed identifier.
+        /// </summary>
+        [JsonPropertyName("hdid")]
+        public string HdId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the patient's PHN.
+        /// </summary>
+        [JsonPropertyName("personalHealthNumber")]
+        public string PersonalHealthNumber { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the patient's common name.
+        /// </summary>
+        [JsonPropertyName("commonName")]
+        public Name? CommonName { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the patient's legal name.
+        /// </summary>
+        [JsonPropertyName("legalName")]
+        public Name LegalName { get; set; } = null!;
+
+        /// <summary>
+        /// Gets the patient's preferred name.
+        /// </summary>
+        [JsonPropertyName("preferredName")]
+        public Name PreferredName => this.CommonName ?? this.LegalName;
+
+        /// <summary>
+        /// Gets or sets the patient's date of birth.
+        /// </summary>
+        [JsonPropertyName("birthdate")]
+        public DateTime Birthdate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the patient's gender.
+        /// </summary>
+        [JsonPropertyName("gender")]
+        public string Gender { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the physical address for the patient.
+        /// </summary>
+        public Address? PhysicalAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the postal address for the patient.
+        /// </summary>
+        public Address? PostalAddress { get; set; }
+
+        /// <summary>
+        /// Gets or sets the response code for the patient.
+        /// </summary>
+        public string ResponseCode { get; set; } = string.Empty;
+    }
+}

--- a/Apps/Patient/src/Services/IPatientService.cs
+++ b/Apps/Patient/src/Services/IPatientService.cs
@@ -18,7 +18,7 @@ namespace HealthGateway.Patient.Services
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
+    using HealthGateway.Patient.Models;
 
     /// <summary>
     /// The Patient data service.
@@ -32,6 +32,6 @@ namespace HealthGateway.Patient.Services
         /// <param name="identifierType">The type of identifier being passed in.</param>
         /// <param name="disableIdValidation">Disables the validation on HDID/PHN when true.</param>
         /// <returns>The patient model.</returns>
-        Task<ApiResult<PatientModel>> GetPatient(string identifier, PatientIdentifierType identifierType = PatientIdentifierType.Hdid, bool disableIdValidation = false);
+        Task<ApiResult<PatientModelV2>> GetPatient(string identifier, PatientIdentifierType identifierType = PatientIdentifierType.Hdid, bool disableIdValidation = false);
     }
 }

--- a/Apps/Patient/src/Services/PatientService.cs
+++ b/Apps/Patient/src/Services/PatientService.cs
@@ -24,8 +24,8 @@ namespace HealthGateway.Patient.Services
     using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.Validations;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
     using HealthGateway.Patient.Delegates;
+    using HealthGateway.Patient.Models;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -67,11 +67,11 @@ namespace HealthGateway.Patient.Services
         private static ActivitySource Source { get; } = new(nameof(PatientService));
 
         /// <inheritdoc/>
-        public async Task<ApiResult<PatientModel>> GetPatient(string identifier, PatientIdentifierType identifierType = PatientIdentifierType.Hdid, bool disableIdValidation = false)
+        public async Task<ApiResult<PatientModelV2>> GetPatient(string identifier, PatientIdentifierType identifierType = PatientIdentifierType.Hdid, bool disableIdValidation = false)
         {
             using Activity? activity = Source.StartActivity();
 
-            ApiResult<PatientModel> apiResult = new()
+            ApiResult<PatientModelV2> apiResult = new()
             {
                 ResourcePayload = this.GetFromCache(identifier, identifierType),
             };
@@ -112,22 +112,22 @@ namespace HealthGateway.Patient.Services
         /// <param name="identifier">The resource identifier used to determine the key to use.</param>
         /// <param name="identifierType">The type of patient identifier we are searching for.</param>
         /// <returns>The found Patient model or null.</returns>
-        private PatientModel? GetFromCache(string identifier, PatientIdentifierType identifierType)
+        private PatientModelV2? GetFromCache(string identifier, PatientIdentifierType identifierType)
         {
             using Activity? activity = Source.StartActivity();
-            PatientModel? retPatient = null;
+            PatientModelV2? retPatient = null;
             if (this.cacheTtl > 0)
             {
                 switch (identifierType)
                 {
                     case PatientIdentifierType.Hdid:
                         this.logger.LogDebug("Querying Patient Cache by HDID");
-                        retPatient = this.cacheProvider.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{identifier}");
+                        retPatient = this.cacheProvider.GetItem<PatientModelV2>($"{PatientCacheDomain}:HDID:{identifier}");
                         break;
 
                     case PatientIdentifierType.Phn:
                         this.logger.LogDebug("Querying Patient Cache by PHN");
-                        retPatient = this.cacheProvider.GetItem<PatientModel>($"{PatientCacheDomain}:PHN:{identifier}");
+                        retPatient = this.cacheProvider.GetItem<PatientModelV2>($"{PatientCacheDomain}:PHN:{identifier}");
                         break;
                 }
 
@@ -143,7 +143,7 @@ namespace HealthGateway.Patient.Services
         /// Caches the Patient model if enabled.
         /// </summary>
         /// <param name="patient">The patient to cache.</param>
-        private void CachePatient(PatientModel patient)
+        private void CachePatient(PatientModelV2 patient)
         {
             using Activity? activity = Source.StartActivity();
             string hdid = patient.HdId;

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.PatientTests.Controllers
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Patient.Controllers;
+    using HealthGateway.Patient.Models;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
     using Moq;
@@ -88,7 +89,7 @@ namespace HealthGateway.PatientTests.Controllers
             Assert.IsType<OkObjectResult>(actualResult);
             OkObjectResult? okResult = actualResult as OkObjectResult;
             Assert.Equal(StatusCodes.Status200OK, okResult?.StatusCode);
-            ApiResult<PatientModel> apiResult = Assert.IsAssignableFrom<ApiResult<PatientModel>>(okResult?.Value);
+            ApiResult<PatientModelV2> apiResult = Assert.IsAssignableFrom<ApiResult<PatientModelV2>>(okResult?.Value);
             Assert.Equal(MockedHdId, apiResult.ResourcePayload!.HdId);
         }
 
@@ -117,6 +118,34 @@ namespace HealthGateway.PatientTests.Controllers
             };
         }
 
+        private static PatientModelV2 GetPatientModelV2()
+        {
+            return new()
+            {
+                Birthdate = MockedBirthDate,
+                CommonName = new Name
+                {
+                    GivenName = MockedFirstName,
+                    Surname = MockedLastName,
+                },
+                Gender = MockedGender,
+                HdId = MockedHdId,
+                PersonalHealthNumber = MockedPersonalHealthNumber,
+                PhysicalAddress = new Address
+                {
+                    City = "Victoria",
+                    State = "BC",
+                    Country = "CA",
+                },
+                PostalAddress = new Address
+                {
+                    City = "Vancouver",
+                    State = "BC",
+                    Country = "CA",
+                },
+            };
+        }
+
         private static PatientController GetPatientController()
         {
             Mock<IPatientService> patientServiceV1 = new();
@@ -127,9 +156,9 @@ namespace HealthGateway.PatientTests.Controllers
                 ResourcePayload = GetPatientModel(),
             };
 
-            ApiResult<PatientModel> apiResult = new()
+            ApiResult<PatientModelV2> apiResult = new()
             {
-                ResourcePayload = GetPatientModel(),
+                ResourcePayload = GetPatientModelV2(),
             };
 
             patientServiceV2.Setup(x => x.GetPatient(It.IsAny<string>(), PatientIdentifierType.Hdid, false)).ReturnsAsync(apiResult);

--- a/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Patient/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.PatientTests.Delegates
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
     using HealthGateway.Patient.Delegates;
+    using HealthGateway.Patient.Models;
     using Microsoft.Extensions.Logging;
     using Moq;
     using ServiceReference;
@@ -347,13 +348,13 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
 
             // Verify
             Assert.Equal(expectedHdId, actual.ResourcePayload?.HdId);
             Assert.Equal(expectedPhn, actual.ResourcePayload?.PersonalHealthNumber);
-            Assert.Equal(expectedFirstName, actual.ResourcePayload?.FirstName);
-            Assert.Equal(expectedLastName, actual.ResourcePayload?.LastName);
+            Assert.Equal(expectedFirstName, actual.ResourcePayload?.PreferredName.GivenName);
+            Assert.Equal(expectedLastName, actual.ResourcePayload?.PreferredName.Surname);
             Assert.Equal(expectedBirthDate, actual.ResourcePayload?.Birthdate);
             Assert.Equal(expectedGender, actual.ResourcePayload?.Gender);
             expectedPhysicalAddr.ShouldDeepEqual(actual.ResourcePayload?.PhysicalAddress);
@@ -578,13 +579,13 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
 
             // Verify
             Assert.Equal(expectedHdId, actual.ResourcePayload?.HdId);
             Assert.Equal(expectedPhn, actual.ResourcePayload?.PersonalHealthNumber);
-            Assert.Equal(expectedFirstName, actual.ResourcePayload?.FirstName);
-            Assert.Equal(expectedLastName, actual.ResourcePayload?.LastName);
+            Assert.Equal(expectedFirstName, actual.ResourcePayload?.PreferredName.GivenName);
+            Assert.Equal(expectedLastName, actual.ResourcePayload?.PreferredName.Surname);
             Assert.Equal(expectedBirthDate, actual.ResourcePayload?.Birthdate);
             Assert.Equal(expectedGender, actual.ResourcePayload?.Gender);
         }
@@ -726,13 +727,13 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
 
             // Verify
             Assert.Equal(expectedHdId, actual.ResourcePayload?.HdId);
             Assert.Equal(expectedPhn, actual.ResourcePayload?.PersonalHealthNumber);
-            Assert.Equal(expectedFirstName, actual.ResourcePayload?.FirstName);
-            Assert.Equal(expectedLastName, actual.ResourcePayload?.LastName);
+            Assert.Equal(expectedFirstName, actual.ResourcePayload?.PreferredName.GivenName);
+            Assert.Equal(expectedLastName, actual.ResourcePayload?.PreferredName.Surname);
             Assert.Equal(expectedBirthDate, actual.ResourcePayload?.Birthdate);
             Assert.Equal(expectedGender, actual.ResourcePayload?.Gender);
         }
@@ -833,7 +834,7 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0019", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -935,7 +936,7 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0021", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -1037,7 +1038,7 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0022", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -1139,7 +1140,7 @@ namespace HealthGateway.PatientTests.Delegates
                 clientMock.Object);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0023", actual.ResourcePayload?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -1220,7 +1221,7 @@ namespace HealthGateway.PatientTests.Delegates
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, true);
 
             // Act
-            ApiResult<PatientModel> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn, true).ConfigureAwait(true);
+            ApiResult<PatientModelV2> actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn, true).ConfigureAwait(true);
 
             // Verify
             Assert.NotNull(actual.ResourcePayload);

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -22,8 +22,8 @@ namespace HealthGateway.PatientTests.Services
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.ViewModels;
-    using HealthGateway.Common.Models;
     using HealthGateway.Patient.Delegates;
+    using HealthGateway.Patient.Models;
     using HealthGateway.Patient.Services;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -48,7 +48,7 @@ namespace HealthGateway.PatientTests.Services
             IPatientService service = GetPatientService(Phn, Hdid);
 
             // Act
-            ApiResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Hdid).ConfigureAwait(true)).Result;
+            ApiResult<PatientModelV2> actual = Task.Run(async () => await service.GetPatient(Hdid).ConfigureAwait(true)).Result;
 
             // Verify
             Assert.Equal(Hdid, actual.ResourcePayload?.HdId);
@@ -64,7 +64,7 @@ namespace HealthGateway.PatientTests.Services
             IPatientService service = GetPatientService(Phn, Hdid, true);
 
             // Act
-            ApiResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Hdid).ConfigureAwait(true)).Result;
+            ApiResult<PatientModelV2> actual = Task.Run(async () => await service.GetPatient(Hdid).ConfigureAwait(true)).Result;
 
             // Verify
             Assert.Equal(Hdid, actual.ResourcePayload?.HdId);
@@ -80,7 +80,7 @@ namespace HealthGateway.PatientTests.Services
             IPatientService service = GetPatientService(Phn, Phn, true);
 
             // Act
-            ApiResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
+            ApiResult<PatientModelV2> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
 
             // Verify
             Assert.Equal(Hdid, actual.ResourcePayload?.HdId);
@@ -96,7 +96,7 @@ namespace HealthGateway.PatientTests.Services
             IPatientService service = GetPatientService(Phn, Phn);
 
             // Act
-            ApiResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
+            ApiResult<PatientModelV2> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
 
             // Verify
             Assert.Equal(Phn, actual.ResourcePayload?.PersonalHealthNumber);
@@ -127,12 +127,15 @@ namespace HealthGateway.PatientTests.Services
 
         private static IPatientService GetPatientService(string expectedPhn, string expectedIdentifier, bool returnValidCache = false)
         {
-            ApiResult<PatientModel> requestResult = new()
+            ApiResult<PatientModelV2> requestResult = new()
             {
-                ResourcePayload = new PatientModel
+                ResourcePayload = new PatientModelV2
                 {
-                    FirstName = "John",
-                    LastName = "Doe",
+                    CommonName = new Name
+                    {
+                        GivenName = "John",
+                        Surname = "Doe",
+                    },
                     PersonalHealthNumber = expectedPhn,
                     HdId = Hdid,
                 },
@@ -152,7 +155,7 @@ namespace HealthGateway.PatientTests.Services
             Mock<ICacheProvider> cacheProviderMock = new();
             if (returnValidCache)
             {
-                cacheProviderMock.Setup(p => p.GetItem<PatientModel>(It.IsAny<string>())).Returns(requestResult.ResourcePayload);
+                cacheProviderMock.Setup(p => p.GetItem<PatientModelV2>(It.IsAny<string>())).Returns(requestResult.ResourcePayload);
             }
 
             return new PatientService(

--- a/Apps/WebClient/src/ClientApp/src/components/report/ReportsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/ReportsComponent.vue
@@ -130,10 +130,12 @@ export default class ReportsComponent extends Vue {
 
     get headerData(): ReportHeader {
         return {
-            phn: this.patientData.personalhealthnumber,
+            phn: this.patientData.personalHealthNumber,
             dateOfBirth: this.formatDate(this.patientData.birthdate || ""),
             name: this.patientData
-                ? this.patientData.firstname + " " + this.patientData.lastname
+                ? this.patientData.preferredName.givenName +
+                  " " +
+                  this.patientData.preferredName.surname
                 : "",
             isRedacted: this.reportFilter.hasMedicationsFilter(),
             datePrinted: new DateWrapper(new DateWrapper().toISO()).format(),

--- a/Apps/WebClient/src/ClientApp/src/models/patientData.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/patientData.ts
@@ -2,12 +2,18 @@ import { StringISODate } from "@/models/dateWrapper";
 
 export default class PatientData {
     public hdid!: string;
-    public personalhealthnumber!: string;
-    public firstname!: string;
-    public lastname!: string;
+    public personalHealthNumber!: string;
+    public preferredName!: Name;
+    public commonName: Name | undefined;
+    public legalName: Name | undefined;
     public birthdate?: StringISODate;
     public physicalAddress?: Address;
     public postalAddress?: Address;
+}
+
+export class Name {
+    public givenName: string | undefined;
+    public surname: string | undefined;
 }
 
 export class Address {

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -151,7 +151,7 @@ export default class ProfileView extends Vue {
     }
 
     private get phn(): string {
-        return this.patientData.personalhealthnumber;
+        return this.patientData.personalHealthNumber;
     }
 
     private get isEmptyEmail(): boolean {


### PR DESCRIPTION
# Fixes or Implements [AB#15020](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15020)

## Description
Post a clarification of the intended outcome of the task, the work has been completed focusing only on the refactor of the Patient project's delegate and controller to leave V1 intact and unaffected.

1. Patient project's controller, service and delegate for patient information has been refactored to return PatientModelV2.
2. Unit Tests have been updated
3. WebClient changes have been performed to consume the updated name objects and the update naming convention of personalHealthNumber.
4. Functional tests are returning correctly.


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
### Profile page PHN value
`personalhealthnumber` => `personalHealthNumber`
<img width="188" alt="image" src="https://user-images.githubusercontent.com/19548348/223234297-46d50167-4e2e-4fe4-83b0-8ffeb1430a49.png">

### Report header:
PatientModel v1 properties to  PatientModelV2.preferredName properties
![image](https://user-images.githubusercontent.com/19548348/223236118-05632fe1-1d2a-4c72-9288-75d98c704037.png)

### Swagger Models:
#### V1:
![image](https://user-images.githubusercontent.com/19548348/223236482-e324bed8-7086-4b02-9e63-63ec104116a5.png)

#### V2:
![image](https://user-images.githubusercontent.com/19548348/223238344-e13674c6-6489-4c0b-878e-c8fe9f848560.png)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
