### PR TITLE
Add spacing between timeline card title and date AB#15066

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntrycardTimelineComponent.vue
@@ -137,7 +137,7 @@ export default class EntrycardTimelineComponent extends Vue {
                                 <strong>{{ displayTitle }}</strong>
                             </span>
                         </b-col>
-                        <b-col cols="auto" class="text-right text-nowrap">
+                        <b-col cols="auto" class="text-right text-nowrap ml-3">
                             <span
                                 class="text-muted small"
                                 data-testid="entryCardDate"


### PR DESCRIPTION
# Implements [AB#15066](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15066)

## Description

Adds a left margin to the date in the timeline card header.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-03-08-124246](https://user-images.githubusercontent.com/16570293/223845680-1ae0ddd8-42f5-423b-914e-6c1371532285.png)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
