### PR TITLE
Add disclaimer to timeline when clinical doc filter is selected for AB#15195.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -282,6 +282,13 @@ export default class TimelineComponent extends Vue {
         );
     }
 
+    get isOnlyClinicalDocumentSelected(): boolean {
+        return (
+            this.selectedEntryTypes.size === 1 &&
+            this.selectedEntryTypes.has(EntryType.ClinicalDocument)
+        );
+    }
+
     get isOnlyImmunizationSelected(): boolean {
         return (
             this.selectedEntryTypes.size === 1 &&
@@ -654,6 +661,29 @@ export default class TimelineComponent extends Vue {
                     {{ filteredTimelineEntries.length }} records
                 </b-col>
             </b-row>
+            <div
+                v-show="isOnlyClinicalDocumentSelected"
+                id="linear-timeline-clinical-document-disclaimer"
+                class="pb-2"
+            >
+                <b-alert
+                    show
+                    variant="info"
+                    class="mt-0 mb-1"
+                    data-testid="linear-timeline-clinical-document-disclaimer-alert"
+                >
+                    <span>
+                        Only documents shared by your provider at some sites are
+                        available.
+                        <a
+                            href="https://www2.gov.bc.ca/gov/content/health/managing-your-health/health-gateway/guide#clindocs"
+                            target="_blank"
+                            rel="noopener"
+                            >Learn more.</a
+                        >.
+                    </span>
+                </b-alert>
+            </div>
             <div
                 v-show="isOnlyImmunizationSelected"
                 id="linear-timeline-immunization-disclaimer"

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -663,7 +663,7 @@ export default class TimelineComponent extends Vue {
             </b-row>
             <div
                 v-show="isOnlyClinicalDocumentSelected"
-                id="linear-timeline-clinical-document-disclaimer"
+                id="timeline-clinical-document-disclaimer"
                 class="pb-2"
             >
                 <b-alert

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -670,7 +670,7 @@ export default class TimelineComponent extends Vue {
                     show
                     variant="info"
                     class="mt-0 mb-1"
-                    data-testid="linear-timeline-clinical-document-disclaimer-alert"
+                    data-testid="timeline-clinical-document-disclaimer-alert"
                 >
                     <span>
                         Only documents shared by your provider at some sites are
@@ -679,7 +679,7 @@ export default class TimelineComponent extends Vue {
                             href="https://www2.gov.bc.ca/gov/content/health/managing-your-health/health-gateway/guide#clindocs"
                             target="_blank"
                             rel="noopener"
-                            >Learn more.</a
+                            >Learn more</a
                         >.
                     </span>
                 </b-alert>

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -2,6 +2,9 @@ const { AuthMethod } = require("../../../support/constants");
 
 describe("Filters", () => {
     beforeEach(() => {
+        cy.intercept("GET", "**/ClinicalDocument/*", {
+            fixture: "ClinicalDocumentService/clinicalDocument.json",
+        });
         cy.intercept("GET", "**/Immunization?*", {
             fixture: "ImmunizationService/immunization.json",
         });
@@ -10,6 +13,10 @@ describe("Filters", () => {
         });
         cy.configureSettings({
             datasets: [
+                {
+                    name: "clinicalDocument",
+                    enabled: true,
+                },
                 {
                     name: "healthVisit",
                     enabled: true,
@@ -29,7 +36,7 @@ describe("Filters", () => {
     });
 
     it("Verify filtered record count", () => {
-        const unfilteredRecordsMessage = "Displaying 25 out of 32 records";
+        const unfilteredRecordsMessage = "Displaying 25 out of 34 records";
 
         cy.get("[data-testid=timeline-record-count]").contains(
             unfilteredRecordsMessage
@@ -97,6 +104,29 @@ describe("Filters", () => {
 
         cy.get(
             "[data-testid=linear-timeline-immunization-disclaimer-alert]"
+        ).should("not.be.visible");
+    });
+
+    it("Verify clinical document record alert appears when only clinical document is selected", () => {
+        cy.get(
+            "[data-testid=linear-timeline-clinical-document-disclaimer-alert]"
+        ).should("not.be.visible");
+
+        cy.get("[data-testid=filterDropdown]").click();
+        cy.get("[data-testid=ClinicalDocument-filter]").click({ force: true });
+        cy.get("[data-testid=btnFilterApply]").click();
+        cy.get("[data-testid=btnFilterApply]").should("not.exist");
+
+        cy.get(
+            "[data-testid=linear-timeline-clinical-document-disclaimer-alert]"
+        ).should("be.visible");
+
+        cy.get("[data-testid=filterDropdown]").click();
+        cy.get("[data-testid=HealthVisit-filter]").click({ force: true });
+        cy.get("[data-testid=btnFilterApply]").click();
+
+        cy.get(
+            "[data-testid=linear-timeline-clinical-document-disclaimer-alert]"
         ).should("not.be.visible");
     });
 });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -109,7 +109,7 @@ describe("Filters", () => {
 
     it("Verify clinical document record alert appears when only clinical document is selected", () => {
         cy.get(
-            "[data-testid=linear-timeline-clinical-document-disclaimer-alert]"
+            "[data-testid=timeline-clinical-document-disclaimer-alert]"
         ).should("not.be.visible");
 
         cy.get("[data-testid=filterDropdown]").click();
@@ -118,7 +118,7 @@ describe("Filters", () => {
         cy.get("[data-testid=btnFilterApply]").should("not.exist");
 
         cy.get(
-            "[data-testid=linear-timeline-clinical-document-disclaimer-alert]"
+            "[data-testid=timeline-clinical-document-disclaimer-alert]"
         ).should("be.visible");
 
         cy.get("[data-testid=filterDropdown]").click();
@@ -126,7 +126,7 @@ describe("Filters", () => {
         cy.get("[data-testid=btnFilterApply]").click();
 
         cy.get(
-            "[data-testid=linear-timeline-clinical-document-disclaimer-alert]"
+            "[data-testid=timeline-clinical-document-disclaimer-alert]"
         ).should("not.be.visible");
     });
 });


### PR DESCRIPTION
# Implements [AB#15195](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15195)

## Description

- Add disclaimer to timeline when clinical document filter is selected
- Implemented same as Immuniztion
- Added functional test to check when disclaimer is shown and not shown

**Timeline:**

<img width="1243" alt="Screenshot 2023-03-22 at 6 38 38 PM" src="https://user-images.githubusercontent.com/58790456/227076952-4e4af1c7-7dcc-463b-97e6-85640969795c.png">


**Functional Test:**

<img width="1211" alt="Screenshot 2023-03-22 at 5 06 40 PM" src="https://user-images.githubusercontent.com/58790456/227067100-8b8fc627-1aa9-4420-b73f-468abf5dce98.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

Yes

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
