### PR TITLE
Update dependent expiry date job and functional test for AB#15330

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/delegation.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/delegation.cy.js
@@ -1,12 +1,11 @@
-const dependentWithAudit = "9872868128";
+const dependentWithAudit = "9872868128"; // Leroy Desmond Tobias
 const dependentWithoutGuardian = { phn: "9874307168" };
 const dependentWithGuardian = { phn: "9874307175", guardianPhn: "9735353315" };
 const dependentExceedingAgeCutoff = { phn: "9735353315" };
 const dependentToProtect = "9872868095"; // Jeffrey Lawrence Stallings
-const dependentToValidate = "9872868135"; // Oscar Calvin Gartner
 const guardianToAdd = "9735352488"; // Turpentine Garlandry
 const guardianNotFound = "9735352489";
-const guardianAlreadyAdded = "9735352495"; // Byline Ballistas
+const guardianAlreadyAdded = "9735353315"; // BONNET PROTERVITY
 
 function performSearch(phn) {
     cy.get("[data-testid=query-input]").clear().type(phn);
@@ -220,24 +219,11 @@ describe("Delegation Protect", () => {
     });
 
     it("Verify add delegate dialog guardian not found and guardian already added.", () => {
-        cy.get("[data-testid=query-input]").clear().type(dependentToValidate);
+        cy.get("[data-testid=query-input]").clear().type(dependentWithAudit);
         cy.get("[data-testid=search-button]").click();
 
         // Protect dependent toggle
-        cy.get("[data-testid=dependent-protected-switch]").should(
-            "not.be.checked"
-        );
-
-        // Protect
-        cy.get("[data-testid=dependent-protected-switch]").click();
         cy.get("[data-testid=dependent-protected-switch]").should("be.checked");
-
-        // Delegation Save button
-        cy.get("[data-testid=save-button]").click();
-
-        // Delegation Confirmation button
-        cy.get("[data-testid=protect-reason-input]").type("test");
-        cy.get("[data-testid=confirm-button]").click({ force: true });
 
         // Add guardian
         cy.get("[data-testid=add-button]").click();
@@ -253,6 +239,16 @@ describe("Delegation Protect", () => {
             "be.visible"
         );
 
+        // Cancel add guardian to list dialog
+        cy.get("[data-testid=delegate-dialog-cancel-button]").click();
+
+        // Add guardian
+        cy.get("[data-testid=add-button]").click();
+
+        cy.get("[data-testid=delegate-search-error-message]").should(
+            "not.exist"
+        );
+
         // Delegate dialog - phn already added
         cy.get("[data-testid=delegate-phn-input]")
             .clear()
@@ -260,7 +256,7 @@ describe("Delegation Protect", () => {
         cy.get("[data-testid=communication-dialog-modal-text]").within(() => {
             cy.get("[data-testid=search-button]").click();
         });
-        cy.get("[data-testid=delegate-search-error-message]").should(
+        cy.get("[data-testid=delegate-search-warning-message]").should(
             "be.visible"
         );
     });

--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -262,7 +262,7 @@ namespace HealthGateway.Common.Delegates
                     ResultStatus = ResultType.Error,
                     ResultError = new RequestResultError
                     {
-                        ResultMessage = "Client Registry did not return a person",
+                        ResultMessage = ErrorMessages.ClientRegistryDoesNotReturnPerson,
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.ClientRegistries),
                     },
                 };
@@ -299,7 +299,7 @@ namespace HealthGateway.Common.Delegates
                         ResultStatus = ResultType.Error,
                         ResultError = new RequestResultError
                         {
-                            ResultMessage = "Client Registry returned a person with the deceased indicator set to true",
+                            ResultMessage = ErrorMessages.ClientRegistryReturnedDeceasedPerson,
                             ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.ClientRegistries),
                         },
                     };


### PR DESCRIPTION
# Implements AB#15330

## Description

Updated dependent expiry job as per rules in story:

- If result status is SUCCESS, then update expiry date with birthdate plus 12 years
- If result status is ERROR and error is deceased, then update expiry date to now
- If result status is ERROR and error is not found, then update expiry date to now
- Else, leave expiry date null => this scenario should not happen

Also updated functional test to use different dependent and fixed bug in test

<img width="1264" alt="Screenshot 2023-04-22 at 2 34 44 PM" src="https://user-images.githubusercontent.com/58790456/233807757-b747149f-1f38-4aec-8a97-760310f106d2.png">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
