### PR TITLE
Add cypress config setup for services AB#15120

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/user/organDonorCardQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/organDonorCardQuickLink.js
@@ -105,7 +105,6 @@ describe("Disabling organ donor services", () => {
                 },
             ],
             services: {
-                enabled: false,
                 services: [
                     {
                         name: "organDonorRegistration",
@@ -127,12 +126,6 @@ describe("Disabling organ donor services", () => {
             ],
             services: {
                 enabled: true,
-                services: [
-                    {
-                        name: "organDonorRegistration",
-                        enabled: false,
-                    },
-                ],
             },
         });
         testOrganDonorNotPresent(cy);

--- a/Testing/functional/tests/cypress/integration/ui/services/view.js
+++ b/Testing/functional/tests/cypress/integration/ui/services/view.js
@@ -1,25 +1,30 @@
+const { AuthMethod } = require("../../../support/constants");
+
 const servicesTestsConstants = {
     servicesUrl: "/services",
+    unauthorized: "/unauthorized",
 };
-const { AuthMethod } = require("../../../support/constants");
 
 describe("Authenticated Services View", () => {
     beforeEach(() => {
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/services"
+        );
+    });
+
+    it("The url should be the services url if services enabled", () => {
         cy.configureSettings({
             services: {
                 enabled: true,
             },
         });
-        cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/home"
-        );
-        cy.visit(servicesTestsConstants.servicesUrl);
+        cy.url().should("include", servicesTestsConstants.servicesUrl);
     });
 
-    it("The page should load correctly", () => {
-        cy.url().should("include", servicesTestsConstants.servicesUrl);
+    it("The url should be the unauthorized url if services is disabled", () => {
+        cy.url().should("include", servicesTestsConstants.unauthorized);
     });
 });

--- a/Testing/functional/tests/cypress/integration/ui/services/view.js
+++ b/Testing/functional/tests/cypress/integration/ui/services/view.js
@@ -25,6 +25,7 @@ describe("Authenticated Services View", () => {
     });
 
     it("The url should be the unauthorized url if services is disabled", () => {
+        cy.configureSettings({});
         cy.url().should("include", servicesTestsConstants.unauthorized);
     });
 });

--- a/Testing/functional/tests/cypress/integration/ui/services/view.js
+++ b/Testing/functional/tests/cypress/integration/ui/services/view.js
@@ -19,10 +19,6 @@ describe("Authenticated Services View", () => {
         cy.visit(servicesTestsConstants.servicesUrl);
     });
 
-    afterEach(() => {
-        Cypress.session.clearAllSavedSessions();
-    });
-
     it("The page should load correctly", () => {
         cy.url().should("include", servicesTestsConstants.servicesUrl);
     });

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -11,13 +11,36 @@ const { AuthMethod } = require("./constants");
 const { globalStorage } = require("./globalStorage");
 require("cy-verify-downloads").addCustomCommand();
 
