### PR TITLE
Update history after protecting/unprotecting dependent AB#15348

### DIFF
--- a/Apps/Admin/Client/Api/IDelegationApi.cs
+++ b/Apps/Admin/Client/Api/IDelegationApi.cs
@@ -46,9 +46,9 @@ namespace HealthGateway.Admin.Client.Api
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to protect.</param>
         /// <param name="request">The request object containing data used to protect a dependent.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>The delegation change entry created from the operation.</returns>
         [Put("/{dependentHdid}/ProtectDependent")]
-        Task ProtectDependentAsync(string dependentHdid, ProtectDependentRequest request);
+        Task<DelegationChange> ProtectDependentAsync(string dependentHdid, ProtectDependentRequest request);
 
         /// <summary>
         /// Unprotects the dependent and if necessary removes the allowed delegation(s) and keeps the resource delegates
@@ -56,8 +56,8 @@ namespace HealthGateway.Admin.Client.Api
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to unprotect.</param>
         /// <param name="request">The request object containing data used to unprotect a dependent.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>The delegation change entry created from the operation.</returns>
         [Put("/{dependentHdid}/UnprotectDependent")]
-        Task UnprotectDependentAsync(string dependentHdid, UnprotectDependentRequest request);
+        Task<DelegationChange> UnprotectDependentAsync(string dependentHdid, UnprotectDependentRequest request);
     }
 }

--- a/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationActions.cs
@@ -200,6 +200,10 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         /// </summary>
         public class ProtectDependentSuccessAction
         {
+            /// <summary>
+            /// Gets the delegation change entry created from the operation.
+            /// </summary>
+            public required DelegationChange DelegationChange { get; init; }
         }
 
         /// <summary>
@@ -233,6 +237,10 @@ namespace HealthGateway.Admin.Client.Store.Delegation
         /// </summary>
         public class UnprotectDependentSuccessAction
         {
+            /// <summary>
+            /// Gets the delegation change entry created from the operation.
+            /// </summary>
+            public required DelegationChange DelegationChange { get; init; }
         }
 
         /// <summary>

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -123,9 +123,9 @@ namespace HealthGateway.Admin.Client.Store.Delegation
 
                 ProtectDependentRequest protectDependentRequest = new(delegateHdids, action.Reason);
 
-                await this.Api.ProtectDependentAsync(dependentHdid, protectDependentRequest).ConfigureAwait(true);
+                DelegationChange change = await this.Api.ProtectDependentAsync(dependentHdid, protectDependentRequest).ConfigureAwait(true);
                 this.Logger.LogInformation("Dependent protected successfully");
-                dispatcher.Dispatch(new DelegationActions.ProtectDependentSuccessAction());
+                dispatcher.Dispatch(new DelegationActions.ProtectDependentSuccessAction { DelegationChange = change });
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
@@ -151,9 +151,9 @@ namespace HealthGateway.Admin.Client.Store.Delegation
 
                 UnprotectDependentRequest unprotectDependentRequest = new(action.Reason);
 
-                await this.Api.UnprotectDependentAsync(dependentHdid, unprotectDependentRequest).ConfigureAwait(true);
+                DelegationChange change = await this.Api.UnprotectDependentAsync(dependentHdid, unprotectDependentRequest).ConfigureAwait(true);
                 this.Logger.LogInformation("Dependent unprotected successfully");
-                dispatcher.Dispatch(new DelegationActions.UnprotectDependentSuccessAction());
+                dispatcher.Dispatch(new DelegationActions.UnprotectDependentSuccessAction { DelegationChange = change });
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {

--- a/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
@@ -165,8 +165,8 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             };
         }
 
-        [ReducerMethod(typeof(DelegationActions.ProtectDependentSuccessAction))]
-        public static DelegationState ReduceProtectDependentSuccessAction(DelegationState state)
+        [ReducerMethod]
+        public static DelegationState ReduceProtectDependentSuccessAction(DelegationState state, DelegationActions.ProtectDependentSuccessAction action)
         {
             DependentInfo? dependent = state.Dependent;
             if (dependent != null)
@@ -182,6 +182,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     Error = null,
                 },
                 Dependent = dependent,
+                DelegationChanges = state.DelegationChanges.Insert(0, action.DelegationChange),
                 Delegates = state.Delegates
                     .Where(d => d.StagedDelegationStatus is not DelegationStatus.Disallowed)
                     .Select(
@@ -219,8 +220,8 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             };
         }
 
-        [ReducerMethod(typeof(DelegationActions.UnprotectDependentSuccessAction))]
-        public static DelegationState ReduceUnprotectDependentSuccessAction(DelegationState state)
+        [ReducerMethod]
+        public static DelegationState ReduceUnprotectDependentSuccessAction(DelegationState state, DelegationActions.UnprotectDependentSuccessAction action)
         {
             DependentInfo? dependent = state.Dependent;
             if (dependent != null)
@@ -236,6 +237,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     Error = null,
                 },
                 Dependent = dependent,
+                DelegationChanges = state.DelegationChanges.Insert(0, action.DelegationChange),
                 Delegates = state.Delegates
                     .Where(d => d.DelegationStatus is not DelegationStatus.Allowed)
                     .ToImmutableList(),

