### PR TITLE
Prevent scroll on mobile when menu open AB#15068

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
@@ -88,6 +88,17 @@ export default class SidebarComponent extends Vue {
         this.clearOverlay();
     }
 
+    @Watch("isOpen")
+    @Watch("isMobileWidth")
+    private onIsSidebarOpenChange(isOpen: boolean): void {
+        console.log("Checking");
+        if (this.isMobileWidth && isOpen) {
+            document.body.classList.add("overflow-hidden");
+        } else {
+            document.body.classList.remove("overflow-hidden");
+        }
+    }
+
     private created(): void {
         this.logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
     }

--- a/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/navmenu/SidebarComponent.vue
@@ -91,7 +91,6 @@ export default class SidebarComponent extends Vue {
     @Watch("isOpen")
     @Watch("isMobileWidth")
     private onIsSidebarOpenChange(isOpen: boolean): void {
-        console.log("Checking");
         if (this.isMobileWidth && isOpen) {
             document.body.classList.add("overflow-hidden");
         } else {


### PR DESCRIPTION
# Fixes or Implements [AB#15068](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15068)

## Description
Monitor conditions to block scrolling to improve usability of the mobile menu
Monitor for isMobileWidth changes as well in the fringe possibility of the following scenario:

1. Sight opens up on small window.
2. Menu is opened -> overflow-hidden is applied to body
3. Window is resized till the menu is in a large enough to be ever present -> overflow-hidden needs to be removed. 

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
Menu open and class applied:
![image](https://user-images.githubusercontent.com/19548348/223873480-8408f210-4d4e-4744-b67d-61f51c9155a1.png)

Menu closed and class removed:
![image](https://user-images.githubusercontent.com/19548348/223873585-bc0f9ccf-6442-4954-bd0d-4a38cb6b48fa.png)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
