### PR TITLE
Update patient support query in Admin.Server AB#15345

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/Address.cs
+++ b/Apps/AccountDataAccess/src/Patient/Address.cs
@@ -19,8 +19,8 @@ using System.Runtime.CompilerServices;
 
 namespace HealthGateway.AccountDataAccess.Patient
 {
-    using System;
     using System.Collections.Generic;
+    using System.Linq;
 
     /// <summary>
     /// Represents an address.
@@ -28,16 +28,9 @@ namespace HealthGateway.AccountDataAccess.Patient
     public class Address
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Address"/> class.
-        /// </summary>
-        public Address()
-        {
-        }
-
-        /// <summary>
         /// Gets or sets the street lines.
         /// </summary>
-        public IEnumerable<string> StreetLines { get; set; } = Array.Empty<string>();
+        public IEnumerable<string> StreetLines { get; set; } = Enumerable.Empty<string>();
 
         /// <summary>
         /// Gets or sets the city name.

--- a/Apps/AccountDataAccess/src/Patient/PatientModel.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientModel.cs
@@ -17,6 +17,7 @@
 namespace HealthGateway.AccountDataAccess.Patient
 {
     using System;
+    using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
     /// The patient data model.

--- a/Apps/Admin/Client/Api/ISupportApi.cs
+++ b/Apps/Admin/Client/Api/ISupportApi.cs
@@ -17,23 +17,24 @@ namespace HealthGateway.Admin.Client.Api;
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using HealthGateway.Admin.Common.Models;
 using HealthGateway.Common.Data.Constants;
 using HealthGateway.Common.Data.ViewModels;
 using Refit;
 
 /// <summary>
-/// APIs to fetch support related data from the server.
+/// APIs to fetch support-related data from the server.
 /// </summary>
 public interface ISupportApi
 {
     /// <summary>
-    /// Gets the list of users from the server.
+    /// Retrieves the collection of patients that match the query.
     /// </summary>
-    /// <param name="queryType">queryType.</param>
-    /// <param name="queryString">queryString.</param>
-    /// <returns>The list of SupportUser objects.</returns>
+    /// <param name="queryType">The type of query to perform.</param>
+    /// <param name="queryString">The value to query on.</param>
+    /// <returns>The collection of patient support details that match the query.</returns>
     [Get("/Users?queryType={queryType}&queryString={queryString}")]
-    Task<RequestResult<IEnumerable<SupportUser>>> GetSupportUsersAsync(UserQueryType queryType, string queryString);
+    Task<RequestResult<IEnumerable<PatientSupportDetails>>> GetPatientsAsync(PatientQueryType queryType, string queryString);
 
     /// <summary>
     /// Gets the list of messaging verification models from the server.

--- a/Apps/Admin/Client/Models/ExtendedPatientSupportDetails.cs
+++ b/Apps/Admin/Client/Models/ExtendedPatientSupportDetails.cs
@@ -16,37 +16,37 @@
 
 namespace HealthGateway.Admin.Client.Models;
 
-using HealthGateway.Common.Data.ViewModels;
+using HealthGateway.Admin.Common.Models;
 
 /// <summary>
-/// A system communication with additional state information.
+/// Patient support details with additional state information.
 /// </summary>
-public class ExtendedSupportUser : SupportUser
+public class ExtendedPatientSupportDetails : PatientSupportDetails
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ExtendedSupportUser"/> class.
+    /// Initializes a new instance of the <see cref="ExtendedPatientSupportDetails"/> class.
     /// </summary>
-    /// <param name="model">The support user model.</param>
-    public ExtendedSupportUser(SupportUser model)
+    /// <param name="model">The patient support details model.</param>
+    public ExtendedPatientSupportDetails(PatientSupportDetails model)
     {
         this.PopulateFromModel(model);
     }
 
     /// <summary>
-    /// Gets or sets a value indicating whether the support user details have been expanded.
+    /// Gets or sets a value indicating whether the details have been expanded.
     /// </summary>
     public bool IsExpanded { get; set; }
 
     /// <summary>
-    /// Populates all properties from a support user model.
+    /// Populates all properties from a patient support details model.
     /// </summary>
-    /// <param name="model">The support user model.</param>
-    public void PopulateFromModel(SupportUser model)
+    /// <param name="model">The patient support details model.</param>
+    public void PopulateFromModel(PatientSupportDetails model)
     {
         this.PersonalHealthNumber = model.PersonalHealthNumber;
         this.Hdid = model.Hdid;
-        this.CreatedDateTime = model.CreatedDateTime;
-        this.LastLoginDateTime = model.LastLoginDateTime;
+        this.ProfileCreatedDateTime = model.ProfileCreatedDateTime;
+        this.ProfileLastLoginDateTime = model.ProfileLastLoginDateTime;
         this.PhysicalAddress = model.PhysicalAddress;
         this.PostalAddress = model.PostalAddress;
     }

--- a/Apps/Admin/Client/Pages/FeedbackPage.razor.cs
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor.cs
@@ -183,7 +183,7 @@ public partial class FeedbackPage : FluxorComponent
 
     private void NavigateToSupport(string hdid)
     {
-        this.NavigationManager.NavigateTo($"support?{UserQueryType.Hdid}={hdid}");
+        this.NavigationManager.NavigateTo($"support?{PatientQueryType.Hdid}={hdid}");
     }
 
     private string DescribeTags(List<string> tagIds)

--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -2,7 +2,7 @@
 @layout MainLayout
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer}")]
 @using HealthGateway.Admin.Client.Store.MessageVerification
-@using HealthGateway.Admin.Client.Store.SupportUser
+@using HealthGateway.Admin.Client.Store.PatientSupport
 @using HealthGateway.Common.Data.Constants
 @using HealthGateway.Common.Data.Utils
 @using HealthGateway.Common.Ui.Constants
@@ -15,21 +15,21 @@
 <HgBannerFeedback Severity="Severity.Error" IsEnabled="HasMessagingVerificationsError" TResetAction="MessageVerificationActions.ResetStateAction" DataTestId="messaging-verification-banner-feedback-error-message">
     @MessageVerificationState.Value.Error?.Message
 </HgBannerFeedback>
-<HgBannerFeedback Severity="Severity.Error" IsEnabled="HasSupportUsersError" TResetAction="SupportUserActions.ResetStateAction" DataTestId="user-banner-feedback-error-message">
-    @SupportUserState.Value.Error?.Message
+<HgBannerFeedback Severity="Severity.Error" IsEnabled="HasPatientsError" TResetAction="PatientSupportActions.ResetStateAction" DataTestId="user-banner-feedback-error-message">
+    @PatientSupportState.Value.Error?.Message
 </HgBannerFeedback>
 
 <MudForm @ref="Form">
     <MudGrid Spacing="0">
         <MudItem xs="12" sm="3">
             <HgSelect
-                T="UserQueryType"
+                T="PatientQueryType"
                 Label="Query Type"
                 Required="@true"
                 @bind-Value="SelectedQueryType"
                 TopMargin="Breakpoint.None"
                 data-testid="query-type-select">
-                @foreach (UserQueryType queryType in QueryTypes)
+                @foreach (PatientQueryType queryType in QueryTypes)
                 {
                     <MudSelectItem Value="@queryType" data-testid="query-type">@FormatQueryType(queryType)</MudSelectItem>
                 }
@@ -41,7 +41,7 @@
                 {
                     <HgTextField
                         T="string"
-                        Label="@FormatQueryType(UserQueryType.Phn)"
+                        Label="@FormatQueryType(PatientQueryType.Phn)"
                         Required="@true"
                         Validation="@ValidateQueryParameter"
                         Mask="@(new PatternMask(Mask.PhnMaskTemplate))"
@@ -79,11 +79,11 @@
     </MudGrid>
 </MudForm>
 
-<HgBannerFeedback Severity="@Severity.Info" IsEnabled="HasSupportUsersWarning" TResetAction="SupportUserActions.ResetStateAction" DataTestId="user-banner-feedback-warning-message">
-    @SupportUserState.Value.WarningMessage
+<HgBannerFeedback Severity="@Severity.Info" IsEnabled="HasPatientsWarning" TResetAction="PatientSupportActions.ResetStateAction" DataTestId="user-banner-feedback-warning-message">
+    @PatientSupportState.Value.WarningMessage
 </HgBannerFeedback>
 
-@if (SupportUsersLoaded || SupportUsersLoading)
+@if (PatientsLoaded || PatientsLoading)
 {
     <MudGrid>
         <MudItem xs="12" lg="12">
@@ -91,8 +91,8 @@
                 @FormatQueryType(SelectedQueryType) Query Results
             </MudText>
             <MudTable Class="mt-3"
-                      Items="SupportUserRows"
-                      Loading="SupportUsersLoading"
+                      Items="PatientRows"
+                      Loading="PatientsLoading"
                       AllowUnsorted="false"
                       Breakpoint="Breakpoint.Md"
                       HorizontalScrollbar="true"
@@ -101,23 +101,23 @@
                       data-testid="user-table">
                 <HeaderContent>
                     <MudTh>
-                        <MudTableSortLabel SortBy="new Func<SupportUserRow, object>(x => x.Hdid)">
+                        <MudTableSortLabel SortBy="new Func<PatientRow, object>(x => x.Hdid)">
                             HDID
                         </MudTableSortLabel>
                     </MudTh>
                     <MudTh>
-                        <MudTableSortLabel SortBy="new Func<SupportUserRow, object>(x => x.PersonalHealthNumber)">
+                        <MudTableSortLabel SortBy="new Func<PatientRow, object>(x => x.PersonalHealthNumber)">
                             PHN
                         </MudTableSortLabel>
                     </MudTh>
                     <MudTh>
-                        <MudTableSortLabel SortBy="new Func<SupportUserRow, object>(x => x.LastLoginDateTime ?? DateTime.MinValue)"
+                        <MudTableSortLabel SortBy="new Func<PatientRow, object>(x => x.LastLoginDateTime ?? DateTime.MinValue)"
                                            InitialDirection="@SortDirection.Descending">
                             Last Login
                         </MudTableSortLabel>
                     </MudTh>
                     <MudTh>
-                        <MudTableSortLabel SortBy="new Func<SupportUserRow, object>(x => x.CreatedDateTime ?? DateTime.MinValue)"
+                        <MudTableSortLabel SortBy="new Func<PatientRow, object>(x => x.CreatedDateTime ?? DateTime.MinValue)"
                                            InitialDirection="@SortDirection.Descending">
                             Account Created
                         </MudTableSortLabel>
@@ -142,7 +142,7 @@
                     </MudTd>
                 </RowTemplate>
                 <ChildRowContent>
-                    @if (!context.IsSameAddress && SelectedQueryType is UserQueryType.Phn or UserQueryType.Hdid)
+                    @if (!context.IsSameAddress && SelectedQueryType is PatientQueryType.Phn or PatientQueryType.Hdid)
                     {
                         <div Class="mx-4 my-3">
                             <MudText Typo="Typo.subtitle1" data-testid=@($"physical-address-label-{context.Hdid}")>
@@ -155,12 +155,12 @@
                                 }
                                 else
                                 {
-                                    @SupportUserRow.NoAddressMessage
+                                    @PatientRow.NoAddressMessage
                                 }
                             </MudText>
                         </div>
                     }
-                    @if (SelectedQueryType is UserQueryType.Phn or UserQueryType.Hdid)
+                    @if (SelectedQueryType is PatientQueryType.Phn or PatientQueryType.Hdid)
                     {
                         <div Class="mx-4 my-3">
                             <MudText Typo="Typo.subtitle1" data-testid=@($"postal-address-label-{context.Hdid}")>
@@ -173,7 +173,7 @@
                                 }
                                 else
                                 {
-                                    @SupportUserRow.NoAddressMessage
+                                    @PatientRow.NoAddressMessage
                                 }
                             </MudText>
                         </div>

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportActions.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportActions.cs
@@ -13,10 +13,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.Admin.Client.Store.SupportUser
+namespace HealthGateway.Admin.Client.Store.PatientSupport
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
 
@@ -24,7 +25,7 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     /// Static class that implements all actions for the feature.
     /// </summary>
     [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Team decision")]
-    public static class SupportUserActions
+    public static class PatientSupportActions
     {
         /// <summary>
         /// The action representing the initiation of a load.
@@ -36,7 +37,7 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             /// </summary>
             /// <param name="queryType">Represents the type of query being performed.</param>
             /// <param name="queryString">Represents the query string being performed.</param>
-            public LoadAction(UserQueryType queryType, string queryString)
+            public LoadAction(PatientQueryType queryType, string queryString)
             {
                 this.QueryString = queryString;
                 this.QueryType = queryType;
@@ -45,7 +46,7 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             /// <summary>
             /// Gets or sets query type.
             /// </summary>
-            public UserQueryType QueryType { get; set; }
+            public PatientQueryType QueryType { get; set; }
 
             /// <summary>
             /// Gets or sets query string.
@@ -71,13 +72,13 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
         /// <summary>
         /// The action representing a successful load.
         /// </summary>
-        public class LoadSuccessAction : BaseSuccessAction<RequestResult<IEnumerable<SupportUser>>>
+        public class LoadSuccessAction : BaseSuccessAction<RequestResult<IEnumerable<PatientSupportDetails>>>
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="LoadSuccessAction"/> class.
             /// </summary>
             /// <param name="data">Result data.</param>
-            public LoadSuccessAction(RequestResult<IEnumerable<SupportUser>> data)
+            public LoadSuccessAction(RequestResult<IEnumerable<PatientSupportDetails>> data)
                 : base(data)
             {
             }

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportEffects.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportEffects.cs
@@ -14,7 +14,7 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 
-namespace HealthGateway.Admin.Client.Store.SupportUser
+namespace HealthGateway.Admin.Client.Store.PatientSupport
 {
     using System;
     using System.Collections.Generic;
@@ -23,6 +23,7 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     using Fluxor;
     using HealthGateway.Admin.Client.Api;
     using HealthGateway.Admin.Client.Utils;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using Microsoft.AspNetCore.Components;
@@ -30,51 +31,50 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     using Refit;
 
 #pragma warning disable CS1591, SA1600
-    public class SupportUserEffects
+    public class PatientSupportEffects
     {
-        public SupportUserEffects(ILogger<SupportUserEffects> logger, ISupportApi supportApi)
+        public PatientSupportEffects(ILogger<PatientSupportEffects> logger, ISupportApi supportApi)
         {
             this.Logger = logger;
             this.SupportApi = supportApi;
         }
 
         [Inject]
-        private ILogger<SupportUserEffects> Logger { get; set; }
+        private ILogger<PatientSupportEffects> Logger { get; set; }
 
         [Inject]
         private ISupportApi SupportApi { get; set; }
 
         [EffectMethod]
-        public async Task HandleLoadAction(SupportUserActions.LoadAction action, IDispatcher dispatcher)
+        public async Task HandleLoadAction(PatientSupportActions.LoadAction action, IDispatcher dispatcher)
         {
-            this.Logger.LogInformation("Loading users!");
+            this.Logger.LogInformation("Loading patients!");
 
             try
             {
-                RequestResult<IEnumerable<SupportUser>> response = await this.SupportApi.GetSupportUsersAsync(action.QueryType, action.QueryString).ConfigureAwait(true);
+                RequestResult<IEnumerable<PatientSupportDetails>> response = await this.SupportApi.GetPatientsAsync(action.QueryType, action.QueryString).ConfigureAwait(true);
                 if (response.ResultStatus == ResultType.Success)
                 {
-                    this.Logger.LogInformation("Users loaded successfully!");
-                    dispatcher.Dispatch(new SupportUserActions.LoadSuccessAction(response));
+                    this.Logger.LogInformation("Patients loaded successfully!");
+                    dispatcher.Dispatch(new PatientSupportActions.LoadSuccessAction(response));
                 }
                 else if (response.ResultStatus == ResultType.ActionRequired)
                 {
-                    this.Logger.LogInformation("Users loaded with warning message: {WarningMessage}", response.ResultError?.ResultMessage);
-                    dispatcher.Dispatch(new SupportUserActions.LoadSuccessAction(response));
+                    this.Logger.LogInformation("Patients loaded with warning message: {WarningMessage}", response.ResultError?.ResultMessage);
+                    dispatcher.Dispatch(new PatientSupportActions.LoadSuccessAction(response));
                 }
                 else
                 {
                     RequestError error = StoreUtility.FormatRequestError(response.ResultError);
-                    this.Logger.LogError("Error loading users, reason: {ErrorMessage}", error.Message);
-                    dispatcher.Dispatch(new SupportUserActions.LoadFailAction(error));
+                    this.Logger.LogError("Error loading patients, reason: {ErrorMessage}", error.Message);
+                    dispatcher.Dispatch(new PatientSupportActions.LoadFailAction(error));
                 }
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.Logger.LogError("Error loading users...{Error}", e);
                 RequestError error = StoreUtility.FormatRequestError(e);
-                this.Logger.LogError("Error loading users, reason: {ErrorMessage}", error.Message);
-                dispatcher.Dispatch(new SupportUserActions.LoadFailAction(error));
+                this.Logger.LogError("Error loading patients, reason: {ErrorMessage}", error.Message);
+                dispatcher.Dispatch(new PatientSupportActions.LoadFailAction(error));
             }
         }
     }

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportReducers.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportReducers.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.Admin.Client.Store.SupportUser
+namespace HealthGateway.Admin.Client.Store.PatientSupport
 {
     using System.Collections.Generic;
     using System.Linq;
@@ -21,10 +21,10 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     using HealthGateway.Admin.Client.Models;
 
 #pragma warning disable CS1591, SA1600
-    public static class SupportUserReducers
+    public static class PatientSupportReducers
     {
-        [ReducerMethod(typeof(SupportUserActions.LoadAction))]
-        public static SupportUserState ReduceLoadAction(SupportUserState state)
+        [ReducerMethod(typeof(PatientSupportActions.LoadAction))]
+        public static PatientSupportState ReduceLoadAction(PatientSupportState state)
         {
             return state with
             {
@@ -33,7 +33,7 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
         }
 
         [ReducerMethod]
-        public static SupportUserState ReduceLoadSuccessAction(SupportUserState state, SupportUserActions.LoadSuccessAction action)
+        public static PatientSupportState ReduceLoadSuccessAction(PatientSupportState state, PatientSupportActions.LoadSuccessAction action)
         {
             return state with
             {
@@ -41,12 +41,12 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
                 Result = action.Data,
                 Error = null,
                 WarningMessage = action.Data.ResultError?.ResultMessage,
-                Data = action.Data.ResourcePayload?.Select(u => new ExtendedSupportUser(u)).ToList(),
+                Data = action.Data.ResourcePayload?.Select(u => new ExtendedPatientSupportDetails(u)).ToList(),
             };
         }
 
         [ReducerMethod]
-        public static SupportUserState ReduceLoadFailAction(SupportUserState state, SupportUserActions.LoadFailAction action)
+        public static PatientSupportState ReduceLoadFailAction(PatientSupportState state, PatientSupportActions.LoadFailAction action)
         {
             return state with
             {
@@ -55,8 +55,8 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
             };
         }
 
-        [ReducerMethod(typeof(SupportUserActions.ResetStateAction))]
-        public static SupportUserState ReduceResetStateAction(SupportUserState state)
+        [ReducerMethod(typeof(PatientSupportActions.ResetStateAction))]
+        public static PatientSupportState ReduceResetStateAction(PatientSupportState state)
         {
             return state with
             {
@@ -69,11 +69,11 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
         }
 
         [ReducerMethod]
-        public static SupportUserState ReduceToggleIsExpandedAction(SupportUserState state, SupportUserActions.ToggleIsExpandedAction action)
+        public static PatientSupportState ReduceToggleIsExpandedAction(PatientSupportState state, PatientSupportActions.ToggleIsExpandedAction action)
         {
-            IEnumerable<ExtendedSupportUser> data = state.Data ?? Enumerable.Empty<ExtendedSupportUser>();
+            IEnumerable<ExtendedPatientSupportDetails> data = state.Data ?? Enumerable.Empty<ExtendedPatientSupportDetails>();
 
-            ExtendedSupportUser? user = data.SingleOrDefault(c => c.Hdid == action.Hdid);
+            ExtendedPatientSupportDetails? user = data.SingleOrDefault(c => c.Hdid == action.Hdid);
             if (user != null)
             {
                 user.IsExpanded = !user.IsExpanded;

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportState.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportState.cs
@@ -14,11 +14,12 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 
-namespace HealthGateway.Admin.Client.Store.SupportUser
+namespace HealthGateway.Admin.Client.Store.PatientSupport
 {
     using System.Collections.Generic;
     using Fluxor;
     using HealthGateway.Admin.Client.Models;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
@@ -26,12 +27,12 @@ namespace HealthGateway.Admin.Client.Store.SupportUser
     /// State should be decorated with [FeatureState] for automatic discovery when services.AddFluxor is called.
     /// </summary>
     [FeatureState]
-    public record SupportUserState : BaseRequestState<RequestResult<IEnumerable<SupportUser>>>
+    public record PatientSupportState : BaseRequestState<RequestResult<IEnumerable<PatientSupportDetails>>>
     {
         /// <summary>
         /// Gets the collection of data.
         /// </summary>
-        public IList<ExtendedSupportUser>? Data { get; init; }
+        public IList<ExtendedPatientSupportDetails>? Data { get; init; }
 
         /// <summary>
         /// Gets the warning message for display.

--- a/Apps/Admin/Common/Constants/PatientStatus.cs
+++ b/Apps/Admin/Common/Constants/PatientStatus.cs
@@ -1,0 +1,45 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Constants;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// Represents the status of a user returned from a support query.
+/// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PatientStatus
+{
+    /// <summary>
+    /// Indicates that the patient has no special status.
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// Indicates that the patient was not found.
+    /// </summary>
+    NotFound,
+
+    /// <summary>
+    /// Indicates that the patient is deceased.
+    /// </summary>
+    Deceased,
+
+    /// <summary>
+    /// Indicates that the patient is not a user of Health Gateway.
+    /// </summary>
+    NotUser,
+}

--- a/Apps/Admin/Common/Models/PatientSupportDetails.cs
+++ b/Apps/Admin/Common/Models/PatientSupportDetails.cs
@@ -1,4 +1,4 @@
-// -------------------------------------------------------------------------
+﻿// -------------------------------------------------------------------------
 //  Copyright © 2019 Province of British Columbia
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,73 +13,75 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Patient.Models
+namespace HealthGateway.Admin.Common.Models
 {
     using System;
-    using System.Text.Json.Serialization;
-    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
-    /// The patient details.
+    /// Represents details associated with a patient retrieved by a support query.
     /// </summary>
-    public class PatientDetails
+    public class PatientSupportDetails
     {
         /// <summary>
-        /// Gets or sets the health directed identifier.
+        /// Gets or sets the patient's status.
         /// </summary>
-        [JsonPropertyName("hdid")]
-        public string HdId { get; set; } = string.Empty;
+        public PatientStatus Status { get; set; }
+
+        /// <summary>
+        /// Gets or sets a warning message associated with the patient.
+        /// </summary>
+        public string WarningMessage { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the patient's HDID.
+        /// </summary>
+        public string Hdid { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the patient's PHN.
         /// </summary>
-        [JsonPropertyName("personalHealthNumber")]
-        public string Phn { get; set; } = string.Empty;
+        public string PersonalHealthNumber { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the patient's common name.
         /// </summary>
-        [JsonPropertyName("commonName")]
         public Name? CommonName { get; set; }
 
         /// <summary>
         /// Gets or sets the patient's legal name.
         /// </summary>
-        [JsonPropertyName("legalName")]
         public Name? LegalName { get; set; }
 
         /// <summary>
         /// Gets the patient's preferred name.
         /// </summary>
-        [JsonPropertyName("preferredName")]
-        public Name PreferredName => this.CommonName ?? this.LegalName!;
+        public Name? PreferredName => this.CommonName ?? this.LegalName;
 
         /// <summary>
         /// Gets or sets the patient's date of birth.
         /// </summary>
-        [JsonPropertyName("birthdate")]
-        public DateTime Birthdate { get; set; }
-
-        /// <summary>
-        /// Gets or sets the patient's gender.
-        /// </summary>
-        [JsonPropertyName("gender")]
-        public string Gender { get; set; } = string.Empty;
+        public DateOnly? Birthdate { get; set; }
 
         /// <summary>
         /// Gets or sets the physical address for the patient.
         /// </summary>
-        public Address? PhysicalAddress { get; set; }
+        public string PhysicalAddress { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the postal address for the patient.
         /// </summary>
-        public Address? PostalAddress { get; set; }
+        public string PostalAddress { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the response code for the patient.
+        /// Gets or sets the user's created datetime.
         /// </summary>
-        public string ResponseCode { get; set; } = string.Empty;
+        public DateTime? ProfileCreatedDateTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets the user's last login datetime.
+        /// </summary>
+        public DateTime? ProfileLastLoginDateTime { get; set; }
     }
 }

--- a/Apps/Admin/Server/Admin.Server.csproj
+++ b/Apps/Admin/Server/Admin.Server.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\Client\Admin.Client.csproj" />
     <ProjectReference Include="..\Common\Admin.Common.csproj" />
     <ProjectReference Include="..\..\Common\src\Common.csproj">

--- a/Apps/Admin/Server/MapProfiles/AddressProfile.cs
+++ b/Apps/Admin/Server/MapProfiles/AddressProfile.cs
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.MapProfiles
+{
+    using AutoMapper;
+    using HealthGateway.Common.Data.Utils;
+
+    /// <summary>
+    /// An AutoMapper profile class which defines a mapping between a data access model and common model.
+    /// </summary>
+    public class AddressProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AddressProfile"/> class.
+        /// </summary>
+        public AddressProfile()
+        {
+            this.CreateMap<AccountDataAccess.Patient.Address?, HealthGateway.Common.Data.Models.Address?>()
+                .ReverseMap();
+
+            this.CreateMap<HealthGateway.Common.Data.Models.Address?, string>()
+                .ConvertUsing(address => AddressUtility.GetAddressAsSingleLine(address, false));
+
+            this.CreateMap<AccountDataAccess.Patient.Address?, string>()
+                .ConvertUsing(
+                    (src, _, context) => context.Mapper.Map<HealthGateway.Common.Data.Models.Address?, string>(
+                        context.Mapper.Map<AccountDataAccess.Patient.Address?, HealthGateway.Common.Data.Models.Address?>(src)));
+        }
+    }
+}

--- a/Apps/Admin/Server/MapProfiles/PatientSupportDetailsProfile.cs
+++ b/Apps/Admin/Server/MapProfiles/PatientSupportDetailsProfile.cs
@@ -1,0 +1,50 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.MapProfiles
+{
+    using System;
+    using System.Linq;
+    using AutoMapper;
+    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Admin.Common.Models;
+
+    /// <summary>
+    /// An AutoMapper profile class which defines a mapping between a data access model and data transfer object.
+    /// </summary>
+    public class PatientSupportDetailsProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatientSupportDetailsProfile"/> class.
+        /// </summary>
+        public PatientSupportDetailsProfile()
+        {
+            this.CreateMap<PatientModel?, PatientSupportDetails>()
+                .ForMember(dest => dest.WarningMessage, opt => opt.MapFrom(src => src == null ? null : GetWarningFromResponseCode(src.ResponseCode)))
+                .ForMember(dest => dest.WarningMessage, opt => opt.NullSubstitute(string.Empty))
+                .ForMember(dest => dest.Hdid, opt => opt.NullSubstitute(string.Empty))
+                .ForMember(dest => dest.PersonalHealthNumber, opt => opt.MapFrom(src => src == null ? string.Empty : src.Phn))
+                .ForMember(dest => dest.PersonalHealthNumber, opt => opt.NullSubstitute(string.Empty))
+                .ForMember(dest => dest.Birthdate, opt => opt.MapFrom(src => src == null ? null : (DateOnly?)DateOnly.FromDateTime(src.Birthdate)))
+                .ForMember(dest => dest.ProfileCreatedDateTime, opt => opt.Ignore())
+                .ForMember(dest => dest.ProfileLastLoginDateTime, opt => opt.Ignore());
+        }
+
+        private static string? GetWarningFromResponseCode(string? responseCode)
+        {
+            return responseCode?.Length > 0 ? responseCode.Split('|', StringSplitOptions.TrimEntries).ElementAtOrDefault(1) : null;
+        }
+    }
+}

--- a/Apps/Admin/Server/MapUtils/PatientSupportDetailsMapUtils.cs
+++ b/Apps/Admin/Server/MapUtils/PatientSupportDetailsMapUtils.cs
@@ -1,0 +1,67 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.MapUtils
+{
+    using AutoMapper;
+    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Admin.Common.Constants;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// Static Helper classes for conversion of model objects.
+    /// </summary>
+    public static class PatientSupportDetailsMapUtils
+    {
+        /// <summary>
+        /// Creates a UI model from a user profile model and a patient model.
+        /// </summary>
+        /// <param name="userProfile">The user profile model to convert.</param>
+        /// <param name="patientModel">The patient model to convert.</param>
+        /// <param name="mapper">The AutoMapper IMapper.</param>
+        /// <returns>The created UI model.</returns>
+        public static PatientSupportDetails ToUiModel(UserProfile? userProfile, PatientModel? patientModel, IMapper mapper)
+        {
+            return mapper.Map<PatientModel?, PatientSupportDetails>(
+                patientModel,
+                opts => opts.AfterMap(
+                    (_, dest) =>
+                    {
+                        dest.Status = PatientStatus.Default;
+                        if (patientModel == null)
+                        {
+                            dest.Status = PatientStatus.NotFound;
+                        }
+                        else if (patientModel.IsDeceased == true)
+                        {
+                            dest.Status = PatientStatus.Deceased;
+                        }
+                        else if (userProfile == null)
+                        {
+                            dest.Status = PatientStatus.NotUser;
+                        }
+
+                        dest.ProfileCreatedDateTime = userProfile?.CreatedDateTime;
+                        dest.ProfileLastLoginDateTime = userProfile?.LastLoginDateTime;
+
+                        if (patientModel == null && userProfile != null)
+                        {
+                            dest.Hdid = userProfile.HdId;
+                        }
+                    }));
+        }
+    }
+}

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Admin.Server
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
+    using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Api;
@@ -119,6 +120,7 @@ namespace HealthGateway.Admin.Server
 
         private static void AddServices(IServiceCollection services)
         {
+            services.AddPatientRepositoryConfiguration();
             services.AddTransient<IBroadcastService, BroadcastService>();
             services.AddTransient<IConfigurationService, ConfigurationService>();
             services.AddTransient<IUserFeedbackService, UserFeedbackService>();

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -247,7 +247,7 @@ namespace HealthGateway.Admin.Server.Services
         private async Task<IEnumerable<ResourceDelegate>> SearchDelegates(string ownerHdid)
         {
             ResourceDelegateQuery query = new() { ByOwnerHdid = ownerHdid };
-            ResourceDelegateQueryResult result = await this.resourceDelegateDelegate.Search(query).ConfigureAwait(true);
+            ResourceDelegateQueryResult result = await this.resourceDelegateDelegate.SearchAsync(query).ConfigureAwait(true);
             return result.Items;
         }
 

--- a/Apps/Admin/Server/Services/ISupportService.cs
+++ b/Apps/Admin/Server/Services/ISupportService.cs
@@ -13,10 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Services
+namespace HealthGateway.Admin.Server.Services
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
 
@@ -26,18 +28,20 @@ namespace HealthGateway.Common.Services
     public interface ISupportService
     {
         /// <summary>
-        /// Retrieves a list of message verifications matching the query.
+        /// Retrieves a list of messaging verifications matching the query.
         /// </summary>
-        /// <param name="hdid">The hdid associated with the messaging verification.</param>
-        /// <returns>A list of users matching the query.</returns>
-        RequestResult<IEnumerable<MessagingVerificationModel>> GetMessageVerifications(string hdid);
+        /// <param name="hdid">The HDID associated with the messaging verifications.</param>
+        /// <param name="ct">A cancellation token.</param>
+        /// <returns>A list of messaging verifications matching the query.</returns>
+        Task<RequestResult<IEnumerable<MessagingVerificationModel>>> GetMessageVerificationsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
-        /// Retrieves a list of users matching the query.
+        /// Retrieves the collection of patients that match the query.
         /// </summary>
         /// <param name="queryType">The type of query to perform.</param>
         /// <param name="queryString">The value to query on.</param>
-        /// <returns>A list of users matching the query.</returns>
-        Task<RequestResult<IEnumerable<SupportUser>>> GetUsers(UserQueryType queryType, string queryString);
+        /// <param name="ct">A cancellation token.</param>
+        /// <returns>The collection of patient support details that match the query.</returns>
+        Task<IList<PatientSupportDetails>> GetPatientsAsync(PatientQueryType queryType, string queryString, CancellationToken ct = default);
     }
 }

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -1,0 +1,190 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Admin.Common.Constants;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ErrorHandling;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.Utils;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.MapUtils;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using Microsoft.Extensions.Configuration;
+
+    /// <inheritdoc/>
+    public class SupportService : ISupportService
+    {
+        private readonly IMapper autoMapper;
+        private readonly IConfiguration configuration;
+        private readonly IMessagingVerificationDelegate messagingVerificationDelegate;
+        private readonly IPatientRepository patientRepository;
+        private readonly IResourceDelegateDelegate resourceDelegateDelegate;
+        private readonly IUserProfileDelegate userProfileDelegate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SupportService"/> class.
+        /// </summary>
+        /// <param name="autoMapper">The injected automapper provider.</param>
+        /// <param name="configuration">The configuration to use.</param>
+        /// <param name="messagingVerificationDelegate">The Messaging verification delegate to interact with the DB.</param>
+        /// <param name="patientRepository">The injected patient repository.</param>
+        /// <param name="resourceDelegateDelegate">The resource delegate used to lookup delegates and owners.</param>
+        /// <param name="userProfileDelegate">The user profile delegate to interact with the DB.</param>
+        public SupportService(
+            IMapper autoMapper,
+            IConfiguration configuration,
+            IMessagingVerificationDelegate messagingVerificationDelegate,
+            IPatientRepository patientRepository,
+            IResourceDelegateDelegate resourceDelegateDelegate,
+            IUserProfileDelegate userProfileDelegate)
+        {
+            this.autoMapper = autoMapper;
+            this.configuration = configuration;
+            this.messagingVerificationDelegate = messagingVerificationDelegate;
+            this.patientRepository = patientRepository;
+            this.resourceDelegateDelegate = resourceDelegateDelegate;
+            this.userProfileDelegate = userProfileDelegate;
+        }
+
+        /// <inheritdoc/>
+        public async Task<RequestResult<IEnumerable<MessagingVerificationModel>>> GetMessageVerificationsAsync(string hdid, CancellationToken ct = default)
+        {
+            IList<MessagingVerification> dbResult = await this.messagingVerificationDelegate.GetUserMessageVerificationsAsync(hdid).ConfigureAwait(true);
+            TimeZoneInfo localTimezone = DateFormatter.GetLocalTimeZone(this.configuration);
+            RequestResult<IEnumerable<MessagingVerificationModel>> result = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = dbResult.Select(m => MessagingVerificationMapUtils.ToUiModel(m, this.autoMapper, localTimezone)),
+            };
+            return result;
+        }
+
+        /// <inheritdoc/>
+        public async Task<IList<PatientSupportDetails>> GetPatientsAsync(PatientQueryType queryType, string queryString, CancellationToken ct = default)
+        {
+            if (queryType is PatientQueryType.Hdid or PatientQueryType.Phn)
+            {
+                PatientIdentifierType identifierType = queryType == PatientQueryType.Phn ? PatientIdentifierType.Phn : PatientIdentifierType.Hdid;
+                PatientSupportDetails? patientSupportDetails = await this.GetPatientSupportDetailsAsync(identifierType, queryString, ct).ConfigureAwait(true);
+                return patientSupportDetails == null ? Array.Empty<PatientSupportDetails>() : new List<PatientSupportDetails> { patientSupportDetails };
+            }
+
+            IEnumerable<UserProfile> profiles = queryType switch
+            {
+                PatientQueryType.Dependent =>
+                    await this.GetDelegateProfilesAsync(queryString).ConfigureAwait(true),
+                PatientQueryType.Email =>
+                    await this.userProfileDelegate.GetUserProfilesAsync(UserQueryType.Email, queryString).ConfigureAwait(true),
+                PatientQueryType.Sms =>
+                    await this.userProfileDelegate.GetUserProfilesAsync(UserQueryType.Sms, queryString).ConfigureAwait(true),
+                _ =>
+                    throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails($"Unknown {nameof(queryType)}", HttpStatusCode.BadRequest, nameof(SupportService))),
+            };
+
+            IEnumerable<Task<PatientSupportDetails>> tasks = profiles.Select(profile => this.GetPatientSupportDetailsAsync(profile, ct));
+            return await Task.WhenAll(tasks).ConfigureAwait(true);
+        }
+
+        private async Task<IEnumerable<UserProfile>> GetDelegateProfilesAsync(string dependentHdid)
+        {
+            ResourceDelegateQuery query = new()
+            {
+                ByOwnerHdid = dependentHdid,
+                IncludeProfile = true,
+                TakeAmount = 25,
+            };
+            ResourceDelegateQueryResult result = await this.resourceDelegateDelegate.SearchAsync(query).ConfigureAwait(true);
+            return result.Items.Select(rd => rd.UserProfile);
+        }
+
+        private async Task<PatientSupportDetails?> GetPatientSupportDetailsAsync(PatientIdentifierType identifierType, string identifier, CancellationToken ct)
+        {
+            PatientModel? patient = await this.GetPatientAsync(identifierType, identifier, ct).ConfigureAwait(true);
+            UserProfile? profile = null;
+
+            string? hdid = identifierType == PatientIdentifierType.Hdid ? identifier : patient?.Hdid;
+            if (hdid != null)
+            {
+                profile = await this.userProfileDelegate.GetUserProfileAsync(hdid).ConfigureAwait(true);
+            }
+
+            if (patient == null && profile == null)
+            {
+                return null;
+            }
+
+            return this.MapToPatientSupportDetails(patient, profile);
+        }
+
+        private async Task<PatientSupportDetails> GetPatientSupportDetailsAsync(UserProfile profile, CancellationToken ct)
+        {
+            PatientModel? patient = await this.GetPatientAsync(PatientIdentifierType.Hdid, profile.HdId, ct).ConfigureAwait(true);
+
+            return this.MapToPatientSupportDetails(patient, profile);
+        }
+
+        private async Task<PatientModel?> GetPatientAsync(PatientIdentifierType identifierType, string queryString, CancellationToken ct)
+        {
+            PatientDetailsQuery query = identifierType == PatientIdentifierType.Hdid
+                ? new PatientDetailsQuery(Hdid: queryString)
+                : new PatientDetailsQuery(Phn: queryString);
+
+            PatientQueryResult result = await this.patientRepository.Query(query, ct).ConfigureAwait(true);
+            return result.Items.SingleOrDefault();
+        }
+
+        private PatientSupportDetails MapToPatientSupportDetails(PatientModel? patient, UserProfile? userProfile)
+        {
+            PatientSupportDetails patientSupportDetails = this.autoMapper.Map<PatientModel?, PatientSupportDetails>(patient) ?? new PatientSupportDetails();
+
+            patientSupportDetails.Status = PatientStatus.Default;
+            if (patient == null)
+            {
+                patientSupportDetails.Status = PatientStatus.NotFound;
+            }
+            else if (patient.IsDeceased == true)
+            {
+                patientSupportDetails.Status = PatientStatus.Deceased;
+            }
+            else if (userProfile == null)
+            {
+                patientSupportDetails.Status = PatientStatus.NotUser;
+            }
+
+            patientSupportDetails.ProfileCreatedDateTime = userProfile?.CreatedDateTime;
+            patientSupportDetails.ProfileLastLoginDateTime = userProfile?.LastLoginDateTime;
+
+            if (patient == null && userProfile != null)
+            {
+                patientSupportDetails.Hdid = userProfile.HdId;
+            }
+
+            return patientSupportDetails;
+        }
+    }
+}

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -741,7 +741,7 @@ namespace HealthGateway.Admin.Tests.Services
                 },
             };
             Mock<IResourceDelegateDelegate> resourceDelegateDelegate = new();
-            resourceDelegateDelegate.Setup(r => r.Search(It.IsAny<ResourceDelegateQuery>())).ReturnsAsync(result);
+            resourceDelegateDelegate.Setup(r => r.SearchAsync(It.IsAny<ResourceDelegateQuery>())).ReturnsAsync(result);
 
             Mock<IDelegationDelegate> delegationDelegate = new();
             delegationDelegate.Setup(p => p.GetDependentAsync(DependentHdid, true)).ReturnsAsync(protectedDependent);
@@ -769,7 +769,7 @@ namespace HealthGateway.Admin.Tests.Services
             authenticationDelegate.Setup(a => a.FetchAuthenticatedPreferredUsername()).Returns(authenticatedPreferredUsername);
 
             Mock<IResourceDelegateDelegate> resourceDelegateDelegate = new();
-            resourceDelegateDelegate.Setup(r => r.Search(new() { ByOwnerHdid = resourceOwnerHdid })).ReturnsAsync(resourceDelegates);
+            resourceDelegateDelegate.Setup(r => r.SearchAsync(new() { ByOwnerHdid = resourceOwnerHdid })).ReturnsAsync(resourceDelegates);
 
             delegationDelegate.Setup(p => p.GetDependentAsync(resourceOwnerHdid, true)).ReturnsAsync(dependent);
 

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -1,0 +1,638 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using AutoMapper;
+    using DeepEqual.Syntax;
+    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Admin.Common.Constants;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Admin.Tests.Utils;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ErrorHandling;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.Utils;
+    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// SupportService's Unit Tests.
+    /// </summary>
+    public class SupportServiceTests
+    {
+        private const string Hdid = "DEV4FPEGCXG2NB5K2USBL52S66SC3GOUHWRP3GTXR2BTY5HEC4YA";
+        private const string Hdid2 = "C3GOUHWRP3GTXR2BTY5HEC4YADEV4FPEGCXG2NB5K2USBL52S66S";
+        private const string Phn = "9735361219";
+        private const string Phn2 = "9219735361";
+        private const string SmsNumber = "2501234567";
+        private const string Email = "fakeemail@healthgateway.gov.bc.ca";
+
+        private const string ClientRegistryWarning = "Client Registry Warning";
+        private const string PatientResponseCode = $"500|{ClientRegistryWarning}";
+
+        private const string ConfigUnixTimeZoneId = "America/Vancouver";
+        private const string ConfigWindowsTimeZoneId = "Pacific Standard Time";
+
+        private static readonly DateTime Birthdate = new(2000, 1, 1);
+        private static readonly DateTime Birthdate2 = new(1999, 12, 31);
+
+        private static readonly IMapper AutoMapper = MapperUtil.InitializeAutoMapper();
+        private static readonly IConfiguration Configuration = GetIConfigurationRoot();
+
+        /// <summary>
+        /// GetMessageVerificationsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetMessageVerificationsAsync()
+        {
+            // Arrange
+            IList<MessagingVerification> messagingVerifications = GenerateMessagingVerifications(SmsNumber, Email);
+            ISupportService supportService = CreateSupportService(GetMessagingVerificationDelegateMock(messagingVerifications));
+
+            // Act
+            RequestResult<IEnumerable<MessagingVerificationModel>> actualResult = await supportService.GetMessageVerificationsAsync(Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+            Assert.Equal(2, actualResult.ResourcePayload.Count());
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdid()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(patient, profile),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.Default, actualResult.First().Status);
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - Happy Path with Warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdidWithWarning()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid };
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate, responseCode: PatientResponseCode);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.Default, actualResult.First().Status);
+            Assert.Equal(ClientRegistryWarning, actualResult.First().WarningMessage);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - Not Found.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdidNotFound()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid };
+            PatientModel? patient = null;
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(patient, profile),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.NotFound, actualResult.First().Status);
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - Deceased.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdidDeceased()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress, isDeceased: true);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(patient, profile),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.Deceased, actualResult.First().Status);
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - Not User.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdidNotUser()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile? profile = null;
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(patient, profile),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.NotUser, actualResult.First().Status);
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - Not Found and Not User.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdidNotFoundNotUser()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid };
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, null));
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock();
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Empty(actualResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - PHN - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByPhn()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Phn = Phn };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(patient, profile),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn).ConfigureAwait(true);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.Default, actualResult.First().Status);
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - PHN - Not Found and Not User.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByPhnNotFoundNotUser()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Phn = Phn };
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, null));
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock();
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn).ConfigureAwait(true);
+
+            // Assert
+            Assert.Empty(actualResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - Invalid Arguments Result in Exception.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetPatientShouldThrowBadRequest()
+        {
+            // Arrange
+            ISupportService supportService = CreateSupportService();
+
+            // Act
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(async () => await supportService.GetPatientsAsync((PatientQueryType)99, Hdid).ConfigureAwait(true))
+                .ConfigureAwait(true);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.BadRequest, exception.ProblemDetails?.StatusCode);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - Dependent - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientsByDependentHdid()
+        {
+            // Arrange
+            const string dependentHdid = "dependentHdid";
+            PatientDetailsQuery firstQuery = new() { Hdid = Hdid };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel firstPatient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress);
+
+            PatientDetailsQuery secondQuery = new() { Hdid = Hdid2 };
+            PatientModel secondPatient = GeneratePatientModel(Phn2, Hdid2, Birthdate2);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((firstQuery, firstPatient), (secondQuery, secondPatient));
+
+            ResourceDelegateQuery resourceDelegateQuery = new() { ByOwnerHdid = dependentHdid, IncludeProfile = true, TakeAmount = 25 };
+            IList<ResourceDelegate> resourceDelegates = GenerateResourceDelegates(dependentHdid, new List<string> { Hdid, Hdid2 }, DateTime.Now.Subtract(TimeSpan.FromDays(1)), DateTime.Now);
+            Mock<IResourceDelegateDelegate> resourceDelegateDelegateMock = GetResourceDelegateDelegateMock(resourceDelegateQuery, resourceDelegates);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, resourceDelegateDelegateMock: resourceDelegateDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(firstPatient, resourceDelegates.ElementAt(0).UserProfile),
+                GetExpectedPatientSupportDetails(secondPatient, resourceDelegates.ElementAt(1).UserProfile),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Dependent, dependentHdid).ConfigureAwait(true);
+
+            // Assert
+            Assert.Equal(resourceDelegates.Count, actualResult.Count());
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - Email - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientsByEmail()
+        {
+            // Arrange
+            List<UserProfile> profiles = new()
+            {
+                new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now },
+                new() { HdId = Hdid2, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(5)), LastLoginDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(1)) },
+            };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profiles: profiles);
+
+            PatientDetailsQuery firstQuery = new() { Hdid = Hdid };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel firstPatient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress);
+
+            PatientDetailsQuery secondQuery = new() { Hdid = Hdid2 };
+            PatientModel secondPatient = GeneratePatientModel(Phn2, Hdid2, Birthdate2);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((firstQuery, firstPatient), (secondQuery, secondPatient));
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(firstPatient, profiles[0]),
+                GetExpectedPatientSupportDetails(secondPatient, profiles[1]),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Email, "email").ConfigureAwait(true);
+
+            // Assert
+            Assert.Equal(profiles.Count, actualResult.Count());
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - SMS - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientsBySms()
+        {
+            // Arrange
+            List<UserProfile> profiles = new()
+            {
+                new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now },
+                new() { HdId = Hdid2, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(5)), LastLoginDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(1)) },
+            };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profiles: profiles);
+
+            PatientDetailsQuery firstQuery = new() { Hdid = Hdid };
+            Name commonName = GenerateName();
+            Name legalName = GenerateName("Jim", "Bo");
+            AccountDataAccess.Patient.Address physicalAddress = GenerateAddress(GenerateStreetLines());
+            AccountDataAccess.Patient.Address postalAddress = GenerateAddress(new List<string> { "PO BOX 1234" });
+            PatientModel firstPatient = GeneratePatientModel(Phn, Hdid, Birthdate, commonName, legalName, physicalAddress, postalAddress);
+
+            PatientDetailsQuery secondQuery = new() { Hdid = Hdid2 };
+            PatientModel secondPatient = GeneratePatientModel(Phn2, Hdid2, Birthdate2);
+            Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((firstQuery, firstPatient), (secondQuery, secondPatient));
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportDetails> expectedResult = new List<PatientSupportDetails>
+            {
+                GetExpectedPatientSupportDetails(firstPatient, profiles[0]),
+                GetExpectedPatientSupportDetails(secondPatient, profiles[1]),
+            };
+
+            // Act
+            IEnumerable<PatientSupportDetails> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Sms, "sms").ConfigureAwait(true);
+
+            // Assert
+            Assert.Equal(profiles.Count, actualResult.Count());
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        private static PatientSupportDetails GetExpectedPatientSupportDetails(PatientModel? patient, UserProfile? profile)
+        {
+            PatientStatus status = PatientStatus.Default;
+            if (patient == null)
+            {
+                status = PatientStatus.NotFound;
+            }
+            else if (patient.IsDeceased == true)
+            {
+                status = PatientStatus.Deceased;
+            }
+            else if (profile == null)
+            {
+                status = PatientStatus.NotUser;
+            }
+
+            return new()
+            {
+                Status = status,
+                WarningMessage = string.Empty,
+                Hdid = patient?.Hdid ?? profile?.HdId ?? string.Empty,
+                PersonalHealthNumber = patient?.Phn ?? string.Empty,
+                CommonName = patient?.CommonName,
+                LegalName = patient?.LegalName,
+                Birthdate = patient == null ? null : DateOnly.FromDateTime(patient.Birthdate),
+                PhysicalAddress = AddressUtility.GetAddressAsSingleLine(AutoMapper.Map<HealthGateway.Common.Data.Models.Address?>(patient?.PhysicalAddress)),
+                PostalAddress = AddressUtility.GetAddressAsSingleLine(AutoMapper.Map<HealthGateway.Common.Data.Models.Address?>(patient?.PostalAddress)),
+                ProfileCreatedDateTime = profile?.CreatedDateTime,
+                ProfileLastLoginDateTime = profile?.LastLoginDateTime,
+            };
+        }
+
+        private static IList<MessagingVerification> GenerateMessagingVerifications(string sms, string email)
+        {
+            return new List<MessagingVerification>
+            {
+                new() { Id = Guid.NewGuid(), Validated = true, SmsNumber = sms },
+                new() { Id = Guid.NewGuid(), Validated = false, Email = new() { To = email } },
+            };
+        }
+
+        private static IList<ResourceDelegate> GenerateResourceDelegates(
+            string dependentHdid,
+            IEnumerable<string> delegateHdids,
+            DateTime profileCreatedDateTime,
+            DateTime profileLastLoginDateTime)
+        {
+            return delegateHdids.Select(
+                    delegateHdid => new ResourceDelegate
+                    {
+                        ResourceOwnerHdid = dependentHdid,
+                        ProfileHdid = delegateHdid,
+                        UserProfile = new() { HdId = delegateHdid, CreatedDateTime = profileCreatedDateTime, LastLoginDateTime = profileLastLoginDateTime },
+                    })
+                .ToList();
+        }
+
+        private static Name GenerateName(string givenName = "John", string surname = "Doe")
+        {
+            return new Name { GivenName = givenName, Surname = surname };
+        }
+
+        private static IEnumerable<string> GenerateStreetLines()
+        {
+            return new List<string> { "Line 1", "Line 2", "Physical" };
+        }
+
+        private static AccountDataAccess.Patient.Address GenerateAddress(IEnumerable<string> streetLines, string city = "City", string state = "BC", string postalCode = "N0N0N0")
+        {
+            return new()
+            {
+                StreetLines = streetLines,
+                City = city,
+                State = state,
+                Country = "CA",
+                PostalCode = postalCode,
+            };
+        }
+
+        private static PatientModel GeneratePatientModel(
+            string phn,
+            string hdid,
+            DateTime birthdate,
+            Name? commonName = null,
+            Name? legalName = null,
+            AccountDataAccess.Patient.Address? physicalAddress = null,
+            AccountDataAccess.Patient.Address? postalAddress = null,
+            string? responseCode = null,
+            bool isDeceased = false)
+        {
+            return new()
+            {
+                Phn = phn,
+                Hdid = hdid,
+                Birthdate = birthdate,
+                CommonName = commonName,
+                LegalName = legalName,
+                PhysicalAddress = physicalAddress,
+                PostalAddress = postalAddress,
+                ResponseCode = responseCode ?? string.Empty,
+                IsDeceased = isDeceased,
+            };
+        }
+
+        private static Mock<IMessagingVerificationDelegate> GetMessagingVerificationDelegateMock(IList<MessagingVerification> result)
+        {
+            Mock<IMessagingVerificationDelegate> mock = new();
+            mock.Setup(d => d.GetUserMessageVerificationsAsync(It.IsAny<string>())).ReturnsAsync(result);
+            return mock;
+        }
+
+        private static Mock<IPatientRepository> GetPatientRepositoryMock(params (PatientDetailsQuery Query, PatientModel? Patient)[] pairs)
+        {
+            Mock<IPatientRepository> mock = new();
+            foreach ((PatientDetailsQuery query, PatientModel? patient) in pairs)
+            {
+                PatientQueryResult result = new(patient == null ? Enumerable.Empty<PatientModel>() : new List<PatientModel> { patient });
+                mock.Setup(p => p.Query(query, It.IsAny<CancellationToken>())).ReturnsAsync(result);
+            }
+
+            return mock;
+        }
+
+        private static Mock<IResourceDelegateDelegate> GetResourceDelegateDelegateMock(ResourceDelegateQuery query, IEnumerable<ResourceDelegate> result)
+        {
+            Mock<IResourceDelegateDelegate> mock = new();
+            mock.Setup(d => d.SearchAsync(query)).ReturnsAsync(new ResourceDelegateQueryResult { Items = result });
+            return mock;
+        }
+
+        private static Mock<IUserProfileDelegate> GetUserProfileDelegateMock(UserProfile? profile = null, IList<UserProfile>? profiles = null)
+        {
+            Mock<IUserProfileDelegate> mock = new();
+            mock.Setup(u => u.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(profile);
+            mock.Setup(u => u.GetUserProfilesAsync(It.IsAny<UserQueryType>(), It.IsAny<string>())).ReturnsAsync(profiles ?? Array.Empty<UserProfile>());
+            return mock;
+        }
+
+        private static ISupportService CreateSupportService(
+            Mock<IMessagingVerificationDelegate>? messagingVerificationDelegateMock = null,
+            Mock<IPatientRepository>? patientRepositoryMock = null,
+            Mock<IResourceDelegateDelegate>? resourceDelegateDelegateMock = null,
+            Mock<IUserProfileDelegate>? userProfileDelegateMock = null)
+        {
+            userProfileDelegateMock ??= new Mock<IUserProfileDelegate>();
+            messagingVerificationDelegateMock ??= new Mock<IMessagingVerificationDelegate>();
+            patientRepositoryMock ??= new Mock<IPatientRepository>();
+            resourceDelegateDelegateMock ??= new Mock<IResourceDelegateDelegate>();
+
+            return new SupportService(
+                AutoMapper,
+                Configuration,
+                messagingVerificationDelegateMock.Object,
+                patientRepositoryMock.Object,
+                resourceDelegateDelegateMock.Object,
+                userProfileDelegateMock.Object);
+        }
+
+        private static IConfigurationRoot GetIConfigurationRoot()
+        {
+            Dictionary<string, string?> myConfiguration = new()
+            {
+                { "TimeZone:UnixTimeZoneId", ConfigUnixTimeZoneId },
+                { "TimeZone:WindowsTimeZoneId", ConfigWindowsTimeZoneId },
+            };
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration.ToList())
+                .Build();
+        }
+    }
+}

