### PR TITLE
Add permission policy to webclient AB#15247

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
@@ -73,7 +73,10 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// <param name="configuration">The configuration to use.</param>
         /// <param name="environment">The environment to use.</param>
         /// <param name="blazor">If true, will add blazor optimizations for static files.</param>
-        /// <param name="useExceptionPage">If true, app will use development exception page. Should be false when using problem details middleware.</param>
+        /// <param name="useExceptionPage">
+        /// If true, app will use development exception page. Should be false when using problem
+        /// details middleware.
+        /// </param>
         public static void UseHttp(IApplicationBuilder app, ILogger logger, IConfiguration configuration, IWebHostEnvironment environment, bool blazor, bool useExceptionPage)
         {
             app.UseResponseCompression();
@@ -233,7 +236,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         }
 
         /// <summary>
-        /// Configures the app to to use content security policies.
+        /// Configures the app to use content security policies.
         /// </summary>
         /// <param name="app">The application builder provider.</param>
         /// <param name="configuration">The configuration to use.</param>
@@ -248,6 +251,25 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                     context.Response.Headers.Add("Content-Security-Policy", csp);
                     await next().ConfigureAwait(true);
                 });
+        }
+
+        /// <summary>
+        /// Configures the app to use permission policies.
+        /// </summary>
+        /// <param name="app">The application builder provider.</param>
+        /// <param name="configuration">The configuration to use.</param>
+        public static void UsePermissionPolicy(IApplicationBuilder app, IConfiguration configuration)
+        {
+            string? policyValue = configuration["PermissionPolicy"];
+            if (policyValue != null)
+            {
+                app.Use(
+                    async (context, next) =>
+                    {
+                        context.Response.Headers.Add("Permissions-Policy", policyValue);
+                        await next().ConfigureAwait(true);
+                    });
+            }
         }
 
         /// <summary>

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -221,12 +221,21 @@ namespace HealthGateway.Common.AspNetConfiguration
         }
 
         /// <summary>
-        /// Configures the app to to use content security policies.
+        /// Configures the app to use content security policies.
         /// </summary>
         /// <param name="app">The application builder provider.</param>
         public void UseContentSecurityPolicy(IApplicationBuilder app)
         {
             HttpWeb.UseContentSecurityPolicy(app, this.Configuration);
+        }
+
+        /// <summary>
+        /// Configures the app to use permission policies.
+        /// </summary>
+        /// <param name="app">The application builder provider.</param>
+        public void UsePermissionPolicy(IApplicationBuilder app)
+        {
+            HttpWeb.UsePermissionPolicy(app, this.Configuration);
         }
 
         /// <summary>

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -95,6 +95,7 @@ namespace HealthGateway.WebClient.Server
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             this.startupConfig.UseContentSecurityPolicy(app);
+            this.startupConfig.UsePermissionPolicy(app);
             this.startupConfig.UseForwardHeaders(app);
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app);

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -116,6 +116,7 @@
         "FrameSource": "'self' https://loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://loginproxy.gov.bc.ca/"
     },
+    "PermissionPolicy": "*",
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -116,7 +116,7 @@
         "FrameSource": "'self' https://loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://loginproxy.gov.bc.ca/"
     },
-    "PermissionPolicy": "*",
+    "PermissionPolicy": "camera=(self)",
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [


### PR DESCRIPTION
# Fixes or Implements [AB#15247](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15247)

## Description

Add configurable permission policy header to web client startup.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## Notes
<img width="575" alt="image" src="https://user-images.githubusercontent.com/19548348/229878475-458a9357-848a-4b08-b77f-141aece3ba7a.png">

Other Zap scan files have also the missing permissions-policy header.


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
