### PR TITLE
Demographics for Guardian on Exports

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/report/ReportsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/report/ReportsComponent.vue
@@ -22,6 +22,7 @@ import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
+import { Dependent } from "@/models/dependent";
 import { ResultError } from "@/models/errors";
 import MedicationStatementHistory from "@/models/medicationStatementHistory";
 import MedicationSummary from "@/models/medicationSummary";
@@ -83,6 +84,9 @@ export default class ReportsComponent extends Vue {
     @Getter("patient", { namespace: "user" })
     patient!: Patient;
 
+    @Getter("dependents", { namespace: "dependent" })
+    private dependents!: Dependent[];
+
     @Ref("messageModal")
     readonly messageModal!: MessageModalComponent;
 
@@ -131,18 +135,42 @@ export default class ReportsComponent extends Vue {
     }
 
     get headerData(): ReportHeader {
-        return {
-            phn: this.patient.personalHealthNumber,
-            dateOfBirth: this.formatDate(this.patient.birthdate || ""),
-            name: this.patient
-                ? this.patient.preferredName.givenName +
-                  " " +
-                  this.patient.preferredName.surname
-                : "",
-            isRedacted: this.reportFilter.hasMedicationsFilter(),
-            datePrinted: new DateWrapper(new DateWrapper().toISO()).format(),
-            filterText: this.reportFilter.filterText,
-        };
+        const dependent = this.dependents.find(
+            (d) => d.dependentInformation.hdid === this.hdid
+        );
+        if (dependent) {
+            return {
+                phn: dependent.dependentInformation.PHN,
+                dateOfBirth: this.formatDate(
+                    dependent.dependentInformation.dateOfBirth || ""
+                ),
+                name: dependent.dependentInformation
+                    ? dependent.dependentInformation.firstname +
+                      " " +
+                      dependent.dependentInformation.lastname
+                    : "",
+                isRedacted: this.reportFilter.hasMedicationsFilter(),
+                datePrinted: new DateWrapper(
+                    new DateWrapper().toISO()
+                ).format(),
+                filterText: this.reportFilter.filterText,
+            };
+        } else {
+            return {
+                phn: this.patient.personalHealthNumber,
+                dateOfBirth: this.formatDate(this.patient.birthdate || ""),
+                name: this.patient
+                    ? this.patient.preferredName.givenName +
+                      " " +
+                      this.patient.preferredName.surname
+                    : "",
+                isRedacted: this.reportFilter.hasMedicationsFilter(),
+                datePrinted: new DateWrapper(
+                    new DateWrapper().toISO()
+                ).format(),
+                filterText: this.reportFilter.filterText,
+            };
+        }
     }
 
     get isMedicationReport(): boolean {


### PR DESCRIPTION
# Fixes [AB#15275](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15275)

## Demographics for Guardian on Exports

- fixed getting header data by looking for dependent by hdid from dependents in the store
- if no dependent then set with user data

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

Dependent Export Records report: 
![Screenshot 2023-03-31 at 3 47 22 PM](https://user-images.githubusercontent.com/5408101/229246023-7d9443b4-14a2-44d5-a194-c182c55179ba.png)

Export Records report: 
![Screenshot 2023-03-31 at 3 47 48 PM](https://user-images.githubusercontent.com/5408101/229246045-a9a70cc9-3f61-4fc7-9ef8-91b3582be936.png)


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
