### PR TITLE
Audit columns not populated for dependent  and allowed delegation for AB#15316

### DIFF
--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Admin.Tests.Services
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Admin.Tests.Utils;
+    using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
@@ -354,6 +355,7 @@ namespace HealthGateway.Admin.Tests.Services
                 patientService.Object,
                 new Mock<IResourceDelegateDelegate>().Object,
                 new Mock<IDelegationDelegate>().Object,
+                new Mock<IAuthenticationDelegate>().Object,
                 this.autoMapper);
 
             await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegationInformationAsync(DependentPhn)).ConfigureAwait(true);
@@ -670,7 +672,13 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IDelegationDelegate> delegationDelegate = new();
             delegationDelegate.Setup(p => p.GetDependentAsync(DependentHdid, true)).ReturnsAsync(protectedDependent);
 
-            return new DelegationService(this.configuration, patientService.Object, resourceDelegateDelegate.Object, delegationDelegate.Object, this.autoMapper);
+            return new DelegationService(
+                this.configuration,
+                patientService.Object,
+                resourceDelegateDelegate.Object,
+                delegationDelegate.Object,
+                new Mock<IAuthenticationDelegate>().Object,
+                this.autoMapper);
         }
 
         private DelegationService GetDelegationService(Dependent? dependent, Mock<IDelegationDelegate> delegationDelegate, ResourceDelegateQueryResult resourceDelegates, string resourceOwnerHdid)
@@ -680,14 +688,20 @@ namespace HealthGateway.Admin.Tests.Services
 
             delegationDelegate.Setup(p => p.GetDependentAsync(resourceOwnerHdid, true)).ReturnsAsync(dependent);
 
-            return new(this.configuration, new Mock<IPatientService>().Object, resourceDelegateDelegate.Object, delegationDelegate.Object, this.autoMapper);
+            return new(this.configuration, new Mock<IPatientService>().Object, resourceDelegateDelegate.Object, delegationDelegate.Object, new Mock<IAuthenticationDelegate>().Object, this.autoMapper);
         }
 
         private DelegationService GetDelegationService(RequestResult<PatientModel> patient)
         {
             Mock<IPatientService> patientService = new();
             patientService.Setup(p => p.GetPatient(It.IsAny<string>(), PatientIdentifierType.Phn, false)).ReturnsAsync(patient);
-            return new(this.configuration, patientService.Object, new Mock<IResourceDelegateDelegate>().Object, new Mock<IDelegationDelegate>().Object, this.autoMapper);
+            return new(
+                this.configuration,
+                patientService.Object,
+                new Mock<IResourceDelegateDelegate>().Object,
+                new Mock<IDelegationDelegate>().Object,
+                new Mock<IAuthenticationDelegate>().Object,
+                this.autoMapper);
         }
     }
 }


### PR DESCRIPTION
# Fixes AB#15316

## Description

Audit properties now being populated for Dependent
Audit properties now being populated for AllowedDelegation
Updated BaseDbContext to handle SaveChangesAsync calls in addition to SaveChanges
Updated unit tests

**Unit Tests:**

<img width="2519" alt="Screenshot 2023-04-05 at 4 38 01 PM" src="https://user-images.githubusercontent.com/58790456/230237313-973d4f12-66ef-4ec6-8fa8-72a08dd08b80.png">

**Dependent:**

<img width="1436" alt="Screenshot 2023-04-05 at 4 38 14 PM" src="https://user-images.githubusercontent.com/58790456/230237352-a4e5e71a-d6b9-40d4-8407-5cb1d9d18597.png">

**Allowed Delegation:**

<img width="1673" alt="Screenshot 2023-04-05 at 4 41 31 PM" src="https://user-images.githubusercontent.com/58790456/230237487-217221ea-6b4c-42ea-8715-5df61a17ef01.png">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
