### PR TITLE
Replace Material icons with Font Awesome icons AB#15067

### DIFF
--- a/Apps/Admin/Client/Components/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/BroadcastsTable.razor
@@ -54,19 +54,19 @@
             <div>
                 <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">
                     <MudIconButton OnClick="@(() => ToggleExpandRow(context.Id))"
-                                   Icon="@(context.IsExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                   Icon="@(context.IsExpanded ? "fas fa-chevron-up" : "fas fa-chevron-down")"
                                    Color="@Color.Primary"
                                    data-testid="broadcast-table-expand-btn" />
                 </MudTooltip>
                 <MudTooltip Text="Edit">
                     <MudIconButton OnClick="@(async () => await EditBroadcastAsync(context.Id))"
-                                   Icon="@Icons.Material.Filled.Edit"
+                                   Icon="fas fa-pen"
                                    Color="@Color.Primary"
                                    data-testid="broadcast-table-edit-btn" />
                 </MudTooltip>
                 <MudTooltip Text="Delete">
                     <MudIconButton OnClick="@(() => DeleteBroadcast(context.Id))"
-                                   Icon="@Icons.Material.Filled.Delete"
+                                   Icon="fas fa-trash"
                                    Color="@Color.Primary"
                                    data-testid="broadcast-table-delete-btn" />
                 </MudTooltip>
@@ -95,7 +95,7 @@
         </span>
     </MessageContent>
     <YesButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteForever" data-testid="confirm-delete-btn">
+        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="fas fa-trash" data-testid="confirm-delete-btn">
             Delete
         </MudButton>
     </YesButton>

--- a/Apps/Admin/Client/Components/CommunicationsTable.razor
+++ b/Apps/Admin/Client/Components/CommunicationsTable.razor
@@ -53,19 +53,19 @@
             <div>
                 <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">
                     <MudIconButton OnClick="@(() => ToggleExpandRow(context.Id))"
-                                   Icon="@(context.IsExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                   Icon="@(context.IsExpanded ? "fas fa-chevron-up" : "fas fa-chevron-down")"
                                    Color="@Color.Primary"
                                    data-testid="comm-table-expand-btn" />
                 </MudTooltip>
                 <MudTooltip Text="Edit">
                     <MudIconButton OnClick="@(async () => await EditCommunicationAsync(context.Id))"
-                                   Icon="@Icons.Material.Filled.Edit"
+                                   Icon="fas fa-pen"
                                    Color="@Color.Primary"
                                    data-testid="comm-table-edit-btn" />
                 </MudTooltip>
                 <MudTooltip Text="Delete">
                     <MudIconButton OnClick="@(() => DeleteCommunication(context.Id))"
-                                   Icon="@Icons.Material.Filled.Delete"
+                                   Icon="fas fa-trash"
                                    Color="@Color.Primary"
                                    data-testid="comm-table-delete-btn" />
                 </MudTooltip>
@@ -94,7 +94,7 @@
         </span>
     </MessageContent>
     <YesButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="@Icons.Material.Filled.DeleteForever" data-testid="confirm-delete-btn">
+        <MudButton Variant="Variant.Filled" Color="Color.Error" StartIcon="fas fa-trash" data-testid="confirm-delete-btn">
             Delete
         </MudButton>
     </YesButton>

