### PR TITLE
Restores analyzers and resolves associated issues with AB#15014

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -299,7 +299,7 @@ dotnet_diagnostic.ca2000.severity = warning
 dotnet_diagnostic.ca2002.severity = warning
 
 # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.ca2007.severity = warning
+dotnet_diagnostic.ca2007.severity = none
 
 # CA2008: Do not create tasks without passing a TaskScheduler
 dotnet_diagnostic.ca2008.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -688,6 +688,9 @@ dotnet_diagnostic.sa1203.severity = none
 # SA1204: Static elements should appear before instance elements
 dotnet_diagnostic.sa1204.severity = none
 
+# SA1629: Documentation text should end with a period
+dotnet_diagnostic.sa1629.severity = none
+
 # Microsoft .NET properties
 csharp_new_line_before_members_in_object_initializers = false
 csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -676,6 +676,18 @@ dotnet_diagnostic.sa1000.severity = error
  # SA1200: Using directives should be placed correctly
 dotnet_diagnostic.sa1200.severity = none
 
+# SA1201: Elements should appear in the correct order
+dotnet_diagnostic.sa1201.severity = none
+
+# SA1202: Elements should be ordered by access
+dotnet_diagnostic.sa1202.severity = none
+
+# SA1203: Constants should appear before fields
+dotnet_diagnostic.sa1203.severity = none
+
+# SA1204: Static elements should appear before instance elements
+dotnet_diagnostic.sa1204.severity = none
+
 # Microsoft .NET properties
 csharp_new_line_before_members_in_object_initializers = false
 csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -806,3 +806,8 @@ resharper_unused_auto_property_accessor_global_highlighting = hint
 resharper_web_config_module_not_resolved_highlighting = warning
 resharper_web_config_type_not_resolved_highlighting = warning
 resharper_web_config_wrong_module_highlighting = warning
