### PR TITLE
Convert emails to links AB#15250

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/ErrorCardComponent.vue
@@ -146,7 +146,11 @@ export default class ErrorCardComponent extends Vue {
                     <div class="py-2">
                         <p>
                             Try refreshing the page. If this issue persists,
-                            contact HealthGateway@gov.bc.ca and provide
+                            contact
+                            <a href="mailto:HealthGateway@gov.bc.ca"
+                                >HealthGateway@gov.bc.ca</a
+                            >
+                            and provide
                             <hg-button
                                 v-clipboard:copy="errorDetailsCopyToClipboard"
                                 v-clipboard:success="onCopy"

--- a/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/AddQuickLinkComponent.vue
@@ -288,7 +288,9 @@ export default class AddQuickLinkComponent extends Vue {
                 <p>{{ bannerError.title }}</p>
                 <span>
                     If you continue to have issues, please contact
-                    HealthGateway@gov.bc.ca.
+                    <a href="mailto:HealthGateway@gov.bc.ca"
+                        >HealthGateway@gov.bc.ca</a
+                    >.
                 </span>
             </b-alert>
             <b-row

--- a/Apps/WebClient/src/ClientApp/src/components/modal/NoteEditComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/modal/NoteEditComponent.vue
@@ -253,7 +253,9 @@ export default class NoteEditComponent extends Vue {
             <p data-testid="noteEditErrorText">{{ errorMessage }}</p>
             <span>
                 If you continue to have issues, please contact
-                HealthGateway@gov.bc.ca.
+                <a href="mailto:HealthGateway@gov.bc.ca"
+                    >HealthGateway@gov.bc.ca</a
+                >.
             </span>
         </b-alert>
         <template #modal-header>

--- a/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/RegistrationView.vue
@@ -456,7 +456,12 @@ export default class RegistrationView extends Vue {
                     <h1>Error retrieving user information</h1>
                     <p data-testid="clientRegistryErrorText">
                         There may be an issue in our Client Registry. Please
-                        contact <strong>HealthGateway@gov.bc.ca</strong>
+                        contact
+                        <strong
+                            ><a href="mailto:HealthGateway@gov.bc.ca"
+                                >HealthGateway@gov.bc.ca</a
+                            ></strong
+                        >
                     </p>
                 </div>
                 <div v-else><h1>Unknown error</h1></div>

--- a/Apps/WebClient/src/ClientApp/src/views/errors/PatientRetrievalErrorView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/errors/PatientRetrievalErrorView.vue
@@ -19,7 +19,11 @@ export default class PatientRetrievalErrorView extends Vue {}
     <PageErrorComponent title="Error retrieving user information">
         <p>
             There may be an issue in our Client Registry. Please contact
-            <strong>HealthGateway@gov.bc.ca</strong>
+            <strong
+                ><a href="mailto:HealthGateway@gov.bc.ca"
+                    >HealthGateway@gov.bc.ca</a
+                ></strong
+            >
         </p>
     </PageErrorComponent>
 </template>


### PR DESCRIPTION
# Fixes or Implements [AB#15250](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15250)

## Description

1. Convert text only email addresses into `mailto` links.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
ErrorCardComponent.vue:
![image](https://user-images.githubusercontent.com/19548348/228907299-558ab28f-441a-4584-81bd-2faa57fdd9e5.png)

PatientRetrievalErrorView.vue:
![image](https://user-images.githubusercontent.com/19548348/228908357-5fe60bf3-5bcc-4be3-8458-0972439fb688.png)

AddQuickLinkComponent.vue Error banner:
![image](https://user-images.githubusercontent.com/19548348/228909229-6b5f2c13-16bb-4f31-890f-607e5828439b.png)

Others are similar.

## Notes


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