--- a/Apps/Admin/Server/Controllers/DelegationController.cs
+++ b/Apps/Admin/Server/Controllers/DelegationController.cs
@@ -102,16 +102,16 @@ namespace HealthGateway.Admin.Server.Controllers
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to protect.</param>
         /// <param name="request">The request object containing data used to protect a dependent.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>The delegation change entry created from the operation.</returns>
         /// <response code="200">The dependent is protected.</response>
         /// <response code="401">The client must authenticate itself to get the requested resource.</response>
         [HttpPut]
         [Route("{dependentHdid}/ProtectDependent")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
-        public async Task ProtectDependent(string dependentHdid, ProtectDependentRequest request)
+        public async Task<DelegationChange> ProtectDependent(string dependentHdid, ProtectDependentRequest request)
         {
-            await this.delegationService.ProtectDependentAsync(dependentHdid, request.DelegateHdids, request.Reason).ConfigureAwait(true);
+            return await this.delegationService.ProtectDependentAsync(dependentHdid, request.DelegateHdids, request.Reason).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to unprotect.</param>
         /// <param name="request">The request object containing data used to unprotect a dependent.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        /// <returns>The delegation change entry created from the operation.</returns>
         /// <response code="200">The dependent is unprotected.</response>
         /// <response code="401">The client must authenticate itself to get the requested resource.</response>
         /// <response code="404">The dependent could not be found.</response>
@@ -129,9 +129,9 @@ namespace HealthGateway.Admin.Server.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
-        public async Task UnprotectDependent(string dependentHdid, UnprotectDependentRequest request)
+        public async Task<DelegationChange> UnprotectDependent(string dependentHdid, UnprotectDependentRequest request)
         {
-            await this.delegationService.UnprotectDependentAsync(dependentHdid, request.Reason).ConfigureAwait(true);
+            return await this.delegationService.UnprotectDependentAsync(dependentHdid, request.Reason).ConfigureAwait(true);
         }
     }
 }

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -155,7 +155,7 @@ namespace HealthGateway.Admin.Server.Services
         }
 
         /// <inheritdoc/>
-        public async Task ProtectDependentAsync(string dependentHdid, IEnumerable<string> delegateHdids, string reason)
+        public async Task<DelegationChange> ProtectDependentAsync(string dependentHdid, IEnumerable<string> delegateHdids, string reason)
         {
             string authenticatedUserId = this.authenticationDelegate.FetchAuthenticatedUserId() ?? UserId.DefaultUser;
             Dependent? dependent = await this.delegationDelegate.GetDependentAsync(dependentHdid, true).ConfigureAwait(true);
@@ -209,10 +209,12 @@ namespace HealthGateway.Admin.Server.Services
 
             // Update dependent, allow delegation and resource delegate in database
             await this.delegationDelegate.UpdateDelegationAsync(dependent, resourceDelegatesToDelete, dependentAudit).ConfigureAwait(true);
+
+            return this.autoMapper.Map<DependentAudit, DelegationChange>(dependentAudit);
         }
 
         /// <inheritdoc/>
-        public async Task UnprotectDependentAsync(string dependentHdid, string reason)
+        public async Task<DelegationChange> UnprotectDependentAsync(string dependentHdid, string reason)
         {
             string authenticatedUserId = this.authenticationDelegate.FetchAuthenticatedUserId() ?? UserId.DefaultUser;
             Dependent? dependent = await this.delegationDelegate.GetDependentAsync(dependentHdid, true).ConfigureAwait(true);
@@ -238,6 +240,8 @@ namespace HealthGateway.Admin.Server.Services
             };
 
             await this.delegationDelegate.UpdateDelegationAsync(dependent, Enumerable.Empty<ResourceDelegate>(), dependentAudit).ConfigureAwait(true);
+
+            return this.autoMapper.Map<DependentAudit, DelegationChange>(dependentAudit);
         }
 
         private async Task<IEnumerable<ResourceDelegate>> SearchDelegates(string ownerHdid)

--- a/Apps/Admin/Server/Services/IDelegationService.cs
+++ b/Apps/Admin/Server/Services/IDelegationService.cs
@@ -45,8 +45,8 @@ namespace HealthGateway.Admin.Server.Services
         /// <param name="dependentHdid">The hdid of the dependent to protect.</param>
         /// <param name="delegateHdids">The list of delegate hdid(s) to allow delegation for the dependent.</param>
         /// <param name="reason">The reason to protect.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task ProtectDependentAsync(string dependentHdid, IEnumerable<string> delegateHdids, string reason);
+        /// <returns>The delegation change entry created from the operation.</returns>
+        Task<DelegationChange> ProtectDependentAsync(string dependentHdid, IEnumerable<string> delegateHdids, string reason);
 
         /// <summary>
         /// Unprotects the dependent and if necessary creates the allowed delegation(s) and keeps the resource delegates
@@ -54,7 +54,7 @@ namespace HealthGateway.Admin.Server.Services
         /// </summary>
         /// <param name="dependentHdid">The hdid of the dependent to unprotect.</param>
         /// <param name="reason">The reason to protect.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task UnprotectDependentAsync(string dependentHdid, string reason);
+        /// <returns>The delegation change entry created from the operation.</returns>
+        Task<DelegationChange> UnprotectDependentAsync(string dependentHdid, string reason);
     }
 }


### PR DESCRIPTION
# Implements [AB#15348](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15348)

## Description

Updates Admin to returns the delegation change entry created after protecting or unprotecting a dependent, and adds it to the collection in the store so it can be seen.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