--- a/Apps/Admin/Tests/Utils/MapperUtil.cs
+++ b/Apps/Admin/Tests/Utils/MapperUtil.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Tests.Utils
 {
     using AutoMapper;
     using HealthGateway.Admin.Server.MapProfiles;
+    using HealthGateway.Common.MapProfiles;
 
     /// <summary>
     /// Static utility class to provide a fully initialized AutoMapper.
@@ -33,10 +34,13 @@ namespace HealthGateway.Admin.Tests.Utils
             MapperConfiguration config = new(
                 cfg =>
                 {
+                    cfg.AddProfile(new AddressProfile());
                     cfg.AddProfile(new AdminUserProfileViewProfile());
                     cfg.AddProfile(new DependentInfoProfile());
                     cfg.AddProfile(new DelegateInfoProfile());
                     cfg.AddProfile(new DelegationChangeProfile());
+                    cfg.AddProfile(new MessagingVerificationProfile());
+                    cfg.AddProfile(new PatientSupportDetailsProfile());
                 });
 
             return config.CreateMapper();

--- a/Apps/AdminWebClient/src/Server/Controllers/SupportController.cs
+++ b/Apps/AdminWebClient/src/Server/Controllers/SupportController.cs
@@ -16,8 +16,8 @@
 namespace HealthGateway.Admin.Controllers
 {
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Services;
     using HealthGateway.Common.Data.Constants;
-    using HealthGateway.Common.Services;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
@@ -56,9 +56,9 @@ namespace HealthGateway.Admin.Controllers
         /// </response>
         [HttpGet]
         [Route("Users")]
-        public async Task<IActionResult> GetSupportUsers([FromQuery] UserQueryType queryType, [FromQuery] string queryString)
+        public async Task<IActionResult> GetSupportUsers([FromQuery] PatientQueryType queryType, [FromQuery] string queryString)
         {
-            return new JsonResult(await this.supportService.GetUsers(queryType, queryString).ConfigureAwait(true));
+            return new JsonResult(await this.supportService.GetPatientsAsync(queryType, queryString).ConfigureAwait(true));
         }
 
         /// <summary>

--- a/Apps/AdminWebClient/src/Server/MapProfiles/PatientSupportDetailsProfile.cs
+++ b/Apps/AdminWebClient/src/Server/MapProfiles/PatientSupportDetailsProfile.cs
@@ -1,0 +1,43 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.MapProfiles
+{
+    using AutoMapper;
+    using HealthGateway.Admin.Models;
+    using HealthGateway.Database.Models;
+
+    /// <summary>
+    /// An AutoMapper profile class which defines mappings between DB models and data transfer objects.
+    /// </summary>
+    public class PatientSupportDetailsProfile : Profile
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatientSupportDetailsProfile"/> class.
+        /// </summary>
+        public PatientSupportDetailsProfile()
+        {
+            this.CreateMap<Common.Data.Models.UserProfile, PatientSupportDetails>()
+                .ForMember(dest => dest.Hdid, opt => opt.MapFrom(src => src.HdId))
+                .ReverseMap();
+
+            this.CreateMap<ResourceDelegate, PatientSupportDetails>()
+                .ForMember(d => d.Hdid, opts => opts.MapFrom(s => s.ProfileHdid))
+                .ForMember(d => d.PersonalHealthNumber, opts => opts.Ignore())
+                .ForMember(d => d.LastLoginDateTime, opts => opts.Ignore())
+                .ForMember(d => d.CreatedDateTime, opts => opts.Ignore());
+        }
+    }
+}

--- a/Apps/AdminWebClient/src/Server/MapUtils/PatientSupportDetailsMapUtils.cs
+++ b/Apps/AdminWebClient/src/Server/MapUtils/PatientSupportDetailsMapUtils.cs
@@ -1,4 +1,4 @@
-// -------------------------------------------------------------------------
+﻿// -------------------------------------------------------------------------
 //  Copyright © 2019 Province of British Columbia
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,29 +13,28 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.MapUtils
+namespace HealthGateway.Admin.MapUtils
 {
     using AutoMapper;
-    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Admin.Models;
     using HealthGateway.Common.Data.Utils;
-    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
 
     /// <summary>
     /// Static Helper classes for conversion of model objects.
     /// </summary>
-    public static class SupportUserMapUtils
+    public static class PatientSupportDetailsMapUtils
     {
         /// <summary>
-        /// Creates a UI model from a DB model.
+        /// Creates a UI model from a user profile model and a patient model.
         /// </summary>
-        /// <param name="userProfile">The DB model to convert.</param>
+        /// <param name="userProfile">The user profile model to convert.</param>
         /// <param name="patientModel">The patient model to convert.</param>
         /// <param name="mapper">The AutoMapper IMapper.</param>
         /// <returns>The created UI model.</returns>
-        public static SupportUser ToUiModel(UserProfile userProfile, PatientModel patientModel, IMapper mapper)
+        public static PatientSupportDetails ToUiModel(Common.Data.Models.UserProfile userProfile, PatientModel patientModel, IMapper mapper)
         {
-            SupportUser supportUser = mapper.Map<UserProfile, SupportUser>(
+            PatientSupportDetails patientSupportDetails = mapper.Map<Common.Data.Models.UserProfile, PatientSupportDetails>(
                 userProfile,
                 opts => opts.AfterMap(
                     (_, dest) =>
@@ -44,7 +43,7 @@ namespace HealthGateway.Common.MapUtils
                         dest.PhysicalAddress = AddressUtility.GetAddressAsSingleLine(patientModel.PhysicalAddress);
                         dest.PostalAddress = AddressUtility.GetAddressAsSingleLine(patientModel.PostalAddress);
                     }));
-            return supportUser;
+            return patientSupportDetails;
         }
     }
 }

--- a/Apps/AdminWebClient/src/Server/Models/PatientSupportDetails.cs
+++ b/Apps/AdminWebClient/src/Server/Models/PatientSupportDetails.cs
@@ -13,14 +13,14 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Data.ViewModels
+namespace HealthGateway.Admin.Models
 {
     using System;
 
     /// <summary>
-    /// Represents a Support User.
+    /// Represents details associated with a patient retrieved by a support query.
     /// </summary>
-    public class SupportUser
+    public class PatientSupportDetails
     {
         /// <summary>
         /// Gets or sets the patient's PHN.
@@ -28,17 +28,17 @@ namespace HealthGateway.Common.Data.ViewModels
         public string PersonalHealthNumber { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the user's hdid.
+        /// Gets or sets the patient's hdid.
         /// </summary>
         public string Hdid { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets the user's created date time.
+        /// Gets or sets the user's created datetime.
         /// </summary>
         public DateTime? CreatedDateTime { get; set; }
 
         /// <summary>
-        /// Gets or sets the user's last login date time.
+        /// Gets or sets the user's last login datetime.
         /// </summary>
         public DateTime? LastLoginDateTime { get; set; }
 

--- a/Apps/AdminWebClient/src/Server/Services/ISupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/ISupportService.cs
@@ -1,0 +1,44 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Services
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Admin.Models;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.ViewModels;
+
+    /// <summary>
+    /// Service that provides functionality to admin support.
+    /// </summary>
+    public interface ISupportService
+    {
+        /// <summary>
+        /// Retrieves a list of message verifications matching the query.
+        /// </summary>
+        /// <param name="hdid">The hdid associated with the messaging verification.</param>
+        /// <returns>A list of users matching the query.</returns>
+        RequestResult<IEnumerable<MessagingVerificationModel>> GetMessageVerifications(string hdid);
+
+        /// <summary>
+        /// Retrieves the collection of patients that match the query.
+        /// </summary>
+        /// <param name="queryType">The type of query to perform.</param>
+        /// <param name="queryString">The value to query on.</param>
+        /// <returns>The collection of patient support details that match the query.</returns>
+        Task<RequestResult<IEnumerable<PatientSupportDetails>>> GetPatientsAsync(PatientQueryType queryType, string queryString);
+    }
+}

--- a/Apps/AdminWebClient/src/Server/Startup.cs
+++ b/Apps/AdminWebClient/src/Server/Startup.cs
@@ -27,7 +27,6 @@ namespace HealthGateway.Admin
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.MapProfiles;
     using HealthGateway.Common.Models.PHSA;
-    using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
     using Microsoft.AspNetCore.Authentication;
     using Microsoft.AspNetCore.Authentication.Cookies;

--- a/Apps/AdminWebClient/test/unit/AdminWebClientTests.csproj
+++ b/Apps/AdminWebClient/test/unit/AdminWebClientTests.csproj
@@ -37,9 +37,6 @@
     <ProjectReference Include="..\..\src\AdminWebClient.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Services.Test\" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="UnitTest.json">
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/Apps/AdminWebClient/test/unit/Utils/MapperUtil.cs
+++ b/Apps/AdminWebClient/test/unit/Utils/MapperUtil.cs
@@ -13,28 +13,31 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.MapProfiles
+namespace HealthGateway.AdminWebClientTests.Utils
 {
-    using System;
     using AutoMapper;
-    using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Admin.MapProfiles;
 
     /// <summary>
-    /// An AutoMapper profile class which defines mapping between DB Model UserProfile and API Model UserProfileModel.
+    /// Static utility class to provide a fully initialized AutoMapper.
+    /// NOTE: Any newly added profiles will have to be registered.
     /// </summary>
-    public class UserProfileProfile : Profile
+    public static class MapperUtil
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="UserProfileProfile"/> class.
+        /// Creates an AutoMapper.
         /// </summary>
-        public UserProfileProfile()
+        /// <returns>A configured AutoMapper.</returns>
+        public static IMapper InitializeAutoMapper()
         {
-            this.CreateMap<UserProfile, UserProfileModel>()
-                .ForMember(dest => dest.IsEmailVerified, opt => opt.MapFrom(src => !string.IsNullOrEmpty(src.Email)))
-                .ForMember(dest => dest.IsSmsNumberVerified, opt => opt.MapFrom(src => !string.IsNullOrEmpty(src.SmsNumber)))
-                .ForMember(dest => dest.AcceptedTermsOfService, opt => opt.MapFrom(src => src.TermsOfServiceId != Guid.Empty))
-                .ReverseMap();
+            MapperConfiguration config = new(
+                cfg =>
+                {
+                    cfg.AddProfile(new Common.MapProfiles.MessagingVerificationProfile());
+                    cfg.AddProfile(new PatientSupportDetailsProfile());
+                });
+
+            return config.CreateMapper();
         }
     }
 }

--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -184,7 +184,7 @@ namespace HealthGateway.Common.Delegates
                         case ADStreetAddressLine line when line.Text != null:
                             foreach (string s in line.Text)
                             {
-                                retAddress.AddLine(s ?? string.Empty);
+                                retAddress.StreetLines = retAddress.StreetLines.Append(s ?? string.Empty);
                             }
 
                             break;

--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -16,7 +16,9 @@
 namespace HealthGateway.CommonTests.Delegates
 {
     using System;
+    using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using System.Net;
     using System.Security.Claims;
     using System.Security.Principal;
@@ -149,7 +151,7 @@ namespace HealthGateway.CommonTests.Delegates
             string expectedGender = "Female";
             Address expectedPhysicalAddr = new()
             {
-                StreetLines = { "Line 1", "Line 2", "Physical" },
+                StreetLines = new List<string> { "Line 1", "Line 2", "Physical" },
                 City = "city",
                 Country = "CA",
                 PostalCode = "N0N0N0",
@@ -157,7 +159,7 @@ namespace HealthGateway.CommonTests.Delegates
             };
             Address expectedPostalAddr = new()
             {
-                StreetLines = { "Line 1", "Line 2", "Postal" },
+                StreetLines = new List<string> { "Line 1", "Line 2", "Postal" },
                 City = "city",
                 Country = "CA",
                 PostalCode = "N0N0N0",
@@ -190,9 +192,9 @@ namespace HealthGateway.CommonTests.Delegates
                             {
                                 Text = new[]
                                 {
-                                    expectedPhysicalAddr.StreetLines[0],
-                                    expectedPhysicalAddr.StreetLines[1],
-                                    expectedPhysicalAddr.StreetLines[2],
+                                    expectedPhysicalAddr.StreetLines.ElementAt(0),
+                                    expectedPhysicalAddr.StreetLines.ElementAt(1),
+                                    expectedPhysicalAddr.StreetLines.ElementAt(2),
                                 },
                             },
                             new ADCity
@@ -237,9 +239,9 @@ namespace HealthGateway.CommonTests.Delegates
                             {
                                 Text = new[]
                                 {
-                                    expectedPostalAddr.StreetLines[0],
-                                    expectedPostalAddr.StreetLines[1],
-                                    expectedPostalAddr.StreetLines[2],
+                                    expectedPostalAddr.StreetLines.ElementAt(0),
+                                    expectedPostalAddr.StreetLines.ElementAt(1),
+                                    expectedPostalAddr.StreetLines.ElementAt(2),
                                 },
                             },
                             new ADCity

--- a/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
@@ -48,8 +48,9 @@ namespace HealthGateway.CommonTests.Delegates
 
         private readonly string qrCodeData = string.Empty;
 
-        private readonly Address address = new(new List<string> { "3815 HILLSPOINT STREET" })
+        private readonly Address address = new()
         {
+            StreetLines = new List<string> { "3815 HILLSPOINT STREET" },
             City = "CHATHAM",
             Country = "CA",
             PostalCode = "V0G 8B8",

--- a/Apps/Common/test/unit/Utils/MapperUtil.cs
+++ b/Apps/Common/test/unit/Utils/MapperUtil.cs
@@ -33,7 +33,6 @@ namespace HealthGateway.CommonTests.Utils
             MapperConfiguration config = new(
                 cfg =>
                 {
-                    cfg.AddProfile(new MessagingVerificationProfile());
                     cfg.AddProfile(new UserProfileProfile());
                     cfg.AddProfile(new BroadcastProfile());
                 });

--- a/Apps/CommonData/src/Constants/PatientQueryType.cs
+++ b/Apps/CommonData/src/Constants/PatientQueryType.cs
@@ -19,7 +19,7 @@ namespace HealthGateway.Common.Data.Constants
     /// <summary>
     /// Represents the type of query being performed.
     /// </summary>
-    public enum UserQueryType
+    public enum PatientQueryType
     {
         /// <summary>
         /// Query by Personal Health Number.

--- a/Apps/CommonData/src/Models/Address.cs
+++ b/Apps/CommonData/src/Models/Address.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.Common.Data.Models
 {
     using System.Collections.Generic;
-    using System.Text.Json.Serialization;
+    using System.Linq;
 
     /// <summary>
     /// Represents an address.
@@ -24,27 +24,9 @@ namespace HealthGateway.Common.Data.Models
     public class Address
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="Address"/> class.
+        /// Gets or sets the street lines.
         /// </summary>
-        public Address()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Address"/> class.
-        /// </summary>
-        /// <param name="streetLines">The list of address street lines.</param>
-        [JsonConstructor]
-        public Address(
-            IList<string> streetLines)
-        {
-            this.StreetLines = streetLines;
-        }
-
-        /// <summary>
-        /// Gets the street lines.
-        /// </summary>
-        public IList<string> StreetLines { get; } = new List<string>();
+        public IEnumerable<string> StreetLines { get; set; } = Enumerable.Empty<string>();
 
         /// <summary>
         /// Gets or sets the city name.
@@ -65,14 +47,5 @@ namespace HealthGateway.Common.Data.Models
         /// Gets or sets the country.
         /// </summary>
         public string Country { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Adds an address line to the internal lines list.
-        /// </summary>
-        /// <param name="line">The address line to add.</param>
-        public void AddLine(string line)
-        {
-            this.StreetLines.Add(line);
-        }
     }
 }

--- a/Apps/CommonData/src/ViewModels/Name.cs
+++ b/Apps/CommonData/src/ViewModels/Name.cs
@@ -13,7 +13,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.AccountDataAccess.Patient
+namespace HealthGateway.Common.Data.ViewModels
 {
     /// <summary>
     ///  Represents the name of a person.

--- a/Apps/CommonData/test/unit/Utils/AddressUtilityTests.cs
+++ b/Apps/CommonData/test/unit/Utils/AddressUtilityTests.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Data.Tests.Utils
 {
+    using System.Collections.Generic;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.Utils;
     using Xunit;
@@ -35,7 +36,7 @@ namespace HealthGateway.Common.Data.Tests.Utils
             // Arrange
             Address address = new()
             {
-                StreetLines = { "1025 Sutlej Street" },
+                StreetLines = new List<string> { "1025 Sutlej Street" },
                 City = "Victoria",
                 State = "BC",
                 PostalCode = "V8V2V8",
@@ -59,7 +60,7 @@ namespace HealthGateway.Common.Data.Tests.Utils
             // Arrange
             Address address = new()
             {
-                StreetLines = { "1025 Sutlej Street", "Suite 310" },
+                StreetLines = new List<string> { "1025 Sutlej Street", "Suite 310" },
                 City = "Victoria",
                 State = "BC",
                 PostalCode = "V8V2V8",
@@ -83,7 +84,7 @@ namespace HealthGateway.Common.Data.Tests.Utils
             // Arrange
             Address address = new()
             {
-                StreetLines = { "1025 Sutlej Street", "Suite 310" },
+                StreetLines = new List<string> { "1025 Sutlej Street", "Suite 310" },
                 City = "Victoria",
                 PostalCode = "V8V2V8",
             };
@@ -106,7 +107,7 @@ namespace HealthGateway.Common.Data.Tests.Utils
             // Arrange
             Address address = new()
             {
-                StreetLines = { "1025 Sutlej Street", "Suite 310" },
+                StreetLines = new List<string> { "1025 Sutlej Street", "Suite 310" },
                 City = "Victoria",
                 State = "BC",
             };

--- a/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
@@ -19,11 +19,10 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
-    using HealthGateway.Database.Wrapper;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
 
@@ -136,21 +135,14 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IEnumerable<MessagingVerification>> GetUserMessageVerifications(string hdid)
+        public async Task<IList<MessagingVerification>> GetUserMessageVerificationsAsync(string hdid)
         {
-            IList<MessagingVerification> verifications = this.dbContext.MessagingVerification.Where(mv => mv.UserProfileId == hdid)
+            return await this.dbContext.MessagingVerification.Where(mv => mv.UserProfileId == hdid)
                 .Include(mv => mv.Email)
                 .OrderByDescending(mv => mv.CreatedDateTime)
                 .AsNoTracking()
-                .ToList();
-
-            DbResult<IEnumerable<MessagingVerification>> result = new()
-            {
-                Payload = verifications,
-                Status = DbStatusCode.Read,
-            };
-
-            return result;
+                .ToListAsync()
+                .ConfigureAwait(true);
         }
     }
 }

--- a/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
@@ -17,8 +17,8 @@ namespace HealthGateway.Database.Delegates
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Database.Wrapper;
 
     /// <summary>
     /// Delegate that performs operations for the MessageVerification model.
@@ -68,10 +68,10 @@ namespace HealthGateway.Database.Delegates
         void Expire(MessagingVerification messageVerification, bool markDeleted);
 
         /// <summary>
-        /// Retrieves a list of message verifications matching the query.
+        /// Retrieves a list of messaging verifications matching the query.
         /// </summary>
-        /// <param name="hdid">The hdid associated with the messaging verification.</param>
-        /// <returns>A list of users matching the query.</returns>
-        DbResult<IEnumerable<MessagingVerification>> GetUserMessageVerifications(string hdid);
+        /// <param name="hdid">The HDID associated with the messaging verifications.</param>
+        /// <returns>A list of messaging verifications matching the query.</returns>
+        Task<IList<MessagingVerification>> GetUserMessageVerificationsAsync(string hdid);
     }
 }

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -91,22 +91,32 @@ namespace HealthGateway.Database.Delegates
         /// <summary>
         /// Search resource delegates by criteria specified in the query.
         /// </summary>
-        /// <param name="query">the query criteria.</param>
+        /// <param name="query">The query criteria.</param>
         /// <returns>A <see cref="Task{TResult}"/> representing the result of the asynchronous operation.</returns>
-        public Task<ResourceDelegateQueryResult> Search(ResourceDelegateQuery query);
+        public Task<ResourceDelegateQueryResult> SearchAsync(ResourceDelegateQuery query);
     }
 
     public record ResourceDelegateQuery
     {
         /// <summary>
-        /// Gets or sets search by owner's hdid.
+        /// Gets the resource owner HDID to search by.
         /// </summary>
-        public string? ByOwnerHdid { get; set; }
+        public string? ByOwnerHdid { get; init; }
 
         /// <summary>
-        /// Gets or sets search by delegate hdid.
+        /// Gets the delegate HDID to search by.
         /// </summary>
-        public string? ByDelegateHdid { get; set; }
+        public string? ByDelegateHdid { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the associated UserProfile data should be included in the result.
+        /// </summary>
+        public bool IncludeProfile { get; init; }
+
+        /// <summary>
+        /// Gets the maximum number of records to return. If null, all matching records will be returned.
+        /// </summary>
+        public int? TakeAmount { get; init; }
     }
 
     public record ResourceDelegateQueryResult

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Database.Delegates
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Models;
@@ -63,6 +64,13 @@ namespace HealthGateway.Database.Delegates
         DbResult<UserProfile> GetUserProfile(string hdId);
 
         /// <summary>
+        /// Fetches a UserProfile from the database by HDID.
+        /// </summary>
+        /// <param name="hdid">The unique profile key to find.</param>
+        /// <returns>The matching UserProfile, or null if not found.</returns>
+        Task<UserProfile?> GetUserProfileAsync(string hdid);
+
+        /// <summary>
         /// Fetches UserProfiles from the database.
         /// </summary>
         /// <param name="hdIds">The unique profile keys to find.</param>
@@ -75,7 +83,7 @@ namespace HealthGateway.Database.Delegates
         /// <param name="queryType">The type of query to perform.</param>
         /// <param name="queryString">The value to query on.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<List<UserProfile>> GetUserProfiles(UserQueryType queryType, string queryString);
+        Task<IList<UserProfile>> GetUserProfilesAsync(UserQueryType queryType, string queryString);
 
         /// <summary>
         /// Returns the list of all UserProfiles who have an email address and have

--- a/Apps/Database/src/Models/ResourceDelegate.cs
+++ b/Apps/Database/src/Models/ResourceDelegate.cs
@@ -60,5 +60,10 @@ namespace HealthGateway.Database.Models
         /// Gets or sets the resource delegation Reason object.
         /// </summary>
         public JsonDocument? ReasonObject { get; set; }
+
+        /// <summary>
+        /// Gets or sets the UserProfile associated with <see cref="ProfileHdid"/>.
+        /// </summary>
+        public virtual UserProfile UserProfile { get; set; } = null!;
     }
 }

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading.Tasks;
@@ -127,6 +128,7 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Requires refactoring")]
         public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, DateTime jwtAuthTime)
         {
             this.logger.LogTrace("Getting user profile... {Hdid}", hdid);

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
@@ -109,7 +109,7 @@ namespace HealthGateway.MedicationTests.Delegates
                             },
                             GenericName = "Generic Name",
                             Id = 0,
-                            Practitioner = new Name
+                            Practitioner = new Medication.Models.ODR.Name
                             {
                                 GivenName = "Given",
                                 MiddleInitial = "I",

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -18,10 +18,11 @@ namespace HealthGateway.PatientTests.Controllers
     using System;
     using System.Threading;
     using DeepEqual.Syntax;
-    using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Patient.Controllers;
     using HealthGateway.Patient.Models;
@@ -29,8 +30,6 @@ namespace HealthGateway.PatientTests.Controllers
     using Microsoft.AspNetCore.Mvc;
     using Moq;
     using Xunit;
-    using Address = HealthGateway.Common.Data.Models.Address;
-    using PatientModel = HealthGateway.Common.Models.PatientModel;
 
     /// <summary>
     /// Unit Tests for PatientController.

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.PatientTests.Services
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
+    using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Patient.Models;
     using HealthGateway.Patient.Services;
     using HealthGateway.PatientTests.Utils;


### PR DESCRIPTION
# Implements [AB#15345](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15345)

## Description

- introduces separate SupportService for Admin.Server and AdminWebServer
- renames SupportUser to PatientSupportDetails
- updates patient support query in Admin.Server SupportService
- introduces and updates async DB delegate methods needed for patient support query
- refactors Address classes in different projects to match
- moves Name to Common.Data.ViewModels

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
