### PR TITLE
Fix card shadows for iOS AB#15227

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/shared/HgCardButtonComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/HgCardButtonComponent.vue
@@ -13,8 +13,8 @@ export default class HgCardButtonComponent extends Vue {
     @Prop({ required: false, default: false })
     hasChevron!: boolean;
 
-    private get hasClickListener() {
-        return this.$listeners && this.$listeners.click;
+    private get hasClickListener(): boolean {
+        return this.$listeners && Boolean(this.$listeners.click);
     }
 
     private get hasIconSlot(): boolean {
@@ -33,7 +33,7 @@ export default class HgCardButtonComponent extends Vue {
 
 <template>
     <b-button
-        class="hg-card-button h-100 w-100 p-0"
+        class="hg-card-button h-100 w-100 p-0 shadow"
         v-bind="$attrs"
         v-on="$listeners"
     >

--- a/Apps/WebClient/src/ClientApp/src/components/shared/HgCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/HgCardComponent.vue
@@ -32,9 +32,10 @@ export default class HgCardComponent extends Vue {
 
 <template>
     <div
-        class="hg-card h-100 w-100 d-flex flex-column align-content-start text-left rounded shadow"
+        class="hg-card h-100 w-100 d-flex flex-column align-content-start text-left rounded"
         :class="{
             interactable: isInteractable,
+            shadow: !isInteractable,
             'p-3': dense,
             'p-4': !dense,
         }"


### PR DESCRIPTION
# Fixes [AB#15227](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15227)

## Description

- re-adds shadow to HgCardButton and updates HgCard so it's not applied twice
- fixes console error relating to boolean conversion

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
