### PR TITLE
Agent Log on Protect User Update - update front end

### DIFF
--- a/Apps/Admin/Client/Api/IDelegationApi.cs
+++ b/Apps/Admin/Client/Api/IDelegationApi.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Api
 {
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Common.Models;
     using Refit;
@@ -46,18 +45,19 @@ namespace HealthGateway.Admin.Client.Api
         /// synchronized.
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to protect.</param>
-        /// <param name="delegateHdids">The list of delegate hdid(s) to allow delegation for the dependent.</param>
+        /// <param name="request">The request object containing data used to protect a dependent.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [Put("/{dependentHdid}/ProtectDependent")]
-        Task ProtectDependentAsync(string dependentHdid, [Body] IEnumerable<string> delegateHdids);
+        Task ProtectDependentAsync(string dependentHdid, ProtectDependentRequest request);
 
         /// <summary>
         /// Unprotects the dependent and if necessary removes the allowed delegation(s) and keeps the resource delegates
         /// synchronized.
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to unprotect.</param>
+        /// <param name="request">The request object containing data used to unprotect a dependent.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [Put("/{dependentHdid}/UnprotectDependent")]
-        Task UnprotectDependentAsync(string dependentHdid);
+        Task UnprotectDependentAsync(string dependentHdid, UnprotectDependentRequest request);
     }
 }

--- a/Apps/Admin/Client/Components/Delegation/DelegationConfirmationDialog.razor
+++ b/Apps/Admin/Client/Components/Delegation/DelegationConfirmationDialog.razor
@@ -15,6 +15,15 @@
             TResetAction="@DelegationActions.UnprotectDependentAction">
             @UnprotectErrorMessage
         </HgBannerFeedback>
+        <MudTextField
+            @ref="@ProtectReasonTextField"
+            Label="Reason"
+            @bind-Value="@ProtectReasonString"
+            T="@string"
+            MaxLength="500"
+            Required="true"
+            Lines="@(4)"
+            data-testid="protect-reason-input" />
     </DialogContent>
     <DialogActions>
         <HgButton
@@ -32,6 +41,7 @@
             BottomMargin="Breakpoint.Always"
             Color="@Color.Primary"
             Loading="@Loading"
+            Disabled="@SaveButtonDisabled"
             OnClick="@HandleClickConfirm"
             data-testid="confirm-button">
             Confirm

--- a/Apps/Admin/Client/Components/Delegation/DelegationConfirmationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Delegation/DelegationConfirmationDialog.razor.cs
@@ -71,6 +71,12 @@ public partial class DelegationConfirmationDialog : FluxorComponent
 
     private string? UnprotectErrorMessage => this.DelegationState.Value.Unprotect.Error?.Message;
 
+    private string ProtectReasonString { get; set; } = string.Empty;
+
+    private MudTextField<string> ProtectReasonTextField { get; set; } = default!;
+
+    private bool SaveButtonDisabled => this.ProtectReasonString.Length < 2;
+
     private bool Loading => this.Type switch
     {
         ConfirmationType.Protect => this.DelegationState.Value.Protect.IsLoading,
@@ -95,6 +101,8 @@ public partial class DelegationConfirmationDialog : FluxorComponent
 
     private void HandleClickConfirm()
     {
+        this.DelegationState.Value.Reason = this.ProtectReasonString;
+
         switch (this.Type)
         {
             case ConfirmationType.Protect:

--- a/Apps/Admin/Client/Components/Delegation/DelegationConfirmationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Delegation/DelegationConfirmationDialog.razor.cs
@@ -101,15 +101,21 @@ public partial class DelegationConfirmationDialog : FluxorComponent
 
     private void HandleClickConfirm()
     {
-        this.DelegationState.Value.Reason = this.ProtectReasonString;
-
         switch (this.Type)
         {
             case ConfirmationType.Protect:
-                this.Dispatcher.Dispatch(new DelegationActions.ProtectDependentAction());
+                this.Dispatcher.Dispatch(
+                    new DelegationActions.ProtectDependentAction
+                    {
+                        Reason = this.ProtectReasonString,
+                    });
                 break;
             case ConfirmationType.Unprotect:
-                this.Dispatcher.Dispatch(new DelegationActions.UnprotectDependentAction());
+                this.Dispatcher.Dispatch(
+                    new DelegationActions.UnprotectDependentAction
+                    {
+                        Reason = this.ProtectReasonString,
+                    });
                 break;
         }
     }

--- a/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
@@ -169,6 +169,10 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         /// </summary>
         public class ProtectDependentAction
         {
+            /// <summary>
+            /// Gets the reason associated with the delegation change.
+            /// </summary>
+            public required string Reason { get; init; }
         }
 
         /// <summary>
@@ -198,6 +202,10 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         /// </summary>
         public class UnprotectDependentAction
         {
+            /// <summary>
+            /// Gets the reason associated with the delegation change.
+            /// </summary>
+            public required string Reason { get; init; }
         }
 
         /// <summary>

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -102,8 +102,8 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             }
         }
 
-        [EffectMethod(typeof(DelegationActions.ProtectDependentAction))]
-        public async Task HandleProtectDependentAction(IDispatcher dispatcher)
+        [EffectMethod]
+        public async Task HandleProtectDependentAction(DelegationActions.ProtectDependentAction action, IDispatcher dispatcher)
         {
             this.Logger.LogInformation("Protect dependent");
             try
@@ -120,7 +120,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     .Where(d => d.StagedDelegationStatus is DelegationStatus.Added or DelegationStatus.Allowed)
                     .Select(x => x.Hdid);
 
-                ProtectDependentRequest protectDependentRequest = new(delegateHdids, this.DelegationState.Value.Reason);
+                ProtectDependentRequest protectDependentRequest = new(delegateHdids, action.Reason);
 
                 await this.Api.ProtectDependentAsync(dependentHdid, protectDependentRequest).ConfigureAwait(true);
                 this.Logger.LogInformation("Dependent protected successfully");
@@ -134,8 +134,8 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             }
         }
 
