### PR TITLE
Fixed unused variable warning for AccountDataAccess unit tests for AB#15642

### DIFF
--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -98,8 +98,6 @@ namespace AccountDataAccessTest.Strategy
             Mock<IPatientIdentityApi> patientIdentityApi = new();
             patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(Hdid))!.ReturnsAsync(patientIdentity);
 
-            Mock<ILogger<HdidPhsaStrategy>> logger = new();
-
             HdidPhsaStrategy hdidPhsaStrategy = new(
                 GetConfiguration(),
                 cacheProvider.Object,

--- a/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
@@ -101,8 +101,6 @@ namespace AccountDataAccessTest.Strategy
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
             clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Phn, Phn, false)).ReturnsAsync(patient);
 
-            Mock<ILogger<PhnEmpiStrategy>> logger = new();
-
             PhnEmpiStrategy phnEmpiStrategy = new(
                 GetConfiguration(),
                 cacheProvider.Object,


### PR DESCRIPTION
# Fixes [AB#15642](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15642)

## Description

Fixed unused variable warning for AccountDataAccess unit tests.

<img width="1272" alt="Screenshot 2023-05-24 at 1 35 09 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/2041f15a-dfb8-46a0-8350-9103c976c447">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
