### PR TITLE
Add HasTourChanged Property AB#15331

### DIFF
--- a/Apps/CommonData/src/ViewModels/UserProfileModel.cs
+++ b/Apps/CommonData/src/ViewModels/UserProfileModel.cs
@@ -105,6 +105,11 @@ namespace HealthGateway.Common.Data.ViewModels
         public DateTime? ClosedDateTime { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether the user should be prompted of new tour slides.
+        /// </summary>
+        public bool HasTourUpdated { get; set; }
+
+        /// <summary>
         /// Gets the user preference.
         /// </summary>
         public IDictionary<string, UserPreferenceModel> Preferences { get; } = new Dictionary<string, UserPreferenceModel>();

--- a/Apps/GatewayApi/src/Constants/TourApplicationSettings.cs
+++ b/Apps/GatewayApi/src/Constants/TourApplicationSettings.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Constants
+{
+    /// <summary>
+    /// Contains the ApplicationSettings values and mapping logic for the TourConfiguration.
+    /// </summary>
+    public static class TourApplicationSettings
+    {
+        /// <summary>
+        /// The application name.
+        /// </summary>
+        public const string Application = "WEB";
+
+        /// <summary>
+        /// The component name.
+        /// </summary>
+        public const string Component = "Tour";
+
+        /// <summary>
+        /// The latest change date time key.
+        /// </summary>
+        public static readonly string LatestChangeDateTime = "latestChangeDateTime";
+    }
+}

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -111,6 +111,7 @@ namespace HealthGateway.GatewayApi
             services.AddTransient<IDelegationDelegate, DbDelegationDelegate>();
             services.AddTransient<IResourceDelegateDelegate, DbResourceDelegateDelegate>();
             services.AddTransient<ICDogsDelegate, CDogsDelegate>();
+            services.AddTransient<IApplicationSettingsDelegate, DbApplicationSettingsDelegate>();
 
             // Add API Clients
             CDogsConfig cdogsConfig = new();

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
     using System;
     using System.Collections.Generic;
     using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Delegates;
@@ -27,6 +28,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
+    using HealthGateway.GatewayApi.Constants;
     using HealthGateway.GatewayApi.Services;
     using HealthGateway.GatewayApiTests.Services.Test.Utils;
     using Microsoft.AspNetCore.Http;
@@ -54,6 +56,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="patientModel">patient model.</param>
         /// <param name="configuration">configuration.</param>
         /// <param name="userProfileHistoryDbResult">user profile history from DbResult.</param>
+        /// <param name="tourLatestChangeDateTime">result of application setting for tour latestChangeDateTime.</param>
         public UserProfileServiceMock(
             string hdId,
             UserProfile userProfileData,
@@ -62,9 +65,21 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
             LegalAgreement termsOfService,
             PatientModel patientModel,
             IConfiguration configuration,
-            DbResult<IEnumerable<UserProfileHistory>> userProfileHistoryDbResult)
+            DbResult<IEnumerable<UserProfileHistory>> userProfileHistoryDbResult,
+            DateTime? tourLatestChangeDateTime = null)
         {
             int limit = configuration.GetSection(this.webClientConfigSection).GetValue(this.userProfileHistoryRecordLimitKey, 2);
+
+            Mock<ICacheProvider> mockCacheProvider = new();
+            if (tourLatestChangeDateTime != null)
+            {
+                mockCacheProvider.Setup(
+                        cp => cp.GetOrSet(
+                            It.Is<string>(key => key.Contains($"{TourApplicationSettings.Application}:{TourApplicationSettings.Component}")),
+                            It.IsAny<Func<DateTime?>>(),
+                            It.IsAny<TimeSpan?>()))
+                    .Returns(tourLatestChangeDateTime);
+            }
 
             this.userProfileService = new UserProfileService(
                 new Mock<ILogger<UserProfileService>>().Object,
@@ -81,7 +96,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 new Mock<IHttpContextAccessor>().Object,
                 configuration,
                 MapperUtil.InitializeAutoMapper(),
-                new Mock<IAuthenticationDelegate>().Object);
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IApplicationSettingsDelegate>().Object,
+                mockCacheProvider.Object);
         }
 
         /// <summary>
@@ -110,7 +127,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 new Mock<IHttpContextAccessor>().Object,
                 configuration,
                 MapperUtil.InitializeAutoMapper(),
-                new Mock<IAuthenticationDelegate>().Object);
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IApplicationSettingsDelegate>().Object,
+                new Mock<ICacheProvider>().Object);
         }
 
         /// <summary>
@@ -136,7 +155,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 new Mock<IHttpContextAccessor>().Object,
                 configuration,
                 MapperUtil.InitializeAutoMapper(),
-                new Mock<IAuthenticationDelegate>().Object);
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IApplicationSettingsDelegate>().Object,
+                new Mock<ICacheProvider>().Object);
         }
 
         /// <summary>
@@ -175,7 +196,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 new Mock<IHttpContextAccessor>().Object,
                 configuration,
                 MapperUtil.InitializeAutoMapper(),
-                new Mock<IAuthenticationDelegate>().Object);
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IApplicationSettingsDelegate>().Object,
+                new Mock<ICacheProvider>().Object);
         }
 
         /// <summary>
@@ -201,7 +224,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 new Mock<IHttpContextAccessor>().Object,
                 configuration,
                 MapperUtil.InitializeAutoMapper(),
-                new Mock<IAuthenticationDelegate>().Object);
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IApplicationSettingsDelegate>().Object,
+                new Mock<ICacheProvider>().Object);
         }
 
         /// <summary>
@@ -238,7 +263,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 new HttpContextAccessorMock(headerDictionary).Object,
                 configuration,
                 MapperUtil.InitializeAutoMapper(),
-                new Mock<IAuthenticationDelegate>().Object);
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IApplicationSettingsDelegate>().Object,
+                new Mock<ICacheProvider>().Object);
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixes or Implements [AB#15331](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15331)

## Description

1. Attached the HasTourChanged property to the UserProfile Controller of the GatewayAPI
2. Updated Appropriate Unit Tests

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Notes
### User Profile Changes with LatestChangeDateTime setting to 5 minutes in the future.
![image](https://user-images.githubusercontent.com/19548348/232846408-00191328-beed-4b2e-93a3-91c8a99e42a5.png)
### Defaults to false when no entry in DB
![image](https://user-images.githubusercontent.com/19548348/232846776-81ac03c1-749d-4aca-8249-89c7ecc625c0.png)
### Unit Tests
![image](https://user-images.githubusercontent.com/19548348/232914927-dc92c032-63a2-4283-b0bc-9b028430aada.png)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