--- a/Apps/Admin/Client/Components/NavMenu.razor
+++ b/Apps/Admin/Client/Components/NavMenu.razor
@@ -3,43 +3,43 @@
 <MudNavMenu>
     @if (ConfigurationState.Value.Result?.Features["Showcase"] ?? false)
     {
-        <MudNavGroup Title="Showcase" Icon="@Icons.Material.Filled.WbSunny" Expanded="false">
-            <MudNavLink Href="showcase/alerts" Icon="@Icons.Material.Filled.PriorityHigh">Alerts</MudNavLink>
-            <MudNavLink Href="showcase/chips" Icon="@Icons.Material.Filled.Label">Chips</MudNavLink>
-            <MudNavLink Href="showcase/forms" Icon="@Icons.Material.Filled.DynamicForm">Forms</MudNavLink>
-            <MudNavGroup Title="Layout" Icon="@Icons.Material.Filled.Dashboard" Expanded="false">
-                <MudNavLink Href="showcase/expansion-panels" Icon="@Icons.Material.Filled.Expand">Expansion Panels</MudNavLink>
-                <MudNavLink Href="showcase/paper-and-cards" Icon="@Icons.Material.Filled.Note">Paper and Cards</MudNavLink>
-                <MudNavLink Href="showcase/tabs" Icon="@Icons.Material.Filled.Tab">Tabs</MudNavLink>
+        <MudNavGroup Title="Showcase" Icon="fas fa-sun" Expanded="false">
+            <MudNavLink Href="showcase/alerts" Icon="fas fa-exclamation">Alerts</MudNavLink>
+            <MudNavLink Href="showcase/chips" Icon="fas fa-tag">Chips</MudNavLink>
+            <MudNavLink Href="showcase/forms" Icon="fas fa-square-check">Forms</MudNavLink>
+            <MudNavGroup Title="Layout" Icon="fas fa-table-columns" Expanded="false">
+                <MudNavLink Href="showcase/expansion-panels" Icon="fas fa-arrows-up-down">Expansion Panels</MudNavLink>
+                <MudNavLink Href="showcase/paper-and-cards" Icon="fas fa-note-sticky">Paper and Cards</MudNavLink>
+                <MudNavLink Href="showcase/tabs" Icon="fas fa-folder">Tabs</MudNavLink>
             </MudNavGroup>
-            <MudNavLink Href="showcase/links-and-buttons" Icon="@Icons.Material.Filled.Link">Links and Buttons</MudNavLink>
-            <MudNavLink Href="showcase/message-box" Icon="@Icons.Material.Filled.HelpOutline">Message Box</MudNavLink>
-            <MudNavLink Href="showcase/pagination" Icon="@Icons.Material.Filled.KeyboardArrowRight">Pagination</MudNavLink>
-            <MudNavLink Href="showcase/tool-bar" Icon="@Icons.Material.Filled.Construction">Tool Bar</MudNavLink>
-            <MudNavLink Href="showcase/typography" Icon="@Icons.Material.Filled.TextFields">Typography</MudNavLink>
+            <MudNavLink Href="showcase/links-and-buttons" Icon="fas fa-arrow-up-right-from-square">Links and Buttons</MudNavLink>
+            <MudNavLink Href="showcase/message-box" Icon="fas fa-message">Message Box</MudNavLink>
+            <MudNavLink Href="showcase/pagination" Icon="fas fa-forward-step">Pagination</MudNavLink>
+            <MudNavLink Href="showcase/tool-bar" Icon="fas fa-screwdriver-wrench">Tool Bar</MudNavLink>
+            <MudNavLink Href="showcase/typography" Icon="fas fa-font">Typography</MudNavLink>
         </MudNavGroup>
     }
 
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")">
-        <MudNavLink Href="dashboard" Icon="@Icons.Material.Filled.ViewQuilt">Dashboard</MudNavLink>
+        <MudNavLink Href="dashboard" Icon="fas fa-gauge">Dashboard</MudNavLink>
     </AuthorizeView>
     @if (JobSchedulerUrl.Length > 0)
     {
         <AuthorizeView Roles="@Roles.Admin">
-            <MudNavLink Href="@JobSchedulerUrl" Icon="@Icons.Material.Filled.Schedule">Job Scheduler</MudNavLink>
+            <MudNavLink Href="@JobSchedulerUrl" Icon="fas fa-business-time">Job Scheduler</MudNavLink>
         </AuthorizeView>
     }
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")">
-        <MudNavLink Href="communications" Icon="@Icons.Material.Filled.Announcement">Communications</MudNavLink>
+        <MudNavLink Href="communications" Icon="fas fa-satellite-dish">Communications</MudNavLink>
     </AuthorizeView>
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")">
-        <MudNavLink Href="feedback" Icon="@Icons.Material.Filled.Email">Feedback Review</MudNavLink>
+        <MudNavLink Href="feedback" Icon="fas fa-star">Feedback Review</MudNavLink>
     </AuthorizeView>
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")">
-        <MudNavLink Href="analytics" Icon="fas fa-download">System Analytics</MudNavLink>
+        <MudNavLink Href="analytics" Icon="fas fa-chart-line">System Analytics</MudNavLink>
     </AuthorizeView>
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")">
-        <MudNavLink Href="support" Icon="@Icons.Material.Filled.PersonSearch">Support</MudNavLink>
+        <MudNavLink Href="support" Icon="fas fa-headset">Support</MudNavLink>
     </AuthorizeView>
     <AuthorizeView Roles="@Roles.Admin">
         <MudNavLink Href="provision" Icon="fas fa-user-shield">Provision</MudNavLink>

--- a/Apps/Admin/Client/Components/RatingSummary.razor
+++ b/Apps/Admin/Client/Components/RatingSummary.razor
@@ -15,7 +15,7 @@
                 <MudItem xs="6" lg="2" Class="d-flex justify-end">
                     @for (int x = 1; x <= stars; x++)
                     {
-                        <MudIcon Icon="@Icons.Material.Filled.StarRate" Color="Color.Warning" Size="Size.Small" />
+                        <MudIcon Icon="fas fa-star" Color="Color.Warning" Size="Size.Small" />
                     }
                 </MudItem>
                 <MudItem xs="6" lg="3" Class="mt-3">

