### PR TITLE
Add Blazor store and Refit API for delegation lookup AB#15080

### DIFF
--- a/Apps/Admin/Client/Api/IDelegationApi.cs
+++ b/Apps/Admin/Client/Api/IDelegationApi.cs
@@ -1,0 +1,36 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Api
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
+    using Refit;
+
+    /// <summary>
+    /// API for interacting with delegation.
+    /// </summary>
+    public interface IDelegationApi
+    {
+        /// <summary>
+        /// Retrieves delegation information for a person.
+        /// </summary>
+        /// <param name="phn">The phn to query on.</param>
+        /// <returns>Information about the person and their delegates.</returns>
+        [Get("/")]
+        Task<IEnumerable<DelegationInfo>> GetDelegationInformationAsync([Header("phn")] string phn);
+    }
+}

--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -108,6 +108,7 @@ namespace HealthGateway.Admin.Client
             RegisterRefitClient<ICommunicationsApi>(builder, "v1/api/Communication", true);
             RegisterRefitClient<IConfigurationApi>(builder, "v1/api/Configuration", false);
             RegisterRefitClient<IDashboardApi>(builder, "v1/api/Dashboard", true);
+            RegisterRefitClient<IDelegationApi>(builder, "v1/api/Delegation", true);
             RegisterRefitClient<ISupportApi>(builder, "v1/api/Support", true);
             RegisterRefitClient<ITagApi>(builder, "v1/api/Tag", true);
             RegisterRefitClient<IUserFeedbackApi>(builder, "v1/api/UserFeedback", true);

--- a/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
@@ -1,0 +1,85 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.Delegation
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Admin.Common.Models;
+
+    /// <summary>
+    /// Static class that implements all actions for the feature.
+    /// </summary>
+    [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Team decision")]
+    public static class DelegationActions
+    {
+        /// <summary>
+        /// The action representing the initiation of a search.
+        /// </summary>
+        public class SearchAction
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SearchAction"/> class.
+            /// </summary>
+            /// <param name="phn">The PHN to query on.</param>
+            public SearchAction(string phn)
+            {
+                this.Phn = phn;
+            }
+
+            /// <summary>
+            /// Gets or sets the PHN.
+            /// </summary>
+            public string Phn { get; set; }
+        }
+
+        /// <summary>
+        /// The action representing a failed search.
+        /// </summary>
+        public class SearchFailAction : BaseFailAction
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SearchFailAction"/> class.
+            /// </summary>
+            /// <param name="error">The request error.</param>
+            public SearchFailAction(RequestError error)
+                : base(error)
+            {
+            }
+        }
+
+        /// <summary>
+        /// The action representing a successful search.
+        /// </summary>
+        public class SearchSuccessAction : BaseSuccessAction<IEnumerable<DelegationInfo>>
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SearchSuccessAction"/> class.
+            /// </summary>
+            /// <param name="data">Agent data.</param>
+            public SearchSuccessAction(IEnumerable<DelegationInfo> data)
+                : base(data)
+            {
+            }
+        }
+
+        /// <summary>
+        /// The action that clears the state.
+        /// </summary>
+        public class ResetStateAction
+        {
+        }
+    }
+}

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -1,0 +1,64 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Store.Delegation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Fluxor;
+    using HealthGateway.Admin.Client.Api;
+    using HealthGateway.Admin.Client.Utils;
+    using HealthGateway.Admin.Common.Models;
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.Logging;
+    using Refit;
+
+#pragma warning disable CS1591, SA1600
+    public class DelegationEffects
+    {
+        public DelegationEffects(ILogger<DelegationEffects> logger, IDelegationApi api)
+        {
+            this.Logger = logger;
+            this.Api = api;
+        }
+
+        [Inject]
+        private ILogger<DelegationEffects> Logger { get; set; }
+
+        [Inject]
+        private IDelegationApi Api { get; set; }
+
+        [EffectMethod]
+        public async Task HandleSearchAction(DelegationActions.SearchAction action, IDispatcher dispatcher)
+        {
+            this.Logger.LogInformation("Retrieving delegation info");
+            try
+            {
+                IEnumerable<DelegationInfo> response = await this.Api.GetDelegationInformationAsync(action.Phn).ConfigureAwait(true);
+                this.Logger.LogInformation("Delegation info retrieved successfully");
+                dispatcher.Dispatch(new DelegationActions.SearchSuccessAction(response));
+            }
+            catch (Exception e) when (e is ApiException or HttpRequestException)
+            {
+                RequestError error = StoreUtility.FormatRequestError(e);
+                this.Logger.LogError(e, "Error retrieving delegation info, reason: {Exception}", e.ToString());
+                dispatcher.Dispatch(new DelegationActions.SearchFailAction(error));
+            }
+        }
+    }
+}

--- a/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
@@ -1,0 +1,74 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.Delegation
+{
+    using System.Linq;
+    using Fluxor;
+
+#pragma warning disable CS1591, SA1600
+    public static class DelegationReducers
+    {
+        [ReducerMethod(typeof(DelegationActions.SearchAction))]
+        public static DelegationState ReduceSearchAction(DelegationState state)
+        {
+            return state with
+            {
+                Search = state.Search with
+                {
+                    IsLoading = true,
+                },
+            };
+        }
+
+        [ReducerMethod]
+        public static DelegationState ReduceSearchSuccessAction(DelegationState state, DelegationActions.SearchSuccessAction action)
+        {
+            return state with
+            {
+                Search = state.Search with
+                {
+                    IsLoading = false,
+                    Result = action.Data,
+                    Error = null,
+                },
+                Data = action.Data.ToList(),
+            };
+        }
+
+        [ReducerMethod]
+        public static DelegationState ReduceSearchFailAction(DelegationState state, DelegationActions.SearchFailAction action)
+        {
+            return state with
+            {
+                Search = state.Search with
+                {
+                    IsLoading = false,
+                    Error = action.Error,
+                },
+            };
+        }
+
+        [ReducerMethod(typeof(DelegationActions.ResetStateAction))]
+        public static DelegationState ReduceResetStateAction(DelegationState state)
+        {
+            return state with
+            {
+                Search = new(),
+                Data = null,
+            };
+        }
+    }
+}

