### PR TITLE
Functional test failures - Registration tests

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
@@ -50,7 +50,8 @@ describe("Registration Page", () => {
             .type(Cypress.env("phoneNumber"));
         cy.get("[data-testid=acceptCheckbox]")
             .should("be.enabled")
-            .check({ force: true });
+            .check({ force: true })
+            .wait(500);
         cy.get("[data-testid=registerButton]")
             .should("be.visible", "be.enabled")
             .click();

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -80,7 +80,8 @@ function testRegisterError(statusCode = serverErrorStatusCode) {
         .type(Cypress.env("phoneNumber"));
     cy.get("[data-testid=acceptCheckbox]")
         .should("be.enabled")
-        .check({ force: true });
+        .check({ force: true })
+        .wait(500);
     cy.get("[data-testid=registerButton]")
         .should("be.visible", "be.enabled")
         .click();


### PR DESCRIPTION
# Fixes [AB#15228](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15228)

## Functional test failures - Registration tests
- local testing consistently recreated the problem when the register button was hit for the first time after app startup
- so which ever registration test hit the button first had a chance of encountering a timing issue where Cypress was hitting the register button too fast after it was enabled by checking the accept checkbox.
- had to add a 500 millisecond wait in both the Registration.js and errorAlerts.js tests before the register button is hit to prevent the problem.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

![Screenshot 2023-03-23 at 2 21 47 PM](https://user-images.githubusercontent.com/5408101/227368712-063a645a-1339-4b58-8f78-d7718ca6b8e0.png)

![Screenshot 2023-03-23 at 2 30 37 PM](https://user-images.githubusercontent.com/5408101/227368733-1cfd3144-685a-4b34-86b4-14109f2e54b8.png)

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
