### PR TITLE
Unit tests for add guardian to allow list for AB#15138

### DIFF
--- a/Apps/Admin/Tests/Validations/DelegatePatientValidatorTests.cs
+++ b/Apps/Admin/Tests/Validations/DelegatePatientValidatorTests.cs
@@ -1,0 +1,73 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Validations
+{
+    using System;
+    using FluentValidation.Results;
+    using HealthGateway.Admin.Server.Validations;
+    using HealthGateway.Common.Models;
+    using Xunit;
+
+    /// <summary>
+    /// DelegatePatientValidator unit tests.
+    /// </summary>
+    public class DelegatePatientValidatorTests
+    {
+        private const int MinDelegateAge = 12;
+
+        /// <summary>
+        /// Test range of valid birth dates.
+        /// </summary>
+        /// <param name="daysToAdd">The number of days(+/-) from utc now minus minimum age(years) used to create a birthdate.</param>
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-100)]
+        [InlineData(-365)]
+        public void ShouldBeValid(int daysToAdd)
+        {
+            PatientModel patient = GetPatient(daysToAdd);
+            ValidationResult validationResult = new DelegatePatientValidator(MinDelegateAge).Validate(patient);
+            Assert.True(validationResult.IsValid);
+        }
+
+        /// <summary>
+        /// Test range of invalid birth dates.
+        /// </summary>
+        /// <param name="daysToAdd">The number of days(+/-) from utc now minus minimum age(years) used to create a birthdate.</param>
+        [Theory]
+        [InlineData(1)]
+        [InlineData(100)]
+        [InlineData(365)]
+        public void ShouldNotBeValid(int daysToAdd)
+        {
+            PatientModel patient = GetPatient(daysToAdd);
+            ValidationResult validationResult = new DelegatePatientValidator(MinDelegateAge).Validate(patient);
+            Assert.False(validationResult.IsValid);
+        }
+
+        private static PatientModel GetPatient(int daysToAdd)
+        {
+            // Creating dynamic birthdate where minimum delegate age (years) is minus from current utc date and then days are either added to or subtracted from
+            // to create the date.
+            DateTime birthDate = DateTime.UtcNow.AddYears(-MinDelegateAge).AddDays(daysToAdd);
+
+            return new()
+            {
+                Birthdate = birthDate,
+            };
+        }
+    }
+}


### PR DESCRIPTION
# Implements [AB#15138](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15138)

## Description

- Add unit tests to determine valid and invalid delegate age for DelegatePatientValidator
- Add unit test for Get Delegate Information happy path
- Add unit test for Get Delegate Information throws problem details exception

**Unit Tests:**

<img width="1281" alt="Screenshot 2023-03-29 at 4 14 20 PM" src="https://user-images.githubusercontent.com/58790456/228689227-91db5762-2edf-4db6-903b-19dcca3af01a.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