-        [EffectMethod(typeof(DelegationActions.UnprotectDependentAction))]
-        public async Task HandleUnprotectDependentAction(IDispatcher dispatcher)
+        [EffectMethod]
+        public async Task HandleUnprotectDependentAction(DelegationActions.UnprotectDependentAction action, IDispatcher dispatcher)
         {
             this.Logger.LogInformation("Unprotecting dependent");
             try
@@ -148,7 +148,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     return;
                 }
 
-                UnprotectDependentRequest unprotectDependentRequest = new(this.DelegationState.Value.Reason);
+                UnprotectDependentRequest unprotectDependentRequest = new(action.Reason);
 
                 await this.Api.UnprotectDependentAsync(dependentHdid, unprotectDependentRequest).ConfigureAwait(true);
                 this.Logger.LogInformation("Dependent unprotected successfully");

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -120,7 +120,9 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     .Where(d => d.StagedDelegationStatus is DelegationStatus.Added or DelegationStatus.Allowed)
                     .Select(x => x.Hdid);
 
-                await this.Api.ProtectDependentAsync(dependentHdid, delegateHdids).ConfigureAwait(true);
+                ProtectDependentRequest protectDependentRequest = new(delegateHdids, this.DelegationState.Value.Reason);
+
+                await this.Api.ProtectDependentAsync(dependentHdid, protectDependentRequest).ConfigureAwait(true);
                 this.Logger.LogInformation("Dependent protected successfully");
                 dispatcher.Dispatch(new DelegationActions.ProtectDependentSuccessAction());
             }
@@ -146,7 +148,9 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     return;
                 }
 
-                await this.Api.UnprotectDependentAsync(dependentHdid).ConfigureAwait(true);
+                UnprotectDependentRequest unprotectDependentRequest = new(this.DelegationState.Value.Reason);
+
+                await this.Api.UnprotectDependentAsync(dependentHdid, unprotectDependentRequest).ConfigureAwait(true);
                 this.Logger.LogInformation("Dependent unprotected successfully");
                 dispatcher.Dispatch(new DelegationActions.UnprotectDependentSuccessAction());
             }

--- a/Apps/Admin/Client/Store/Delegation/DelegationState.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationState.cs
@@ -59,6 +59,11 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         public IImmutableList<ExtendedDelegateInfo> Delegates { get; init; } = ImmutableList<ExtendedDelegateInfo>.Empty;
 
         /// <summary>
+        /// Gets or sets the reason to protect or unprotect the delegate.
+        /// </summary>
+        public string? Reason { get; set; }
+
+        /// <summary>
         /// Gets a value indicating whether the delegation page is in edit mode.
         /// </summary>
         public bool InEditMode { get; init; }

