### PR TITLE
Replace smart apostrophe with regular apostrophe for AB#15380

### DIFF
--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -47,6 +47,8 @@ namespace HealthGateway.GatewayApi.Services
     {
         private const string WebClientConfigSection = "WebClient";
         private const string MaxDependentAgeKey = "MaxDependentAge";
+        private const string SmartApostrophe = "’";
+        private const string RegularApostrophe = "'";
         private readonly IMapper autoMapper;
         private readonly ILogger logger;
         private readonly int maxDependentAge;
@@ -275,12 +277,12 @@ namespace HealthGateway.GatewayApi.Services
                 return false;
             }
 
-            if (!patientModel.LastName.Equals(dependent.LastName, StringComparison.OrdinalIgnoreCase))
+            if (!patientModel.LastName.Equals(ReplaceSmartApostrophe(dependent.LastName), StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
 
-            if (!patientModel.FirstName.Equals(dependent.FirstName, StringComparison.OrdinalIgnoreCase))
+            if (!patientModel.FirstName.Equals(ReplaceSmartApostrophe(dependent.FirstName), StringComparison.OrdinalIgnoreCase))
             {
                 return false;
             }
@@ -293,6 +295,12 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             return true;
+        }
+
+        private static string ReplaceSmartApostrophe(string value)
+        {
+            string replacedValue = value.Replace(SmartApostrophe, RegularApostrophe, StringComparison.Ordinal);
+            return replacedValue;
         }
 
         private void UpdateNotificationSettings(string dependentHdid, string delegateHdid, bool isDelete = false)

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -46,10 +46,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     {
         private readonly string mismatchedError = "The information you entered does not match our records. Please try again.";
         private readonly DateTime mockDateOfBirth = DateTime.UtcNow.Date.AddYears(-12).AddDays(1);
-        private readonly string mockFirstName = "MockFirstName";
+        private readonly string mockFirstName = "Tory D'Bill"; // First name with regular apostrophe
         private readonly string mockGender = "Male";
         private readonly string mockHdId = "MockHdId";
-        private readonly string mockLastName = "MockLastName";
+        private readonly string mockLastName = "O'Neil"; // Last name with regular apostrophe
         private readonly string mockParentHdid = "MockFirstName";
         private readonly string mockPhn = "9735353315";
         private readonly string noHdidError = "Please ensure you are using a current BC Services Card.";
@@ -129,6 +129,25 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ValidateAddDependent()
         {
             AddDependentRequest addDependentRequest = this.SetupMockInput();
+            IDependentService service = this.SetupMockDependentService(addDependentRequest);
+
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Dictionary<string, int> delegateCounts = this.GenerateMockDelegateCounts(true);
+            Assert.Equal(delegateCounts[actualResult.ResourcePayload?.OwnerId], actualResult.ResourcePayload?.TotalDelegateCount);
+        }
+
+        /// <summary>
+        /// AddDependentAsync - Ensure names with smart quotes are transformed to regular quotes and validated.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateAddDependentWithNamesContainingSmartApostrophe()
+        {
+            AddDependentRequest addDependentRequest = this.SetupMockInput();
+            addDependentRequest.FirstName = "Tory D’Bill"; // First name with smart apostrophe
+            addDependentRequest.LastName = "O’Neil"; // Last name with smart apostrophe
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
             RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);


### PR DESCRIPTION
# Implements [AB#15380](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15380)

## Description

When adding a dependent and validating first name and last name, replace smart apostrophe with regular apostrophe

**EMPI returns regular apostrophe:**

<img width="2527" alt="Screenshot 2023-04-25 at 1 32 33 PM" src="https://user-images.githubusercontent.com/58790456/234401492-a538f537-f646-4076-81f1-8a3c74a0066a.png">

**Smart apostrophe is entered:**

<img width="2542" alt="Screenshot 2023-04-25 at 1 32 11 PM" src="https://user-images.githubusercontent.com/58790456/234401563-b872ce1d-2f50-4ee7-989a-8d84a9d4f22d.png">

**Unit tests:**

<img width="1303" alt="Screenshot 2023-04-25 at 1 32 51 PM" src="https://user-images.githubusercontent.com/58790456/234401511-d0a144d0-0f41-4090-bb58-c67c1016fd36.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