--- a/Apps/Admin/Client/Layouts/MainLayout.razor
+++ b/Apps/Admin/Client/Layouts/MainLayout.razor
@@ -6,17 +6,17 @@
 
 <MudLayout>
     <MudAppBar Elevation="1">
-        <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Edge="Edge.Start" OnClick="DrawerToggle" />
+        <MudIconButton Icon="fas fa-bars" Color="Color.Inherit" Edge="Edge.Start" OnClick="DrawerToggle" />
         <MudText Typo="Typo.h6" Class="ml-4">HG Admin</MudText>
         <MudSpacer />
         <MudTooltip Text="Toggle Dark Mode">
-            <MudIconButton Icon="@Icons.Material.Filled.BrightnessMedium" Color="Color.Inherit" Edge="Edge.End" OnClick="ToggleTheme" />
+            <MudIconButton Icon="fas fa-circle-half-stroke" Color="Color.Inherit" Edge="Edge.End" OnClick="ToggleTheme" />
         </MudTooltip>
         <AuthorizeView>
             <Authorized>
                 <MudMenu Direction="Direction.Left" OffsetX="true" Dense="true" Class="mt-1 ml-4">
                     <ActivatorContent>
-                        <MudIcon Icon="@Icons.Material.Filled.AccountCircle" Color="Color.Inherit" Edge="Edge.End" data-testid="user-account-icon" />
+                        <MudIcon Icon="fas fa-user" Color="Color.Inherit" Edge="Edge.End" data-testid="user-account-icon" />
                     </ActivatorContent>
                     <ChildContent>
                         <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")" Context="_">
@@ -24,7 +24,7 @@
                                 @(context.User.Identity?.Name ?? "Unknown")
                             </MudNavLink>
                         </AuthorizeView>
-                        <MudNavLink Icon="@Icons.Material.Outlined.Logout" OnClick="@LogOut" data-testid="logout-text-link">Log Out</MudNavLink>
+                        <MudNavLink Icon="fas fa-right-from-bracket" OnClick="@LogOut" data-testid="logout-text-link">Log Out</MudNavLink>
                     </ChildContent>
                 </MudMenu>
             </Authorized>

--- a/Apps/Admin/Client/Pages/AgentAccessPage.razor
+++ b/Apps/Admin/Client/Pages/AgentAccessPage.razor
@@ -29,7 +29,7 @@
         <MudItem Class="d-flex justify-end" xs="12">
             <HgButton
                 TopMargin="Breakpoint.Always"
-                EndIcon="@Icons.Material.Filled.Search"
+                EndIcon="fas fa-magnifying-glass"
                 @onclick="SearchAsync"
                 data-testid="search-btn">
                 Search
@@ -37,7 +37,7 @@
         </MudItem>
         <MudItem Class="d-flex justify-end" xs="12">
             <HgButton TopMargin="Breakpoint.Always"
-                      EndIcon="@Icons.Material.Filled.Add"
+                      EndIcon="fas fa-plus"
                       @onclick="@AddAsync"
                       data-testid="create-btn">
                 Create
@@ -92,13 +92,13 @@
                 <div>
                     <MudTooltip Text="Edit">
                         <MudIconButton OnClick="@(async () => await EditAsync(context.Id))"
-                                       Icon="@Icons.Material.Filled.Edit"
+                                       Icon="fas fa-pen"
                                        Color="@Color.Primary"
                                        data-testid="agent-table-edit-btn" />
                     </MudTooltip>
                     <MudTooltip Text="Delete">
                         <MudIconButton OnClick="@(async () => await DeleteAsync(context.Id))"
-                                       Icon="@Icons.Material.Filled.Delete"
+                                       Icon="fas fa-trash"
                                        Color="@Color.Primary"
                                        data-testid="agent-table-delete-btn" />
                     </MudTooltip>
@@ -131,7 +131,7 @@
             <HgButton
                 Variant="@Variant.Filled"
                 Color="@Color.Error"
-                StartIcon="@Icons.Material.Filled.DeleteForever"
+                StartIcon="fas fa-trash"
                 RightMargin="Breakpoint.Always"
                 BottomMargin="Breakpoint.Always"
                 data-testid="confirm-delete-btn">

