### PR TITLE
Update UI for delegation change history AB#15268

### DIFF
--- a/Apps/Admin/Client/Components/Delegation/DelegationChangeEntry.razor
+++ b/Apps/Admin/Client/Components/Delegation/DelegationChangeEntry.razor
@@ -1,0 +1,20 @@
+@using HealthGateway.Common.Data.Utils
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudGrid Spacing="2">
+    <MudItem xs="12">
+        <MudText Typo="Typo.body2" Color="@Color.Primary" data-testid="agent">
+            @Data.AgentUsername
+        </MudText>
+    </MudItem>
+    <MudItem xs="12">
+        <MudText Class="px-4" Typo="Typo.body2" data-testid="reason">
+            @Data.Reason
+        </MudText>
+    </MudItem>
+    <MudItem xs="12">
+        <MudText Class="px-4" Typo="Typo.body2" Color="@Color.Primary" data-testid="datetime">
+            @DateFormatter.ToShortDateAndTime(DateTime)
+        </MudText>
+    </MudItem>
+</MudGrid>

--- a/Apps/Admin/Client/Components/Delegation/DelegationChangeEntry.razor
+++ b/Apps/Admin/Client/Components/Delegation/DelegationChangeEntry.razor
@@ -1,20 +1,14 @@
 @using HealthGateway.Common.Data.Utils
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<MudGrid Spacing="2">
-    <MudItem xs="12">
-        <MudText Typo="Typo.body2" Color="@Color.Primary" data-testid="agent">
-            @Data.AgentUsername
-        </MudText>
-    </MudItem>
-    <MudItem xs="12">
-        <MudText Class="px-4" Typo="Typo.body2" data-testid="reason">
-            @Data.Reason
-        </MudText>
-    </MudItem>
-    <MudItem xs="12">
-        <MudText Class="px-4" Typo="Typo.body2" Color="@Color.Primary" data-testid="datetime">
-            @DateFormatter.ToShortDateAndTime(DateTime)
-        </MudText>
-    </MudItem>
-</MudGrid>
+<MudText Typo="Typo.body1" Color="@Color.Primary" data-testid="agent">
+    @Data.AgentUsername
+</MudText>
+<div class="mt-4 px-4">
+    <MudText Typo="Typo.body1" data-testid="reason">
+        @Data.Reason
+    </MudText>
+    <MudText Typo="Typo.body2" Color="@Color.Primary" data-testid="datetime">
+        @DateFormatter.ToShortDateAndTime(DateTime)
+    </MudText>
+</div>

--- a/Apps/Admin/Client/Components/Delegation/DelegationChangeEntry.razor.cs
+++ b/Apps/Admin/Client/Components/Delegation/DelegationChangeEntry.razor.cs
@@ -1,0 +1,47 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components.Delegation
+{
+    using System;
+    using Fluxor.Blazor.Web.Components;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Common.Data.Utils;
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.Configuration;
+
+    /// <summary>
+    /// Backing logic for the DelegationChangeEntry component.
+    /// </summary>
+    public partial class DelegationChangeEntry : FluxorComponent
+    {
+        /// <summary>
+        /// Gets or sets the data to populate the component.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public DelegationChange Data { get; set; } = default!;
+
+        [Inject]
+        private IConfiguration Configuration { get; set; } = default!;
+
+        private DateTime DateTime => TimeZoneInfo.ConvertTimeFromUtc(this.Data.TransactionDateTime, this.GetTimeZone());
+
+        private TimeZoneInfo GetTimeZone()
+        {
+            return DateFormatter.GetLocalTimeZone(this.Configuration);
+        }
+    }
+}

--- a/Apps/Admin/Client/Components/Delegation/DependentTable.razor
+++ b/Apps/Admin/Client/Components/Delegation/DependentTable.razor
@@ -1,7 +1,7 @@
 @using HealthGateway.Common.Data.Utils
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-<MudTable Class="mt-3"
+<MudTable Class="mt-3 rounded-b-0"
           Items="@Rows"
           AllowUnsorted="false"
           Breakpoint="@Breakpoint.Md"

--- a/Apps/Admin/Client/Pages/DelegationPage.razor
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor
@@ -3,6 +3,7 @@
 @attribute [Authorize(Roles = $"{Roles.Admin}")]
 @using HealthGateway.Common.Ui.Constants
 @using HealthGateway.Admin.Client.Store.Delegation
+@using HealthGateway.Admin.Common.Models
 @using HealthGateway.Admin.Client.Components.Site
 @using HealthGateway.Admin.Client.Components.Delegation
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
@@ -52,6 +53,28 @@
         Dependent
     </MudText>
     <DependentTable Data="@Dependent" />
