### PR TITLE
Specify JSON converters for enums via attribute AB#15186

### DIFF
--- a/Apps/Patient/src/Constants/PatientDataType.cs
+++ b/Apps/Patient/src/Constants/PatientDataType.cs
@@ -15,9 +15,12 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Patient.Constants
 {
+    using System.Text.Json.Serialization;
+
     /// <summary>
     /// Patient data types.
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum PatientDataType
     {
         /// <summary>

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Patient
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Text.Json.Serialization;
     using System.Threading.Tasks;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
@@ -69,7 +68,6 @@ namespace HealthGateway.Patient
             services.AddPatientDataAccess(new PatientDataAccessConfiguration(configuration.GetSection("PhsaV2:BaseUrl").Get<Uri>()!));
 
             Utility.ConfigureTracing(services, logger, configuration);
-            services.AddControllers().AddJsonOptions(opts => { opts.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()); });
 
             ExceptionHandling.ConfigureProblemDetails(services, environment);
 


### PR DESCRIPTION
# Fixes [AB#15186](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15186)

## Description

Restores default enum serialization, requiring enums to be decorated with an attribute to apply string serialization.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)