### PR TITLE
Add "Clear" Button to Support Lookup

### DIFF
--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -75,6 +75,16 @@
                     data-testid="search-btn">
                     Search
                 </HgButton>
+                <HgButton
+                    EndIcon="fas fa-delete-left"
+                    Variant="Variant.Outlined"
+                    Color="Color.Primary"
+                    TopMargin="Breakpoint.Always"
+                    LeftMargin="Breakpoint.Always"
+                    OnClick="Clear"
+                    data-testid="clear-btn">
+                    Clear
+                </HgButton>
             </div>
         </MudItem>
     </MudGrid>

--- a/Apps/Admin/Client/Pages/SupportPage.razor.cs
+++ b/Apps/Admin/Client/Pages/SupportPage.razor.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.Admin.Client.Pages
 
             set
             {
-                this.ResetPatientSupportState();
+                this.Dispatcher.Dispatch(new PatientSupportActions.ResetStateAction());
                 this.QueryParameter = string.Empty;
                 this.QueryType = value;
             }
@@ -130,6 +130,12 @@ namespace HealthGateway.Admin.Client.Pages
                 PatientQueryType.Sms => "SMS",
                 _ => queryType.ToString(),
             };
+        }
+
+        private void Clear()
+        {
+            this.Dispatcher.Dispatch(new PatientSupportActions.ResetStateAction());
+            this.QueryParameter = string.Empty;
         }
 
         private void ResetPatientSupportState()

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
@@ -141,4 +141,13 @@ describe("Support", () => {
         verifyParameterIsRequired("Email");
         verifyParameterIsRequired("Dependent");
     });
+
+    it("Verify clear button", () => {
+        performSearch("HDID", hdid);
+        verifySupportTableResults(hdid, phn);
+        cy.get("[data-testid=clear-btn]").click();
+        cy.get("[data-testid=query-type-select]").should("have.value", "Hdid");
+        cy.get("[data-testid=query-input]").should("be.empty");
+        cy.get("[data-testid=user-table]").should("not.exist");
+    });
 });


### PR DESCRIPTION
# Implements [AB#15571](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15571)

## Add "Clear" Button to Support Lookup - update component and functional test
- added new Clear button to support page
- updated functional test to verify
- fixed bug where selecting Query Type after returning from Details page was not clearing results

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

![Screenshot 2023-05-25 at 9 33 26 AM](https://github.com/bcgov/healthgateway/assets/5408101/717c50a3-39f3-4372-9644-296a437f9f43)

## UI Changes

![Screenshot 2023-05-25 at 9 34 23 AM](https://github.com/bcgov/healthgateway/assets/5408101/a0c97d0e-9d65-44b6-a4e6-b3bbfc40ec0f)

![Screenshot 2023-05-25 at 9 35 30 AM](https://github.com/bcgov/healthgateway/assets/5408101/3b76ddcc-0683-4c92-8097-e1dbb6e2fb5f)

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