+
+[**/test/**.{cs}]
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -16,113 +16,778 @@ indent_size = 2
 
 [*.{cs,razor,cshtml}]
 
-# SA1629: Documentation text should end with a period
-dotnet_diagnostic.SA1629.severity = none
-
-# SA1600: Elements should be documented
-dotnet_diagnostic.SA1600.severity = none
-
-# SA1502: Element should not be on a single line
-dotnet_diagnostic.SA1502.severity = suggestion
-
-# SA1649: File name should match first type name
-dotnet_diagnostic.SA1649.severity = silent
-
-# SA1413: Use trailing comma in multi-line initializers
-dotnet_diagnostic.SA1413.severity = none
-
-# SA1602: Enumeration items should be documented
-dotnet_diagnostic.SA1602.severity = silent
-
-# SA1518: Use line endings correctly at end of file
-dotnet_diagnostic.SA1518.severity = suggestion
-
-# SA1201: Elements should appear in the correct order
-dotnet_diagnostic.SA1201.severity = none
-
-# SA1101: Prefix local calls with this
-dotnet_diagnostic.SA1101.severity = none
-
-# CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = none
-
-# CA1822: Mark members as static
-dotnet_diagnostic.CA1822.severity = suggestion
-
-# SA1625: Element documentation should not be copied and pasted
-dotnet_diagnostic.SA1625.severity = silent
-
-# CA1812: Avoid uninstantiated internal classes
-dotnet_diagnostic.CA1812.severity = none
-
-# CA1852: Seal internal types
-dotnet_diagnostic.CA1852.severity = none
-
-# SA1200: Using directives should be placed correctly
-dotnet_diagnostic.SA1200.severity = none
-
-# SA1203: Constants should appear before fields
-dotnet_diagnostic.SA1203.severity = none
-
-# CA1062: Validate arguments of public methods
-dotnet_diagnostic.CA1062.severity = suggestion
-
-# IDE0011: Add braces
-csharp_prefer_braces = when_multiline
-
-# SA1503: Braces should not be omitted
-dotnet_diagnostic.SA1503.severity = silent
-
-# SA1513: Closing brace should be followed by blank line
-dotnet_diagnostic.SA1513.severity = silent
-
-# CA1063: Implement IDisposable Correctly
-dotnet_diagnostic.CA1063.severity = suggestion
-
-# CA1816: Dispose methods should call SuppressFinalize
-dotnet_diagnostic.CA1816.severity = suggestion
-
-# S3881: "IDisposable" should be implemented correctly
-dotnet_diagnostic.S3881.severity = suggestion
-
-# SA1311: Static readonly fields should begin with upper-case letter
-dotnet_diagnostic.SA1311.severity = none
-
-# SA1202: Elements should be ordered by access
-dotnet_diagnostic.SA1202.severity = none
-
-# SA1128: Put constructor initializers on their own line
-dotnet_diagnostic.SA1128.severity = none
-
-# CA1819: Properties should not return arrays
-dotnet_diagnostic.CA1819.severity = suggestion
-
-# CA1711: Identifiers should not have incorrect suffix
-dotnet_diagnostic.CA1711.severity = suggestion
-
-# SA1516: Elements should be separated by blank line
-dotnet_diagnostic.SA1516.severity = suggestion
-
-# S1066: Collapsible "if" statements should be merged
-dotnet_diagnostic.S1066.severity = suggestion
-
-# SA1623: Property summary documentation should match accessors
-dotnet_diagnostic.SA1623.severity = silent
-
-# CS8604: Possible null reference argument.
-dotnet_diagnostic.CS8604.severity = suggestion
-
-# CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1303.severity = suggestion
+# All Rules are enabled with default severity.
+# Rules with IsEnabledByDefault = false are force-enabled with default severity.
 
 # S101: Types should be named in PascalCase
-dotnet_diagnostic.S101.severity = suggestion
+dotnet_diagnostic.s101.severity = none
 
-# S125: Sections of code should not be commented out
-dotnet_diagnostic.S125.severity = suggestion
+# CA1000: Do not declare static members on generic types
+dotnet_diagnostic.ca1000.severity = warning
 
-# SA1515: Single-line comment should be preceded by blank line
-dotnet_diagnostic.SA1515.severity = suggestion
+# CA1001: Types that own disposable fields should be disposable
+dotnet_diagnostic.ca1001.severity = warning
 
-# SA1204: Static elements should appear before instance elements
-dotnet_diagnostic.SA1204.severity = none
+# CA1003: Use generic event handler instances
+dotnet_diagnostic.ca1003.severity = warning
+
+# CA1008: Enums should have zero value
+dotnet_diagnostic.ca1008.severity = warning
+
+# CA1010: Generic interface should also be implemented
+dotnet_diagnostic.ca1010.severity = warning
+
+# CA1012: Abstract types should not have constructors
+dotnet_diagnostic.ca1012.severity = warning
+
+# CA1014: Mark assemblies with CLSCompliant
+dotnet_diagnostic.ca1014.severity = warning
+
+# CA1016: Mark assemblies with assembly version
+dotnet_diagnostic.ca1016.severity = warning
+
+# CA1017: Mark assemblies with ComVisible
+dotnet_diagnostic.ca1017.severity = warning
+
+# CA1018: Mark attributes with AttributeUsageAttribute
+dotnet_diagnostic.ca1018.severity = warning
+
+# CA1019: Define accessors for attribute arguments
+dotnet_diagnostic.ca1019.severity = warning
+
+# CA1021: Avoid out parameters
+dotnet_diagnostic.ca1021.severity = warning
+
+# CA1024: Use properties where appropriate
+dotnet_diagnostic.ca1024.severity = warning
+
+# CA1027: Mark enums with FlagsAttribute
+dotnet_diagnostic.ca1027.severity = warning
+
+# CA1028: Enum Storage should be Int32
+dotnet_diagnostic.ca1028.severity = warning
+
+# CA1030: Use events where appropriate
+dotnet_diagnostic.ca1030.severity = warning
+
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.ca1031.severity = warning
+
+# CA1032: Implement standard exception constructors
+dotnet_diagnostic.ca1032.severity = warning
+
+# CA1033: Interface methods should be callable by child types
+dotnet_diagnostic.ca1033.severity = warning
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.ca1034.severity = warning
+
+# CA1036: Override methods on comparable types
+dotnet_diagnostic.ca1036.severity = warning
+
+# CA1040: Avoid empty interfaces
+dotnet_diagnostic.ca1040.severity = warning
+
+# CA1041: Provide ObsoleteAttribute message
+dotnet_diagnostic.ca1041.severity = warning
+
+# CA1043: Use Integral Or String Argument For Indexers
+dotnet_diagnostic.ca1043.severity = warning
+
+# CA1044: Properties should not be write only
+dotnet_diagnostic.ca1044.severity = warning
+
+# CA1050: Declare types in namespaces
+dotnet_diagnostic.ca1050.severity = warning
+
+# CA1051: Do not declare visible instance fields
+dotnet_diagnostic.ca1051.severity = warning
+
+# CA1052: Static holder types should be Static or NotInheritable
+dotnet_diagnostic.ca1052.severity = warning
+
+# CA1054: Uri parameters should not be strings
+dotnet_diagnostic.ca1054.severity = warning
+
+# CA1055: Uri return values should not be strings
+dotnet_diagnostic.ca1055.severity = warning
+
+# CA1056: Uri properties should not be strings
+dotnet_diagnostic.ca1056.severity = warning
+
+# CA1058: Types should not extend certain base types
+dotnet_diagnostic.ca1058.severity = warning
+
+# CA1060: Move pinvokes to native methods class
+dotnet_diagnostic.ca1060.severity = warning
+
+# CA1061: Do not hide base class methods
+dotnet_diagnostic.ca1061.severity = warning
+
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.ca1062.severity = none
+
+# CA1063: Implement IDisposable Correctly
+dotnet_diagnostic.ca1063.severity = warning
+
+# CA1064: Exceptions should be public
+dotnet_diagnostic.ca1064.severity = warning
+
+# CA1065: Do not raise exceptions in unexpected locations
+dotnet_diagnostic.ca1065.severity = warning
+
+# CA1066: Type {0} should implement IEquatable<T> because it overrides Equals
+dotnet_diagnostic.ca1066.severity = warning
+
+# CA1067: Override Object.Equals(object) when implementing IEquatable<T>
+dotnet_diagnostic.ca1067.severity = warning
+
+# CA1068: CancellationToken parameters must come last
+dotnet_diagnostic.ca1068.severity = warning
+
+# CA1069: Enums values should not be duplicated
+dotnet_diagnostic.ca1069.severity = warning
+
+# CA1200: Avoid using cref tags with a prefix
+dotnet_diagnostic.ca1200.severity = warning
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.ca1303.severity = none
+
+# CA1304: Specify CultureInfo
+dotnet_diagnostic.ca1304.severity = warning
+
+# CA1305: Specify IFormatProvider
+dotnet_diagnostic.ca1305.severity = warning
+
+# CA1307: Specify StringComparison
+dotnet_diagnostic.ca1307.severity = warning
+
+# CA1308: Normalize strings to uppercase
+dotnet_diagnostic.ca1308.severity = warning
+
+# CA1309: Use ordinal stringcomparison
+dotnet_diagnostic.ca1309.severity = warning
+
+# CA1401: P/Invokes should not be visible
+dotnet_diagnostic.ca1401.severity = warning
+
+# CA1501: Avoid excessive inheritance
+dotnet_diagnostic.ca1501.severity = warning
+
+# CA1502: Avoid excessive complexity
+dotnet_diagnostic.ca1502.severity = warning
+
+# CA1505: Avoid unmaintainable code
+dotnet_diagnostic.ca1505.severity = warning
+
+# CA1506: Avoid excessive class coupling
+dotnet_diagnostic.ca1506.severity = warning
+
+# CA1507: Use nameof to express symbol names
+dotnet_diagnostic.ca1507.severity = warning
+
+# CA1508: Avoid dead conditional code
+dotnet_diagnostic.ca1508.severity = warning
+
+# CA1509: Invalid entry in code metrics rule specification file
+dotnet_diagnostic.ca1509.severity = warning
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.ca1707.severity = warning
+
+# CA1708: Identifiers should differ by more than case
+dotnet_diagnostic.ca1708.severity = warning
+
+# CA1710: Identifiers should have correct suffix
+dotnet_diagnostic.ca1710.severity = warning
+
+# CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.ca1711.severity = none
+
+# CA1712: Do not prefix enum values with type name
+dotnet_diagnostic.ca1712.severity = warning
+
+# CA1714: Flags enums should have plural names
+dotnet_diagnostic.ca1714.severity = warning
+
+# CA1715: Identifiers should have correct prefix
+dotnet_diagnostic.ca1715.severity = warning
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.ca1716.severity = warning
+
+# CA1717: Only FlagsAttribute enums should have plural names
+dotnet_diagnostic.ca1717.severity = warning
+
+# CA1720: Identifier contains type name
+dotnet_diagnostic.ca1720.severity = warning
+
+# CA1721: Property names should not match get methods
+dotnet_diagnostic.ca1721.severity = warning
+
+# CA1724: Type names should not match namespaces
+dotnet_diagnostic.ca1724.severity = warning
+
+# CA1725: Parameter names should match base declaration
+dotnet_diagnostic.ca1725.severity = warning
+
+# CA1801: Review unused parameters
+dotnet_diagnostic.ca1801.severity = warning
+
+# CA1802: Use literals where appropriate
+dotnet_diagnostic.ca1802.severity = warning
+
+# CA1806: Do not ignore method results
+dotnet_diagnostic.ca1806.severity = warning
+
+# CA1810: Initialize reference type static fields inline
+dotnet_diagnostic.ca1810.severity = warning
+
+# CA1812: Avoid uninstantiated internal classes
+dotnet_diagnostic.ca1812.severity = warning
+
+# CA1813: Avoid unsealed attributes
+dotnet_diagnostic.ca1813.severity = warning
+
+# CA1814: Prefer jagged arrays over multidimensional
+dotnet_diagnostic.ca1814.severity = warning
+
+# CA1815: Override equals and operator equals on value types
+dotnet_diagnostic.ca1815.severity = warning
+
+# CA1816: Dispose methods should call SuppressFinalize
+dotnet_diagnostic.ca1816.severity = warning
+
+# CA1819: Properties should not return arrays
+dotnet_diagnostic.ca1819.severity = warning
+
+# CA1820: Test for empty strings using string length
+dotnet_diagnostic.ca1820.severity = warning
+
+# CA1821: Remove empty Finalizers
+dotnet_diagnostic.ca1821.severity = warning
+
+# CA1822: Mark members as static
+dotnet_diagnostic.ca1822.severity = warning
+
+# CA1823: Avoid unused private fields
+dotnet_diagnostic.ca1823.severity = warning
+
+# CA1824: Mark assemblies with NeutralResourcesLanguageAttribute
+dotnet_diagnostic.ca1824.severity = warning
+
+# CA1825: Avoid zero-length array allocations.
+dotnet_diagnostic.ca1825.severity = warning
+
+# CA1826: Do not use Enumerable methods on indexable collections. Instead use the collection directly
+dotnet_diagnostic.ca1826.severity = warning
+
+# CA1827: Do not use Count() or LongCount() when Any() can be used
+dotnet_diagnostic.ca1827.severity = warning
+
+# CA1828: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+dotnet_diagnostic.ca1828.severity = warning
+
+# CA1829: Use Length/Count property instead of Count() when available
+dotnet_diagnostic.ca1829.severity = warning
+
+# CA2000: Dispose objects before losing scope
+dotnet_diagnostic.ca2000.severity = warning
+
+# CA2002: Do not lock on objects with weak identity
+dotnet_diagnostic.ca2002.severity = warning
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.ca2007.severity = warning
+
+# CA2008: Do not create tasks without passing a TaskScheduler
+dotnet_diagnostic.ca2008.severity = warning
+
+# CA2009: Do not call ToImmutableCollection on an ImmutableCollection value
+dotnet_diagnostic.ca2009.severity = warning
+
+# CA2010: Always consume the value returned by methods marked with PreserveSigAttribute
+dotnet_diagnostic.ca2010.severity = warning
+
+# CA2011: Avoid infinite recursion
+dotnet_diagnostic.ca2011.severity = warning
+
+# CA2012: Use ValueTasks correctly
+dotnet_diagnostic.ca2012.severity = warning
+
+# CA2013: Do not use ReferenceEquals with value types
+dotnet_diagnostic.ca2013.severity = warning
+
+# CA2100: Review SQL queries for security vulnerabilities
+dotnet_diagnostic.ca2100.severity = warning
+
+# CA2101: Specify marshaling for P/Invoke string arguments
+dotnet_diagnostic.ca2101.severity = warning
+
+# CA2119: Seal methods that satisfy private interfaces
+dotnet_diagnostic.ca2119.severity = warning
+
+# CA2153: Do Not Catch Corrupted State Exceptions
+dotnet_diagnostic.ca2153.severity = warning
+
+# CA2200: Rethrow to preserve stack details.
+dotnet_diagnostic.ca2200.severity = warning
+
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.ca2201.severity = warning
+
+# CA2207: Initialize value type static fields inline
+dotnet_diagnostic.ca2207.severity = warning
+
+# CA2208: Instantiate argument exceptions correctly
+dotnet_diagnostic.ca2208.severity = warning
+
+# CA2211: Non-constant fields should not be visible
+dotnet_diagnostic.ca2211.severity = warning
+
+# CA2213: Disposable fields should be disposed
+dotnet_diagnostic.ca2213.severity = warning
+
+# CA2214: Do not call overridable methods in constructors
+dotnet_diagnostic.ca2214.severity = warning
+
+# CA2215: Dispose methods should call base class dispose
+dotnet_diagnostic.ca2215.severity = warning
+
+# CA2216: Disposable types should declare finalizer
+dotnet_diagnostic.ca2216.severity = warning
+
+# CA2217: Do not mark enums with FlagsAttribute
+dotnet_diagnostic.ca2217.severity = warning
+
+# CA2218: Override GetHashCode on overriding Equals
+dotnet_diagnostic.ca2218.severity = warning
+
+# CA2219: Do not raise exceptions in finally clauses
+dotnet_diagnostic.ca2219.severity = warning
+
+# CA2224: Override Equals on overloading operator equals
+dotnet_diagnostic.ca2224.severity = warning
+
+# CA2225: Operator overloads have named alternates
+dotnet_diagnostic.ca2225.severity = warning
+
+# CA2226: Operators should have symmetrical overloads
+dotnet_diagnostic.ca2226.severity = warning
+
+# CA2227: Collection properties should be read only
+dotnet_diagnostic.ca2227.severity = warning
+
+# CA2229: Implement serialization constructors
+dotnet_diagnostic.ca2229.severity = warning
+
+# CA2231: Overload operator equals on overriding value type Equals
+dotnet_diagnostic.ca2231.severity = warning
+
+# CA2234: Pass system uri objects instead of strings
+dotnet_diagnostic.ca2234.severity = warning
+
+# CA2235: Mark all non-serializable fields
+dotnet_diagnostic.ca2235.severity = warning
+
+# CA2237: Mark ISerializable types with serializable
+dotnet_diagnostic.ca2237.severity = warning
+
+# CA2241: Provide correct arguments to formatting methods
+dotnet_diagnostic.ca2241.severity = warning
+
+# CA2242: Test for NaN correctly
+dotnet_diagnostic.ca2242.severity = warning
+
+# CA2243: Attribute string literals should parse correctly
+dotnet_diagnostic.ca2243.severity = warning
+
+# CA2244: Do not duplicate indexed element initializations
+dotnet_diagnostic.ca2244.severity = warning
+
+# CA2245: Do not assign a property to itself.
+dotnet_diagnostic.ca2245.severity = warning
+
+# CA2246: Assigning symbol and its member in the same statement.
+dotnet_diagnostic.ca2246.severity = warning
+
+# CA2300: Do not use insecure deserializer BinaryFormatter
+dotnet_diagnostic.ca2300.severity = warning
+
+# CA2301: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+dotnet_diagnostic.ca2301.severity = warning
+
+# CA2302: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+dotnet_diagnostic.ca2302.severity = warning
+
+# CA2305: Do not use insecure deserializer LosFormatter
+dotnet_diagnostic.ca2305.severity = warning
+
+# CA2310: Do not use insecure deserializer NetDataContractSerializer
+dotnet_diagnostic.ca2310.severity = warning
+
+# CA2311: Do not deserialize without first setting NetDataContractSerializer.Binder
+dotnet_diagnostic.ca2311.severity = warning
+
+# CA2312: Ensure NetDataContractSerializer.Binder is set before deserializing
+dotnet_diagnostic.ca2312.severity = warning
+
+# CA2315: Do not use insecure deserializer ObjectStateFormatter
+dotnet_diagnostic.ca2315.severity = warning
+
+# CA2321: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+dotnet_diagnostic.ca2321.severity = warning
+
+# CA2322: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+dotnet_diagnostic.ca2322.severity = warning
+
+# CA2326: Do not use TypeNameHandling values other than None
+dotnet_diagnostic.ca2326.severity = warning
+
+# CA2327: Do not use insecure JsonSerializerSettings
+dotnet_diagnostic.ca2327.severity = warning
+
+# CA2328: Ensure that JsonSerializerSettings are secure
+dotnet_diagnostic.ca2328.severity = warning
+
+# CA2329: Do not deserialize with JsonSerializer using an insecure configuration
+dotnet_diagnostic.ca2329.severity = warning
+
+# CA2330: Ensure that JsonSerializer has a secure configuration when deserializing
+dotnet_diagnostic.ca2330.severity = warning
+
+# CA3001: Review code for SQL injection vulnerabilities
+dotnet_diagnostic.ca3001.severity = warning
+
+# CA3002: Review code for XSS vulnerabilities
+dotnet_diagnostic.ca3002.severity = warning
+
+# CA3003: Review code for file path injection vulnerabilities
+dotnet_diagnostic.ca3003.severity = warning
+
+# CA3004: Review code for information disclosure vulnerabilities
+dotnet_diagnostic.ca3004.severity = warning
+
+# CA3005: Review code for LDAP injection vulnerabilities
+dotnet_diagnostic.ca3005.severity = warning
+
+# CA3006: Review code for process command injection vulnerabilities
+dotnet_diagnostic.ca3006.severity = warning
+
+# CA3007: Review code for open redirect vulnerabilities
+dotnet_diagnostic.ca3007.severity = warning
+
+# CA3008: Review code for XPath injection vulnerabilities
+dotnet_diagnostic.ca3008.severity = warning
+
+# CA3009: Review code for XML injection vulnerabilities
+dotnet_diagnostic.ca3009.severity = warning
+
+# CA3010: Review code for XAML injection vulnerabilities
+dotnet_diagnostic.ca3010.severity = warning
+
+# CA3011: Review code for DLL injection vulnerabilities
+dotnet_diagnostic.ca3011.severity = warning
+
+# CA3012: Review code for regex injection vulnerabilities
+dotnet_diagnostic.ca3012.severity = warning
+
+# CA3061: Do Not Add Schema By URL
+dotnet_diagnostic.ca3061.severity = warning
+
+# CA3075: Insecure DTD processing in XML
+dotnet_diagnostic.ca3075.severity = warning
+
+# CA3076: Insecure XSLT script processing.
+dotnet_diagnostic.ca3076.severity = warning
+
+# CA3077: Insecure Processing in API Design, XmlDocument and XmlTextReader
+dotnet_diagnostic.ca3077.severity = warning
+
+# CA3147: Mark Verb Handlers With Validate Antiforgery Token
+dotnet_diagnostic.ca3147.severity = warning
+
+# CA5350: Do Not Use Weak Cryptographic Algorithms
+dotnet_diagnostic.ca5350.severity = warning
+
+# CA5351: Do Not Use Broken Cryptographic Algorithms
+dotnet_diagnostic.ca5351.severity = warning
+
+# CA5358: Review cipher mode usage with cryptography experts
+dotnet_diagnostic.ca5358.severity = warning
+
+# CA5359: Do Not Disable Certificate Validation
+dotnet_diagnostic.ca5359.severity = warning
+
+# CA5360: Do Not Call Dangerous Methods In Deserialization
+dotnet_diagnostic.ca5360.severity = warning
+
+# CA5361: Do Not Disable SChannel Use of Strong Crypto
+dotnet_diagnostic.ca5361.severity = warning
+
+# CA5362: Do Not Refer Self In Serializable Class
+dotnet_diagnostic.ca5362.severity = warning
+
+# CA5363: Do Not Disable Request Validation
+dotnet_diagnostic.ca5363.severity = warning
+
+# CA5364: Do Not Use Deprecated Security Protocols
+dotnet_diagnostic.ca5364.severity = warning
+
+# CA5365: Do Not Disable HTTP Header Checking
+dotnet_diagnostic.ca5365.severity = warning
+
+# CA5366: Use XmlReader For DataSet Read Xml
+dotnet_diagnostic.ca5366.severity = warning
+
+# CA5367: Do Not Serialize Types With Pointer Fields
+dotnet_diagnostic.ca5367.severity = warning
+
+# CA5368: Set ViewStateUserKey For Classes Derived From Page
+dotnet_diagnostic.ca5368.severity = warning
+
+# CA5369: Use XmlReader For Deserialize
+dotnet_diagnostic.ca5369.severity = warning
+
+# CA5370: Use XmlReader For Validating Reader
+dotnet_diagnostic.ca5370.severity = warning
+
+# CA5371: Use XmlReader For Schema Read
+dotnet_diagnostic.ca5371.severity = warning
+
+# CA5372: Use XmlReader For XPathDocument
+dotnet_diagnostic.ca5372.severity = warning
+
+# CA5373: Do not use obsolete key derivation function
+dotnet_diagnostic.ca5373.severity = warning
+
+# CA5374: Do Not Use XslTransform
+dotnet_diagnostic.ca5374.severity = warning
+
+# CA5375: Do Not Use Account Shared Access Signature
+dotnet_diagnostic.ca5375.severity = warning
+
+# CA5376: Use SharedAccessProtocol HttpsOnly
+dotnet_diagnostic.ca5376.severity = warning
+
+# CA5377: Use Container Level Access Policy
+dotnet_diagnostic.ca5377.severity = warning
+
+# CA5378: Do not disable ServicePointManagerSecurityProtocols
+dotnet_diagnostic.ca5378.severity = warning
+
+# CA5379: Do Not Use Weak Key Derivation Function Algorithm
+dotnet_diagnostic.ca5379.severity = warning
+
+# CA5380: Do Not Add Certificates To Root Store
+dotnet_diagnostic.ca5380.severity = warning
+
+# CA5381: Ensure Certificates Are Not Added To Root Store
+dotnet_diagnostic.ca5381.severity = warning
+
+# CA5382: Use Secure Cookies In ASP.Net Core
+dotnet_diagnostic.ca5382.severity = warning
+
+# CA5383: Ensure Use Secure Cookies In ASP.Net Core
+dotnet_diagnostic.ca5383.severity = warning
+
+# CA5384: Do Not Use Digital Signature Algorithm (DSA)
+dotnet_diagnostic.ca5384.severity = warning
+
+# CA5385: Use Rivest–Shamir–Adleman (RSA) Algorithm With Sufficient Key Size
+dotnet_diagnostic.ca5385.severity = warning
+
+# CA5386: Avoid hardcoding SecurityProtocolType value
+dotnet_diagnostic.ca5386.severity = warning
+
+# CA5387: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+dotnet_diagnostic.ca5387.severity = warning
+
+# CA5388: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+dotnet_diagnostic.ca5388.severity = warning
+
+# CA5389: Do Not Add Archive Item's Path To The Target File System Path
+dotnet_diagnostic.ca5389.severity = warning
+
+# CA5390: Do not hard-code encryption key
+dotnet_diagnostic.ca5390.severity = warning
+
+# CA5391: Use antiforgery tokens in ASP.NET Core MVC controllers
+dotnet_diagnostic.ca5391.severity = warning
+
+# CA5392: Use DefaultDllImportSearchPaths attribute for P/Invokes
+dotnet_diagnostic.ca5392.severity = warning
+
+# CA5393: Do not use unsafe DllImportSearchPath value
+dotnet_diagnostic.ca5393.severity = warning
+
+# CA5394: Do not use insecure randomness
+dotnet_diagnostic.ca5394.severity = warning
+
+# CA5395: Miss HttpVerb attribute for action methods
+dotnet_diagnostic.ca5395.severity = warning
+
+# CA5396: Set HttpOnly to true for HttpCookie
+dotnet_diagnostic.ca5396.severity = warning
+
+# CA5397: Do not use deprecated SslProtocols values
+dotnet_diagnostic.ca5397.severity = warning
+
+# CA5398: Avoid hardcoded SslProtocols values
+dotnet_diagnostic.ca5398.severity = warning
+
+# CA5399: HttpClients should enable certificate revocation list checks
+dotnet_diagnostic.ca5399.severity = warning
+
+# CA5400: Ensure HttpClient certificate revocation list check is not disabled
+dotnet_diagnostic.ca5400.severity = warning
+
+# CA5401: Do not use CreateEncryptor with non-default IV
+dotnet_diagnostic.ca5401.severity = warning
+
+# CA5402: Use CreateEncryptor with the default IV 
+dotnet_diagnostic.ca5402.severity = warning
+
+# CA5403: Do not hard-code certificate
+dotnet_diagnostic.ca5403.severity = warning
+
+# CA9999: Analyzer version mismatch
+dotnet_diagnostic.ca9999.severity = warning
+
+# CS8600: Converting null literal or possible null value to non-nullable type
+dotnet_diagnostic.cs8600.severity = error
+
+# CS8602: Dereference of a possibly null reference
+dotnet_diagnostic.cs8602.severity = error
+
+# CS8603: Possible null reference return
+dotnet_diagnostic.cs8603.severity = error
+
+# CS8604: Possible null reference argument
+dotnet_diagnostic.cs8604.severity = silent
+
+# S1135: Complete the task associated to this 'TODO' comment
+dotnet_diagnostic.s1135.severity = warning
+
+# SA1000: Keywords should be spaced correctly
+dotnet_diagnostic.sa1000.severity = error
+
+# Microsoft .NET properties
+csharp_new_line_before_members_in_object_initializers = false
+csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_using_directive_placement = inside_namespace:silent
+dotnet_naming_rule.private_constants_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_constants_rule.severity = warning
+dotnet_naming_rule.private_constants_rule.style = upper_camel_case_style
+dotnet_naming_rule.private_constants_rule.symbols = private_constants_symbols
+dotnet_naming_rule.private_instance_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_instance_fields_rule.severity = warning
+dotnet_naming_rule.private_instance_fields_rule.style = lower_camel_case_style
+dotnet_naming_rule.private_instance_fields_rule.symbols = private_instance_fields_symbols
+dotnet_naming_rule.private_static_fields_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_fields_rule.severity = warning
+dotnet_naming_rule.private_static_fields_rule.style = lower_camel_case_style
+dotnet_naming_rule.private_static_fields_rule.symbols = private_static_fields_symbols
+dotnet_naming_rule.private_static_readonly_rule.import_to_resharper = as_predefined
+dotnet_naming_rule.private_static_readonly_rule.severity = warning
+dotnet_naming_rule.private_static_readonly_rule.style = upper_camel_case_style
+dotnet_naming_rule.private_static_readonly_rule.symbols = private_static_readonly_symbols
+dotnet_naming_style.lower_camel_case_style.capitalization = camel_case
+dotnet_naming_style.upper_camel_case_style.capitalization = pascal_case
+dotnet_naming_symbols.private_constants_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_constants_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_constants_symbols.required_modifiers = const
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_instance_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_fields_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_fields_symbols.required_modifiers = static
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_accessibilities = private
+dotnet_naming_symbols.private_static_readonly_symbols.applicable_kinds = field
+dotnet_naming_symbols.private_static_readonly_symbols.required_modifiers = static,readonly
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:none
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:none
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:none
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
+dotnet_style_predefined_type_for_member_access = true:suggestion
+dotnet_style_qualification_for_event = true:none
+dotnet_style_qualification_for_field = true:none
+dotnet_style_qualification_for_method = true:none
+dotnet_style_qualification_for_property = true:none
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion
+
+# ReSharper properties
+resharper_add_imports_to_deepest_scope = true
+resharper_arguments_skip_single = true
+resharper_autodetect_indent_settings = true
+resharper_blank_lines_after_start_comment = 0
+resharper_blank_lines_around_accessor = 1
+resharper_braces_for_for = required
+resharper_braces_for_foreach = required
+resharper_braces_for_ifelse = required
+resharper_braces_for_while = required
+resharper_braces_redundant = false
+resharper_csharp_blank_lines_around_field = 0
+resharper_csharp_max_line_length = 200
+resharper_csharp_naming_rule.private_instance_fields = aaBb
+resharper_csharp_naming_rule.private_static_fields = aaBb
+resharper_csharp_parentheses_group_non_obvious_operations = arithmetic, conditional
+resharper_csharp_parentheses_non_obvious_operations = bitwise, shift, multiplicative
+resharper_csharp_parentheses_redundancy_style = remove_if_not_clarifies_precedence
+resharper_csharp_parentheses_same_type_operations = false
+resharper_csharp_wrap_after_declaration_lpar = true
+resharper_csharp_wrap_after_invocation_lpar = true
+resharper_csharp_wrap_arguments_style = chop_if_long
+resharper_csharp_wrap_array_initializer_style = chop_if_long
+resharper_csharp_wrap_before_declaration_rpar = false
+resharper_csharp_wrap_before_first_type_parameter_constraint = true
+resharper_csharp_wrap_before_invocation_rpar = false
+resharper_csharp_wrap_chained_method_calls = chop_if_long
+resharper_csharp_wrap_extends_list_style = chop_if_long
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_enforce_line_ending_style = true
+resharper_for_built_in_types = use_explicit_type
+resharper_for_other_types = use_explicit_type
+resharper_for_simple_types = use_explicit_type
+resharper_indent_pars = outside
+resharper_instance_members_qualify_members = none, field, property, event, method
+resharper_keep_existing_attribute_arrangement = true
+resharper_keep_existing_declaration_block_arrangement = true
+resharper_max_attribute_length_for_same_line = 200
+resharper_max_initializer_elements_on_line = 1
+resharper_namespace_body = block_scoped
+resharper_new_line_before_while = true
+resharper_place_accessorholder_attribute_on_same_line = false
+resharper_place_field_attribute_on_same_line = false
+resharper_place_simple_accessor_on_single_line = false
+resharper_place_simple_initializer_on_single_line = false
+resharper_qualified_using_at_nested_scope = true
+resharper_trailing_comma_in_multiline_lists = true
+resharper_use_indent_from_vs = false
+resharper_xmldoc_indent_child_elements = DoNotTouch
+resharper_xmldoc_indent_text = DoNotTouch
+resharper_xmldoc_space_before_self_closing = false
+
+# ReSharper inspection severities
+resharper_arrange_object_creation_when_type_not_evident_highlighting = none
+resharper_arrange_redundant_parentheses_highlighting = hint
+resharper_arrange_this_qualifier_highlighting = none
+resharper_arrange_type_member_modifiers_highlighting = hint
+resharper_arrange_type_modifiers_highlighting = hint
+resharper_built_in_type_reference_style_for_member_access_highlighting = hint
+resharper_built_in_type_reference_style_highlighting = hint
+resharper_invert_if_highlighting = none
+resharper_member_can_be_private_global_highlighting = hint
+resharper_property_can_be_made_init_only_global_highlighting = hint
+resharper_return_type_can_be_enumerable_global_highlighting = none
+resharper_suggest_var_or_type_built_in_types_highlighting = hint
+resharper_suggest_var_or_type_elsewhere_highlighting = hint
+resharper_suggest_var_or_type_simple_types_highlighting = hint
+resharper_unused_auto_property_accessor_global_highlighting = hint
+resharper_web_config_module_not_resolved_highlighting = warning
+resharper_web_config_type_not_resolved_highlighting = warning
+resharper_web_config_wrong_module_highlighting = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -673,6 +673,9 @@ dotnet_diagnostic.s1135.severity = warning
 # SA1000: Keywords should be spaced correctly
 dotnet_diagnostic.sa1000.severity = error
 
+ # SA1200: Using directives should be placed correctly
+dotnet_diagnostic.sa1200.severity = none
+
 # Microsoft .NET properties
 csharp_new_line_before_members_in_object_initializers = false
 csharp_preferred_modifier_order = public, private, protected, internal, new, static, abstract, virtual, sealed, readonly, override, extern, unsafe, volatile, async:suggestion

--- a/Apps/Common/src/AspNetConfiguration/Modules/PersonalAccount.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/PersonalAccount.cs
@@ -46,7 +46,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig!.BaseUrl)
                 .AddHttpMessageHandler<AuthHeaderHandler>();
 
-            services.TryAddTransient<Common.Services.IPersonalAccountsService, Common.Services.PersonalAccountsService>();
+            services.TryAddTransient<IPersonalAccountsService, PersonalAccountsService>();
         }
     }
 }

--- a/Apps/Common/src/AspNetConfiguration/Modules/PersonalAccount.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/PersonalAccount.cs
@@ -14,18 +14,18 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System.Diagnostics.CodeAnalysis;
-using HealthGateway.Common.Api;
-using HealthGateway.Common.Models.PHSA;
-using HealthGateway.Common.Utils.Phsa;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
-using Microsoft.Extensions.Logging;
-using Refit;
-
 namespace HealthGateway.Common.AspNetConfiguration.Modules
 {
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Models.PHSA;
+    using HealthGateway.Common.Utils.Phsa;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.DependencyInjection.Extensions;
+    using Microsoft.Extensions.Logging;
+    using Refit;
+
     /// <summary>
     /// Provides ASP.Net Services for personal account access.
     /// </summary>

--- a/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
+++ b/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
@@ -14,12 +14,12 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using System.Text.Json;
-using System.Text.Json.Serialization;
-
 namespace HealthGateway.Common.Utils
 {
+    using System;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+
     /// <summary>
     /// A json converter for types that inherits from T.
     /// It uses a discriminator to write and read json payload

--- a/Apps/HealthGateway.sln.DotSettings
+++ b/Apps/HealthGateway.sln.DotSettings
@@ -1,0 +1,92 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=7267BD8D_002DB2B0_002D4C12_002DA938_002DCE5C40467732_002Fd_003ASoap_002Fd_003AServices/@EntryIndexedValue">7267BD8D-B2B0-4C12-A938-CE5C40467732/d:Soap/d:Services</s:String>
+	<s:String x:Key="/Default/CodeInspection/ExcludedFiles/GeneratedFilesAndFolders/=8660083F_002DF582_002D47C6_002DBC98_002D6DCF0F4AC851_002Fd_003AServiceReference/@EntryIndexedValue">8660083F-F582-47C6-BC98-6DCF0F4AC851/d:ServiceReference</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=LogMessageIsSentenceProblem/@EntryIndexedValue">HINT</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=WithExpressionModifiesAllMembers/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/SweaWarningsMode/@EntryValue">ShowAndRun</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=HG_0020Full_0020Cleanup/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="HG Full Cleanup"&gt;&lt;CppCodeStyleCleanupDescriptor /&gt;&lt;CSCodeStyleAttributes ArrangeVarStyle="True" ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" ArrangeArgumentsStyle="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeCodeBodyStyle="True" ArrangeTrailingCommas="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" /&gt;&lt;RemoveCodeRedundancies&gt;True&lt;/RemoveCodeRedundancies&gt;&lt;CSUseAutoProperty&gt;True&lt;/CSUseAutoProperty&gt;&lt;CSMakeFieldReadonly&gt;True&lt;/CSMakeFieldReadonly&gt;&lt;CSMakeAutoPropertyGetOnly&gt;True&lt;/CSMakeAutoPropertyGetOnly&gt;&lt;CSOptimizeUsings&gt;&lt;OptimizeUsings&gt;True&lt;/OptimizeUsings&gt;&lt;/CSOptimizeUsings&gt;&lt;IDEA_SETTINGS&gt;&amp;lt;profile version="1.0"&amp;gt;&#xD;
+  &amp;lt;option name="myName" value="HG Full Cleanup" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="ES6ShorthandObjectProperty" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSArrowFunctionBracesCanBeRemoved" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSPrimitiveTypeWrapperUsage" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSRemoveUnnecessaryParentheses" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="JSUnnecessarySemicolon" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="TypeScriptExplicitMemberType" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryContinueJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryLabelJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryLabelOnBreakStatementJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryLabelOnContinueStatementJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="UnnecessaryReturnJS" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+  &amp;lt;inspection_tool class="WrongPropertyKeyValueDelimiter" enabled="false" level="WARNING" enabled_by_default="false" /&amp;gt;&#xD;
+&amp;lt;/profile&amp;gt;&lt;/IDEA_SETTINGS&gt;&lt;RIDER_SETTINGS&gt;&amp;lt;profile&amp;gt;&#xD;
+  &amp;lt;Language id="CSS"&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="EditorConfig"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="HTML"&amp;gt;&#xD;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="HTTP Request"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="Handlebars"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="Ini"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="JSON"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="Jade"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="JavaScript"&amp;gt;&#xD;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="Markdown"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="Properties"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="RELAX-NG"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="SQL"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="XML"&amp;gt;&#xD;
+    &amp;lt;OptimizeImports&amp;gt;false&amp;lt;/OptimizeImports&amp;gt;&#xD;
+    &amp;lt;Rearrange&amp;gt;false&amp;lt;/Rearrange&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+  &amp;lt;Language id="yaml"&amp;gt;&#xD;
+    &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
+  &amp;lt;/Language&amp;gt;&#xD;
+&amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;CSShortenReferences&gt;True&lt;/CSShortenReferences&gt;&lt;AspOptimizeRegisterDirectives&gt;True&lt;/AspOptimizeRegisterDirectives&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;FormatAttributeQuoteDescriptor&gt;True&lt;/FormatAttributeQuoteDescriptor&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;/Profile&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=AHFS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=BCMP/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Blazored/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CDOGS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=DIN/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=EMPI/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HDID/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=HDIDs/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=IDIR/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=LOINC/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PharmaNet/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PHSA/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=PLIS/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>

--- a/Apps/Patient/src/AssemblyInfo.cs
+++ b/Apps/Patient/src/AssemblyInfo.cs
@@ -14,5 +14,7 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 using System;
+using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
+[assembly: InternalsVisibleTo("PatientTests")]

--- a/Apps/Patient/src/Controllers/PatientDataController.cs
+++ b/Apps/Patient/src/Controllers/PatientDataController.cs
@@ -62,11 +62,16 @@ namespace HealthGateway.Patient.Controllers
         public async Task<ActionResult<PatientDataResponse>> Get(string hdid, [FromQuery] PatientDataType[] patientDataTypes, CancellationToken ct)
         {
             if (string.IsNullOrEmpty(hdid))
+            {
                 throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(hdid), "Hdid is missing"));
-            if (patientDataTypes == null || !patientDataTypes.Any())
-                throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(patientDataTypes), "Must have at least one data type"));
+            }
 
-            var response = await patientDataService.Query(new PatientDataQuery(hdid, patientDataTypes), ct);
+            if (patientDataTypes == null || !patientDataTypes.Any())
+            {
+                throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(patientDataTypes), "Must have at least one data type"));
+            }
+
+            var response = await this.patientDataService.Query(new PatientDataQuery(hdid, patientDataTypes), ct);
             return response;
         }
 
@@ -88,11 +93,16 @@ namespace HealthGateway.Patient.Controllers
         public async Task<ActionResult<PatientFileResponse>> GetFile(string hdid, string fileId, CancellationToken ct)
         {
             if (string.IsNullOrEmpty(hdid))
+            {
                 throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(hdid), "Hdid is missing"));
-            if (string.IsNullOrEmpty(fileId))
-                throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(fileId), "File id is missing"));
+            }
 
-            return await patientDataService.Query(new PatientFileQuery(hdid, fileId), ct) ??
+            if (string.IsNullOrEmpty(fileId))
+            {
+                throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(fileId), "File id is missing"));
+            }
+
+            return await this.patientDataService.Query(new PatientFileQuery(hdid, fileId), ct) ??
                    throw new ProblemDetailsException(ExceptionUtility.CreateNotFoundError($"file {fileId} not found"));
         }
     }

--- a/Apps/Patient/src/Controllers/PatientDataController.cs
+++ b/Apps/Patient/src/Controllers/PatientDataController.cs
@@ -14,18 +14,18 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using HealthGateway.Common.AccessManagement.Authorization.Policy;
-using HealthGateway.Common.Data.ErrorHandling;
-using HealthGateway.Patient.Services;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-
 namespace HealthGateway.Patient.Controllers
 {
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.AccessManagement.Authorization.Policy;
+    using HealthGateway.Common.Data.ErrorHandling;
+    using HealthGateway.Patient.Services;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+
     /// <summary>
     /// Endpoint to query and manage patient related data
     /// </summary>

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -14,23 +14,23 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 
-using System;
-using System.Diagnostics.CodeAnalysis;
-using System.Text.Json.Serialization;
-using System.Threading.Tasks;
-using HealthGateway.Common.AspNetConfiguration;
-using HealthGateway.Common.AspNetConfiguration.Modules;
-using HealthGateway.Patient.Delegates;
-using HealthGateway.Patient.Services;
-using HealthGateway.PatientDataAccess;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-
 namespace HealthGateway.Patient
 {
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.AspNetConfiguration.Modules;
+    using HealthGateway.Patient.Delegates;
+    using HealthGateway.Patient.Services;
+    using HealthGateway.PatientDataAccess;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
+
     /// <summary>
     /// The entry point for the project.
     /// </summary>

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.Patient
             Auth.ConfigureAuthorizationServices(services, logger, configuration);
             SwaggerDoc.ConfigureSwaggerServices(services, configuration);
 
-            Common.AspNetConfiguration.Modules.Patient.ConfigurePatientAccess(services, logger, configuration);
+            Patient.ConfigurePatientAccess(services, logger, configuration);
             PersonalAccount.ConfigurePersonalAccountAccess(services, logger, configuration);
 
             services.AddTransient<IClientRegistriesDelegate, ClientRegistriesDelegate>();

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -14,16 +14,16 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
-using HealthGateway.Common.Utils;
-
 namespace HealthGateway.Patient.Services
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Utils;
+
     /// <summary>
     /// Provides access to patient related data services
     /// </summary>

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -52,7 +52,7 @@ namespace HealthGateway.Patient.Services
     /// </summary>
     /// <param name="Hdid">The patient hdid</param>
     /// <param name="PatientDataTypes">The data types to query</param>
-    public record PatientDataQuery(string Hdid, PatientDataType[] PatientDataTypes);
+    public record PatientDataQuery(string Hdid, IEnumerable<PatientDataType> PatientDataTypes);
 
     /// <summary>
     /// Patiend data types
@@ -79,7 +79,7 @@ namespace HealthGateway.Patient.Services
     public abstract record PatientData
     {
         /// <summary>
-        /// The type of the patient data
+        /// Gets or sets the type of the patient data
         /// </summary>
         public abstract string Type { get; set; }
     }
@@ -97,23 +97,23 @@ namespace HealthGateway.Patient.Services
         /// <param name="registrationFileId">Optional registration file id</param>
         public OrganDonorRegistrationData(string status, string? statusMessage, string? registrationFileId)
         {
-            Status = status;
-            StatusMessage = statusMessage;
-            RegistrationFileId = registrationFileId;
+            this.Status = status;
+            this.StatusMessage = statusMessage;
+            this.RegistrationFileId = registrationFileId;
         }
 
         /// <summary>
-        /// The registration status
+        /// Gets or sets the donor registration status
         /// </summary>
         public string Status { get; set; } = null!;
 
         /// <summary>
-        /// Message related to the status
+        /// Gets or sets the message associated with the donor registration status
         /// </summary>
         public string? StatusMessage { get; set; }
 
         /// <summary>
-        /// Registration file id
+        /// Gets or sets the file ID associated with the donor registration
         /// </summary>
         public string? RegistrationFileId { get; set; }
 
@@ -133,7 +133,7 @@ namespace HealthGateway.Patient.Services
     /// </summary>
     /// <param name="Content">The file content</param>
     /// <param name="ContentType">The file content type</param>
-    public record PatientFileResponse(byte[] Content, string ContentType);
+    public record PatientFileResponse(IEnumerable<byte> Content, string ContentType);
 
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Team decision")]
     internal class PatientDataJsonConverter : PolymorphicJsonConverter<PatientData>
@@ -147,7 +147,7 @@ namespace HealthGateway.Patient.Services
             {
                 nameof(OrganDonorRegistrationData) => typeof(OrganDonorRegistrationData),
 
-                _ => null
+                _ => null,
             };
     }
 }

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Patient.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
     using System.Threading;
@@ -134,10 +135,13 @@ namespace HealthGateway.Patient.Services
     /// <param name="ContentType">The file content type</param>
     public record PatientFileResponse(byte[] Content, string ContentType);
 
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Team decision")]
     internal class PatientDataJsonConverter : PolymorphicJsonConverter<PatientData>
     {
+        /// <inheritdoc/>
         protected override string ResolveDiscriminatorValue(PatientData value) => value.Type;
 
+        /// <inheritdoc/>
         protected override Type? ResolveType(string discriminatorValue) =>
             discriminatorValue switch
             {

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -14,15 +14,15 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-using HealthGateway.Common.Services;
-using HealthGateway.PatientDataAccess;
-
 namespace HealthGateway.Patient.Services
 {
+    using System;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Services;
+    using HealthGateway.PatientDataAccess;
+
     internal class PatientDataService : IPatientDataService
     {
         private readonly IPatientDataRepository patientDataRepository;

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -17,12 +17,14 @@
 namespace HealthGateway.Patient.Services
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Services;
     using HealthGateway.PatientDataAccess;
 
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Team decision")]
     internal class PatientDataService : IPatientDataService
     {
         private readonly IPatientDataRepository patientDataRepository;

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -31,7 +31,7 @@ namespace HealthGateway.Patient.Services
         private readonly IPersonalAccountsService personalAccountsService;
 
         private async Task<Guid> ResolvePidFromHdid(string patientHdid) =>
-            (await personalAccountsService.GetPatientAccountAsync(patientHdid)).PatientIdentity.Pid;
+            (await this.personalAccountsService.GetPatientAccountAsync(patientHdid)).PatientIdentity.Pid;
 
         public PatientDataService(IPatientDataRepository patientDataRepository, IPersonalAccountsService personalAccountsService)
         {
@@ -41,18 +41,18 @@ namespace HealthGateway.Patient.Services
 
         public async Task<PatientDataResponse> Query(PatientDataQuery query, CancellationToken ct)
         {
-            var pid = await ResolvePidFromHdid(query.Hdid);
-            var results = await patientDataRepository.Query(
-                new HealthServicesQuery(pid, query.PatientDataTypes.Select(MapToHealthServiceCategory)),
+            var pid = await this.ResolvePidFromHdid(query.Hdid);
+            var results = await this.patientDataRepository.Query(
+                new HealthServicesQuery(pid, query.PatientDataTypes.Select(this.MapToHealthServiceCategory)),
                 ct);
 
-            return new PatientDataResponse(results.Items.Select(MapToPatientData).ToArray());
+            return new PatientDataResponse(results.Items.Select(this.MapToPatientData).ToArray());
         }
 
         public async Task<PatientFileResponse?> Query(PatientFileQuery query, CancellationToken ct)
         {
-            var pid = await ResolvePidFromHdid(query.Hdid);
-            var file = (await patientDataRepository.Query(new PatientDataAccess.PatientFileQuery(pid, query.FileId), ct)).Items.FirstOrDefault() as PatientFile;
+            var pid = await this.ResolvePidFromHdid(query.Hdid);
+            var file = (await this.patientDataRepository.Query(new PatientDataAccess.PatientFileQuery(pid, query.FileId), ct)).Items.FirstOrDefault() as PatientFile;
 
             return file != null
                 ? new PatientFileResponse(file.Content, file.ContentType)
@@ -64,7 +64,7 @@ namespace HealthGateway.Patient.Services
             {
                 OrganDonorRegistration hd => new OrganDonorRegistrationData(hd.Status.ToString(), hd.StatusMessage, hd.RegistrationFileId),
 
-                _ => throw new NotImplementedException($"{healthData.GetType().Name} is not mapped to {nameof(PatientData)}")
+                _ => throw new NotImplementedException($"{healthData.GetType().Name} is not mapped to {nameof(PatientData)}"),
             };
 
         private HealthServiceCategory MapToHealthServiceCategory(PatientDataType patientDataType) =>
@@ -72,7 +72,7 @@ namespace HealthGateway.Patient.Services
             {
                 PatientDataType.OrganDonorRegistrationStatus => HealthServiceCategory.OrganDonor,
 
-                _ => throw new NotImplementedException($"{patientDataType} is not mapped to {nameof(HealthServiceCategory)}")
+                _ => throw new NotImplementedException($"{patientDataType} is not mapped to {nameof(HealthServiceCategory)}"),
             };
     }
 }

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.PatientTests.Services
 
             var data = new PatientData[]
             {
-                organDonorRegistationData
+                organDonorRegistationData,
             };
 
             var response = new PatientDataResponse(data);
@@ -63,31 +63,31 @@ namespace HealthGateway.PatientTests.Services
         [Fact]
         public async Task CanGetPatientData()
         {
-            var expected = new PatientDataAccess.OrganDonorRegistration
+            var expected = new OrganDonorRegistration
             {
-                Status = PatientDataAccess.DonorRegistrationStatus.Registered,
+                Status = DonorRegistrationStatus.Registered,
                 RegistrationFileId = Guid.NewGuid().ToString(),
-                StatusMessage = "some message"
+                StatusMessage = "some message",
             };
 
-            var patientDataRepository = new Mock<PatientDataAccess.IPatientDataRepository>();
+            var patientDataRepository = new Mock<IPatientDataRepository>();
             patientDataRepository
                 .Setup(o => o.Query(
-                    It.Is<PatientDataAccess.HealthServicesQuery>(q =>
-                        q.Pid == pid && q.Categories.Any(c => c == PatientDataAccess.HealthServiceCategory.OrganDonor)),
+                    It.Is<HealthServicesQuery>(q =>
+                        q.Pid == this.pid && q.Categories.Any(c => c == HealthServiceCategory.OrganDonor)),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new PatientDataAccess.PatientDataQueryResult(new[] { expected }));
+                .ReturnsAsync(new PatientDataQueryResult(new[] { expected }));
 
             var personalAccountService = new Mock<IPersonalAccountsService>();
-            personalAccountService.Setup(o => o.GetPatientAccountAsync(hdid)).ReturnsAsync(new Common.Models.PHSA.PersonalAccount
+            personalAccountService.Setup(o => o.GetPatientAccountAsync(this.hdid)).ReturnsAsync(new Common.Models.PHSA.PersonalAccount
             {
                 Id = Guid.NewGuid(),
-                PatientIdentity = new Common.Models.PHSA.PatientIdentity { Pid = pid }
+                PatientIdentity = new Common.Models.PHSA.PatientIdentity { Pid = this.pid },
             });
 
             var sut = new PatientDataService(patientDataRepository.Object, personalAccountService.Object);
 
-            var result = await sut.Query(new PatientDataQuery(hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None);
+            var result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None);
 
             var actual = result.Items.ShouldHaveSingleItem().ShouldBeOfType<OrganDonorRegistrationData>();
             actual.Status.ShouldBe(expected.Status.ToString());
@@ -98,26 +98,26 @@ namespace HealthGateway.PatientTests.Services
         [Fact]
         public async Task CanGetPatientFile()
         {
-            var expected = new PatientDataAccess.PatientFile(Guid.NewGuid().ToString(), RandomNumberGenerator.GetBytes(1024), "text/plain");
+            var expected = new PatientFile(Guid.NewGuid().ToString(), RandomNumberGenerator.GetBytes(1024), "text/plain");
 
-            var patientDataRepository = new Mock<PatientDataAccess.IPatientDataRepository>();
+            var patientDataRepository = new Mock<IPatientDataRepository>();
             patientDataRepository
                 .Setup(o => o.Query(
                     It.Is<PatientDataAccess.PatientFileQuery>(q =>
-                        q.Pid == pid && q.FileId == expected.FileId),
+                        q.Pid == this.pid && q.FileId == expected.FileId),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new PatientDataAccess.PatientDataQueryResult(new[] { expected }));
+                .ReturnsAsync(new PatientDataQueryResult(new[] { expected }));
 
             var personalAccountService = new Mock<IPersonalAccountsService>();
-            personalAccountService.Setup(o => o.GetPatientAccountAsync(hdid)).ReturnsAsync(new Common.Models.PHSA.PersonalAccount
+            personalAccountService.Setup(o => o.GetPatientAccountAsync(this.hdid)).ReturnsAsync(new Common.Models.PHSA.PersonalAccount
             {
                 Id = Guid.NewGuid(),
-                PatientIdentity = new Common.Models.PHSA.PatientIdentity { Pid = pid }
+                PatientIdentity = new Common.Models.PHSA.PatientIdentity { Pid = this.pid },
             });
 
             var sut = new PatientDataService(patientDataRepository.Object, personalAccountService.Object);
 
-            var result = await sut.Query(new PatientFileQuery(hdid, expected.FileId), CancellationToken.None);
+            var result = await sut.Query(new PatientFileQuery(this.hdid, expected.FileId), CancellationToken.None);
 
             var actual = result.ShouldBeOfType<PatientFileResponse>();
             actual.Content.ShouldBe(expected.Content);
@@ -129,24 +129,24 @@ namespace HealthGateway.PatientTests.Services
         {
             var fileId = Guid.NewGuid().ToString();
 
-            var patientDataRepository = new Mock<PatientDataAccess.IPatientDataRepository>();
+            var patientDataRepository = new Mock<IPatientDataRepository>();
             patientDataRepository
                 .Setup(o => o.Query(
                     It.Is<PatientDataAccess.PatientFileQuery>(q =>
-                        q.Pid == pid && q.FileId == fileId),
+                        q.Pid == this.pid && q.FileId == fileId),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new PatientDataAccess.PatientDataQueryResult(Array.Empty<PatientFile>()));
+                .ReturnsAsync(new PatientDataQueryResult(Array.Empty<PatientFile>()));
 
             var personalAccountService = new Mock<IPersonalAccountsService>();
-            personalAccountService.Setup(o => o.GetPatientAccountAsync(hdid)).ReturnsAsync(new Common.Models.PHSA.PersonalAccount
+            personalAccountService.Setup(o => o.GetPatientAccountAsync(this.hdid)).ReturnsAsync(new Common.Models.PHSA.PersonalAccount
             {
                 Id = Guid.NewGuid(),
-                PatientIdentity = new Common.Models.PHSA.PatientIdentity { Pid = pid }
+                PatientIdentity = new Common.Models.PHSA.PatientIdentity { Pid = this.pid },
             });
 
             var sut = new PatientDataService(patientDataRepository.Object, personalAccountService.Object);
 
-            var result = await sut.Query(new PatientFileQuery(hdid, fileId), CancellationToken.None);
+            var result = await sut.Query(new PatientFileQuery(this.hdid, fileId), CancellationToken.None);
 
             result.ShouldBeNull();
         }

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -14,23 +14,23 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Text.Json;
-using System.Threading;
-using System.Threading.Tasks;
-using HealthGateway.Common.Services;
-using HealthGateway.Patient.Services;
-using HealthGateway.PatientDataAccess;
-using Moq;
-using Shouldly;
-using Xunit;
-using PatientDataQuery = HealthGateway.Patient.Services.PatientDataQuery;
-using PatientFileQuery = HealthGateway.Patient.Services.PatientFileQuery;
-
 namespace HealthGateway.PatientTests.Services
 {
+    using System;
+    using System.Linq;
+    using System.Security.Cryptography;
+    using System.Text.Json;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Services;
+    using HealthGateway.Patient.Services;
+    using HealthGateway.PatientDataAccess;
+    using Moq;
+    using Shouldly;
+    using Xunit;
+    using PatientDataQuery = HealthGateway.Patient.Services.PatientDataQuery;
+    using PatientFileQuery = HealthGateway.Patient.Services.PatientFileQuery;
+
     public class PatientDataServiceTests
     {
         private readonly Guid pid = Guid.NewGuid();

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -14,6 +14,8 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
+#pragma warning disable SA1600
+#pragma warning disable SA1602
 namespace HealthGateway.PatientDataAccess.Api
 {
     using System;

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -60,7 +60,7 @@ namespace HealthGateway.PatientDataAccess.Api
         Registered,
         NonRegistered,
         Error,
-        Pending
+        Pending,
     }
 
     internal class HealthOptionDataJsonConverter : PolymorphicJsonConverter<HealthOptionData>
@@ -72,7 +72,7 @@ namespace HealthGateway.PatientDataAccess.Api
             {
                 "BcTransplantOrganDonor" => typeof(OrganDonor),
 
-                _ => null
+                _ => null,
             };
     }
 }

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -14,16 +14,16 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Text.Json.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
-using HealthGateway.Common.Utils;
-using Refit;
-
 namespace HealthGateway.PatientDataAccess.Api
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Text.Json.Serialization;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Utils;
+    using Refit;
+
     internal interface IPatientApi
     {
         [Get("/patient/{pid}/file/{fileId}")]

--- a/Apps/PatientDataAccess/src/ConfigurationExtentions.cs
+++ b/Apps/PatientDataAccess/src/ConfigurationExtentions.cs
@@ -32,7 +32,7 @@ namespace HealthGateway.PatientDataAccess
         /// </summary>
         /// <param name="services">DI service collection</param>
         /// <param name="configuration">configuration settings</param>
-        /// <returns>DI service collection</returns>
+        /// <returns>The updated DI service collection</returns>
         public static IServiceCollection AddPatientDataAccess(this IServiceCollection services, PatientDataAccessConfiguration configuration)
         {
             services.AddAutoMapper(typeof(Mappings));

--- a/Apps/PatientDataAccess/src/ConfigurationExtentions.cs
+++ b/Apps/PatientDataAccess/src/ConfigurationExtentions.cs
@@ -14,14 +14,13 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using HealthGateway.Common.Utils.Phsa;
-using HealthGateway.PatientDataAccess.Api;
-using Refit;
-
 namespace HealthGateway.PatientDataAccess
 {
+    using System;
+    using HealthGateway.Common.Utils.Phsa;
+    using HealthGateway.PatientDataAccess.Api;
     using Microsoft.Extensions.DependencyInjection;
+    using Refit;
 
     /// <summary>
     /// Helper class to add and configure <see cref="IPatientDataRepository"/> dependencies

--- a/Apps/PatientDataAccess/src/Contract.cs
+++ b/Apps/PatientDataAccess/src/Contract.cs
@@ -14,6 +14,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
+#pragma warning disable SA1649
 namespace HealthGateway.PatientDataAccess
 {
     using System;

--- a/Apps/PatientDataAccess/src/Contract.cs
+++ b/Apps/PatientDataAccess/src/Contract.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.PatientDataAccess
         /// <summary>
         /// BC Transplant Organ Donor
         /// </summary>
-        OrganDonor
+        OrganDonor,
     }
 
     /// <summary>
@@ -83,17 +83,17 @@ namespace HealthGateway.PatientDataAccess
     public record OrganDonorRegistration : HealthServiceData
     {
         /// <summary>
-        /// The donor registration status
+        /// Gets or sets the donor registration status
         /// </summary>
         public DonorRegistrationStatus Status { get; set; }
 
         /// <summary>
-        /// Status related message
+        /// Gets or sets the message associated with the donor registration status
         /// </summary>
         public string? StatusMessage { get; set; }
 
         /// <summary>
-        /// RegistrationFileId
+        /// Gets or sets the file ID associated with the donor registration
         /// </summary>
         public string? RegistrationFileId { get; set; }
     }
@@ -121,11 +121,11 @@ namespace HealthGateway.PatientDataAccess
         /// <summary>
         /// Registration is pending
         /// </summary>
-        Pending
+        Pending,
     }
 
     /// <summary>
     /// Represents a patient file
     /// </summary>
-    public record PatientFile(string FileId, byte[] Content, string ContentType) : HealthData;
+    public record PatientFile(string FileId, IEnumerable<byte> Content, string ContentType) : HealthData;
 }

--- a/Apps/PatientDataAccess/src/Contract.cs
+++ b/Apps/PatientDataAccess/src/Contract.cs
@@ -14,12 +14,11 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System.Threading;
-
 namespace HealthGateway.PatientDataAccess
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>

--- a/Apps/PatientDataAccess/src/Mappings.cs
+++ b/Apps/PatientDataAccess/src/Mappings.cs
@@ -14,11 +14,11 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using AutoMapper;
-using HealthGateway.PatientDataAccess.Api;
-
 namespace HealthGateway.PatientDataAccess
 {
+    using AutoMapper;
+    using HealthGateway.PatientDataAccess.Api;
+
     internal class Mappings : Profile
     {
         public Mappings()

--- a/Apps/PatientDataAccess/src/Mappings.cs
+++ b/Apps/PatientDataAccess/src/Mappings.cs
@@ -16,9 +16,11 @@
 
 namespace HealthGateway.PatientDataAccess
 {
+    using System.Diagnostics.CodeAnalysis;
     using AutoMapper;
     using HealthGateway.PatientDataAccess.Api;
 
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Team decision")]
     internal class Mappings : Profile
     {
         public Mappings()

--- a/Apps/PatientDataAccess/src/Mappings.cs
+++ b/Apps/PatientDataAccess/src/Mappings.cs
@@ -25,10 +25,10 @@ namespace HealthGateway.PatientDataAccess
     {
         public Mappings()
         {
-            CreateMap<HealthOptionData, HealthData>()
+            this.CreateMap<HealthOptionData, HealthData>()
                 .IncludeAllDerived();
 
-            CreateMap<OrganDonor, OrganDonorRegistration>()
+            this.CreateMap<OrganDonor, OrganDonorRegistration>()
                 .ForMember(d => d.Status, opts => opts.MapFrom(s => s.DonorStatus))
                 .ForMember(d => d.RegistrationFileId, opts => opts.MapFrom(s => s.HealthDataFileId))
                 ;

--- a/Apps/PatientDataAccess/src/PatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/PatientDataRepository.cs
@@ -14,17 +14,17 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using AutoMapper;
-using HealthGateway.PatientDataAccess.Api;
-using Refit;
-
 namespace HealthGateway.PatientDataAccess
 {
+    using System;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using HealthGateway.PatientDataAccess.Api;
+    using Refit;
+
     internal class PatientDataRepository : IPatientDataRepository
     {
         private readonly IPatientApi patientApi;

--- a/Apps/PatientDataAccess/src/PatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/PatientDataRepository.cs
@@ -17,6 +17,7 @@
 namespace HealthGateway.PatientDataAccess
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -25,6 +26,7 @@ namespace HealthGateway.PatientDataAccess
     using HealthGateway.PatientDataAccess.Api;
     using Refit;
 
+    [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Team decision")]
     internal class PatientDataRepository : IPatientDataRepository
     {
         private readonly IPatientApi patientApi;

--- a/Apps/PatientDataAccess/src/PatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/PatientDataRepository.cs
@@ -42,10 +42,10 @@ namespace HealthGateway.PatientDataAccess
         {
             return query switch
             {
-                HealthServicesQuery q => await Handle(q, ct),
-                PatientFileQuery q => await Handle(q, ct),
+                HealthServicesQuery q => await this.Handle(q, ct),
+                PatientFileQuery q => await this.Handle(q, ct),
 
-                _ => throw new NotImplementedException($"{query.GetType().Name} doesn't have a handler")
+                _ => throw new NotImplementedException($"{query.GetType().Name} doesn't have a handler"),
             };
         }
 
@@ -53,15 +53,15 @@ namespace HealthGateway.PatientDataAccess
         {
             var categories = query.Categories.Select(c => Map(c)).ToArray();
 
-            var results = await patientApi.GetHealthOptionsAsync(query.Pid, categories, ct) ?? new HealthOptionsResult(new HealthOptionMetadata(), Array.Empty<HealthOptionData>());
-            return new PatientDataQueryResult(results.Data.Select(Map));
+            var results = await this.patientApi.GetHealthOptionsAsync(query.Pid, categories, ct) ?? new HealthOptionsResult(new HealthOptionMetadata(), Array.Empty<HealthOptionData>());
+            return new PatientDataQueryResult(results.Data.Select(this.Map));
         }
 
         private async Task<PatientDataQueryResult> Handle(PatientFileQuery query, CancellationToken ct)
         {
             try
             {
-                var fileResult = await patientApi.GetFile(query.Pid, query.FileId, ct);
+                var fileResult = await this.patientApi.GetFile(query.Pid, query.FileId, ct);
                 var mappedFiles = new[] { fileResult }
                     .Where(f => f?.Data != null)
                     .Select(f => Map(query.FileId, f!));
@@ -74,14 +74,14 @@ namespace HealthGateway.PatientDataAccess
             }
         }
 
-        private HealthData Map(HealthOptionData healthOptionData) => mapper.Map<HealthData>(healthOptionData);
+        private HealthData Map(HealthOptionData healthOptionData) => this.mapper.Map<HealthData>(healthOptionData);
 
         private static string Map(HealthServiceCategory category) =>
             category switch
             {
                 HealthServiceCategory.OrganDonor => "BcTransplantOrganDonor",
 
-                _ => throw new NotImplementedException($"No mapping implemented for {category}")
+                _ => throw new NotImplementedException($"No mapping implemented for {category}"),
             };
 
         private static PatientFile Map(string fileId, FileResult file) =>

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -14,16 +14,16 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------
 
-using System.Net;
-using System.Text;
-using AutoMapper;
-using HealthGateway.PatientDataAccess;
-using HealthGateway.PatientDataAccess.Api;
-using Moq;
-using Refit;
-
 namespace PatientDataAccessTests
 {
+    using System.Net;
+    using System.Text;
+    using AutoMapper;
+    using HealthGateway.PatientDataAccess;
+    using HealthGateway.PatientDataAccess.Api;
+    using Moq;
+    using Refit;
+
     public class PatientDataRepositoryTests
     {
         private readonly Guid pid = Guid.NewGuid();

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -44,16 +44,16 @@ namespace PatientDataAccessTests
                 DonorStatus = DonorStatus.Registered,
                 StatusMessage = "statusmessage",
                 HealthDataFileId = Guid.NewGuid().ToString(),
-                HealthOptionsId = "optid"
+                HealthOptionsId = "optid",
             };
 
             patientApi
-                .Setup(api => api.GetHealthOptionsAsync(pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetHealthOptionsAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new HealthOptionsResult(new HealthOptionMetadata(), new[] { phsaOrganDonorResponse }));
 
             var sut = CreateSut(patientApi.Object);
 
-            var result = await sut.Query(new HealthServicesQuery(pid, new[] { HealthServiceCategory.OrganDonor }), CancellationToken.None);
+            var result = await sut.Query(new HealthServicesQuery(this.pid, new[] { HealthServiceCategory.OrganDonor }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             var organDonorRegistration = result.Items.ShouldHaveSingleItem().ShouldBeOfType<OrganDonorRegistration>();
@@ -70,19 +70,19 @@ namespace PatientDataAccessTests
             var expectedFile = new FileResult("text/plain", "somedata", "encoding");
 
             patientApi
-                .Setup(api => api.GetFile(pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedFile);
 
             var sut = CreateSut(patientApi.Object);
 
-            var result = await sut.Query(new PatientFileQuery(pid, fileId), CancellationToken.None);
+            var result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull();
             var actualFile = result.Items.ShouldHaveSingleItem().ShouldBeOfType<PatientFile>();
             actualFile.FileId.ShouldBe(fileId);
             actualFile.Content.ShouldNotBeEmpty();
             actualFile.ContentType.ShouldBe(expectedFile.MediaType);
-            Encoding.Default.GetString(actualFile.Content).ShouldBe(expectedFile.Data);
+            Encoding.Default.GetString(actualFile.Content.ToArray()).ShouldBe(expectedFile.Data);
         }
 
         [Fact]
@@ -92,12 +92,12 @@ namespace PatientDataAccessTests
             var fileId = Guid.NewGuid().ToString();
 
             patientApi
-                .Setup(api => api.GetFile(pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((FileResult?)null);
 
             var sut = CreateSut(patientApi.Object);
 
-            var result = await sut.Query(new PatientFileQuery(pid, fileId), CancellationToken.None);
+            var result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
@@ -110,13 +110,13 @@ namespace PatientDataAccessTests
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
             patientApi
-                .Setup(api => api.GetFile(pid, fileId, It.IsAny<CancellationToken>()))
-                .ThrowsAsync(await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, new HttpResponseMessage(HttpStatusCode.NotFound), new RefitSettings { }));
+                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
+                .ThrowsAsync(await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, new HttpResponseMessage(HttpStatusCode.NotFound), new RefitSettings()));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
             var sut = CreateSut(patientApi.Object);
 
-            var result = await sut.Query(new PatientFileQuery(pid, fileId), CancellationToken.None);
+            var result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
@@ -129,12 +129,12 @@ namespace PatientDataAccessTests
             var expectedFile = new FileResult(null, null, null);
 
             patientApi
-                .Setup(api => api.GetFile(pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedFile);
 
             var sut = CreateSut(patientApi.Object);
 
-            var result = await sut.Query(new PatientFileQuery(pid, fileId), CancellationToken.None);
+            var result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }


### PR DESCRIPTION
# Related to [AB#15014](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15014)

## Description

- Restores .editorconfig and .DotSettings
- Adjusts SA1200 severity to none
- Adjusts CA2007 severity to none
- Adjusts SA1201-SA1204 severity to none
- Adjusts SA1600 severity to none for unit tests
- Ignores SA1600 and SA1602 for specific files
- Adjusts SA1629 severity to none
- Ignores SA1649 for specific files
- Resolves remaining code analysis issues
- Ensures internal types in Patient are available in unit tests

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