--- a/Apps/Admin/Client/Store/Delegation/DelegationState.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationState.cs
@@ -1,0 +1,50 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+
+namespace HealthGateway.Admin.Client.Store.Delegation
+{
+    using System.Collections.Generic;
+    using Fluxor;
+    using HealthGateway.Admin.Common.Models;
+
+    /// <summary>
+    /// The state for the feature.
+    /// State should be decorated with [FeatureState] for automatic discovery when services.AddFluxor is called.
+    /// </summary>
+    [FeatureState]
+    public record DelegationState
+    {
+        /// <summary>
+        /// Gets the request state for searches.
+        /// </summary>
+        public BaseRequestState<IEnumerable<DelegationInfo>> Search { get; init; } = new();
+
+        /// <summary>
+        /// Gets the collection of data.
+        /// </summary>
+        public IList<DelegationInfo>? Data { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether a request is loading.
+        /// </summary>
+        public bool IsLoading => this.Search.IsLoading;
+
+        /// <summary>
+        /// Gets a value indicating whether the data has been loaded.
+        /// </summary>
+        public bool Loaded => this.Data != null;
+    }
+}

--- a/Apps/Admin/Common/Models/DelegationInfo.cs
+++ b/Apps/Admin/Common/Models/DelegationInfo.cs
@@ -20,7 +20,7 @@ namespace HealthGateway.Admin.Common.Models
     /// <summary>
     /// The delegation info model.
     /// </summary>
-    public class DelegationResponse
+    public class DelegationInfo
     {
         /// <summary>
         /// Gets or sets the dependent info.

--- a/Apps/Admin/Server/Controllers/DelegationController.cs
+++ b/Apps/Admin/Server/Controllers/DelegationController.cs
@@ -47,7 +47,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// Retrieves delegation information for a person.
         /// </summary>
         /// <param name="phn">The phn to query on.</param>
-        /// <returns>A response containing information about the person and their delegates.</returns>
+        /// <returns>Information about the person and their delegates.</returns>
         /// <response code="200">Returns the requested delegation information.</response>
         /// <response code="400">The request parameters did not pass validation.</response>
         /// <response code="401">The client must authenticate itself to get the requested resource.</response>
@@ -64,7 +64,7 @@ namespace HealthGateway.Admin.Server.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status502BadGateway, Type = typeof(ProblemDetails))]
-        public async Task<DelegationResponse> GetDelegationInformation([FromHeader] string phn)
+        public async Task<DelegationInfo> GetDelegationInformation([FromHeader] string phn)
         {
             return await this.delegationService.GetDelegationInformationAsync(phn).ConfigureAwait(true);
         }

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -62,7 +62,7 @@ namespace HealthGateway.Admin.Server.Services
         }
 
         /// <inheritdoc/>
-        public async Task<DelegationResponse> GetDelegationInformationAsync(string phn)
+        public async Task<DelegationInfo> GetDelegationInformationAsync(string phn)
         {
             // Get dependent patient information
             RequestResult<PatientModel> dependentPatientResult = await this.patientService.GetPatient(phn, PatientIdentifierType.Phn).ConfigureAwait(true);
@@ -73,12 +73,12 @@ namespace HealthGateway.Admin.Server.Services
                 throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(MaxDependentAgeKey, HttpStatusCode.BadRequest, nameof(DelegationService)));
             }
 
-            DelegationResponse delegationResponse = new();
+            DelegationInfo delegationInfo = new();
             if (dependentPatientResult.ResourcePayload != null)
             {
                 PatientModel dependentPatientInfo = dependentPatientResult.ResourcePayload;
                 DependentInfo dependentInfo = this.autoMapper.Map<DependentInfo>(dependentPatientInfo);
-                delegationResponse.Dependent = dependentInfo;
+                delegationInfo.Dependent = dependentInfo;
 
                 // Get delegates from database
                 IEnumerable<ResourceDelegate> dbResourceDelegates = await this.SearchDelegates(dependentPatientInfo.HdId).ConfigureAwait(true);
@@ -93,10 +93,10 @@ namespace HealthGateway.Admin.Server.Services
                     delegates.Add(delegateInfo);
                 }
 
-                delegationResponse.Delegates = delegates;
+                delegationInfo.Delegates = delegates;
             }
 
-            return delegationResponse;
+            return delegationInfo;
         }
 
         private async Task<IEnumerable<ResourceDelegate>> SearchDelegates(string ownerHdid)

--- a/Apps/Admin/Server/Services/IDelegationService.cs
+++ b/Apps/Admin/Server/Services/IDelegationService.cs
@@ -27,7 +27,7 @@ namespace HealthGateway.Admin.Server.Services
         /// Retrieves delegation information for a person.
         /// </summary>
         /// <param name="phn">The phn to query on.</param>
-        /// <returns>A response containing information about the person and their delegates.</returns>
-        Task<DelegationResponse> GetDelegationInformationAsync(string phn);
+        /// <returns>Information about the person and their delegates.</returns>
+        Task<DelegationInfo> GetDelegationInformationAsync(string phn);
     }
 }


### PR DESCRIPTION
# Implements [AB#15080](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15080)

## Description

- renames DelegationResponse to DelegationInfo
- adds Refit API for delegation
- adds Fluxor store for delegation

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
