### PR TITLE
Add Refit and FluxorStore for BlockAccess AB#15410

### DIFF
--- a/Apps/Admin/Client/Api/ISupportApi.cs
+++ b/Apps/Admin/Client/Api/ISupportApi.cs
@@ -19,7 +19,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using HealthGateway.Admin.Common.Models;
 using HealthGateway.Common.Data.Constants;
-using HealthGateway.Common.Data.ViewModels;
 using Refit;
 
 /// <summary>
@@ -41,6 +40,16 @@ public interface ISupportApi
     /// </summary>
     /// <param name="hdid">The hdid associated with the messaging verification.</param>
     /// <returns>The list of MessagingVerificationModel objects.</returns>
-    [Get("/Verifications?hdid={hdid}")]
-    Task<RequestResult<IEnumerable<MessagingVerificationModel>>> GetMessagingVerificationsAsync(string hdid);
+    [Get("/PatientSupportDetails?hdid={hdid}")]
+    Task<PatientSupportDetails> GetPatientSupportDetailsAsync(string hdid);
+
+
+    /// <summary>
+    /// Creates, updates, or deletes block access configuration for the passed HDID.
+    /// </summary>
+    /// <param name="hdid">HDID of the patient to restrict access.</param>
+    /// <param name="request">The request containing all datasource names to block for a patient.</param>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [Put("/{hdid}/BlockAccess")]
+    Task BlockAccessAsync(string hdid, BlockAccessRequest request);
 }

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -1,7 +1,7 @@
 @page "/patient-details"
 @layout MainLayout
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer}")]
-@using HealthGateway.Admin.Client.Store.MessageVerification
+@using HealthGateway.Admin.Client.Store.PatientDetails
 @using HealthGateway.Admin.Client.Store.PatientSupport
 @using HealthGateway.Admin.Common.Constants
 @using HealthGateway.Admin.Client.Components.Support
@@ -16,9 +16,9 @@
 <HgBannerFeedback
     Severity="Severity.Error"
     IsEnabled="HasMessagingVerificationsError"
-    TResetAction="MessageVerificationActions.ResetStateAction"
+    TResetAction="PatientSupportDetailsActions.ResetStateAction"
     DataTestId="messaging-verification-banner-feedback-error-message">
-    @MessageVerificationState.Value.Error?.Message
+    @PatientSupportDetailsState.Value.Error?.Message
 </HgBannerFeedback>
 
 <HgBannerFeedback

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -20,7 +20,7 @@ namespace HealthGateway.Admin.Client.Pages
     using System.Linq;
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
-    using HealthGateway.Admin.Client.Store.MessageVerification;
+    using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Client.Store.PatientSupport;
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
@@ -41,7 +41,7 @@ namespace HealthGateway.Admin.Client.Pages
         private IDispatcher Dispatcher { get; set; } = default!;
 
         [Inject]
-        private IState<MessageVerificationState> MessageVerificationState { get; set; } = default!;
+        private IState<PatientSupportDetailsState> PatientSupportDetailsState { get; set; } = default!;
 
         [Inject]
         private IState<PatientSupportState> PatientSupportState { get; set; } = default!;
@@ -55,11 +55,11 @@ namespace HealthGateway.Admin.Client.Pages
         [Inject]
         private IConfiguration Configuration { get; set; } = default!;
 
-        private bool MessagingVerificationsLoading => this.MessageVerificationState.Value.IsLoading;
+        private bool MessagingVerificationsLoading => this.PatientSupportDetailsState.Value.IsLoading;
 
-        private bool HasMessagingVerificationsError => this.MessageVerificationState.Value.Error is { Message.Length: > 0 };
+        private bool HasMessagingVerificationsError => this.PatientSupportDetailsState.Value.Error is { Message.Length: > 0 };
 
-        private IEnumerable<MessagingVerificationModel> MessagingVerifications => this.MessageVerificationState.Value.Data ?? Enumerable.Empty<MessagingVerificationModel>();
+        private IEnumerable<MessagingVerificationModel> MessagingVerifications => this.PatientSupportDetailsState.Value.MessagingVerifications ?? Enumerable.Empty<MessagingVerificationModel>();
 
         private bool PatientsLoaded => this.PatientSupportState.Value.Loaded;
 