--- a/Apps/Admin/Client/Store/Delegation/DelegationState.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationState.cs
@@ -59,11 +59,6 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         public IImmutableList<ExtendedDelegateInfo> Delegates { get; init; } = ImmutableList<ExtendedDelegateInfo>.Empty;
 
         /// <summary>
-        /// Gets or sets the reason to protect or unprotect the delegate.
-        /// </summary>
-        public string? Reason { get; set; }
-
-        /// <summary>
         /// Gets a value indicating whether the delegation page is in edit mode.
         /// </summary>
         public bool InEditMode { get; init; }

--- a/Apps/Admin/Common/Models/ProtectDependentRequest.cs
+++ b/Apps/Admin/Common/Models/ProtectDependentRequest.cs
@@ -1,0 +1,26 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Request data to protect dependent.
+    /// </summary>
+    /// <param name="DelegateHdids">The list of delegate hdid(s) to allow delegation for the dependent.</param>
+    /// <param name="Reason">The reason to protect dependent.</param>
+    public record ProtectDependentRequest(IEnumerable<string> DelegateHdids, string Reason);
+}

--- a/Apps/Admin/Common/Models/UnprotectDependentRequest.cs
+++ b/Apps/Admin/Common/Models/UnprotectDependentRequest.cs
@@ -1,0 +1,23 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models
+{
+    /// <summary>
+    /// Request data to unprotect dependent.
+    /// </summary>
+    /// <param name="Reason">The reason to unprotect dependent.</param>
+    public record UnprotectDependentRequest(string Reason);
+}

--- a/Apps/Admin/Server/Controllers/DelegationController.cs
+++ b/Apps/Admin/Server/Controllers/DelegationController.cs
@@ -15,7 +15,6 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Server.Controllers
 {
-    using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
@@ -135,17 +134,4 @@ namespace HealthGateway.Admin.Server.Controllers
             await this.delegationService.UnprotectDependentAsync(dependentHdid, request.Reason).ConfigureAwait(true);
         }
     }
-
-    /// <summary>
-    /// Request data to protect dependent.
-    /// </summary>
-    /// <param name="DelegateHdids">The list of delegate hdid(s) to allow delegation for the dependent.</param>
-    /// <param name="Reason">The reason to protect dependent.</param>
-    public record ProtectDependentRequest(IEnumerable<string> DelegateHdids, string Reason);
-
-    /// <summary>
-    /// Request data to unprotect dependent.
-    /// </summary>
-    /// <param name="Reason">The reason to unprotect dependent.</param>
-    public record UnprotectDependentRequest(string Reason);
 }


### PR DESCRIPTION
# Implements [AB#15260](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15260)

## Agent Log on Protect User Update - update front end
- add Reason text area to protect/unprotect confirmation dialog and limit to 500 chars
- update store to add protect reason
- update IDelegationApi to use request record objects
- move protect reason request objects to Admin.Common to use in the Refit api

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screenshot 2023-04-12 at 8 38 54 PM](https://user-images.githubusercontent.com/5408101/231645876-86f814c6-30d9-4857-a7b5-2948a14244bb.png)

![Screenshot 2023-04-12 at 8 39 15 PM](https://user-images.githubusercontent.com/5408101/231645943-826bd41d-63e4-47f3-97a6-e5ac54a7ca58.png)

![Screenshot 2023-04-12 at 8 39 30 PM](https://user-images.githubusercontent.com/5408101/231645984-1a97b112-51c3-4b46-a36a-d6e55293490a.png)

![Screenshot 2023-04-12 at 8 39 44 PM](https://user-images.githubusercontent.com/5408101/231646017-3ebdbc41-84cb-4caa-8ccf-6f1b2ae02fbd.png)

![Screenshot 2023-04-12 at 8 40 02 PM](https://user-images.githubusercontent.com/5408101/231646050-82ec9e96-19b8-4347-98ed-b41473b7c8fe.png)

![Screenshot 2023-04-12 at 8 40 35 PM](https://user-images.githubusercontent.com/5408101/231646068-d0d1d51d-0309-4bf6-8089-36d68d7b7231.png)

![Screenshot 2023-04-12 at 8 40 47 PM](https://user-images.githubusercontent.com/5408101/231646093-d6ed3587-df26-430d-b3d9-92296334ad3b.png)

Database updated:
![Screenshot 2023-04-12 at 8 42 12 PM](https://user-images.githubusercontent.com/5408101/231646130-667c23b6-46ed-4a6f-9c16-02e9244fa062.png)

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
