### PR TITLE
Change OrganDonorRegistration status mapping to custom enum value AB#15194

### DIFF
--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Patient.Services
     using System.Threading.Tasks;
     using HealthGateway.Common.Utils;
     using HealthGateway.Patient.Constants;
+    using HealthGateway.PatientDataAccess;
 
     /// <summary>
     /// Provides access to patient related data services.
@@ -83,7 +84,7 @@ namespace HealthGateway.Patient.Services
         /// <param name="status">The registration status.</param>
         /// <param name="statusMessage">Optional message related to the status.</param>
         /// <param name="registrationFileId">Optional registration file id.</param>
-        public OrganDonorRegistrationData(string status, string? statusMessage, string? registrationFileId)
+        public OrganDonorRegistrationData(DonorRegistrationStatus status, string? statusMessage, string? registrationFileId)
         {
             this.Status = status;
             this.StatusMessage = statusMessage;
@@ -93,7 +94,7 @@ namespace HealthGateway.Patient.Services
         /// <summary>
         /// Gets or sets the registration status.
         /// </summary>
-        public string Status { get; set; } = null!;
+        public DonorRegistrationStatus Status { get; set; } = DonorRegistrationStatus.NotRegistered;
 
         /// <summary>
         /// Gets or sets the message associated with the donor registration status.

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -62,7 +62,7 @@ namespace HealthGateway.Patient.Services
         private PatientData MapToPatientData(HealthData healthData) =>
             healthData switch
             {
-                OrganDonorRegistration hd => new OrganDonorRegistrationData(hd.Status.ToString(), hd.StatusMessage, hd.RegistrationFileId),
+                OrganDonorRegistration hd => new OrganDonorRegistrationData(hd.Status, hd.StatusMessage, hd.RegistrationFileId),
                 _ => throw new NotImplementedException($"{healthData.GetType().Name} is not mapped to {nameof(PatientData)}"),
             };
 

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -41,7 +41,7 @@ namespace HealthGateway.PatientTests.Services
         [Fact]
         public void CanSerializePatientData()
         {
-            var organDonorRegistationData = new OrganDonorRegistrationData("Registered", "Message", Guid.NewGuid().ToString());
+            var organDonorRegistationData = new OrganDonorRegistrationData(DonorRegistrationStatus.Registered, "Message", Guid.NewGuid().ToString());
 
             var data = new PatientData[]
             {
@@ -92,7 +92,7 @@ namespace HealthGateway.PatientTests.Services
             var result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None).ConfigureAwait(true);
 
             var actual = result.Items.ShouldHaveSingleItem().ShouldBeOfType<OrganDonorRegistrationData>();
-            actual.Status.ShouldBe(expected.Status.ToString());
+            actual.Status.ShouldBe(expected.Status);
             actual.StatusMessage.ShouldBe(expected.StatusMessage);
             actual.RegistrationFileId.ShouldBe(expected.RegistrationFileId);
         }

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -20,7 +20,6 @@ namespace HealthGateway.PatientDataAccess.Api
 
 // Disables documentation for internal class.
 #pragma warning disable SA1602
-
     using System;
     using System.Collections.Generic;
     using System.Text.Json.Serialization;
@@ -32,7 +31,7 @@ namespace HealthGateway.PatientDataAccess.Api
     internal enum DonorStatus
     {
         Registered,
-        NonRegistered,
+        NotRegistered,
         Error,
         Pending,
     }

--- a/Apps/PatientDataAccess/src/DonorRegistrationStatus.cs
+++ b/Apps/PatientDataAccess/src/DonorRegistrationStatus.cs
@@ -15,9 +15,13 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.PatientDataAccess
 {
+    using System.Runtime.Serialization;
+    using System.Text.Json.Serialization;
+
     /// <summary>
     /// Donor registration status.
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum DonorRegistrationStatus
     {
         /// <summary>
@@ -28,7 +32,8 @@ namespace HealthGateway.PatientDataAccess
         /// <summary>
         /// Not registered patient.
         /// </summary>
-        NonRegistered,
+        [EnumMember(Value = "Not Registered")]
+        NotRegistered,
 
         /// <summary>
         /// Error in registration.


### PR DESCRIPTION
# Fixes or Implements AB#15914

## Description
1. Change return type for service to use enum
2. Use JsonStringEnumMemberConverter to apply custom value mapping for outbound conversion
3. Updated `NonRegistered` to `NotRegistered` as per the PHSA swagger changes.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
I performed this with a spoofed change to `Registered` value to ensure the mapping works. I do not have patients mapped in cache to conveniently test this:
Code of actual and test mapping:
![image](https://user-images.githubusercontent.com/19548348/227044880-852bee38-1135-4d55-b294-6e83a83d9851.png)

Result sent down to front end via the attached JSON converter:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/19548348/227045049-69268a78-f97d-4301-ad70-7844cbed415e.png">

Newly updated enum response value from PHSA:
![image](https://user-images.githubusercontent.com/19548348/227045761-0b7929fb-4f75-43a9-9549-f13200801469.png)




## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
