### PR TITLE
Extend configuration controller to return tour configuration AB#15331

### DIFF
--- a/Apps/WebClient/src/Server/Constants/TourApplicationSettings.cs
+++ b/Apps/WebClient/src/Server/Constants/TourApplicationSettings.cs
@@ -13,18 +13,27 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.WebClient.Server.Models
+namespace HealthGateway.WebClient.Server.Constants
 {
-    using System;
-
     /// <summary>
-    /// The Tour Configuration.
+    /// Contains the ApplicationSettings values and mapping logic for the TourConfiguration.
     /// </summary>
-    public record TourConfiguration
+    public static class TourApplicationSettings
     {
         /// <summary>
-        /// Gets or sets the tour update date time.
+        /// The application name.
         /// </summary>
-        public DateTime? LatestChangeDateTime { get; set; }
+        public const string Application = "WEB";
+
+        /// <summary>
+        /// The component name.
+        /// </summary>
+        public const string Component = "Tour";
+
+
+        /// <summary>
+        /// The latest change date time key.
+        /// </summary>
+        public static readonly string LatestChangeDateTime = "latestChangeDateTime";
     }
 }

--- a/Apps/WebClient/src/Server/Models/TourConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/TourConfiguration.cs
@@ -31,15 +31,32 @@ namespace HealthGateway.WebClient.Server.Models
         public DateTime? LatestChangeDateTime { get; set; }
     }
 
-#pragma warning disable SA1600
-#pragma warning disable SA1602
-    internal static class TourSettingsMapper
+    /// <summary>
+    /// Contains the ApplicationSettings values and mapping logic for the TourConfiguration.
+    /// </summary>
+    public static class TourSettingsMapper
     {
+        /// <summary>
+        /// The application name.
+        /// </summary>
         public const string Application = "WEB";
+
+        /// <summary>
+        /// The component name.
+        /// </summary>
         public const string Component = "Tour";
+
+        /// <summary>
+        /// The latest change date time key.
+        /// </summary>
         public const string LatestChangeDateTime = "latestChangeDateTime";
 
-        public static TourConfiguration Map(IList<ApplicationSetting> settings)
+        /// <summary>
+        /// Transforms a list of ApplicationSetting to a TourConfiguration.
+        /// </summary>
+        /// <param name="settings">list of ApplicationSetting models.</param>
+        /// <returns cref="TourConfiguration">a populated TourConfiguration.</returns>
+        internal static TourConfiguration Map(IList<ApplicationSetting> settings)
         {
             TourConfiguration config = new();
             foreach (ApplicationSetting setting in settings)
@@ -57,6 +74,4 @@ namespace HealthGateway.WebClient.Server.Models
             return config;
         }
     }
-#pragma warning restore SA1600
-#pragma warning restore SA1602
 }

--- a/Apps/WebClient/src/Server/Models/TourConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/TourConfiguration.cs
@@ -1,0 +1,62 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.WebClient.Server.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using HealthGateway.Database.Models;
+
+    /// <summary>
+    /// The Tour Configuration.
+    /// </summary>
+    public record TourConfiguration
+    {
+        /// <summary>
+        /// Gets or sets the tour update date time.
+        /// </summary>
+        public DateTime? LatestChangeDateTime { get; set; }
+    }
+
+#pragma warning disable SA1600
+#pragma warning disable SA1602
+    internal static class TourSettingsMapper
+    {
+        public const string Application = "WEB";
+        public const string Component = "Tour";
+        public const string LatestChangeDateTime = "latestChangeDateTime";
+
+        public static TourConfiguration Map(IList<ApplicationSetting> settings)
+        {
+            TourConfiguration config = new();
+            foreach (ApplicationSetting setting in settings)
+            {
+                switch (setting.Key)
+                {
+                    case LatestChangeDateTime:
+                        config.LatestChangeDateTime = setting.Value != null
+                            ? DateTime.Parse(setting.Value, CultureInfo.InvariantCulture)
+                            : null;
+                        break;
+                }
+            }
+
+            return config;
+        }
+    }
+#pragma warning restore SA1600
+#pragma warning restore SA1602
+}

--- a/Apps/WebClient/src/Server/Models/WebClientConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/WebClientConfiguration.cs
@@ -94,5 +94,10 @@ namespace HealthGateway.WebClient.Server.Models
         /// </summary>
         [JsonPropertyName("clientIP")]
         public string? ClientIp { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client tour configuration.
+        /// </summary>
+        public TourConfiguration? TourConfiguration { get; set; }
     }
 }

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -20,7 +20,9 @@ namespace HealthGateway.WebClient.Server
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Common.AspNetConfiguration;
+    using HealthGateway.Common.AspNetConfiguration.Modules;
     using HealthGateway.Common.Utils;
+    using HealthGateway.Database.Delegates;
     using HealthGateway.WebClient.Server.Services;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
@@ -65,6 +67,7 @@ namespace HealthGateway.WebClient.Server
             this.startupConfig.ConfigureHttpServices(services, false);
             this.startupConfig.ConfigureSwaggerServices(services);
             this.startupConfig.ConfigureTracing(services);
+            this.startupConfig.ConfigureDatabaseServices(services);
 
             // Add Background Services
             services.Configure<ApiBehaviorOptions>(options => options.SuppressModelStateInvalidFilter = true);
@@ -84,7 +87,9 @@ namespace HealthGateway.WebClient.Server
                     });
 
             // Add services
-            services.AddSingleton<IConfigurationService, ConfigurationService>();
+            services.AddTransient<IConfigurationService, ConfigurationService>();
+            services.AddTransient<IApplicationSettingsDelegate, DbApplicationSettingsDelegate>();
+            GatewayCache.ConfigureCaching(services, this.startupConfig.Logger, this.startupConfig.Configuration);
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixes or Implements [AB#15331](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15331)

## Description

1. Extend Configuration returned by WebClient.Server.ConfigurationController
2. Add new TourConfiguration model, populated by DB's ApplicationSetting table.
3. Add caching to reduce communication with database on configuration requests.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