+    <MudExpansionPanels Class="rounded-t-0" DisableGutters="true">
+        <MudExpansionPanel>
+            <TitleContent>
+                <MudText Typo="Typo.subtitle1" Class="mx-n2" data-testid="delegation-changes-header">
+                    Agent Reason History
+                </MudText>
+            </TitleContent>
+            <ChildContent>
+                <MudPaper Class="mud-background mx-4 pa-4 overflow-auto" MaxHeight="400px">
+                    <MudGrid Spacing="4">
+                        @foreach ((DelegationChange change, int index) in DelegationChanges.Select((c, i) => (c, i)))
+                        {
+                            <MudItem xs="12" data-testid=@($"delegation-change-{index}")>
+                                <DelegationChangeEntry Data="@change" />
+                            </MudItem>
+                        }
+                    </MudGrid>
+                </MudPaper>
+            </ChildContent>
+        </MudExpansionPanel>
+    </MudExpansionPanels>
+
     <div class="mt-6 d-flex align-start">
         <MudText Typo="Typo.subtitle1" Class="flex-grow-1">
             Guardians Accessing Dependent

--- a/Apps/Admin/Client/Pages/DelegationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor.cs
@@ -75,6 +75,8 @@ namespace HealthGateway.Admin.Client.Pages
 
         private DependentInfo? Dependent => this.DelegationState.Value.Dependent;
 
+        private IEnumerable<DelegationChange> DelegationChanges => this.DelegationState.Value.DelegationChanges;
+
         private IEnumerable<ExtendedDelegateInfo> Delegates => this.DelegationState.Value.Delegates;
 
         private bool AnyUnsavedDelegationChanges =>

--- a/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
@@ -73,6 +73,11 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             public required DependentInfo Dependent { get; init; }
 
             /// <summary>
+            /// Gets the collection of delegation changes.
+            /// </summary>
+            public required IEnumerable<DelegationChange> DelegationChanges { get; init; }
+
+            /// <summary>
             /// Gets the collection of delegate info.
             /// </summary>
             public required IEnumerable<ExtendedDelegateInfo> Delegates { get; init; }

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -63,6 +63,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     new DelegationActions.SearchSuccessAction
                     {
                         Dependent = response.Dependent,
+                        DelegationChanges = response.DelegationChanges,
                         Delegates = this.AutoMapper.Map<IEnumerable<DelegateInfo>, IEnumerable<ExtendedDelegateInfo>>(response.Delegates),
                     });
             }

--- a/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
@@ -49,6 +49,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     Error = null,
                 },
                 Dependent = action.Dependent,
+                DelegationChanges = action.DelegationChanges.OrderByDescending(c => c.TransactionDateTime).ToImmutableList(),
                 Delegates = action.Delegates.ToImmutableList(),
             };
         }
@@ -320,6 +321,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                 Protect = new(),
                 Unprotect = new(),
                 Dependent = null,
+                DelegationChanges = ImmutableList<DelegationChange>.Empty,
                 Delegates = ImmutableList<ExtendedDelegateInfo>.Empty,
                 InEditMode = false,
             };

--- a/Apps/Admin/Client/Store/Delegation/DelegationState.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationState.cs
@@ -54,6 +54,11 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         public DependentInfo? Dependent { get; init; }
 
         /// <summary>
+        /// Gets the collection of delegation changes.
+        /// </summary>
+        public IImmutableList<DelegationChange> DelegationChanges { get; init; } = ImmutableList<DelegationChange>.Empty;
+
+        /// <summary>
         /// Gets the collection of delegate info.
         /// </summary>
         public IImmutableList<ExtendedDelegateInfo> Delegates { get; init; } = ImmutableList<ExtendedDelegateInfo>.Empty;

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -595,7 +595,7 @@ namespace HealthGateway.Admin.Tests.Services
                     {
                         DependentHdId = DependentHdid,
                         AgentUsername = AuthenticatedPreferredUsername,
-                        ProtectedReason = "Test",
+                        Reason = "Test",
                         OperationCode = isProtected ? DependentAuditOperation.Protect : DependentAuditOperation.Unprotect,
                         TransactionDateTime = TransactionDateTime,
                     },


### PR DESCRIPTION
# Implements [AB#15268](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15268)

## Description

- populates delegation store with delegation changes
- adds expansion panel with collection of delegation changes ordered from newest to oldest
- fixes a property name change that didn't get updated in the unit tests

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-04-14-131246](https://user-images.githubusercontent.com/16570293/232155397-f4cf5052-ab63-411c-98e8-3428fded5c93.png)
![localhost-2023-04-14-142907](https://user-images.githubusercontent.com/16570293/232158808-df7928dd-6daf-4504-bb5c-7299717f54a8.png)
![localhost-2023-04-14-143118](https://user-images.githubusercontent.com/16570293/232158812-9c949957-4cf9-4082-a962-d278186b0dac.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
