### PR TITLE
Fix Commented out Public Covid Tests for AB#12590

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/covid19/publicCovidTest.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/publicCovidTest.js
@@ -122,61 +122,66 @@ describe("Public COVID-19 Test Results", () => {
         cy.visit(covidTestUrl);
     });
 
-    it("See AB#12590", () => {
-        // Intentionally blank
+    it("Successful Response: Negative Result", () => {
+        enterFormInputs(
+            negativeCollectionDateYear,
+            negativeCollectionDateMonth,
+            negativeCollectionDateDay
+        );
+        checkResult("Negative", "Final", "text-success");
     });
 
-    // it("Successful Response: Negative Result", () => {
-    //     enterFormInputs(
-    //         negativeCollectionDateYear,
-    //         negativeCollectionDateMonth,
-    //         negativeCollectionDateDay
-    //     );
-    //     checkResult("Negative", "Final", "text-success");
-    // });
+    it("Successful Response: Negative Result", () => {
+        enterFormInputs(
+            negativeCollectionDateYear,
+            negativeCollectionDateMonth,
+            negativeCollectionDateDay
+        );
+        checkResult("Negative", "Final", "text-success");
+    });
 
-    // it("Successful Response: Positive Result", () => {
-    //     enterFormInputs(
-    //         positiveCollectionDateYear,
-    //         positiveCollectionDateMonth,
-    //         positiveCollectionDateDay
-    //     );
-    //     checkResult("Positive", "Final", "text-danger");
-    // });
+    it("Successful Response: Positive Result", () => {
+        enterFormInputs(
+            positiveCollectionDateYear,
+            positiveCollectionDateMonth,
+            positiveCollectionDateDay
+        );
+        checkResult("Positive", "Final", "text-danger");
+    });
 
-    // it("Successful Response: Indeterminate Result", () => {
-    //     enterFormInputs(
-    //         indeterminateCollectionDateYear,
-    //         indeterminateCollectionDateMonth,
-    //         indeterminateCollectionDateDay
-    //     );
-    //     checkResult("Indeterminate", "Final");
-    // });
+    it("Successful Response: Indeterminate Result", () => {
+        enterFormInputs(
+            indeterminateCollectionDateYear,
+            indeterminateCollectionDateMonth,
+            indeterminateCollectionDateDay
+        );
+        checkResult("Indeterminate", "Final");
+    });
 
-    // it("Successful Response: Pending Result", () => {
-    //     enterFormInputs(
-    //         pendingCollectionDateYear,
-    //         pendingCollectionDateMonth,
-    //         pendingCollectionDateDay
-    //     );
-    //     checkResult("Not Set", "Pending");
-    // });
+    it("Successful Response: Pending Result", () => {
+        enterFormInputs(
+            pendingCollectionDateYear,
+            pendingCollectionDateMonth,
+            pendingCollectionDateDay
+        );
+        checkResult("Pending", "Pending");
+    });
 
-    // it("Successful Response: Cancelled Result", () => {
-    //     enterFormInputs(
-    //         cancelledCollectionDateYear,
-    //         cancelledCollectionDateMonth,
-    //         cancelledCollectionDateDay
-    //     );
-    //     checkResult("Cancelled", "Cancelled");
-    // });
+    it("Successful Response: Cancelled Result", () => {
+        enterFormInputs(
+            cancelledCollectionDateYear,
+            cancelledCollectionDateMonth,
+            cancelledCollectionDateDay
+        );
+        checkResult("Cancelled", "Cancelled");
+    });
 
-    // it("Successful Response: Multiple Results", () => {
-    //     enterFormInputs(
-    //         multipleCollectionDateYear,
-    //         multipleCollectionDateMonth,
-    //         multipleCollectionDateDay
-    //     );
-    //     cy.get(".covid-test-result").should("have.length.at.least", 2);
-    // });
+    it("Successful Response: Multiple Results", () => {
+        enterFormInputs(
+            multipleCollectionDateYear,
+            multipleCollectionDateMonth,
+            multipleCollectionDateDay
+        );
+        cy.get(".covid-test-result").should("have.length.at.least", 2);
+    });
 });


### PR DESCRIPTION
# Fixes AB#12590

## Description

- Uncommented out tests for PublicCovidTest
- Restored original test that was removed
- Fixed expected message for Pending test

<img width="1159" alt="Screenshot 2023-04-13 at 3 15 51 PM" src="https://user-images.githubusercontent.com/58790456/231895859-1b271658-58cc-419b-8edc-5ef2d3c4e283.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
