### PR TITLE
Fix migration down when moving data from AgentAudit back to DependentAudit

### DIFF
--- a/Apps/Database/src/Migrations/20230508204917_CreateBlockedAccessTable.cs
+++ b/Apps/Database/src/Migrations/20230508204917_CreateBlockedAccessTable.cs
@@ -194,7 +194,7 @@ namespace HealthGateway.Database.Migrations
             string agentAuditTempTableSql = @$"
                 SELECT ""AgentAuditId"", ""Hdid"", ""AgentUsername"", ""Reason"", TRIM(TRAILING 'D' FROM TRIM(TRAILING 'ependent' FROM ""OperationCode"")),
                        ""TransactionDateTime"", ""CreatedBy"", ""CreatedDateTime"", ""UpdatedBy"", ""UpdatedDateTime""
-                INTO TEMPORARY {agentAuditTempTable} FROM gateway.""AgentAudit"";
+                INTO TEMPORARY {agentAuditTempTable} FROM gateway.""AgentAudit"" WHERE ""OperationCode"" IN ('ProtectDependent', 'UnprotectDependent');
                 ";
             migrationBuilder.Sql(agentAuditTempTableSql);
 


### PR DESCRIPTION
# Fixes [AB#15599](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15599)

## Description

When backing out of 20230508204917_CreateBlockedAccessTable migration via Down, make sure only ProtectDependent and UnprotectDependent data from AgentAudit is returned back to DependentAudit because DependentOperationCode only supports Protected and Unprotect.

**Migration Down:**

<img width="1832" alt="Screenshot 2023-05-16 at 1 40 03 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/ac563751-ade3-4c58-bc7d-424e122a977e">

**Dependent Audit:**

<img width="2467" alt="Screenshot 2023-05-16 at 1 49 53 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/4587e498-c4bf-498c-a9ff-00fbfdeeea92">

**Agent Audit:**

<img width="1858" alt="Screenshot 2023-05-16 at 1 50 02 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/8c32382c-d626-4479-b24a-48ceeae6121b">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
