### PR TITLE
Fix paging not appearing on old admin support page AB#15415

### DIFF
--- a/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
+++ b/Apps/AdminWebClient/src/ClientApp/src/views/CovidCard.vue
@@ -608,7 +608,7 @@ export default class CovidCardView extends Vue {
                                 :headers="tableHeaders"
                                 :items="immunizations"
                                 :items-per-page="5"
-                                :hide-default-footer="true"
+                                :hide-default-footer="immunizations.length <= 5"
                             >
                                 <template #[`item.date`]="{ item }">
                                     <span>{{ formatDate(item.date) }}</span>


### PR DESCRIPTION
# Fixes [AB#15415](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15415)

## Description

- fixes paging controls not appearing on the immunization table on the old admin support page, which made it impossible to access more than the most recent 5

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

### 5 or fewer
![localhost-2023-04-24-113223](https://user-images.githubusercontent.com/16570293/234085988-94642279-0810-4b36-a13e-26224705c33a.png)

### 6 or more
![localhost-2023-04-24-113318](https://user-images.githubusercontent.com/16570293/234086004-fae9a7a5-7e5a-4828-bb25-868e8888f07a.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
