### PR TITLE
Fix unreliable idle detection AB#13081

### DIFF
--- a/Apps/WebClient/src/ClientApp/package-lock.json
+++ b/Apps/WebClient/src/ClientApp/package-lock.json
@@ -25,7 +25,6 @@
                 "file-saver": "^2.0.5",
                 "html2canvas": "^1.4.1",
                 "https-browserify": "^1.0.0",
-                "idle-vue": "^2.0.5",
                 "image-webpack-loader": "^8.1.0",
                 "inversify": "^6.0.1",
                 "keycloak-js": "^18.0.1",
@@ -36,6 +35,7 @@
                 "qrcode": "^1.5.1",
                 "reflect-metadata": "^0.1.13",
                 "stream-http": "^3.2.0",
+                "throttle-debounce": "^5.0.0",
                 "vue": "^2.7.14",
                 "vue-class-component": "^7.2.6",
                 "vue-clickaway": "^2.2.2",
@@ -54,6 +54,7 @@
             "devDependencies": {
                 "@types/luxon": "^1.27.0",
                 "@types/qrcode": "^1.5.0",
+                "@types/throttle-debounce": "^5.0.0",
                 "@types/vuelidate": "^0.7.16",
                 "@types/webpack-env": "^1.18.0",
                 "@typescript-eslint/eslint-plugin": "^5.58.0",
@@ -1101,6 +1102,12 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/throttle-debounce": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+            "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
+            "dev": true
         },
         "node_modules/@types/vue-clickaway": {
             "version": "2.2.0",
@@ -6937,21 +6944,6 @@
                 "postcss": "^8.1.0"
             }
         },
-        "node_modules/idle-js": {
-            "version": "0.1.3",
-            "license": "MIT"
-        },
-        "node_modules/idle-vue": {
-            "version": "2.0.5",
-            "license": "MIT",
-            "dependencies": {
-                "idle-js": "^0.1.3"
-            },
-            "engines": {
-                "node": ">= 4.0.0",
-                "npm": ">= 3.0.0"
-            }
-        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "funding": [
@@ -11848,6 +11840,14 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/throttle-debounce": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+            "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg==",
+            "engines": {
+                "node": ">=12.22"
+            }
+        },
         "node_modules/through": {
             "version": "2.3.8",
             "license": "MIT",
@@ -14094,6 +14094,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/throttle-debounce": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+            "integrity": "sha512-Pb7k35iCGFcGPECoNE4DYp3Oyf2xcTd3FbFQxXUI9hEYKUl6YX+KLf7HrBmgVcD05nl50LIH6i+80js4iYmWbw==",
+            "dev": true
         },
         "@types/vue-clickaway": {
             "version": "2.2.0",
@@ -17867,15 +17873,6 @@
             "dev": true,
             "requires": {}
         },
-        "idle-js": {
-            "version": "0.1.3"
-        },
-        "idle-vue": {
-            "version": "2.0.5",
-            "requires": {
-                "idle-js": "^0.1.3"
-            }
-        },
         "ieee754": {
             "version": "1.2.1"
         },
@@ -20898,6 +20895,11 @@
                     }
                 }
             }
