### PR TITLE
Rename PatientData to Patient AB#15127

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/ReportsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/ReportsComponent.vue
@@ -25,7 +25,7 @@ import { DateWrapper, StringISODate } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
 import MedicationSummary from "@/models/medicationSummary";
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import Report from "@/models/report";
 import { ReportFilterBuilder } from "@/models/reportFilter";
 import ReportHeader from "@/models/reportHeader";
@@ -78,8 +78,8 @@ export default class ReportsComponent extends Vue {
     @Getter("medications", { namespace: "medication" })
     medications!: (hdid: string) => MedicationStatementHistory[];
 
-    @Getter("patientData", { namespace: "user" })
-    patientData!: PatientData;
+    @Getter("patient", { namespace: "user" })
+    patient!: Patient;
 
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
@@ -130,12 +130,12 @@ export default class ReportsComponent extends Vue {
 
     get headerData(): ReportHeader {
         return {
-            phn: this.patientData.personalHealthNumber,
-            dateOfBirth: this.formatDate(this.patientData.birthdate || ""),
-            name: this.patientData
-                ? this.patientData.preferredName.givenName +
+            phn: this.patient.personalHealthNumber,
+            dateOfBirth: this.formatDate(this.patient.birthdate || ""),
+            name: this.patient
+                ? this.patient.preferredName.givenName +
                   " " +
-                  this.patientData.preferredName.surname
+                  this.patient.preferredName.surname
                 : "",
             isRedacted: this.reportFilter.hasMedicationsFilter(),
             datePrinted: new DateWrapper(new DateWrapper().toISO()).format(),
@@ -175,7 +175,7 @@ export default class ReportsComponent extends Vue {
         return (
             this.isLoading ||
             !this.reportComponentName ||
-            !this.patientData.hdid ||
+            !this.patient.hdid ||
             !this.hasRecords
         );
     }

--- a/Apps/WebClient/src/ClientApp/src/models/patient.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/patient.ts
@@ -1,6 +1,6 @@
 import { StringISODate } from "@/models/dateWrapper";
 
-export default class PatientData {
+export default class Patient {
     public hdid!: string;
     public personalHealthNumber!: string;
     public preferredName!: Name;

--- a/Apps/WebClient/src/ClientApp/src/router.ts
+++ b/Apps/WebClient/src/ClientApp/src/router.ts
@@ -106,7 +106,7 @@ export enum UserState {
     offline = "offline",
     unauthenticated = "unauthenticated",
     invalidIdentityProvider = "invalidIdentityProvider",
-    noPatientData = "noPatientData",
+    noPatient = "noPatient",
     notRegistered = "notRegistered",
     pendingDeletion = "pendingDeletion",
     acceptTermsOfService = "acceptTermsOfService",
@@ -136,7 +136,7 @@ function calculateUserState(): UserState {
     } else if (!isValidIdentityProvider) {
         return UserState.invalidIdentityProvider;
     } else if (patientRetrievalFailed) {
-        return UserState.noPatientData;
+        return UserState.noPatient;
     } else if (!isRegistered) {
         return UserState.notRegistered;
     } else if (!userIsActive) {
@@ -169,7 +169,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
-                UserState.noPatientData,
+                UserState.noPatient,
                 UserState.registered,
                 UserState.offline,
             ],
@@ -305,7 +305,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
-                UserState.noPatientData,
+                UserState.noPatient,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -353,7 +353,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
-                UserState.noPatientData,
+                UserState.noPatient,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -367,7 +367,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
-                UserState.noPatientData,
+                UserState.noPatient,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -381,7 +381,7 @@ const routes = [
             validStates: [
                 UserState.unauthenticated,
                 UserState.invalidIdentityProvider,
-                UserState.noPatientData,
+                UserState.noPatient,
                 UserState.registered,
                 UserState.pendingDeletion,
             ],
@@ -429,7 +429,7 @@ const routes = [
         path: PATIENT_RETRIEVAL_ERROR_PATH,
         component: PatientRetrievalErrorView,
         meta: {
-            validStates: [UserState.noPatientData],
+            validStates: [UserState.noPatient],
             requiresProcessedWaitlistTicket: true,
         },
     },
@@ -618,7 +618,7 @@ function getDefaultPath(
             return REGISTRATION_PATH;
         case UserState.invalidIdentityProvider:
             return IDIR_LOGGED_IN_PATH;
-        case UserState.noPatientData:
+        case UserState.noPatient:
             return PATIENT_RETRIEVAL_ERROR_PATH;
         case UserState.unauthenticated:
             return requiredFeaturesEnabled ? LOGIN_PATH : UNAUTHORIZED_PATH;

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -26,7 +26,7 @@ import {
 import MedicationRequest from "@/models/medicationRequest";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
 import Notification from "@/models/notification";
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import RegisterTestKitRequest from "@/models/registerTestKitRequest";
 import Report from "@/models/report";
 import ReportRequest from "@/models/reportRequest";
@@ -82,7 +82,7 @@ export interface IVaccinationStatusService {
 
 export interface IPatientService {
     initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
-    getPatientData(hdid: string): Promise<ApiResult<PatientData>>;
+    getPatient(hdid: string): Promise<ApiResult<Patient>>;
 }
 
 export interface IMedicationService {

--- a/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
@@ -4,7 +4,7 @@ import { ServiceCode } from "@/constants/serviceCodes";
 import ApiResult from "@/models/apiResult";
 import { ExternalConfiguration } from "@/models/configData";
 import { HttpError } from "@/models/errors";
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { IHttpDelegate, ILogger, IPatientService } from "@/services/interfaces";
@@ -25,16 +25,16 @@ export class RestPatientService implements IPatientService {
         this.http = http;
     }
 
-    public getPatientData(hdid: string): Promise<ApiResult<PatientData>> {
+    public getPatient(hdid: string): Promise<ApiResult<Patient>> {
         return new Promise((resolve, reject) =>
             this.http
-                .get<ApiResult<PatientData>>(
+                .get<ApiResult<Patient>>(
                     `${this.baseUri}${this.PATIENT_BASE_URI}/${hdid}?api-version=2.0`
                 )
                 .then((apiResult) => resolve(apiResult))
                 .catch((err: HttpError) => {
                     this.logger.error(
-                        `Error in RestPatientService.getPatientData()`
+                        `Error in RestPatientService.getPatient()`
                     );
                     reject(
                         ErrorTranslator.internalNetworkError(

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -265,13 +265,10 @@ export const actions: UserActions = {
         return new Promise((resolve) => {
             context.commit("setRequested");
             patientService
-                .getPatientData(context.state.user.hdid)
+                .getPatient(context.state.user.hdid)
                 .then((result) => {
                     if (result.resourcePayload) {
-                        context.commit(
-                            "setPatientData",
-                            result.resourcePayload
-                        );
+                        context.commit("setPatient", result.resourcePayload);
 
                         userProfileService
                             .getProfile(context.state.user.hdid)

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/getters.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/getters.ts
@@ -1,6 +1,6 @@
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { DateWrapper, StringISODateTime } from "@/models/dateWrapper";
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import { QuickLink } from "@/models/quickLink";
 import { LoadStatus } from "@/models/storeOperations";
 import User, { OidcUserInfo } from "@/models/user";
@@ -63,8 +63,8 @@ export const getters: UserGetters = {
         }
         return QuickLinkUtil.toQuickLinks(preference.value);
     },
-    patientData(state: UserState): PatientData {
-        return state.patientData;
+    patient(state: UserState): Patient {
+        return state.patient;
     },
     patientRetrievalFailed(state: UserState): boolean {
         return state.patientRetrievalFailed;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/mutations.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/mutations.ts
@@ -2,7 +2,7 @@ import Vue from "vue";
 
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { DateWrapper } from "@/models/dateWrapper";
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import { LoadStatus } from "@/models/storeOperations";
 import User, { OidcUserInfo } from "@/models/user";
 import type { UserPreference } from "@/models/userPreference";
@@ -115,7 +115,7 @@ export const mutations: UserMutation = {
 
         state.error = false;
         state.statusMessage = "success";
-        if (state.patientData.hdid !== undefined) {
+        if (state.patient.hdid !== undefined) {
             state.status = LoadStatus.LOADED;
         } else {
             state.status = LoadStatus.PARTIALLY_LOADED;
@@ -145,8 +145,8 @@ export const mutations: UserMutation = {
         state.statusMessage = "success";
         state.status = LoadStatus.LOADED;
     },
-    setPatientData(state: UserState, patientData: PatientData) {
-        state.patientData = patientData;
+    setPatient(state: UserState, patient: Patient) {
+        state.patient = patient;
         state.error = false;
         state.statusMessage = "success";
         if (state.user.hdid !== undefined) {
@@ -161,7 +161,7 @@ export const mutations: UserMutation = {
     clearUserData(state: UserState) {
         state.user = new User();
         state.oidcUserInfo = undefined;
-        state.patientData = new PatientData();
+        state.patient = new Patient();
         state.patientRetrievalFailed = false;
         state.smsResendDateTime = undefined;
         state.seenTutorialComment = false;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/types.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/types.ts
@@ -9,7 +9,7 @@ import {
 import { ErrorType } from "@/constants/errorType";
 import { DateWrapper, StringISODateTime } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import { QuickLink } from "@/models/quickLink";
 import RequestResult from "@/models/requestResult";
 import { LoadStatus } from "@/models/storeOperations";
@@ -21,7 +21,7 @@ import { RootState } from "@/store/types";
 export interface UserState {
     user: User;
     oidcUserInfo?: OidcUserInfo;
-    patientData: PatientData;
+    patient: Patient;
     patientRetrievalFailed: boolean;
     smsResendDateTime?: DateWrapper;
     seenTutorialComment: boolean;
@@ -41,7 +41,7 @@ export interface UserGetters extends GetterTree<UserState, RootState> {
     seenTutorialComment(state: UserState): boolean;
     hasTermsOfServiceUpdated(state: UserState): boolean;
     quickLinks(state: UserState): QuickLink[] | undefined;
-    patientData(state: UserState): PatientData;
+    patient(state: UserState): Patient;
     patientRetrievalFailed(state: UserState): boolean;
     isLoading(state: UserState): boolean;
 }
@@ -92,7 +92,7 @@ export interface UserMutation extends MutationTree<UserState> {
     setEmailVerified(state: UserState): void;
     setSMSResendDateTime(state: UserState, dateTime: DateWrapper): void;
     setUserPreference(state: UserState, userPreference: UserPreference): void;
-    setPatientData(state: UserState, patientData: PatientData): void;
+    setPatient(state: UserState, patient: Patient): void;
     setPatientRetrievalFailed(state: UserState): void;
     clearUserData(state: UserState): void;
     setSeenTutorialComment(state: UserState, value: boolean): void;

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/user.ts
@@ -1,4 +1,4 @@
-import PatientData from "@/models/patientData";
+import Patient from "@/models/patient";
 import { LoadStatus } from "@/models/storeOperations";
 import User from "@/models/user";
 
@@ -9,7 +9,7 @@ import { UserModule, UserState } from "./types";
 
 const state: UserState = {
     user: new User(),
-    patientData: new PatientData(),
+    patient: new Patient(),
     patientRetrievalFailed: false,
     seenTutorialComment: false,
     statusMessage: "",

--- a/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/ProfileView.vue
@@ -23,7 +23,7 @@ import BreadcrumbItem from "@/models/breadcrumbItem";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper } from "@/models/dateWrapper";
 import { isTooManyRequestsError, ResultError } from "@/models/errors";
-import PatientData, { Address } from "@/models/patientData";
+import Patient, { Address } from "@/models/patient";
 import User, { OidcUserInfo } from "@/models/user";
 import UserProfile from "@/models/userProfile";
 import container from "@/plugins/container";
@@ -95,8 +95,8 @@ export default class ProfileView extends Vue {
     @Getter("oidcUserInfo", { namespace: "user" })
     oidcUserInfo!: OidcUserInfo | undefined;
 
-    @Getter("patientData", { namespace: "user" })
-    patientData!: PatientData;
+    @Getter("patient", { namespace: "user" })
+    patient!: Patient;
 
     @Getter("userIsActive", { namespace: "user" })
     isActiveProfile!: boolean;
@@ -151,7 +151,7 @@ export default class ProfileView extends Vue {
     }
 
     private get phn(): string {
-        return this.patientData.personalHealthNumber;
+        return this.patient.personalHealthNumber;
     }
 
     private get isEmptyEmail(): boolean {
@@ -163,8 +163,8 @@ export default class ProfileView extends Vue {
     private get isUpdateAddressCombinedTextShown(): boolean {
         return (
             this.isSameAddress() &&
-            this.patientData.physicalAddress !== null &&
-            this.patientData.postalAddress !== null
+            this.patient.physicalAddress !== null &&
+            this.patient.postalAddress !== null
         );
     }
 
@@ -174,15 +174,13 @@ export default class ProfileView extends Vue {
 
     private get isAddAddressTextShown(): boolean {
         return (
-            this.patientData.physicalAddress === null &&
-            this.patientData.postalAddress === null
+            this.patient.physicalAddress === null &&
+            this.patient.postalAddress === null
         );
     }
 
     private get isPhysicalAddressShown(): boolean {
-        return (
-            this.patientData.physicalAddress !== null && !this.isSameAddress()
-        );
+        return this.patient.physicalAddress !== null && !this.isSameAddress();
     }
 
     private get isPhysicalAddressSectionShown(): boolean {
@@ -190,14 +188,14 @@ export default class ProfileView extends Vue {
     }
 
     private get isPostalAddressShown(): boolean {
-        return this.patientData.postalAddress != null;
+        return this.patient.postalAddress != null;
     }
 
     private get postalAddressLabel(): string {
         if (
             !this.isSameAddress() ||
-            (this.patientData.physicalAddress !== null &&
-                this.patientData.postalAddress === null)
+            (this.patient.physicalAddress !== null &&
+                this.patient.postalAddress === null)
         ) {
             return "Mailing Address";
         }
@@ -616,15 +614,13 @@ export default class ProfileView extends Vue {
 
     private setAddresses(): void {
         // Physical Address
-        this.physicalAddress = this.getNewAddress(
-            this.patientData.physicalAddress
-        );
+        this.physicalAddress = this.getNewAddress(this.patient.physicalAddress);
         this.logger.debug(
             `Physical Address: ${JSON.stringify(this.physicalAddress)}`
         );
 
         // Postal Address
-        this.postalAddress = this.getNewAddress(this.patientData.postalAddress);
+        this.postalAddress = this.getNewAddress(this.patient.postalAddress);
         this.logger.debug(
             `Postal Address: ${JSON.stringify(this.postalAddress)}`
         );


### PR DESCRIPTION
# Fixes or Implements [AB#15127](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15127)

## Description

1. Bring front end in line with backend naming context.
  * Rename PatientData type to Patient.
  * Rename properties named patientData (or like) to patient.
2. Remove conflict with new PatientData domain added for PHSA's Health Options endpoint.
3. This change only applies to the WebClient and not the AdminWebClient. Simply cause we're not actively extending AdminWebClient.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
No changes this should be a behind the scenes change.


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
