### PR TITLE
Update add dependent to return no HDID when appropriate AB#15490

### DIFF
--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -105,6 +105,9 @@ namespace HealthGateway.GatewayApi.Services
                 case ResultType.Error:
                     return RequestResultFactory.ServiceError<DependentModel>(ErrorType.CommunicationExternal, ServiceType.Patient, "Communication Exception when trying to retrieve the Dependent");
 
+                case ResultType.ActionRequired when patientResult.ResultError?.ActionCodeValue == ActionType.NoHdId.Value:
+                    return RequestResultFactory.ActionRequired<DependentModel>(ActionType.NoHdId, ErrorMessages.InvalidServicesCard);
+
                 case ResultType.ActionRequired:
                     return RequestResultFactory.ActionRequired<DependentModel>(ActionType.DataMismatch, ErrorMessages.DataMismatch);
 


### PR DESCRIPTION
# Fixes [AB#15490](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15490)

## Description

Fixes adding a dependent with no HDID being treated as a data mismatch.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![Screenshot 2023-05-02 125519](https://user-images.githubusercontent.com/16570293/235773987-f446a72b-29dc-4758-964f-5620ee59fde2.png)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
