### PR TITLE
Handle Not Found for Patient Identity for AB#15487

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -29,6 +29,7 @@ namespace HealthGateway.AccountDataAccess.Patient
     using HealthGateway.Common.Data.Validations;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
+    using Refit;
 
     /// <summary>
     /// Handle Patient data.
@@ -191,10 +192,18 @@ namespace HealthGateway.AccountDataAccess.Patient
             throw new InvalidOperationException("Must specify either Hdid or Phn to query patient details");
         }
 
-        private async Task<PatientModel> GetPatientIdentityAsync(string hdid)
+        private async Task<PatientModel?> GetPatientIdentityAsync(string hdid)
         {
-            PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(hdid).ConfigureAwait(true);
-            return this.mapper.Map<PatientModel>(result);
+            try
+            {
+                PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(hdid).ConfigureAwait(true);
+                return this.mapper.Map<PatientModel>(result);
+            }
+            catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
+            {
+                this.logger.LogError("PHSA could not find patient identity for {Hdid}", hdid);
+                return null;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
# Implements AB#15487

## Description

- When PHSA patient identity returns Not Found 404, return null for Patient Model
- Added unit test to cover Not Found 404

<img width="1279" alt="Screenshot 2023-05-02 at 11 44 30 AM" src="https://user-images.githubusercontent.com/58790456/235757917-a96ab540-b390-4711-9ca6-880cbad2e2ad.png">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
