### PR TITLE
removed ApiResult from patient v2

### DIFF
--- a/Apps/GatewayApi/src/Controllers/PhsaController.cs
+++ b/Apps/GatewayApi/src/Controllers/PhsaController.cs
@@ -115,7 +115,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status502BadGateway)]
-        [Route("Patient")]
+        [Route("patients/{hdid}")]
         [Authorize(Policy = SystemDelegatedPatientPolicy.Read)]
         public async Task<ActionResult<PatientDetails>> GetPatient(string hdid)
         {

--- a/Apps/Patient/src/Controllers/PatientController.cs
+++ b/Apps/Patient/src/Controllers/PatientController.cs
@@ -90,7 +90,7 @@ namespace HealthGateway.Patient.Controllers
         /// <response code="502">Unable to get response from client registry.</response>
         [HttpGet]
         [Produces("application/json")]
-        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(ApiResult<PatientDetails>))]
+        [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -98,10 +98,10 @@ namespace HealthGateway.Patient.Controllers
         [ApiVersion("2.0")]
         [Route("{hdid}")]
         [Authorize(Policy = PatientPolicy.Read)]
-        public async Task<IActionResult> GetPatientV2(string hdid)
+        public async Task<ActionResult<PatientDetails>> GetPatientV2(string hdid)
         {
             var patientDetails = await this.serviceV2.GetPatientAsync(hdid).ConfigureAwait(true);
-            return this.Ok(new ApiResult<PatientDetails> { ResourcePayload = patientDetails });
+            return this.Ok(patientDetails);
         }
     }
 }

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -1,7 +1,6 @@
 import { Store } from "vuex";
 
 import AddDependentRequest from "@/models/addDependentRequest";
-import ApiResult from "@/models/apiResult";
 import { Dictionary } from "@/models/baseTypes";
 import { CheckInRequest } from "@/models/checkInRequest";
 import { ClinicalDocument } from "@/models/clinicalDocument";
@@ -90,7 +89,7 @@ export interface IVaccinationStatusService {
 
 export interface IPatientService {
     initialize(config: ExternalConfiguration, http: IHttpDelegate): void;
-    getPatient(hdid: string): Promise<ApiResult<Patient>>;
+    getPatient(hdid: string): Promise<Patient>;
 }
 
 export interface IMedicationService {

--- a/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
@@ -1,7 +1,6 @@
 import { injectable } from "inversify";
 
 import { ServiceCode } from "@/constants/serviceCodes";
-import ApiResult from "@/models/apiResult";
 import { ExternalConfiguration } from "@/models/configData";
 import { HttpError } from "@/models/errors";
 import Patient from "@/models/patient";
@@ -25,10 +24,10 @@ export class RestPatientService implements IPatientService {
         this.http = http;
     }
 
-    public getPatient(hdid: string): Promise<ApiResult<Patient>> {
+    public getPatient(hdid: string): Promise<Patient> {
         return new Promise((resolve, reject) =>
             this.http
-                .get<ApiResult<Patient>>(
+                .get<Patient>(
                     `${this.baseUri}${this.PATIENT_BASE_URI}/${hdid}?api-version=2.0`
                 )
                 .then((apiResult) => resolve(apiResult))

--- a/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
+++ b/Apps/WebClient/src/ClientApp/src/store/modules/user/actions.ts
@@ -267,8 +267,8 @@ export const actions: UserActions = {
             patientService
                 .getPatient(context.state.user.hdid)
                 .then((result) => {
-                    if (result.resourcePayload) {
-                        context.commit("setPatient", result.resourcePayload);
+                    if (result) {
+                        context.commit("setPatient", result);
 
                         userProfileService
                             .getProfile(context.state.user.hdid)

--- a/Apps/hg-start.cmd
+++ b/Apps/hg-start.cmd
@@ -1,9 +1,9 @@
 @echo off
-start /d "%~dp0\Apps\WebClient\src" dotnet run .
-start /d "%~dp0\Apps\Patient\src" dotnet run .
-start /d "%~dp0\Apps\GatewayApi\src" dotnet run .
-start /d "%~dp0\Apps\Encounter\src" dotnet run .
-start /d "%~dp0\Apps\Immunization\src" dotnet run .
-start /d "%~dp0\Apps\Laboratory\src" dotnet run .
-start /d "%~dp0\Apps\Medication\src" dotnet run .
-start /d "%~dp0\Apps\ClinicalDocument\src" dotnet run .
+start /d "%~dp0\WebClient\src" dotnet run .
+start /d "%~dp0\Patient\src" dotnet run .
+start /d "%~dp0\GatewayApi\src" dotnet run .
+start /d "%~dp0\Encounter\src" dotnet run .
+start /d "%~dp0\Immunization\src" dotnet run .
+start /d "%~dp0\Laboratory\src" dotnet run .
+start /d "%~dp0\Medication\src" dotnet run .
+start /d "%~dp0\ClinicalDocument\src" dotnet run .

--- a/Apps/hg-watch.cmd
+++ b/Apps/hg-watch.cmd
@@ -1,9 +1,9 @@
 @echo off
-start /d "%~dp0\Apps\WebClient\src" dotnet watch run .
-start /d "%~dp0\Apps\Patient\src" dotnet watch run .
-start /d "%~dp0\Apps\GatewayApi\src" dotnet watch run .
-start /d "%~dp0\Apps\Encounter\src" dotnet watch run .
-start /d "%~dp0\Apps\Immunization\src" dotnet watch run .
-start /d "%~dp0\Apps\Laboratory\src" dotnet watch run .
-start /d "%~dp0\Apps\Medication\src" dotnet watch run .
-start /d "%~dp0\Apps\ClinicalDocument\src" dotnet watch run .
+start /d "%~dp0\WebClient\src" dotnet watch run .
+start /d "%~dp0\Patient\src" dotnet watch run .
+start /d "%~dp0\GatewayApi\src" dotnet watch run .
+start /d "%~dp0\Encounter\src" dotnet watch run .
+start /d "%~dp0\Immunization\src" dotnet watch run .
+start /d "%~dp0\Laboratory\src" dotnet watch run .
+start /d "%~dp0\Medication\src" dotnet watch run .
+start /d "%~dp0\ClinicalDocument\src" dotnet watch run .


### PR DESCRIPTION
# Fixes or Implements [AB#15488](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15488)

[Task 15488](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/15488): Remove ApiResult from PHSA V2

## Description

Removed ApiResult from patient v2 api and modified the web client accordingly.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