--- a/Apps/Admin/Client/Pages/AnalyticsPage.razor
+++ b/Apps/Admin/Client/Pages/AnalyticsPage.razor
@@ -13,26 +13,26 @@
 
 <MudGrid>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetProfilesData" data-testid="user-profile-download-btn">User Profiles</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetProfilesData" data-testid="user-profile-download-btn">User Profiles</HgButton>
     </MudItem>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetCommentsData" data-testid="user-comments-download-btn">User Comments</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetCommentsData" data-testid="user-comments-download-btn">User Comments</HgButton>
     </MudItem>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetNotesData" data-testid="user-notes-download-btn">User Notes</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetNotesData" data-testid="user-notes-download-btn">User Notes</HgButton>
     </MudItem>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetRatingsData" data-testid="user-ratings-download-btn">User Ratings</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetRatingsData" data-testid="user-ratings-download-btn">User Ratings</HgButton>
     </MudItem>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetInactiveUsersData" data-testid="inactive-users-download-btn">Inactive Users</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetInactiveUsersData" data-testid="inactive-users-download-btn">Inactive Users</HgButton>
         <HgTextField T="int" Label="Days Inactive" Required="@true" @bind-Value="InactiveDays" Disabled="@AnalyticsState.Value.IsLoading" data-testid="days-inactive-input" />
     </MudItem>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetUserFeedbackData" data-testid="user-feedback-download-btn">User Feedback</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetUserFeedbackData" data-testid="user-feedback-download-btn">User Feedback</HgButton>
     </MudItem>
     <MudItem xs="6" lg="3">
-        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="@Icons.Material.Filled.Download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetYearOfBirthCountsData" data-testid="year-of-birth-download-btn">Year of Birth</HgButton>
+        <HgButton TopMargin="Breakpoint.Always" Disabled="@AnalyticsState.Value.IsLoading" EndIcon="fas fa-download" FullWidth="@true" Variant="Variant.Filled" Color="Color.Primary" @onclick="GetYearOfBirthCountsData" data-testid="year-of-birth-download-btn">Year of Birth</HgButton>
         <MudDateRangePicker data-testid="minimum-maximum-date-time-picker" Mindate="@MinimumDateTime" MaxDate="@MaximumDateTime" @ref="SelectedDateRangePicker" Label="Select Date Range" @bind-DateRange="SelectedDateRange" Color="Color.Success" Style="font-weight:bold">
             <PickerActions>
                 <MudButton Class="mr-auto align-self-start" OnClick="@(() => SelectedDateRangePicker.Clear())">Clear</MudButton>

