### PR TITLE
Resolve vue-router integration with composition API AB#15580

### DIFF
--- a/Apps/WebClient/src/ClientApp/package-lock.json
+++ b/Apps/WebClient/src/ClientApp/package-lock.json
@@ -40,6 +40,7 @@
                 "vue-class-component": "^7.2.6",
                 "vue-clickaway": "^2.2.2",
                 "vue-clipboard2": "^0.3.3",
+                "vue-composition-wrapper": "^2.1.4",
                 "vue-content-placeholders": "^0.2.1",
                 "vue-countdown": "^1.0.4",
                 "vue-loading-overlay": "^3.4.3",
@@ -12319,6 +12320,17 @@
                 "clipboard": "^2.0.0"
             }
         },
+        "node_modules/vue-composition-wrapper": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/vue-composition-wrapper/-/vue-composition-wrapper-2.1.4.tgz",
+            "integrity": "sha512-Um0/F18xQmgkOk8j4AKiA1+1BN7Y8HuYO88Ipshl6pkxEsSieD5IEKyHvc2RH4WHNwGbulQtk79b95Wt8/k0lA==",
+            "engines": {
+                "node": ">=12.x"
+            },
+            "peerDependencies": {
+                "vue": "^2.7.3"
+            }
+        },
         "node_modules/vue-content-placeholders": {
             "version": "0.2.1",
             "license": "MIT"
@@ -21211,6 +21223,12 @@
             "requires": {
                 "clipboard": "^2.0.0"
             }
+        },
+        "vue-composition-wrapper": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/vue-composition-wrapper/-/vue-composition-wrapper-2.1.4.tgz",
+            "integrity": "sha512-Um0/F18xQmgkOk8j4AKiA1+1BN7Y8HuYO88Ipshl6pkxEsSieD5IEKyHvc2RH4WHNwGbulQtk79b95Wt8/k0lA==",
+            "requires": {}
         },
         "vue-content-placeholders": {
             "version": "0.2.1"

--- a/Apps/WebClient/src/ClientApp/package.json
+++ b/Apps/WebClient/src/ClientApp/package.json
@@ -76,6 +76,7 @@
         "vue-class-component": "^7.2.6",
         "vue-clickaway": "^2.2.2",
         "vue-clipboard2": "^0.3.3",
+        "vue-composition-wrapper": "^2.1.4",
         "vue-content-placeholders": "^0.2.1",
         "vue-countdown": "^1.0.4",
         "vue-loading-overlay": "^3.4.3",


### PR DESCRIPTION
# Implements [AB#15580](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15580)

## Description

Introduces the vue-composition-wrapper package as a stop-gap measure to allow easy access to the route, router, and store using the style of Vue 3 with the composition API in Vue 2.7.

The following wiki pages have been updated to showcase usage:

- [Vue Composition API: Routing](https://github.com/bcgov/healthgateway/wiki/Vue-Composition-API:-Routing)
- [Vue Composition API: Vuex Actions and Getters](https://github.com/bcgov/healthgateway/wiki/Vue-Composition-API:-Vuex-Actions-and-Getters)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
