### PR TITLE
Enable execution of inline scripts used on Swagger page AB#15322

### DIFF
--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -15,7 +15,8 @@
     "ContentSecurityPolicy": {
         "ConnectSource": "'self' file: data: blob: filesystem: https: http: ws:",
         "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
-        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
+        "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/",
+        "ScriptSource": "'self' 'wasm-eval' 'unsafe-eval' 'sha256-nYaPGPw9zQuQHVl09VRaW597Ut8F9Lf/VDNxGSQu3Sc=' 'sha384-/fIp3d9vqOYL5eP47pOEUYZ/h5dXL4fD9Rc4DWSuIqMZkUj+DA94qNELNYZm8VJS' 'sha384-G+v/7MQzsBBqsKVV3XKv8ThIDYIyXG6LJWqTPBrADbzQf/Ok8cTgjl0X+smak2c5' 'sha256-Tui7QoFlnLXkJCSl1/JvEZdIXTmBttnWNxzJpXomQjg=' 'sha256-vY0Cwh5hLv8sUQ61m3KQgfrqeAmcY7t6wJ2FAdYPNyU='"
     },
     "PatientService": {
         "ClientRegistry": {


### PR DESCRIPTION
# Fixes AB#15322

## Description

Extends CSP for local development with hashes for the 2 inline scripts used on the Swagger page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

![localhost-2023-04-12-185331](https://user-images.githubusercontent.com/16570293/231627024-6a92e5a6-cf3e-4796-b24f-599dfc4c1899.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