--- a/Apps/Admin/Client/Pages/CommunicationsPage.razor
+++ b/Apps/Admin/Client/Pages/CommunicationsPage.razor
@@ -28,7 +28,7 @@
 {
     <HgTabs @ref="@Tabs" data-testid="banner-tabs">
         <Header>
-            <HgButton EndIcon="@Icons.Material.Filled.Add"
+            <HgButton EndIcon="fas fa-plus"
                       TopMargin="@Breakpoint.Always"
                       RightMargin="@Breakpoint.Always"
                       BottomMargin="@Breakpoint.Always"

--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -17,7 +17,7 @@
 <MudGrid>
     <MudItem xs="12" lg="12">
         <MudPaper Class="my-2 pa-4 d-flex justify-end" Elevation="0">
-            <HgButton Loading="@(RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading || RecurringUsersLoading)" EndIcon="@Icons.Material.Filled.Refresh" @onclick="ReloadDispatchActions" data-testid="refresh-btn">Refresh</HgButton>
+            <HgButton Loading="@(RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading || RecurringUsersLoading)" EndIcon="fas fa-arrow-rotate-right" @onclick="ReloadDispatchActions" data-testid="refresh-btn">Refresh</HgButton>
         </MudPaper>
     </MudItem>
 </MudGrid>

--- a/Apps/Admin/Client/Pages/FeedbackPage.razor
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor
@@ -31,7 +31,7 @@
               TopMargin="@Breakpoint.Always"
               LeftMargin="@Breakpoint.Always"
               Class="flex-grow-0"
-              EndIcon="@Icons.Material.Filled.Add"
+              EndIcon="fas fa-plus"
               Variant="@Variant.Filled"
               Color="@Color.Success"
               Loading="@TagState.Value.Add.IsLoading"
@@ -117,8 +117,8 @@ else
                 <MudTd DataLabel="Email" data-testid="feedback-email">
                     @if (context.Hdid.Length > 0)
                     {
-                        <MudIconButton Icon="@Icons.Material.Filled.PersonSearch"
-                                       Color="@Color.Dark"
+                        <MudIconButton Icon="fas fa-person-circle-question"
+                                       Color="@Color.Tertiary"
                                        data-testid="feedback-person-search-button"
                                        OnClick="() => NavigateToSupport(context.Hdid)" />
                     }
@@ -146,7 +146,7 @@ else
                     </MudSelect>
                 </MudTd>
                 <MudTd DataLabel="Reviewed">
-                    <MudIconButton Icon="@(context.IsReviewed ? Icons.Material.Filled.Check : Icons.Material.Filled.Close)"
+                    <MudIconButton Icon="@(context.IsReviewed ? "fas fa-check" : "fas fa-xmark")"
                                    Color="@(context.IsReviewed ? Color.Success : Color.Error)"
                                    Disabled="@FeedbackUpdating"
                                    data-testid="feedback-review-button"

--- a/Apps/Admin/Client/Pages/Showcase/Forms.razor
+++ b/Apps/Admin/Client/Pages/Showcase/Forms.razor
@@ -43,7 +43,7 @@
                     <MudTextField Class="my-3" Variant="@variant" T="string" Label="Required Text Field with Helper Text" Required="true" RequiredError="This field is required!" InputType="InputType.Password" HelperText="Choose a strong password" />
                     <MudTextField Class="my-3" Variant="@variant" T="string" Label="Required Text Field with Helper Text on Focus" Required="true" RequiredError="This field is required!" InputType="InputType.Password" HelperText="Choose a strong password" HelperTextOnFocus="true" />
                     <MudTextField Class="my-3" Variant="@variant" T="string" Label="Required Text Field with Counter" Required="true" RequiredError="This field is required!" Counter="40" />
-                    <MudTextField Class="my-3" Variant="@variant" T="string" Label="Required Text Field with Adornment" Required="true" RequiredError="This field is required!" Adornment="Adornment.End" AdornmentIcon="@Icons.Material.Filled.VisibilityOff" />
+                    <MudTextField Class="my-3" Variant="@variant" T="string" Label="Required Text Field with Adornment" Required="true" RequiredError="This field is required!" Adornment="Adornment.End" AdornmentIcon="fas fa-eye-slash" />
                     <MudTextField Class="my-3" Variant="@variant" T="string" Label="Disabled Text Field" Disabled="true" />
                 </MudItem>
             </MudGrid>

--- a/Apps/Admin/Client/Pages/Showcase/LinksAndButtons.razor
+++ b/Apps/Admin/Client/Pages/Showcase/LinksAndButtons.razor
@@ -21,9 +21,9 @@
         }
     </div>
     <div>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.Login" Variant="Variant.Filled" Color="Color.Primary">Icon Before</MudButton>
-        <MudButton Class="mx-1 my-2" EndIcon="@Icons.Material.Filled.Logout" Variant="Variant.Filled" Color="Color.Secondary">Icon After</MudButton>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.Feedback" Variant="Variant.Filled" Color="Color.Tertiary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-right-to-bracket" Variant="Variant.Filled" Color="Color.Primary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" EndIcon="fas fa-right-from-bracket" Variant="Variant.Filled" Color="Color.Secondary">Icon After</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-comment" Variant="Variant.Filled" Color="Color.Tertiary">Icon Before</MudButton>
     </div>
 </article>
 <article>
@@ -37,9 +37,9 @@
     </div>
     <div>
 
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.Edit" Variant="Variant.Outlined" Color="Color.Primary">Icon Before</MudButton>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.PersonAdd" Variant="Variant.Outlined" Color="Color.Secondary">Icon Before</MudButton>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.Person" Variant="Variant.Outlined" Color="Color.Tertiary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-pen" Variant="Variant.Outlined" Color="Color.Primary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-user-plus" Variant="Variant.Outlined" Color="Color.Secondary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-user" Variant="Variant.Outlined" Color="Color.Tertiary">Icon Before</MudButton>
     </div>
 </article>
 <article>
@@ -52,26 +52,26 @@
         }
     </div>
     <div>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.Search" Variant="Variant.Text" Color="Color.Primary">Icon Before</MudButton>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.CheckCircle" Variant="Variant.Text" Color="Color.Secondary">Icon Before</MudButton>
