### PR TITLE
Replace card buttons on dependent dashboard tab AB#15190

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/shared/HgCardButtonComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/HgCardButtonComponent.vue
@@ -10,15 +10,16 @@ export default class HgCardButtonComponent extends Vue {
     @Prop({ required: false, default: false })
     dense!: boolean;
 
-    @Prop({ required: false, default: false })
-    hasChevron!: boolean;
-
     private get hasClickListener(): boolean {
         return this.$listeners && Boolean(this.$listeners.click);
     }
 
     private get hasIconSlot(): boolean {
         return this.$slots.icon !== undefined;
+    }
+
+    private get hasActionIconSlot(): boolean {
+        return this.$slots.actionIcon !== undefined;
     }
 
     private get hasMenuSlot(): boolean {
@@ -40,7 +41,6 @@ export default class HgCardButtonComponent extends Vue {
         <hg-card
             :title="title"
             :dense="dense"
-            :has-chevron="hasChevron"
             :is-interactable="hasClickListener"
         >
             <template #icon>
@@ -48,6 +48,9 @@ export default class HgCardButtonComponent extends Vue {
             </template>
             <template #menu>
                 <slot name="menu" />
+            </template>
+            <template #action-icon>
+                <slot name="action-icon" />
             </template>
             <slot />
         </hg-card>

--- a/Apps/WebClient/src/ClientApp/src/components/shared/HgCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/shared/HgCardComponent.vue
@@ -11,13 +11,14 @@ export default class HgCardComponent extends Vue {
     dense!: boolean;
 
     @Prop({ required: false, default: false })
-    hasChevron!: boolean;
-
-    @Prop({ required: false, default: false })
     isInteractable!: boolean;
 
     private get hasIconSlot(): boolean {
         return this.$slots.icon !== undefined;
+    }
+
+    private get hasActionIconSlot(): boolean {
+        return this.$slots["action-icon"] !== undefined;
     }
 
     private get hasMenuSlot(): boolean {
@@ -62,17 +63,12 @@ export default class HgCardComponent extends Vue {
                 {{ title }}
             </b-col>
             <b-col
-                v-if="hasChevron"
+                v-if="hasActionIconSlot"
                 cols="auto"
                 align-self="center"
                 class="mt-3 d-flex"
             >
-                <hg-icon
-                    icon="chevron-right"
-                    class="chevron-icon align-self-center"
-                    size="medium"
-                    square
-                />
+                <slot name="action-icon" />
             </b-col>
             <b-col v-if="hasMenuSlot" cols="auto" class="mt-2">
                 <slot name="menu" />

--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -109,9 +109,6 @@ export default class HomeView extends Vue {
     @Action("setFilter", { namespace: "timeline" })
     setFilter!: (filterBuilder: TimelineFilterBuilder) => void;
 
-    @Action("clearFilter", { namespace: "timeline" })
-    clearFilter!: () => void;
-
     @Action("updateQuickLinks", { namespace: "user" })
     updateQuickLinks!: (params: {
         hdid: string;
@@ -353,7 +350,6 @@ export default class HomeView extends Vue {
 
     private handleClickHealthRecords(): void {
         this.trackClickLink("all_records");
-        this.clearFilter();
         this.$router.push({ path: "/timeline" });
     }
 

--- a/Testing/functional/tests/cypress/integration/e2e/dependent/dashboard.js
+++ b/Testing/functional/tests/cypress/integration/e2e/dependent/dashboard.js
@@ -4,18 +4,6 @@ const validDependentHdid = "162346565465464564565463257";
 const validDependentTimelinePath = `/dependents/${validDependentHdid}/timeline`;
 const validDependentFederalProofOfVaccinationButtonId = `[data-testid=proof-vaccination-card-btn-${validDependentHdid}]`;
 
-function validateDatasetCard(dataset) {
-    const selector = `[data-testid=dependent-entry-type-${dataset}-${validDependentHdid}]`;
-    cy.get(selector).should("be.enabled", "be.visible").click();
-    cy.location("pathname").should("eq", validDependentTimelinePath);
-    cy.checkTimelineHasLoaded();
-
-    cy.get("[data-testid=filterContainer]").should("not.exist");
-    cy.get("[data-testid=filterDropdown]").click();
-    cy.get(`[data-testid=${dataset}-filter]`).should("to.be.checked");
-    cy.get("[data-testid=btnFilterCancel]").click();
-}
-
 describe("dependents - dashboard", () => {
     beforeEach(() => {
         cy.configureSettings({
@@ -69,36 +57,10 @@ describe("dependents - dashboard", () => {
         );
     });
 
-    it("Validate dashboard immunizations tab click to timeline", () => {
-        validateDatasetCard("Immunization");
-    });
-
-    it("Validate dashboard lab results tab click to timeline", () => {
-        validateDatasetCard("LabResult");
-    });
-
-    it("Validate dashboard covid19 test results tab click to timeline", () => {
-        validateDatasetCard("Covid19TestResult");
-    });
-
-    it("Validate dashboard clinical documents tab click to timeline", () => {
-        validateDatasetCard("ClinicalDocument");
-    });
-
-    it("Validate dashboard health visits tab click to timeline", () => {
-        validateDatasetCard("HealthVisit");
-    });
-
-    it("Validate dashboard hospital visits tab click to timeline", () => {
-        validateDatasetCard("HospitalVisit");
-    });
-
-    it("Validate dashboard medication tab click to timeline", () => {
-        validateDatasetCard("Medication");
-    });
-
-    it("Validate dashboard special authority requests tab click to timeline", () => {
-        validateDatasetCard("SpecialAuthorityRequest");
+    it("Validate clicking health records button loads timeline", () => {
+        const selector = `[data-testid=dependent-health-records-button-${validDependentHdid}]`;
+        cy.get(selector).should("be.enabled", "be.visible").click();
+        cy.location("pathname").should("eq", validDependentTimelinePath);
     });
 
     it("Validate download of federal proof of vaccination", () => {


### PR DESCRIPTION
# Implements [AB#15190](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15190)

## Description

- [AB#15278](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15278)
  - updates card buttons on dependent dashboard tab
  - removes redundant filter clearing when viewing all records from home page
  - updates functional tests

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

###  Desktop

![localhost-2023-04-03-175242](https://user-images.githubusercontent.com/16570293/229659360-b9faa7ac-4616-4777-9112-4816dcf7f4c2.png)

###  Smartphone
![localhost-2023-04-03-175401](https://user-images.githubusercontent.com/16570293/229659365-663ed6ac-220d-4818-8679-3379ee57fdb0.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
