### PR TITLE
Adjust page title size and remove home page subtitle AB#15277

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
@@ -19,16 +19,16 @@ export default class PageTitleComponent extends Vue {
 <template>
     <div id="pageTitle">
         <b-row no-gutters class="justify-content-between">
-            <b-col cols="auto" sm class="d-flex align-items-end">
-                <h1 id="subject">
+            <b-col cols="auto" sm>
+                <h1 id="subject" class="mb-0 mt-2">
                     <slot v-if="hasPrependSlot" name="prepend" /> {{ title }}
                 </h1>
             </b-col>
-            <b-col v-if="hasSlot" class="mb-2 ml-2">
+            <b-col v-if="hasSlot" class="mb-0 ml-2">
                 <slot />
             </b-col>
         </b-row>
-        <hr />
+        <hr class="my-2" />
     </div>
 </template>
 
@@ -40,7 +40,7 @@ export default class PageTitleComponent extends Vue {
 }
 
 #pageTitle h1 {
-    font-size: 1.25rem;
+    font-size: 1.625rem;
 }
 
 #pageTitle hr {

--- a/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
@@ -19,7 +19,7 @@ export default class PageTitleComponent extends Vue {
 <template>
     <div id="pageTitle">
         <b-row no-gutters class="justify-content-between">
-            <b-col cols="auto" sm>
+            <b-col cols="auto" sm class="d-flex align-items-end">
                 <h1 id="subject">
                     <slot v-if="hasPrependSlot" name="prepend" /> {{ title }}
                 </h1>
@@ -37,6 +37,10 @@ export default class PageTitleComponent extends Vue {
 
 #pageTitle {
     color: $primary;
+}
+
+#pageTitle h1 {
+    font-size: 1.25rem;
 }
 
 #pageTitle hr {

--- a/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/PageTitleComponent.vue
@@ -20,8 +20,9 @@ export default class PageTitleComponent extends Vue {
     <div id="pageTitle">
         <b-row no-gutters class="justify-content-between">
             <b-col cols="auto" sm>
-                <h1 id="subject" class="mb-0 mt-2">
-                    <slot v-if="hasPrependSlot" name="prepend" /> {{ title }}
+                <slot v-if="hasPrependSlot" name="prepend" />
+                <h1 id="subject" class="mb-0 mt-2 d-inline-block">
+                    {{ title }}
                 </h1>
             </b-col>
             <b-col v-if="hasSlot" class="mb-0 ml-2">

--- a/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/DependentTimelineView.vue
@@ -152,7 +152,7 @@ export default class DependentTimelineView extends Vue {
                         data-testid="backBtn"
                         variant="link"
                         size="sm"
-                        class="back-button-icon p-1"
+                        class="back-button-icon align-baseline p-0 mr-2"
                     >
                         <hg-icon icon="arrow-left" size="large" square />
                     </b-button>

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -558,7 +558,6 @@ export default class HomeView extends Vue {
                 </div>
             </TutorialComponent>
         </page-title>
-        <h2>What do you want to focus on today?</h2>
         <b-row cols="1" cols-lg="2" cols-xl="3">
             <b-col class="p-3">
                 <hg-card-button


### PR DESCRIPTION
# Implements [AB#15277](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15277)

## Description

- updates page title header size to 1.625rem
- removes home page subtitle

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-04-04-111133](https://user-images.githubusercontent.com/16570293/229884430-c69cf7b2-ed46-49ee-aea4-910f9ae66241.png)
![localhost-2023-04-04-111144](https://user-images.githubusercontent.com/16570293/229884434-32222de6-840c-4f6a-84ff-0fd5d915076e.png)
![localhost-2023-04-04-111151](https://user-images.githubusercontent.com/16570293/229884439-9280b146-384b-49f5-a215-7aba478b339a.png)
![localhost-2023-04-04-111200](https://user-images.githubusercontent.com/16570293/229884441-f112e58d-4eb4-46ca-9939-c752e9b30a06.png)
![localhost-2023-04-04-111208](https://user-images.githubusercontent.com/16570293/229884444-60da54b5-8bce-453b-a20e-8c0c3bdf8383.png)
![localhost-2023-04-04-112148](https://user-images.githubusercontent.com/16570293/229884450-75e9dbb3-0585-4f3e-afba-17132527073d.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
