### PR TITLE
Prevent exception that hides auth failure details AB#12916

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/Auth.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Auth.cs
@@ -18,9 +18,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.IdentityModel.Tokens.Jwt;
-    using System.Net;
     using System.Security.Claims;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Admin;
     using HealthGateway.Common.AccessManagement.Authorization.Handlers;
@@ -453,16 +451,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
 
             auditLogger.WriteAuditEvent(auditEvent);
 
-            context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-            context.Response.ContentType = "application/json";
-
-            return context.Response.WriteAsync(
-                JsonSerializer.Serialize(
-                    new
-                    {
-                        State = "AuthenticationFailed",
-                        Message = context.Exception.ToString(),
-                    }));
+            return Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
# Fixes [AB#12916](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/12916)

## Description

On a JWT authentication failure, the middleware was trying to write a response containing the error details, but this caused other middleware to throw an exception when they tried to write a response.  The exception prevented any useful details from being returned.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

Response on auth failure in project with Problem Details:
![Screenshot 2023-04-05 170752](https://user-images.githubusercontent.com/16570293/230242243-aba969aa-15ef-4a5c-95e6-a8b6a06bb176.png)

Response on auth failure in project without Problem Details:
![Screenshot 2023-04-05 171954](https://user-images.githubusercontent.com/16570293/230242245-46862f23-aab9-4af4-a63c-954732ac4de0.png)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