-function configureDatasets(datasets, deltaset) {
-    let newDatasets = [];
-    if (deltaset !== undefined && Array.isArray(deltaset)) {
-        const setTable = {};
-        datasets.forEach((s) => (setTable[s.name] = s.enabled));
-        deltaset.forEach((d) => (setTable[d.name] = d.enabled));
+function buildObjectsMap(objects, keyProperty, valueProperty) {
+    const map = {};
+    objects.forEach((obj) => {
+        const key = obj[keyProperty];
+        const value = obj[valueProperty];
+        map[key] = value;
+    });
+    return map;
+}
 
+function configureObjectArray(
+    objectArray,
+    deltaObjectArray,
+    keyProperty = "name",
+    valueProperty = "enabled"
+) {
+    let newDatasets = [];
+    if (deltaObjectArray !== undefined && Array.isArray(deltaObjectArray)) {
+        objectArray = !objectArray ? [] : objectArray;
+        const objectMap = buildObjectsMap(
+            objectArray,
+            keyProperty,
+            valueProperty
+        );
+        const deltaMap = buildObjectsMap(
+            deltaObjectArray,
+            keyProperty,
+            valueProperty
+        );
+        const setTable = { ...objectMap, ...deltaMap };
         for (const key in setTable) {
             newDatasets.push({ name: key, enabled: setTable[key] });
         }
@@ -25,9 +48,12 @@ function configureDatasets(datasets, deltaset) {
     return newDatasets;
 }
 
-function disableDatasets(datasets) {
-    return datasets.map((s) => {
-        s.enabled = false;
+function disablePropertyOfObjectArray(objectArray, property = "enabled") {
+    if (!objectArray) {
+        return [];
+    }
+    return objectArray.map((s) => {
+        s[property] = false;
         return s;
     });
 }
@@ -314,13 +340,18 @@ Cypress.Commands.add("configureSettings", (settings) => {
             };
 
             // Disable datasets
-            const disabledDatasets = disableDatasets(
+            const disabledDatasets = disablePropertyOfObjectArray(
                 config.webClient.featureToggleConfiguration.datasets
             );
 
             // Disable dependents datasets
-            const disabledDependentsDatasets = disableDatasets(
+            const disabledDependentsDatasets = disablePropertyOfObjectArray(
                 config.webClient.featureToggleConfiguration.dependents?.datasets
+            );
+
+            // Disable services
+            const disabledServices = disablePropertyOfObjectArray(
+                config.webClient.featureToggleConfiguration.services?.services
             );
 
             // Disable non dataset object properties
@@ -328,18 +359,26 @@ Cypress.Commands.add("configureSettings", (settings) => {
 
             // Apply disabled datasets to configuration object
             featureToggleConfiguration.datasets = disabledDatasets;
-            featureToggleConfiguration.dependents.datasets = [];
+            featureToggleConfiguration.dependents.datasets =
+                disabledDependentsDatasets;
+            featureToggleConfiguration.services.services = disabledServices;
 
             // Configure datasets with overrides
-            const datasets = configureDatasets(
+            const datasets = configureObjectArray(
                 featureToggleConfiguration.datasets,
                 settings.datasets
             );
 
             // Configure dependents datasets with overrides
-            const dependentsDatasets = configureDatasets(
+            const dependentsDatasets = configureObjectArray(
                 featureToggleConfiguration.dependents.datasets,
                 settings.dependents?.datasets
+            );
+
+            // Configure services.services with overrides
+            const services = configureObjectArray(
+                featureToggleConfiguration.services?.services,
+                settings.services?.services
             );
 
             // Configure overrides to non dataset object properties
@@ -348,6 +387,9 @@ Cypress.Commands.add("configureSettings", (settings) => {
             // Apply dataset overrides to configuration object
             featureToggleConfiguration.datasets = datasets;
             featureToggleConfiguration.dependents.datasets = dependentsDatasets;
+
+            // Apply services.services overrides to configuration object
+            featureToggleConfiguration.services.services = services;
 
             // Apply configured configuration object to configuration to be returned in intercept
             config.webClient.featureToggleConfiguration =

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -63,8 +63,10 @@ function configureObject(baseObj, delta) {
     if (deltaKeys && deltaKeys.length > 0) {
         for (const key of deltaKeys) {
             const baseValue = baseObj[key];
-            if (baseValue === undefined) {
-                throw new Error(`Unknown property: ${key}`);
+            if (baseValue === undefined || baseValue === null) {
+                throw new Error(
+                    `Configuring Object - Unknown property: ${key}`
+                );
             }
             const baseValueKeys = Object.keys(baseValue);
             if (
@@ -85,6 +87,9 @@ function disableObject(config) {
     if (configKeys && configKeys.length > 0) {
         for (const key of configKeys) {
             const configValue = config[key];
+            if (configValue === undefined || configValue === null) {
+                throw new Error(`Disabling Object - Unknown property: ${key}`);
+            }
             const configValueKeys = Object.keys(configValue);
             if (
                 configValueKeys &&


### PR DESCRIPTION
# Fixes or Implements [AB#15120](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15120)

## Description

1. Generalised the `configureSettings`'s  supporting functions.
  * Generalised function names
  * Added default arguments for key and value property names for merging an object array
2. Added configuration flow for services similar to datasets
3. Removed unnecessary clear sessions call in view.js for services page.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

## UI Changes
![image](https://user-images.githubusercontent.com/19548348/224435428-3a9576b7-11e0-4c15-9ff3-e9a66c0d4abf.png)


## Notes
None


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