@@ -114,7 +114,7 @@ namespace HealthGateway.Admin.Client.Pages
             if (this.Patient == null)
             {
                 this.Dispatcher.Dispatch(new PatientSupportActions.ResetStateAction());
-                this.Dispatcher.Dispatch(new MessageVerificationActions.ResetStateAction());
+                this.Dispatcher.Dispatch(new PatientSupportDetailsActions.ResetStateAction());
                 this.Dispatcher.Dispatch(new PatientSupportActions.LoadAction(PatientQueryType.Hdid, this.Hdid));
             }
             else
@@ -137,10 +137,10 @@ namespace HealthGateway.Admin.Client.Pages
 
         private void RetrieveMessagingVerifications()
         {
-            this.Dispatcher.Dispatch(new MessageVerificationActions.ResetStateAction());
+            this.Dispatcher.Dispatch(new PatientSupportDetailsActions.ResetStateAction());
             if (this.Patient?.ProfileCreatedDateTime != null)
             {
-                this.Dispatcher.Dispatch(new MessageVerificationActions.LoadAction(this.Hdid));
+                this.Dispatcher.Dispatch(new PatientSupportDetailsActions.LoadAction(this.Hdid));
             }
         }
 

--- a/Apps/Admin/Client/Store/BlockAccess/BlockAccessActions.cs
+++ b/Apps/Admin/Client/Store/BlockAccess/BlockAccessActions.cs
@@ -1,0 +1,77 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.BlockAccess
+{
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.Data.Constants;
+
+    /// <summary>
+    /// Block Access Actions.
+    /// </summary>
+    [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Team decision")]
+    public static class BlockAccessActions
+    {
+        /// <summary>
+        /// The action representing the configuring of a patient's level of access.
+        /// </summary>
+        public class SetBlockAccessAction
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SetBlockAccessAction"/> class.
+            /// </summary>
+            /// <param name="reason">The agent's reason for the access change.</param>
+            /// <param name="dataSources">The list of Dataset names that will be affected, empty will grant full access.</param>
+            public SetBlockAccessAction(string reason, IEnumerable<DataSource> dataSources)
+            {
+                this.Reason = reason;
+                this.DataSources = dataSources;
+            }
+
+            /// <summary>
+            /// Gets the list of data sources to block.
+            /// </summary>
+            public IEnumerable<DataSource> DataSources { get; init; }
+
+            /// <summary>
+            /// Gets the reason to block data source(s).
+            /// </summary>
+            public string Reason { get; init; }
+        }
+
+        /// <summary>
+        /// The action representing a successful update of a patient's blocked access.
+        /// </summary>
+        public class SetBlockAccessSuccessAction
+        {
+        }
+
+        /// <summary>
+        /// The action representing a failed update of a patient's blocked access.
+        /// </summary>
+        public class SetBlockAccessFailureAction : BaseFailAction
+        {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SetBlockAccessFailureAction"/> class.
+            /// </summary>
+            /// <param name="error">The request error.</param>
+            public SetBlockAccessFailureAction(RequestError error)
+                : base(error)
+            {
+            }
+        }
+    }
+}

