### PR TITLE
Fix too many requests alerts functional tests for AB#15200

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
@@ -849,9 +849,7 @@ describe("Dependent - Immunizaation History Tab - report download error handling
         cy.get("[data-testid=genericMessageModal]").should("be.visible");
         cy.get("[data-testid=genericMessageSubmitBtn]").click();
 
-        cy.get("[data-testid=singleErrorHeader]").contains(
-            "Unable to download Dependent Immunization Report"
-        );
+        cy.get("[data-testid=singleErrorHeader]").should("not.be.empty");
     });
 });
 
@@ -1044,9 +1042,7 @@ describe("Notes", () => {
             cy.get("[data-testid=genericMessageModal]").should("be.visible");
             cy.get("[data-testid=genericMessageSubmitBtn]").click();
 
-            cy.get("[data-testid=singleErrorHeader]").contains(
-                "Unable to download Export Records"
-            );
+            cy.get("[data-testid=singleErrorHeader]").should("not.be.empty");
         });
     });
 });


### PR DESCRIPTION
# Fixes or Implements [AB#15200](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15200)

## Description

- Fix failing too many alerts requests functional tests.
- Text changed for error message.  To make test less brittle, check to see if there is an error message versus specific text.

<img width="1078" alt="Screenshot 2023-03-21 at 3 41 22 PM" src="https://user-images.githubusercontent.com/58790456/226758702-a0b5eb45-600e-4830-af16-29e0d42837b4.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