-        <MudButton Class="mx-1 my-2" StartIcon="@Icons.Material.Filled.ContentCopy" Variant="Variant.Text" Color="Color.Tertiary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-magnifying-glass" Variant="Variant.Text" Color="Color.Primary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-circle-check" Variant="Variant.Text" Color="Color.Secondary">Icon Before</MudButton>
+        <MudButton Class="mx-1 my-2" StartIcon="fas fa-copy" Variant="Variant.Text" Color="Color.Tertiary">Icon Before</MudButton>
     </div>
 </article>
 <article>
     <MudText Class="mt-4 mb-3" Typo="Typo.h4">Icon Buttons</MudText>
     <div>
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Filled" Color="Color.Primary" Disabled="true" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Filled" Color="Color.Primary" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Filled" Color="Color.Secondary" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Filled" Color="Color.Tertiary" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Outlined" Color="Color.Primary" Disabled="true" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Outlined" Color="Color.Primary" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Outlined" Color="Color.Secondary" />
-        <MudIconButton Class="mx-1 my-2" Icon="@Icons.Material.Filled.EditCalendar" Variant="Variant.Outlined" Color="Color.Tertiary" />
-        <MudIconButton Icon="@Icons.Material.Filled.FileDownload" Color="Color.Primary" Disabled="true" />
-        <MudIconButton Icon="@Icons.Material.Filled.FileDownload" Color="Color.Primary" />
-        <MudIconButton Icon="@Icons.Material.Filled.FileDownload" Color="Color.Secondary" />
-        <MudIconButton Icon="@Icons.Material.Filled.FileDownload" Color="Color.Tertiary" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Filled" Color="Color.Primary" Disabled="true" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Filled" Color="Color.Primary" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Filled" Color="Color.Secondary" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Filled" Color="Color.Tertiary" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Outlined" Color="Color.Primary" Disabled="true" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Outlined" Color="Color.Primary" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Outlined" Color="Color.Secondary" />
+        <MudIconButton Class="mx-1 my-2" Icon="fas fa-user-pen" Variant="Variant.Outlined" Color="Color.Tertiary" />
+        <MudIconButton Icon="fas fa-download" Color="Color.Primary" Disabled="true" />
+        <MudIconButton Icon="fas fa-download" Color="Color.Primary" />
+        <MudIconButton Icon="fas fa-download" Color="Color.Secondary" />
+        <MudIconButton Icon="fas fa-download" Color="Color.Tertiary" />
     </div>
 </article>
 <article>
@@ -99,9 +99,9 @@
 </article>
 <article>
     <MudText Class="mt-4 mb-3" Typo="Typo.h4">Floating Action Buttons</MudText>
-    <MudFab Class="mx-1 my-2" Color="Color.Primary" Icon="@Icons.Material.Filled.Add" />
-    <MudFab Class="mx-1 my-2" Color="Color.Secondary" Icon="@Icons.Material.Filled.Edit" />
-    <MudFab Class="mx-1 my-2" Color="Color.Tertiary" Icon="@Icons.Material.Filled.HelpCenter" />
+    <MudFab Class="mx-1 my-2" Color="Color.Primary" Icon="fas fa-plus" />
+    <MudFab Class="mx-1 my-2" Color="Color.Secondary" Icon="fas fa-pen" />
+    <MudFab Class="mx-1 my-2" Color="Color.Tertiary" Icon="fas fa-question" />
 </article>
 
 @code

--- a/Apps/Admin/Client/Pages/Showcase/ToolBar.razor
+++ b/Apps/Admin/Client/Pages/Showcase/ToolBar.razor
@@ -6,23 +6,23 @@
 <article>
     <MudText Class="mt-4 mb-3" Typo="Typo.h4">Tool Bar</MudText>
     <MudToolBar>
-        <MudIconButton Icon="@Icons.Material.Outlined.Menu" Color="Color.Inherit" Class="mr-5" />
-        <MudIconButton Icon="@Icons.Material.Outlined.Add" />
-        <MudIconButton Icon="@Icons.Material.Outlined.Edit" />
-        <MudIconButton Icon="@Icons.Material.Outlined.Remove" Color="Color.Inherit" />
-        <MudIconButton Icon="@Icons.Material.Outlined.Settings" Color="Color.Inherit" />
+        <MudIconButton Icon="fas fa-bars" Color="Color.Inherit" Class="mr-5" />
+        <MudIconButton Icon="fas fa-plus" />
+        <MudIconButton Icon="fas fa-pen" />
+        <MudIconButton Icon="fas fa-minus" Color="Color.Inherit" />
+        <MudIconButton Icon="fas fa-gear" Color="Color.Inherit" />
         <MudSpacer />
-        <MudIconButton Icon="@Icons.Material.Outlined.Notifications" />
-        <MudIconButton Icon="@Icons.Material.Outlined.PushPin" />
-        <MudIconButton Icon="@Icons.Material.Outlined.PeopleAlt" />
-        <MudIconButton Icon="@Icons.Material.Outlined.MoreVert" Color="Color.Inherit" />
+        <MudIconButton Icon="fas fa-bell" />
+        <MudIconButton Icon="fas fa-bookmark" />
+        <MudIconButton Icon="fas fa-users" />
+        <MudIconButton Icon="fas fa-ellipsis-vertical" Color="Color.Inherit" />
     </MudToolBar>
 </article>
 <article>
     <MudText Class="mt-4 mb-3" Typo="Typo.h4">Menu in Tool Bar</MudText>
     <MudToolBar>
         <MudSpacer />