--- a/Apps/Admin/Client/Store/BlockAccess/BlockAccessEffects.cs
+++ b/Apps/Admin/Client/Store/BlockAccess/BlockAccessEffects.cs
@@ -1,0 +1,88 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.BlockAccess
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Fluxor;
+    using HealthGateway.Admin.Client.Api;
+    using HealthGateway.Admin.Client.Store.PatientDetails;
+    using HealthGateway.Admin.Client.Store.PatientSupport;
+    using HealthGateway.Admin.Client.Utils;
+    using HealthGateway.Admin.Common.Models;
+    using Microsoft.Extensions.Logging;
+    using Refit;
+
+#pragma warning disable CS1591, SA1600
+    public class BlockAccessEffects
+    {
+        public BlockAccessEffects(ISupportApi api, ILogger<BlockAccessEffects> logger, IState<PatientSupportState> patientSupportState)
+        {
+            this.Api = api;
+            this.Logger = logger;
+            this.PatientSupportState = patientSupportState;
+        }
+
+        private ISupportApi Api { get; }
+
+        private ILogger<BlockAccessEffects> Logger { get; }
+
+        private IState<PatientSupportState> PatientSupportState { get; }
+
+        [EffectMethod]
+        public async Task HandleSetBlockAccessAction(BlockAccessActions.SetBlockAccessAction action, IDispatcher dispatcher)
+        {
+            this.Logger.LogInformation("Setting block access");
+            try
+            {
+                string? patientHdid = this.PatientSupportState.Value.Result?[0].Hdid;
+                if (patientHdid == null)
+                {
+                    RequestError error = new() { Message = "No patient selected" };
+                    dispatcher.Dispatch(new BlockAccessActions.SetBlockAccessFailureAction(error));
+                    return;
+                }
+
+                BlockAccessRequest request = new(action.DataSources, action.Reason);
+                await this.Api.BlockAccessAsync(patientHdid, request).ConfigureAwait(true);
+                dispatcher.Dispatch(new BlockAccessActions.SetBlockAccessSuccessAction());
+            }
+            catch (Exception e) when (e is ApiException or HttpRequestException)
+            {
+                this.Logger.LogError("Error setting block access: {Exception}", e.ToString());
+                RequestError error = StoreUtility.FormatRequestError(e);
+                dispatcher.Dispatch(new BlockAccessActions.SetBlockAccessFailureAction(error));
+            }
+        }
+
+        [EffectMethod(typeof(BlockAccessActions.SetBlockAccessSuccessAction))]
+        public Task HandleSetBlockSuccessAction(IDispatcher dispatcher)
+        {
+            string? patientHdid = this.PatientSupportState.Value.Result?[0].Hdid;
+            if (patientHdid == null)
+            {
+                RequestError error = new() { Message = "No patient selected" };
+                dispatcher.Dispatch(new BlockAccessActions.SetBlockAccessFailureAction(error));
+                return Task.CompletedTask;
+            }
+
+            // Reload the patient's data for details page.
+            dispatcher.Dispatch(new PatientSupportDetailsActions.LoadAction(patientHdid));
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Apps/Admin/Client/Store/BlockAccess/BlockAccessReducers.cs
+++ b/Apps/Admin/Client/Store/BlockAccess/BlockAccessReducers.cs
@@ -1,0 +1,46 @@
+﻿namespace HealthGateway.Admin.Client.Store.BlockAccess
+{
+    using Fluxor;
+
+#pragma warning disable CS1591, SA1600
+    public static class BlockAccessReducers
+    {
+        [ReducerMethod(typeof(BlockAccessActions.SetBlockAccessAction))]
+        public static BlockAccessState ReduceSetBlockAccessAction(BlockAccessState state)
+        {
+            return state with
+            {
+                BlockAccess = state.BlockAccess with
+                {
+                    IsLoading = true,
+                },
+            };
+        }
+
+        [ReducerMethod(typeof(BlockAccessActions.SetBlockAccessSuccessAction))]
+        public static BlockAccessState ReduceBlockAccessSuccessAction(BlockAccessState state)
+        {
+            return state with
+            {
+                BlockAccess = state.BlockAccess with
+                {
+                    IsLoading = false,
+                    Error = null,
+                },
+            };
+        }
+
+        [ReducerMethod]
+        public static BlockAccessState ReduceBlockAccessFailureAction(BlockAccessState state, BlockAccessActions.SetBlockAccessFailureAction action)
+        {
+            return state with
+            {
+                BlockAccess = state.BlockAccess with
+                {
+                    IsLoading = false,
+                    Error = action.Error,
+                },
+            };
+        }
+    }
+}

--- a/Apps/Admin/Client/Store/BlockAccess/BlockAccessState.cs
+++ b/Apps/Admin/Client/Store/BlockAccess/BlockAccessState.cs
@@ -1,0 +1,32 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store.BlockAccess
+{
+    using Fluxor;
+
+    /// <summary>
+    /// The Block Access feature state.
+    /// State should be decorated with [FeatureState] for automatic discovery when services.AddFluxor is called.
+    /// </summary>
+    [FeatureState]
+    public record BlockAccessState
+    {
+        /// <summary>
+        /// Gets the request state for block access requests.
+        /// </summary>
+        public BaseRequestState BlockAccess { get; init; } = new();
+    }
+}

--- a/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsActions.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsActions.cs
@@ -13,17 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.Admin.Client.Store.MessageVerification
+namespace HealthGateway.Admin.Client.Store.PatientDetails
 {
-    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Admin.Common.Models;
 
     /// <summary>
     /// Static class that implements all actions for the feature.
     /// </summary>
     [SuppressMessage("Design", "CA1034:Nested types should not be visible", Justification = "Team decision")]
-    public static class MessageVerificationActions
+    public static class PatientSupportDetailsActions
     {
         /// <summary>
         /// The action representing the initiation of a load.
@@ -63,14 +62,14 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
         /// <summary>
         /// The action representing a successful load.
         /// </summary>
-        public class LoadSuccessAction : BaseSuccessAction<RequestResult<IEnumerable<MessagingVerificationModel>>>
+        public class LoadSuccessAction : BaseSuccessAction<PatientSupportDetails>
         {
             /// <summary>
             /// Initializes a new instance of the <see cref="LoadSuccessAction"/> class.
             /// </summary>
             /// <param name="data">Result data.</param>
             /// <param name="hdid">hdid associated with the data.</param>
-            public LoadSuccessAction(RequestResult<IEnumerable<MessagingVerificationModel>> data, string hdid)
+            public LoadSuccessAction(PatientSupportDetails data, string hdid)
                 : base(data)
             {
                 this.Hdid = hdid;

--- a/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsEffects.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsEffects.cs
@@ -14,62 +14,51 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 
-namespace HealthGateway.Admin.Client.Store.MessageVerification
+namespace HealthGateway.Admin.Client.Store.PatientDetails
 {
     using System;
-    using System.Collections.Generic;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Fluxor;
     using HealthGateway.Admin.Client.Api;
     using HealthGateway.Admin.Client.Utils;
-    using HealthGateway.Common.Data.Constants;
-    using HealthGateway.Common.Data.ViewModels;
+    using HealthGateway.Admin.Common.Models;
     using Microsoft.AspNetCore.Components;
     using Microsoft.Extensions.Logging;
     using Refit;
 
 #pragma warning disable CS1591, SA1600
-    public class MessageVerificationEffects
+    public class PatientSupportDetailsEffects
     {
-        public MessageVerificationEffects(ILogger<MessageVerificationEffects> logger, ISupportApi supportApi)
+        public PatientSupportDetailsEffects(ILogger<PatientSupportDetailsEffects> logger, ISupportApi supportApi)
         {
             this.Logger = logger;
             this.SupportApi = supportApi;
         }
 
         [Inject]
-        private ILogger<MessageVerificationEffects> Logger { get; set; }
+        private ILogger<PatientSupportDetailsEffects> Logger { get; set; }
 
         [Inject]
         private ISupportApi SupportApi { get; set; }
 
         [EffectMethod]
-        public async Task HandleLoadAction(MessageVerificationActions.LoadAction action, IDispatcher dispatcher)
+        public async Task HandleLoadAction(PatientSupportDetailsActions.LoadAction action, IDispatcher dispatcher)
         {
             this.Logger.LogInformation("Loading messaging verifications");
 
             try
             {
-                RequestResult<IEnumerable<MessagingVerificationModel>> response = await this.SupportApi.GetMessagingVerificationsAsync(action.Hdid).ConfigureAwait(true);
-                if (response.ResultStatus == ResultType.Success)
-                {
-                    this.Logger.LogInformation("Messaging verifications loaded successfully!");
-                    dispatcher.Dispatch(new MessageVerificationActions.LoadSuccessAction(response, action.Hdid));
-                }
-                else
-                {
-                    RequestError error = StoreUtility.FormatRequestError(response.ResultError);
-                    this.Logger.LogError("Error loading messaging verifications, reason: {ErrorMessage}", error.Message);
-                    dispatcher.Dispatch(new MessageVerificationActions.LoadFailAction(error));
-                }
+                PatientSupportDetails response = await this.SupportApi.GetPatientSupportDetailsAsync(action.Hdid).ConfigureAwait(true);
+                this.Logger.LogInformation("Messaging verifications loaded successfully!");
+                dispatcher.Dispatch(new PatientSupportDetailsActions.LoadSuccessAction(response, action.Hdid));
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
                 this.Logger.LogError("Error loading messaging verifications...{Error}", e);
                 RequestError error = StoreUtility.FormatRequestError(e);
                 this.Logger.LogError("Error loading messaging verifications, reason: {ErrorMessage}", error.Message);
-                dispatcher.Dispatch(new MessageVerificationActions.LoadFailAction(error));
+                dispatcher.Dispatch(new PatientSupportDetailsActions.LoadFailAction(error));
             }
         }
     }

--- a/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsReducers.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsReducers.cs
@@ -13,7 +13,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-namespace HealthGateway.Admin.Client.Store.MessageVerification
+namespace HealthGateway.Admin.Client.Store.PatientDetails
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
@@ -21,10 +21,10 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
     using HealthGateway.Common.Data.ViewModels;
 
 #pragma warning disable CS1591, SA1600
-    public static class MessageVerificationReducers
+    public static class PatientSupportDetailsReducers
     {
-        [ReducerMethod(typeof(MessageVerificationActions.LoadAction))]
-        public static MessageVerificationState ReduceLoadAction(MessageVerificationState state)
+        [ReducerMethod(typeof(PatientSupportDetailsActions.LoadAction))]
+        public static PatientSupportDetailsState ReduceLoadAction(PatientSupportDetailsState state)
         {
             return state with
             {
@@ -33,14 +33,14 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
         }
 
         [ReducerMethod]
-        public static MessageVerificationState ReduceLoadSuccessAction(MessageVerificationState state, MessageVerificationActions.LoadSuccessAction action)
+        public static PatientSupportDetailsState ReduceLoadSuccessAction(PatientSupportDetailsState state, PatientSupportDetailsActions.LoadSuccessAction action)
         {
-            ImmutableList<MessagingVerificationModel> data = state.Data ?? new List<MessagingVerificationModel>().ToImmutableList();
+            ImmutableList<MessagingVerificationModel> messageVerifications = state.MessagingVerifications ?? new List<MessagingVerificationModel>().ToImmutableList();
 
-            IEnumerable<MessagingVerificationModel>? verifications = action.Data.ResourcePayload;
+            IEnumerable<MessagingVerificationModel>? verifications = action.Data?.MessagingVerifications;
             if (verifications != null)
             {
-                data = data.RemoveAll(x => x.UserProfileId == action.Hdid).AddRange(verifications);
+                messageVerifications = messageVerifications.RemoveAll(x => x.UserProfileId == action.Hdid).AddRange(verifications);
             }
 
             return state with
@@ -48,12 +48,14 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
                 IsLoading = false,
                 Result = action.Data,
                 Error = null,
-                Data = data,
+                MessagingVerifications = messageVerifications,
+                BlockedDataSources = action.Data?.BlockedDataSources,
+                AgentActions = action.Data?.AgentActions,
             };
         }
 
         [ReducerMethod]
-        public static MessageVerificationState ReduceLoadFailAction(MessageVerificationState state, MessageVerificationActions.LoadFailAction action)
+        public static PatientSupportDetailsState ReduceLoadFailAction(PatientSupportDetailsState state, PatientSupportDetailsActions.LoadFailAction action)
         {
             return state with
             {
@@ -62,15 +64,17 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
             };
         }
 
-        [ReducerMethod(typeof(MessageVerificationActions.ResetStateAction))]
-        public static MessageVerificationState ReduceResetStateAction(MessageVerificationState state)
+        [ReducerMethod(typeof(PatientSupportDetailsActions.ResetStateAction))]
+        public static PatientSupportDetailsState ReduceResetStateAction(PatientSupportDetailsState state)
         {
             return state with
             {
                 IsLoading = false,
                 Result = null,
                 Error = null,
-                Data = null,
+                MessagingVerifications = null,
+                BlockedDataSources = null,
+                AgentActions = null,
             };
         }
     }

--- a/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsState.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientSupportDetailsState.cs
@@ -14,11 +14,13 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 
-namespace HealthGateway.Admin.Client.Store.MessageVerification
+namespace HealthGateway.Admin.Client.Store.PatientDetails
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using Fluxor;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
 
     /// <summary>
@@ -26,11 +28,21 @@ namespace HealthGateway.Admin.Client.Store.MessageVerification
     /// State should be decorated with [FeatureState] for automatic discovery when services.AddFluxor is called.
     /// </summary>
     [FeatureState]
-    public record MessageVerificationState : BaseRequestState<RequestResult<IEnumerable<MessagingVerificationModel>>>
+    public record PatientSupportDetailsState : BaseRequestState<PatientSupportDetails>
     {
         /// <summary>
-        /// Gets the collection of data.
+        /// Gets the message verifications linked to the patient support details.
         /// </summary>
-        public ImmutableList<MessagingVerificationModel>? Data { get; init; }
+        public ImmutableList<MessagingVerificationModel>? MessagingVerifications { get; init; }
+
+        /// <summary>
+        /// Gets the agent actions linked ot the patient support details.
+        /// </summary>
+        public IEnumerable<AgentAction>? AgentActions { get; init; }
+
+        /// <summary>
+        /// Gets the blocked data sources linked to the patient support details.
+        /// </summary>
+        public IEnumerable<DataSource>? BlockedDataSources { get; init; }
     }
 }

--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -87,10 +87,10 @@ namespace HealthGateway.Admin.Server.Controllers
         /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
         /// </response>
         [HttpGet]
-        [Route("Verifications")]
-        public async Task<PatientSupportDetails> GetMessageVerifications([FromQuery] string hdid, CancellationToken ct)
+        [Route("PatientSupportDetails")]
+        public async Task<PatientSupportDetails> GetPatientSupportDetails([FromQuery] string hdid, CancellationToken ct)
         {
-            return await this.supportService.GetMessageVerificationsAsync(hdid, ct).ConfigureAwait(true);
+            return await this.supportService.GetPatientSupportDetailsAsync(hdid, ct).ConfigureAwait(true);
         }
 
         /// <summary>

--- a/Apps/Admin/Server/Services/ISupportService.cs
+++ b/Apps/Admin/Server/Services/ISupportService.cs
@@ -33,7 +33,7 @@ namespace HealthGateway.Admin.Server.Services
         /// <param name="hdid">The HDID associated with the patient support details.</param>
         /// <param name="ct">A cancellation token.</param>
         /// <returns>A patient support details matching the query.</returns>
-        Task<PatientSupportDetails> GetMessageVerificationsAsync(string hdid, CancellationToken ct = default);
+        Task<PatientSupportDetails> GetPatientSupportDetailsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves the collection of patients that match the query.

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -77,7 +77,7 @@ namespace HealthGateway.Admin.Server.Services
         }
 
         /// <inheritdoc/>
-        public async Task<PatientSupportDetails> GetMessageVerificationsAsync(string hdid, CancellationToken ct = default)
+        public async Task<PatientSupportDetails> GetPatientSupportDetailsAsync(string hdid, CancellationToken ct = default)
         {
             IList<MessagingVerification> messagingVerifications = await this.messagingVerificationDelegate.GetUserMessageVerificationsAsync(hdid).ConfigureAwait(true);
             AgentAuditQuery agentAuditQuery = new(hdid);

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -78,7 +78,7 @@ namespace HealthGateway.Admin.Tests.Services
             ISupportService supportService = CreateSupportService(GetMessagingVerificationDelegateMock(messagingVerifications));
 
             // Act
-            PatientSupportDetails actualResult = await supportService.GetMessageVerificationsAsync(Hdid).ConfigureAwait(true);
+            PatientSupportDetails actualResult = await supportService.GetPatientSupportDetailsAsync(Hdid).ConfigureAwait(true);
 
             // Assert
             Assert.Equal(2, actualResult.MessagingVerifications.Count());

--- a/Apps/Database/src/Delegates/DbAgentAuditDelegate.cs
+++ b/Apps/Database/src/Delegates/DbAgentAuditDelegate.cs
@@ -47,11 +47,12 @@ namespace HealthGateway.Database.Delegates
         {
             this.logger.LogTrace("Getting agent audit for group: {Group} - hdid : {Hdid}", group, hdid);
 
-            IQueryable<AgentAudit> dbQuery = this.dbContext.AgentAudit;
+            IQueryable<AgentAudit> dbQuery = this.dbContext.AgentAudit
+                .Where(aa => aa.Hdid == hdid);
 
             if (group != null)
             {
-                dbQuery = dbQuery.Where(d => d.Hdid == hdid && d.GroupCode == group);
+                dbQuery = dbQuery.Where(d => d.GroupCode == group);
             }
 
             return await dbQuery.ToListAsync(ct).ConfigureAwait(true);


### PR DESCRIPTION
# Fixes or Implements AB#15410

## Description

1. Add new Refit endpoint on ISupportAPI for BlockAccess
2. Add FluxorStore for new BlockAccess actions.
3. Update Verifications Fluxor store to properly represent the new PatientSupportDetails context.
4. Correct AgentAudit query to always filter by the appropriate Hdid not only if group is also set.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## Notes
All Unit tests still passing and view has been tested for new Verification message changes.
![image](https://github.com/bcgov/healthgateway/assets/19548348/7c4b972e-7414-4b89-a337-92da13ed306e)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
