### PR TITLE
Add patient to cache after calling phsa patient-identity for AB#15500

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -197,7 +197,9 @@ namespace HealthGateway.AccountDataAccess.Patient
             try
             {
                 PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(hdid).ConfigureAwait(true);
-                return this.mapper.Map<PatientModel>(result);
+                PatientModel patient = this.mapper.Map<PatientModel>(result);
+                this.CachePatient(patient);
+                return patient;
             }
             catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
             {


### PR DESCRIPTION
# Fixes [AB#15500](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15500)

## Description

- Add patient to cache after calling phsa patient-identity

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