-        <MudMenu Icon="@Icons.Material.Filled.MoreVert">
+        <MudMenu Icon="fas fa-ellipsis-vertical">
             <MudMenuItem>Profile</MudMenuItem>
             <MudMenuItem>My account</MudMenuItem>
             <MudMenuItem>Logout</MudMenuItem>

--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -39,7 +39,7 @@
             }
         </MudItem>
         <MudItem Class="d-flex justify-end" xs="12">
-            <HgButton TopMargin="Breakpoint.Always" EndIcon="@Icons.Material.Filled.Search" Variant="Variant.Filled" Color="Color.Primary" @onclick="SearchAsync" data-testid="search-btn">Search</HgButton>
+            <HgButton TopMargin="Breakpoint.Always" EndIcon="fas fa-magnifying-glass" Variant="Variant.Filled" Color="Color.Primary" @onclick="SearchAsync" data-testid="search-btn">Search</HgButton>
         </MudItem>
     </MudGrid>
 </MudForm>
@@ -91,7 +91,7 @@
                         <div>
                             <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">
                                 <MudIconButton OnClick="@(() => ToggleExpandRow(context.Hdid))"
-                                               Icon="@(context.IsExpanded ? Icons.Material.Filled.ExpandLess : Icons.Material.Filled.ExpandMore)"
+                                               Icon="@(context.IsExpanded ? "fas fa-chevron-up" : "fas fa-chevron-down")"
                                                Color="@Color.Primary"
                                                data-testid=@($"messaging-verification-table-expand-btn-{context.Hdid}")>
                                 </MudIconButton>

--- a/Apps/Admin/Client/wwwroot/index.html
+++ b/Apps/Admin/Client/wwwroot/index.html
@@ -1,45 +1,51 @@
 <!DOCTYPE html>
 <html lang="en" xml:lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+        />
+        <title>Health Gateway Admin</title>
+        <base href="/" />
+        <link
+            href="https://use.fontawesome.com/releases/v5.14.0/css/all.css"
+            rel="stylesheet"
+        />
+        <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+        <link href="lib/quill/quill.snow.css" rel="stylesheet" />
+        <link href="lib/quill/quill.bubble.css" rel="stylesheet" />
+        <link href="css/app.css" rel="stylesheet" />
+        <link href="Admin.Client.styles.css" rel="stylesheet" />
+        <link href="manifest.json" rel="manifest" />
+        <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
+        <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
+    </head>
 
-<head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-    <title>Health Gateway Admin</title>
-    <base href="/" />
-    <link href="https://use.fontawesome.com/releases/v5.14.0/css/all.css" rel="stylesheet">
-    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="lib/quill/quill.snow.css" rel="stylesheet">
-    <link href="lib/quill/quill.bubble.css" rel="stylesheet">
-    <link href="css/app.css" rel="stylesheet" />
-    <link href="Admin.Client.styles.css" rel="stylesheet" />
-    <link href="manifest.json" rel="manifest" />
-    <link rel="apple-touch-icon" sizes="512x512" href="icon-512.png" />
-    <link rel="apple-touch-icon" sizes="192x192" href="icon-192.png" />
-</head>
+    <body>
+        <div id="app">
+            <svg class="loading-progress">
+                <circle r="40%" cx="50%" cy="50%" />
+                <circle r="40%" cx="50%" cy="50%" />
+            </svg>
+            <div class="loading-progress-text"></div>
+        </div>
 
-<body>
-    <div id="app">
-        <svg class="loading-progress">
-            <circle r="40%" cx="50%" cy="50%" />
-            <circle r="40%" cx="50%" cy="50%" />
-        </svg>
-        <div class="loading-progress-text"></div>
-    </div>
-
-    <div id="blazor-error-ui">
-        An unhandled error has occurred.
-        <a href="" class="reload">Reload</a>
-        <a class="dismiss">🗙</a>
-    </div>
-    <script src="_framework/blazor.webassembly.js"></script>
-    <script>navigator.serviceWorker.register('service-worker.js');</script>
-    <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
-    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
-    <script src="lib/quill/quill.min.js"></script>
-    <script src="_content/Blazored.TextEditor/quill-blot-formatter.min.js"></script>
-    <script src="_content/Blazored.TextEditor/Blazored-BlazorQuill.js"></script>
-    <script src="js/utilities.js"></script>
-    <script src="js/download.js"></script>
-</body>
-
+        <div id="blazor-error-ui">
+            An unhandled error has occurred.
+            <a href="" class="reload">Reload</a>
+            <a class="dismiss">🗙</a>
+        </div>
+        <script src="_framework/blazor.webassembly.js"></script>
+        <script>
+            navigator.serviceWorker.register("service-worker.js");
+        </script>
+        <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
+        <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+        <script src="lib/quill/quill.min.js"></script>
+        <script src="_content/Blazored.TextEditor/quill-blot-formatter.min.js"></script>
+        <script src="_content/Blazored.TextEditor/Blazored-BlazorQuill.js"></script>
+        <script src="js/utilities.js"></script>
+        <script src="js/download.js"></script>
+    </body>
 </html>

