### PR TITLE
Fix updated by to use current user login for AB#15321

### DIFF
--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -155,9 +155,10 @@ namespace HealthGateway.Admin.Server.Services
         {
             string authenticatedUserId = this.authenticationDelegate.FetchAuthenticatedUserId() ?? UserId.DefaultUser;
             Dependent? dependent = await this.delegationDelegate.GetDependentAsync(dependentHdid, true).ConfigureAwait(true);
-            dependent ??= new() { HdId = dependentHdid, CreatedBy = authenticatedUserId, UpdatedBy = authenticatedUserId };
+            dependent ??= new() { HdId = dependentHdid, CreatedBy = authenticatedUserId };
 
             dependent.Protected = true;
+            dependent.UpdatedBy = authenticatedUserId;
             await this.UpdateDelegationAsync(dependent, delegateHdids.ToList(), authenticatedUserId).ConfigureAwait(true);
         }
 


### PR DESCRIPTION
# Fixes [AB#15321](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15321)

## Description

Fix protect call to use current logged in user when populating 'UpdatedBy' in Dependent table.

<img width="2200" alt="Screenshot 2023-04-06 at 11 50 51 AM" src="https://user-images.githubusercontent.com/58790456/230469491-a0b2819e-7e08-448e-a84c-d750b6dfb6ca.png">

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
