### PR TITLE
Update unit tests for protect/unprotect delegation for AB#15257

### DIFF
--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -171,7 +171,39 @@ namespace HealthGateway.Admin.Server.Services
                 UpdatedBy = authenticatedUserId,
             };
 
-            await this.UpdateDelegationAsync(dependent, delegateHdids.ToList(), authenticatedUserId, dependentAudit).ConfigureAwait(true);
+            // Compare dependent allowed delegations in database with passed in delegate hdids to determine which allowed delegations to remove.
+            IEnumerable<AllowedDelegation> allowedDelegationsToDelete =
+                dependent.AllowedDelegations.Where(x => delegateHdids.All(y => y != x.DelegateHdId));
+
+            foreach (AllowedDelegation delegation in allowedDelegationsToDelete.ToList())
+            {
+                dependent.AllowedDelegations.Remove(delegation);
+            }
+
+            // Compare passed in delegate hdids with dependent allowed delegations in database to determine what allowed delegations to add.
+            IEnumerable<string> delegateHdidEnumerable = delegateHdids.ToList();
+            IEnumerable<string> delegateHdidsToAdd =
+                delegateHdidEnumerable.Where(x => dependent.AllowedDelegations.All(y => y.DelegateHdId != x));
+
+            foreach (string delegateHdid in delegateHdidsToAdd)
+            {
+                dependent.AllowedDelegations.Add(
+                    new()
+                    {
+                        DependentHdId = dependent.HdId,
+                        DelegateHdId = delegateHdid,
+                        CreatedBy = authenticatedUserId,
+                        UpdatedBy = authenticatedUserId,
+                    });
+            }
+
+            IEnumerable<ResourceDelegate> resourceDelegates = await this.SearchDelegates(dependent.HdId).ConfigureAwait(true);
+
+            // Compare resource delegates with passed in delegate hdids to determine which resource delegates to remove
+            IEnumerable<ResourceDelegate> resourceDelegatesToDelete = resourceDelegates.Where(r => delegateHdidEnumerable.All(a => a != r.ProfileHdid));
+
+            // Update dependent, allow delegation and resource delegate in database
+            await this.delegationDelegate.UpdateDelegationAsync(dependent, resourceDelegatesToDelete, dependentAudit).ConfigureAwait(true);
         }
 
         /// <inheritdoc/>
@@ -201,42 +233,6 @@ namespace HealthGateway.Admin.Server.Services
             };
 
             await this.delegationDelegate.UpdateDelegationAsync(dependent, Enumerable.Empty<ResourceDelegate>(), dependentAudit).ConfigureAwait(true);
-        }
-
-        private async Task UpdateDelegationAsync(Dependent dependent, IList<string> delegateHdids, string authenticatedUserId, DependentAudit dependentAudit)
-        {
-            // Compare dependent allowed delegations in database with passed in delegate hdids to determine which allowed delegations to remove.
-            IEnumerable<AllowedDelegation> allowedDelegationsToDelete =
-                dependent.AllowedDelegations.Where(x => delegateHdids.All(y => y != x.DelegateHdId));
-
-            foreach (AllowedDelegation delegation in allowedDelegationsToDelete.ToList())
-            {
-                dependent.AllowedDelegations.Remove(delegation);
-            }
-
-            // Compare passed in delegate hdids with dependent allowed delegations in database to determine what allowed delegations to add.
-            IEnumerable<string> delegateHdidsToAdd =
-                delegateHdids.Where(x => dependent.AllowedDelegations.All(y => y.DelegateHdId != x));
-
-            foreach (string delegateHdid in delegateHdidsToAdd)
-            {
-                dependent.AllowedDelegations.Add(
-                    new()
-                    {
-                        DependentHdId = dependent.HdId,
-                        DelegateHdId = delegateHdid,
-                        CreatedBy = authenticatedUserId,
-                        UpdatedBy = authenticatedUserId,
-                    });
-            }
-
-            IEnumerable<ResourceDelegate> resourceDelegates = await this.SearchDelegates(dependent.HdId).ConfigureAwait(true);
-
-            // Compare resource delegates with passed in delegate hdids to determine which resource delegates to remove
-            IEnumerable<ResourceDelegate> resourceDelegatesToDelete = resourceDelegates.Where(r => delegateHdids.All(a => a != r.ProfileHdid));
-
-            // Update dependent, allow delegation and resource delegate in database
-            await this.delegationDelegate.UpdateDelegationAsync(dependent, resourceDelegatesToDelete, dependentAudit).ConfigureAwait(true);
         }
 
         private async Task<IEnumerable<ResourceDelegate>> SearchDelegates(string ownerHdid)

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -171,9 +171,11 @@ namespace HealthGateway.Admin.Server.Services
                 UpdatedBy = authenticatedUserId,
             };
 
