### PR TITLE
Update delegation dialog test ids AB#15644

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/delegation.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/delegation.cy.js
@@ -183,25 +183,25 @@ describe("Delegation Protect", () => {
         cy.get("[data-testid=save-button]").click();
 
         // Confirmation dialog confirmation button
-        cy.get("[data-testid=confirm-button]").should(
+        cy.get("[data-testid=audit-confirm-button]").should(
             "be.visible",
             "not.be.enabled"
         );
 
         // Enter protect reason
-        cy.get("[data-testid=protect-reason-input]").type("test");
+        cy.get("[data-testid=audit-reason-input]").type("test");
 
         // Cancel confirmation dialog
-        cy.get("[data-testid=cancel-button]").click();
+        cy.get("[data-testid=audit-cancel-button]").click();
 
         // Delegation Save button
         cy.get("[data-testid=save-button]").click();
 
         // Protect reason input is empty
-        cy.get("[data-testid=protect-reason-input]").should("be.empty");
+        cy.get("[data-testid=audit-reason-input]").should("be.empty");
 
         // Cancel confirmation dialog
-        cy.get("[data-testid=cancel-button]").click();
+        cy.get("[data-testid=audit-cancel-button]").click();
 
         // Protect dependent toggle
         cy.get("[data-testid=dependent-protected-switch]").should("be.checked");
@@ -281,8 +281,8 @@ describe("Delegation Protect", () => {
         cy.get("[data-testid=save-button]").click();
 
         // Delegation Confirmation button
-        cy.get("[data-testid=protect-reason-input]").type("test");
-        cy.get("[data-testid=confirm-button]").click({ force: true });
+        cy.get("[data-testid=audit-reason-input]").type("test");
+        cy.get("[data-testid=audit-confirm-button]").click({ force: true });
 
         // Add guardian
         cy.get("[data-testid=add-button]").click();
@@ -303,8 +303,8 @@ describe("Delegation Protect", () => {
         cy.get("[data-testid=save-button]").click();
 
         // Delegation Confirmation button
-        cy.get("[data-testid=protect-reason-input]").type("test");
-        cy.get("[data-testid=confirm-button]").click({ force: true });
+        cy.get("[data-testid=audit-reason-input]").type("test");
+        cy.get("[data-testid=audit-confirm-button]").click({ force: true });
 
         // Confirm guardian has been added to delegate table
         getTableRows("[data-testid=delegate-table]").should("have.length", 3);
@@ -328,8 +328,8 @@ describe("Delegation Protect", () => {
         cy.get("[data-testid=save-button]").click();
 
         // Delegation Confirmation button
-        cy.get("[data-testid=protect-reason-input]").type("test");
-        cy.get("[data-testid=confirm-button]").click({ force: true });
+        cy.get("[data-testid=audit-reason-input]").type("test");
+        cy.get("[data-testid=audit-confirm-button]").click({ force: true });
 
         // Confirm delegate table
         getTableRows("[data-testid=delegate-table]").should("have.length", 2);
@@ -338,8 +338,8 @@ describe("Delegation Protect", () => {
         cy.get("[data-testid=dependent-protected-switch]").click();
 
         // Confirmation button
-        cy.get("[data-testid=protect-reason-input]").type("test");
-        cy.get("[data-testid=confirm-button]").click({ force: true });
+        cy.get("[data-testid=audit-reason-input]").type("test");
+        cy.get("[data-testid=audit-confirm-button]").click({ force: true });
 
         // Protect dependent toggle
         cy.get("[data-testid=dependent-protected-switch]").should(


### PR DESCRIPTION
# Fixes or Implements [AB#15644](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15644)

## Description
Fix Delegation tests by updating confirmation dialog test ids to the new generalised AuditReasonDialog component values.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

## Notes
![image](https://github.com/bcgov/healthgateway/assets/19548348/1d867cc0-eb24-45d0-ae47-3f112fe13d38)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
