### PR TITLE
Add delegation service to patient requests AB#15466

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/Auth.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Auth.cs
@@ -124,7 +124,11 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                         {
                             policy.AuthenticationSchemes.Add(JwtBearerDefaults.AuthenticationScheme);
                             policy.RequireAuthenticatedUser();
-                            policy.Requirements.Add(new PersonalFhirRequirement(FhirResource.Patient, FhirAccessType.Read));
+                            policy.Requirements.Add(
+                                new PersonalFhirRequirement(
+                                    FhirResource.Patient,
+                                    FhirAccessType.Read,
+                                    supportsUserDelegation: true));
                         });
                     options.AddPolicy(
                         PatientPolicy.Write,

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -55,6 +55,7 @@ namespace HealthGateway.Patient
             Audit.ConfigureAuditServices(services, logger, configuration);
             Auth.ConfigureAuthServicesForJwtBearer(services, logger, configuration, environment);
             Auth.ConfigureAuthorizationServices(services, logger, configuration);
+            Auth.ConfigureDelegateAuthorizationServices(services, logger, configuration);
             SwaggerDoc.ConfigureSwaggerServices(services, configuration);
 
             Patient.ConfigurePatientAccess(services, logger, configuration);

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/dependent.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/dependent.js
@@ -138,6 +138,10 @@ describe("Dependent Timeline", () => {
                     enabled: true,
                 },
                 {
+                    name: "diagnosticImaging",
+                    enabled: true,
+                },
+                {
                     name: "healthVisit",
                     enabled: true,
                 },
@@ -297,6 +301,11 @@ describe("Dependent Timeline Datasets", () => {
     it("Validate (lack of) notes on dependent timeline", () => {
         disabledDatasetShouldNotBePresent(Dataset.Note);
         disabledDependentDatasetShouldNotBePresent(Dataset.Note);
+    });
+    it("Validate Diagnostic Imaging requests on dependent timeline", () => {
+        enabledDatasetShouldBePresent(Dataset.DiagnosticImaging);
+        disabledDatasetShouldNotBePresent(Dataset.DiagnosticImaging);
+        disabledDependentDatasetShouldNotBePresent(Dataset.DiagnosticImaging);
     });
     it("Validate Special Authority requests on dependent timeline", () => {
         enabledDatasetShouldBePresent(Dataset.SpecialAuthorityRequest);

--- a/Testing/functional/tests/cypress/support/constants.js
+++ b/Testing/functional/tests/cypress/support/constants.js
@@ -23,6 +23,7 @@ export const monthNames = [
 export const Dataset = {
     ClinicalDocument: "clinicalDocument",
     Covid19TestResult: "covid19TestResult",
+    DiagnosticImaging: "diagnosticImaging",
     HealthVisit: "healthVisit",
     HospitalVisit: "hospitalVisit",
     Immunization: "immunization",
@@ -30,5 +31,4 @@ export const Dataset = {
     Medication: "medication",
     Note: "note",
     SpecialAuthorityRequest: "specialAuthorityRequest",
-    DiagnosticImaging: "diagnosticImaging",
 };

--- a/Testing/functional/tests/cypress/support/constants.js
+++ b/Testing/functional/tests/cypress/support/constants.js
@@ -30,4 +30,5 @@ export const Dataset = {
     Medication: "medication",
     Note: "note",
     SpecialAuthorityRequest: "specialAuthorityRequest",
+    DiagnosticImaging: "diagnosticImaging",
 };


### PR DESCRIPTION
# Fixes or Implements [AB#15466](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15466)

## Description

1. Add delegation to read policy for patient.
2. Add delegation services to patient project.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required - would require integration tests for full token swap process

## Notes
### Results for Jennifer.
![image](https://user-images.githubusercontent.com/19548348/236913905-52166640-e38d-42bd-9705-bce59d8fab79.png)

There are some of the delegates that are not registered in the token swap JWT, and they will result in a 401 problem details exception in the network tab.

### Functional test results:
![image](https://user-images.githubusercontent.com/19548348/236917772-d9cb7113-b7e2-4e4f-83aa-432430dd9d39.png)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
