### PR TITLE
Add dismiss test to notification centre by seed PHSA data for AB#14977

### DIFF
--- a/Apps/CommonData/test/unit/Validations/BroadcastValidatorTests.cs
+++ b/Apps/CommonData/test/unit/Validations/BroadcastValidatorTests.cs
@@ -62,7 +62,7 @@ namespace HealthGateway.Common.Data.Tests.Validations
         /// <param name="shouldBeValid">The validation result to verify.</param>
         [Theory]
         [MemberData(nameof(Broadcasts))]
-        public void ValidateLessThan(Broadcast broadcast, bool shouldBeValid)
+        public void ValidateBroadcast(Broadcast broadcast, bool shouldBeValid)
         {
             BroadcastValidator validator = new();
             ValidationResult? validationResult = validator.Validate(broadcast);

--- a/Apps/WebClient/src/ClientApp/src/components/NotificationCentreComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/NotificationCentreComponent.vue
@@ -179,6 +179,7 @@ export default class NotificationCentreComponent extends Vue {
             v-for="notification in notifications"
             :key="notification.id"
             class="mt-3"
+            data-testid="notifications-div"
         >
             <small :class="{ 'text-muted': !isNew(notification) }">
                 {{ formatDate(notification.scheduledDateTimeUtc) }}

--- a/Testing/functional/tests/cypress/integration/e2e/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/notificationCentre.js
@@ -18,17 +18,17 @@ describe("Notification Centre", () => {
 
     it("Get notifications", () => {
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
-        cy.get("[data-testid=notification-centre-dismiss-all-button]").should(
-            "be.visible"
-        );
+        cy.get("[data-testid=notification-centre-dismiss-all-button]")
+            .should("be.visible", "be.enabled")
+            .click();
+
+        cy.get("[data-testid=notifications-div]").should("not.exist");
 
         cy.get("[data-testid=notification-centre-close-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
         cy.get("[data-testid=notification-centre-close-button]").should(
             "not.be.visible"

--- a/Tools/KeyCloak/Terraform/client_hg_admin.tf
+++ b/Tools/KeyCloak/Terraform/client_hg_admin.tf
@@ -8,7 +8,7 @@ resource "keycloak_openid_client" "hgadmin_client" {
   login_theme                  = local.development ? "bcgov-no-brand" : "bcgov-idp-login-no-brand"
   standard_flow_enabled        = true
   direct_access_grants_enabled = true
-  service_accounts_enabled     = false
+  service_accounts_enabled     = local.development ? true : false
   valid_redirect_uris          = var.client_hg_admin.valid_redirects
   web_origins                  = var.client_hg_admin.web_origins
   full_scope_allowed           = false


### PR DESCRIPTION
# Fixes [AB#14977](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14977)

## Description

1. Added data test id tag to Notification Centre Component
2. Updated Notification Centre functions test to dismiss notifications
3. Changed test name for Broadcast Validator Tests
4. Added Re-seed Phsa Data pipeline
5. Updated Cypress Test pipeline to include re-seed Phsa data
6. Updated Cypress Admin Test pipeline to include re-seed Phsa data
7. Updated terraform script to update hg-admin service account enabled to true for development

<img width="1300" alt="Screenshot 2023-04-22 at 2 54 24 PM" src="https://user-images.githubusercontent.com/58790456/233808175-6c50b1f6-9cfd-4866-a7f2-191b132b042d.png">

## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