+            IList<string> delegateHdidList = delegateHdids.ToList();
+
             // Compare dependent allowed delegations in database with passed in delegate hdids to determine which allowed delegations to remove.
             IEnumerable<AllowedDelegation> allowedDelegationsToDelete =
-                dependent.AllowedDelegations.Where(x => delegateHdids.All(y => y != x.DelegateHdId));
+                dependent.AllowedDelegations.Where(x => delegateHdidList.All(y => y != x.DelegateHdId));
 
             foreach (AllowedDelegation delegation in allowedDelegationsToDelete.ToList())
             {
@@ -181,9 +183,8 @@ namespace HealthGateway.Admin.Server.Services
             }
 
             // Compare passed in delegate hdids with dependent allowed delegations in database to determine what allowed delegations to add.
-            IEnumerable<string> delegateHdidEnumerable = delegateHdids.ToList();
             IEnumerable<string> delegateHdidsToAdd =
-                delegateHdidEnumerable.Where(x => dependent.AllowedDelegations.All(y => y.DelegateHdId != x));
+                delegateHdidList.Where(x => dependent.AllowedDelegations.All(y => y.DelegateHdId != x));
 
             foreach (string delegateHdid in delegateHdidsToAdd)
             {
@@ -200,7 +201,7 @@ namespace HealthGateway.Admin.Server.Services
             IEnumerable<ResourceDelegate> resourceDelegates = await this.SearchDelegates(dependent.HdId).ConfigureAwait(true);
 
             // Compare resource delegates with passed in delegate hdids to determine which resource delegates to remove
-            IEnumerable<ResourceDelegate> resourceDelegatesToDelete = resourceDelegates.Where(r => delegateHdidEnumerable.All(a => a != r.ProfileHdid));
+            IEnumerable<ResourceDelegate> resourceDelegatesToDelete = resourceDelegates.Where(r => delegateHdidList.All(a => a != r.ProfileHdid));
 
             // Update dependent, allow delegation and resource delegate in database
             await this.delegationDelegate.UpdateDelegationAsync(dependent, resourceDelegatesToDelete, dependentAudit).ConfigureAwait(true);

--- a/Apps/Database/src/Models/DependentAudit.cs
+++ b/Apps/Database/src/Models/DependentAudit.cs
@@ -39,14 +39,14 @@ namespace HealthGateway.Database.Models
         /// </summary>
         [Required]
         [MaxLength(52)]
-        public string HdId { get; set; } = null!;
+        public string HdId { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the agent username.
         /// </summary>
         [Required]
         [MaxLength(255)]
-        public string AgentUsername { get; set; } = null!;
+        public string AgentUsername { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the protected reason.


### PR DESCRIPTION
# Implements [AB#15257](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15257)

## Description

- Updated protect/unprotect delegation unit tests to include dependent audit
- Also moved DelegationService.UpdateDelegationAsync into DelegationService.ProtectDependentAsync to simplify code
- Changed null! to string.Empty Hdid and AgentUsername on initialization.

<img width="1049" alt="Screenshot 2023-04-12 at 1 03 11 PM" src="https://user-images.githubusercontent.com/58790456/231571696-b6b134bb-0fc9-4d8c-b426-137abcd547fd.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