--- a/Apps/Admin/Client/wwwroot/index.html
+++ b/Apps/Admin/Client/wwwroot/index.html
@@ -8,10 +8,6 @@
         />
         <title>Health Gateway Admin</title>
         <base href="/" />
-        <link
-            href="https://use.fontawesome.com/releases/v5.14.0/css/all.css"
-            rel="stylesheet"
-        />
         <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
         <link href="lib/quill/quill.snow.css" rel="stylesheet" />
         <link href="lib/quill/quill.bubble.css" rel="stylesheet" />
@@ -41,6 +37,18 @@
             navigator.serviceWorker.register("service-worker.js");
         </script>
         <script src="_content/Microsoft.AspNetCore.Components.WebAssembly.Authentication/AuthenticationService.js"></script>
+        <script
+            defer
+            src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/js/solid.min.js"
+            integrity="sha384-G+v/7MQzsBBqsKVV3XKv8ThIDYIyXG6LJWqTPBrADbzQf/Ok8cTgjl0X+smak2c5"
+            crossorigin="anonymous"
+        ></script>
+        <script
+            defer
+            src="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.3.0/js/fontawesome.min.js"
+            integrity="sha384-/fIp3d9vqOYL5eP47pOEUYZ/h5dXL4fD9Rc4DWSuIqMZkUj+DA94qNELNYZm8VJS"
+            crossorigin="anonymous"
+        ></script>
         <script src="_content/MudBlazor/MudBlazor.min.js"></script>
         <script src="lib/quill/quill.min.js"></script>
         <script src="_content/Blazored.TextEditor/quill-blot-formatter.min.js"></script>

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -60,7 +60,7 @@
     "ContentSecurityPolicy": {
         "Base": "'self'",
         "DefaultSource": "'self'",
-        "ScriptSource": "'self' 'wasm-eval' 'unsafe-eval' 'unsafe-inline'",
+        "ScriptSource": "'self' 'wasm-eval' 'unsafe-eval' 'sha256-nYaPGPw9zQuQHVl09VRaW597Ut8F9Lf/VDNxGSQu3Sc=' 'sha384-/fIp3d9vqOYL5eP47pOEUYZ/h5dXL4fD9Rc4DWSuIqMZkUj+DA94qNELNYZm8VJS' 'sha384-G+v/7MQzsBBqsKVV3XKv8ThIDYIyXG6LJWqTPBrADbzQf/Ok8cTgjl0X+smak2c5'",
         "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/",
         "ImageSource": "'self' data:",
         "StyleSource": "'self' 'unsafe-inline' https://fonts.googleapis.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",


### PR DESCRIPTION
# Implements [AB#15067](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15067)

## Description

- applies Prettier formatting to index.html in Admin.Client
- updates font-awesome in Admin.Client from v5 fonts to v6 SVGs
   - replaces 'unsafe-inline' CSP for scripts with hashes for the Font Awesome .js files and service-worker.js
- replaces Material icons with Font Awesome icons in Admin.Client

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-03-08-165945](https://user-images.githubusercontent.com/16570293/223888696-ff53cb49-a027-44de-9bc4-7c74375c5307.png)

![localhost-2023-03-08-165919](https://user-images.githubusercontent.com/16570293/223888705-9f5290a0-817e-426a-adad-085a3dc071fd.png)

![localhost-2023-03-08-165852](https://user-images.githubusercontent.com/16570293/223888710-0a0aff65-7ee8-416a-a77b-17d30b9e0e60.png)

![localhost-2023-03-08-165842](https://user-images.githubusercontent.com/16570293/223888720-da9f0f4c-3f4d-4024-b218-d22e519dbc5e.png)

![localhost-2023-03-08-165831](https://user-images.githubusercontent.com/16570293/223888726-3b6a4412-12f9-4514-9f53-5de03d580216.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
