### PR TITLE
Check protected status when adding dependent AB#15171

### DIFF
--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -108,6 +108,7 @@ namespace HealthGateway.GatewayApi
             services.AddTransient<ICryptoDelegate, AesCryptoDelegate>();
             services.AddTransient<ICommunicationDelegate, DbCommunicationDelegate>();
             services.AddTransient<IUserPreferenceDelegate, DbUserPreferenceDelegate>();
+            services.AddTransient<IDelegationDelegate, DbDelegationDelegate>();
             services.AddTransient<IResourceDelegateDelegate, DbResourceDelegateDelegate>();
             services.AddTransient<ICDogsDelegate, CDogsDelegate>();
 


### PR DESCRIPTION
# Implements [AB#15171](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15171)

## Description

Updates dependent service to return an error when adding a protected dependent if the proposed delegate is not included in the dependent's allowed delegations.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
