### PR TITLE
Add profile tab to dependent management page AB#15030

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/dependent/DependentCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependent/DependentCardComponent.vue
@@ -4,6 +4,7 @@ import { Component, Prop, Ref } from "vue-property-decorator";
 import { Action, Getter } from "vuex-class";
 
 import DependentDashboardTabComponent from "@/components/dependent/tabs/DependentDashboardTabComponent.vue";
+import DependentProfileTabComponent from "@/components/dependent/tabs/DependentProfileTabComponent.vue";
 import DeleteModalComponent from "@/components/modal/DeleteModalComponent.vue";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper } from "@/models/dateWrapper";
@@ -16,6 +17,7 @@ const options: any = {
     components: {
         DeleteModalComponent,
         DependentDashboardTabComponent,
+        DependentProfileTabComponent,
     },
 };
 
@@ -119,6 +121,14 @@ export default class DependentCardComponent extends Vue {
                         v-else
                         :dependent="dependent"
                     />
+                </b-tab>
+                <b-tab
+                    no-body
+                    :disabled="isExpired"
+                    title="Profile"
+                    data-testid="profile-tab"
+                >
+                    <DependentProfileTabComponent :dependent="dependent" />
                 </b-tab>
             </b-tabs>
         </b-card>

--- a/Apps/WebClient/src/ClientApp/src/components/dependent/tabs/DependentProfileTabComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/dependent/tabs/DependentProfileTabComponent.vue
@@ -1,0 +1,78 @@
+<script lang="ts">
+import Vue from "vue";
+import { Component, Prop } from "vue-property-decorator";
+
+import { DateWrapper, StringISODate } from "@/models/dateWrapper";
+import type { Dependent } from "@/models/dependent";
+
+@Component
+export default class DependentProfileTabComponent extends Vue {
+    @Prop({ required: true })
+    private dependent!: Dependent;
+
+    private get otherDelegateCount(): number {
+        return this.dependent.totalDelegateCount - 1;
+    }
+
+    private formatDate(date: StringISODate): string {
+        return new DateWrapper(date).format();
+    }
+}
+</script>
+<template>
+    <b-row cols="1" cols-lg="2" cols-xl="3" class="mb-n3">
+        <b-col class="mb-3">
+            <div>PHN</div>
+            <b-form-input
+                v-model="dependent.dependentInformation.PHN"
+                data-testid="dependent-phn"
+                readonly
+            />
+        </b-col>
+        <b-col class="mb-3">
+            <div>Date of Birth</div>
+            <b-form-input
+                :value="formatDate(dependent.dependentInformation.dateOfBirth)"
+                data-testid="dependent-date-of-birth"
+                readonly
+            />
+        </b-col>
+        <b-col class="mb-3">
+            <div>How Many Others Have Access</div>
+            <b-form-input
+                v-model="otherDelegateCount"
+                data-testid="dependent-other-delegate-count"
+                readonly
+            />
+            <small
+                :id="`other-delegate-info-${dependent.ownerId}`"
+                class="interactable-text"
+            >
+                What does this mean?
+            </small>
+            <b-popover
+                :target="`other-delegate-info-${dependent.ownerId}`"
+                triggers="hover focus"
+                placement="bottom"
+                boundary="viewport"
+                :data-testid="`other-delegate-info-popover-${dependent.ownerId}`"
+            >
+                This shows you how many people other than you have added your
+                dependent to their Health Gateway account. For privacy, we can’t
+                tell you their names. If this number isn’t what you expect,
+                contact us at
+                <a href="mailto:HealthGateway@gov.bc.ca"
+                    >HealthGateway@gov.bc.ca</a
+                >.
+            </b-popover>
+        </b-col>
+    </b-row>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/_variables.scss";
+
+.interactable-text {
+    color: $hg-link;
+}
+</style>

--- a/Apps/WebClient/src/ClientApp/src/models/dependent.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/dependent.ts
@@ -50,6 +50,11 @@ export interface Dependent {
     delegateId: string;
 
     /**
+     * The total number of users that have delegated access to this dependent.
+     */
+    totalDelegateCount: number;
+
+    /**
      * Code that defines the reason for delegation.
      */
     reasonCode: number;


### PR DESCRIPTION
# Implements [AB#15030](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15030)

## Description

Adds new tab to dependent card with fields for the PHN, Date of Birth, and number of other delegates.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screenshot 2023-03-06 163541](https://user-images.githubusercontent.com/16570293/223292968-fbbd488c-6309-4059-b47c-8449f5e9b6c0.png)

![localhost-2023-03-06-165015](https://user-images.githubusercontent.com/16570293/223292977-78db4542-1686-4727-ae16-bff407306727.png)

![localhost-2023-03-06-165220](https://user-images.githubusercontent.com/16570293/223292988-9d419b38-61ef-4601-8360-01110f9c4894.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