+        },
+        "throttle-debounce": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-5.0.0.tgz",
+            "integrity": "sha512-2iQTSgkkc1Zyk0MeVrt/3BvuOXYPl/R8Z0U2xxo9rjwNciaHDG3R+Lm6dh4EeUci49DanvBnuqI6jshoQQRGEg=="
         },
         "through": {
             "version": "2.3.8",

--- a/Apps/WebClient/src/ClientApp/package.json
+++ b/Apps/WebClient/src/ClientApp/package.json
@@ -12,6 +12,7 @@
     "devDependencies": {
         "@types/luxon": "^1.27.0",
         "@types/qrcode": "^1.5.0",
+        "@types/throttle-debounce": "^5.0.0",
         "@types/vuelidate": "^0.7.16",
         "@types/webpack-env": "^1.18.0",
         "@typescript-eslint/eslint-plugin": "^5.58.0",
@@ -61,7 +62,6 @@
         "file-saver": "^2.0.5",
         "html2canvas": "^1.4.1",
         "https-browserify": "^1.0.0",
-        "idle-vue": "^2.0.5",
         "image-webpack-loader": "^8.1.0",
         "inversify": "^6.0.1",
         "keycloak-js": "^18.0.1",
@@ -72,6 +72,7 @@
         "qrcode": "^1.5.1",
         "reflect-metadata": "^0.1.13",
         "stream-http": "^3.2.0",
+        "throttle-debounce": "^5.0.0",
         "vue": "^2.7.14",
         "vue-class-component": "^7.2.6",
         "vue-clickaway": "^2.2.2",

--- a/Apps/WebClient/src/ClientApp/src/app.vue
+++ b/Apps/WebClient/src/ClientApp/src/app.vue
@@ -51,6 +51,7 @@ import type { WebClientConfiguration } from "@/models/configData";
 import container from "@/plugins/container";
 import { SERVICE_IDENTIFIER } from "@/plugins/inversify";
 import { ILogger } from "@/services/interfaces";
+import { IdleDetector } from "@/utility/idleDetector";
 import AppErrorView from "@/views/errors/AppErrorView.vue";
 
 Vue.use(LayoutPlugin);
@@ -158,35 +159,46 @@ export default class App extends Vue {
     private queuePath = "/queue";
     private queueFullPath = "/busy";
     private landingPath = "/";
+    private idleDetector?: IdleDetector;
 
     constructor() {
         super();
+        logger.debug(`Node ENV: ${Process.NODE_ENV}; host: ${this.host}`);
         logger.debug(
-            `Node ENV: ${JSON.stringify(
-                Process.NODE_ENV
-            )}; host: ${JSON.stringify(this.host)}`
-        );
-        logger.debug(
-            `VUE Config Integrity Environment Variable: ${JSON.stringify(
-                process.env.VUE_APP_CONFIG_INTEGRITY
-            )}`
+            `VUE Config Integrity Environment Variable: ${process.env.VUE_APP_CONFIG_INTEGRITY}`
         );
     }
 
-    @Watch("isAppIdle")
-    private onIsAppIdleChanged(idle: boolean): void {
-        if (idle && this.oidcIsAuthenticated && this.isValidIdentityProvider) {
-            this.idleModal.show();
+    @Watch("oidcIsAuthenticated")
+    private onOidcIsAuthenticatedChanged(value: boolean): void {
+        // enable idle detector when authenticated and disable when not
+        if (value) {
+            this.idleDetector?.enable();
+        } else {
+            this.idleDetector?.disable();
         }
+    }
+
+    get timeBeforeIdle(): number {
+        return this.config.timeouts.idle;
+    }
+
+    get maxIdleDialogCountdown(): number {
+        return 60000;
     }
 
     private created(): void {
         this.windowWidth = window.innerWidth;
         this.$nextTick(() => {
-            window.addEventListener("resize", this.onResize);
-            this.onResize();
+            this.initializeResizeListener();
+            this.initializeIdleDetector();
             this.initialized = true;
         });
+    }
+
+    private initializeResizeListener() {
+        window.addEventListener("resize", this.onResize);
+        this.onResize();
     }
 
     private beforeDestroy(): void {
@@ -204,6 +216,31 @@ export default class App extends Vue {
             if (this.isMobile) {
                 this.setIsMobile(false);
             }
+        }
+    }
+
+    private initializeIdleDetector() {
+        this.idleDetector = new IdleDetector(
+            (timeIdle) => this.handleIsIdle(timeIdle),
+            this.timeBeforeIdle
+        );
+        if (this.oidcIsAuthenticated) {
+            this.idleDetector.enable();
+        }
+    }
+
+    private handleIsIdle(timeIdle: number): void {
+        if (!this.oidcIsAuthenticated) {
+            return;
+        }
+
+        const countdownTime = this.maxIdleDialogCountdown - timeIdle;
+        if (countdownTime <= 0) {
+            this.$router.push("/logout");
+        } else {
+            this.idleModal.show(countdownTime, () =>
+                this.idleDetector?.enable()
+            );
         }
     }
 

--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/EntryDetailsComponent.vue
@@ -52,9 +52,6 @@ export default class EntryDetailsComponent extends Vue {
     @Getter("isMobile")
     isMobile!: boolean;
 
-    @Getter("isVisible", { namespace: "idle" })
-    isIdleWarningVisible!: boolean;
-
     @Getter("lastOperation", { namespace: "note" })
     lastNoteOperation!: Operation | null;
 

--- a/Apps/WebClient/src/ClientApp/src/main.ts
+++ b/Apps/WebClient/src/ClientApp/src/main.ts
@@ -26,7 +26,6 @@ import {
     BTab,
     BTabs,
 } from "bootstrap-vue";
-import IdleVue from "idle-vue";
 import Vue from "vue";
 import VueContentPlaceholders from "vue-content-placeholders";
 import VueRouter from "vue-router";
@@ -230,13 +229,6 @@ configService
         patientDataService.initialize(config, httpDelegate);
 
         authInitializePromise.then(async () => {
-            Vue.use(IdleVue, {
-                eventEmitter: new Vue(),
-                idleTime: config.webClient.timeouts.idle,
-                store,
-                startAtIdle: false,
-            });
-
             if (window.location.pathname !== "/loginCallback") {
                 const signedIn = await store.dispatch("auth/checkStatus");
                 if (signedIn) {

--- a/Apps/WebClient/src/ClientApp/src/shims-vue.d.ts
+++ b/Apps/WebClient/src/ClientApp/src/shims-vue.d.ts
@@ -18,7 +18,6 @@ declare module "*.jpeg" {
     export = value;
 }
 
-declare module "idle-vue";
 declare module "vuelidate";
 declare module "vue-loading-overlay";
 declare module "vue-fullcalendar";

--- a/Apps/WebClient/src/ClientApp/src/utility/idleDetector.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/idleDetector.ts
@@ -1,0 +1,69 @@
+import { throttle } from "throttle-debounce";
+
+import { ReliableTimer } from "@/utility/reliableTimer";
+
+type Event = keyof DocumentEventMap;
+
+export class IdleDetector {
+    private readonly events: Event[] = [
+        "mousemove",
+        "keydown",
+        "mousedown",
+        "touchstart",
+    ];
+    private readonly idleTimer: ReliableTimer;
+    private enabled = false;
+    private notifyActiveThrottled = throttle(1000, () => this.notifyActive());
+
+    constructor(
+        private isIdleCallback: (timeIdle: number) => void,
+        private timeBeforeIdle: number
+    ) {
+        this.idleTimer = new ReliableTimer(
+            () => this.timerCallback(),
+            timeBeforeIdle
+        );
+    }
+
+    public enable() {
+        if (this.enabled) {
+            return;
+        }
+
+        this.idleTimer.start();
+        for (const event of this.events) {
+            document.addEventListener(event, this.notifyActiveThrottled);
+        }
+
+        this.enabled = true;
+    }
+
+    public disable() {
+        if (!this.enabled) {
+            return;
+        }
+
+        this.idleTimer.cancel();
+        for (const event of this.events) {
+            document.removeEventListener(event, this.notifyActiveThrottled);
+        }
+
+        this.enabled = false;
+    }
+
+    public restart() {
+        this.enable();
+    }
+
+    private notifyActive() {
+        if (this.enabled) {
+            this.idleTimer.restart();
+        }
+    }
+
+    private timerCallback(): void {
+        const timeIdle = this.idleTimer.elapsedTime - this.timeBeforeIdle;
+        this.isIdleCallback(timeIdle);
+        this.disable();
+    }
+}

--- a/Apps/WebClient/src/ClientApp/src/utility/reliableTimer.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/reliableTimer.ts
@@ -1,0 +1,48 @@
+export class ReliableTimer {
+    private readonly interval = 1000;
+    private timeoutId?: ReturnType<typeof setTimeout>;
+    private startingTimestamp?: number;
+
+    constructor(private callback: () => void, private duration: number) {
+        if (duration < this.interval) {
+            throw new Error(`Duration must be at least ${this.interval}ms`);
+        }
+    }
+
+    get elapsedTime(): number {
+        if (this.startingTimestamp === undefined) {
+            return 0;
+        }
+
+        return Date.now() - this.startingTimestamp;
+    }
+
+    get remainingTime(): number {
+        return Math.max(this.duration - this.elapsedTime, 0);
+    }
+
+    start() {
+        this.startingTimestamp = Date.now();
+        this.checkTime();
+    }
+
+    cancel() {
+        clearTimeout(this.timeoutId);
+        this.startingTimestamp = undefined;
+    }
+
+    restart() {
+        this.cancel();
+        this.start();
+    }
+
+    private checkTime() {
+        const timeToNextCheck = Math.min(this.remainingTime, this.interval);
+        if (timeToNextCheck === 0) {
+            this.callback();
+            return;
+        }
+
+        this.timeoutId = setTimeout(() => this.checkTime(), timeToNextCheck);
+    }
+}


### PR DESCRIPTION
# Fixes [AB#13081](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/13081)

## Description

When tabs are inactive or the browser is minimized on a mobile device, our idle timeouts don't execute as desired.  I've introduced a ReliableTimer class, which stores the time it was started, then every second, compares the difference between the current time and that original time to determine if it has expired.  This means when the app is resumed, it will immediately detect that the timer has expired.

I also replaced idle-vue with an IdleDetector class that uses ReliableTimer, so if the app resumes and it's been longer than the combined idle time + modal countdown length since the last interaction, it can log out without displaying the modal and waiting for the countdown.  Hypothetically, it should also handle the case where you come back to the app at the point where it should be partway through the countdown: the modal should appear with that much time remaining.

I tested locally and did a couple runs in BrowserStack which seemed to behave as expected.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
