### PR TITLE
Fix Rider Warnings for Patient Repository and Serialization Helper Tests for AB#15656

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.AccountDataAccess.Patient
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -26,7 +25,6 @@ namespace HealthGateway.AccountDataAccess.Patient
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -46,12 +44,10 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// Initializes a new instance of the <see cref="PatientRepository"/> class.
         /// </summary>
         /// <param name="logger">The service Logger.</param>
-        /// <param name="configuration">The Configuration to use.</param>
         /// <param name="blockedAccessDelegate">The injected blocked access delegate.</param>
         /// <param name="authenticationDelegate">The injected authentication delegate.</param>
         /// <param name="patientQueryFactory">The injected patient query factory.</param>
         public PatientRepository(
-            IConfiguration configuration,
             ILogger<PatientRepository> logger,
             IBlockedAccessDelegate blockedAccessDelegate,
             IAuthenticationDelegate authenticationDelegate,
@@ -62,8 +58,6 @@ namespace HealthGateway.AccountDataAccess.Patient
             this.authenticationDelegate = authenticationDelegate;
             this.patientQueryFactory = patientQueryFactory;
         }
-
-        private static ActivitySource Source { get; } = new(nameof(PatientRepository));
 
         /// <inheritdoc/>
         public async Task<PatientQueryResult> Query(PatientQuery query, CancellationToken ct = default)
@@ -93,7 +87,7 @@ namespace HealthGateway.AccountDataAccess.Patient
                 UpdatedBy = authenticatedUserId,
             };
 
-            BlockedAccess? blockedAccess = await this.blockedAccessDelegate.GetBlockedAccessAsync(command.Hdid).ConfigureAwait(true) ?? new()
+            BlockedAccess blockedAccess = await this.blockedAccessDelegate.GetBlockedAccessAsync(command.Hdid).ConfigureAwait(true) ?? new()
             {
                 Hdid = command.Hdid,
                 CreatedBy = authenticatedUserId,

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -370,7 +370,6 @@ namespace AccountDataAccessTest
             blockedAccessDelegate.Setup(p => p.GetDataSourcesAsync(It.IsAny<string>())).ReturnsAsync(dataSources ?? Enumerable.Empty<DataSource>());
 
             PatientRepository patientRepository = new(
-                GetConfiguration(),
                 new Mock<ILogger<PatientRepository>>().Object,
                 blockedAccessDelegate.Object,
                 new Mock<IAuthenticationDelegate>().Object,
@@ -387,7 +386,6 @@ namespace AccountDataAccessTest
             PatientModel? cachedPatient = null)
         {
             PatientRepository patientRepository = new(
-                GetConfiguration(),
                 new Mock<ILogger<PatientRepository>>().Object,
                 new Mock<IBlockedAccessDelegate>().Object,
                 new Mock<IAuthenticationDelegate>().Object,

--- a/Apps/Common/test/unit/Utils/SerializationHelperTests.cs
+++ b/Apps/Common/test/unit/Utils/SerializationHelperTests.cs
@@ -89,7 +89,7 @@ namespace HealthGateway.CommonTests.Utils
         [Fact]
         public void ShouldSerializeWhetherConcreteOrGeneric()
         {
-            string? anyObj = "SomeValue";
+            string anyObj = "SomeValue";
 
             // serialize and deserialize using concrete
             byte[] serialized = anyObj.Serialize();


### PR DESCRIPTION
# Fixes [AB#15656](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15656)

## Description

**Patient Repository:**

- Removed unused configuration
- Removed unused source
- Removed nullable from 'blockedAccess' variable definition
- Updated unit test

**Serialization Helper Tests:**

- Removed nullable from 'anyObj' variable definition

**Patient Repository Tests:**

<img width="783" alt="Screenshot 2023-05-30 at 12 20 31 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/4321f23f-883e-41e6-acb8-16b9ac625837">

**Serialization Helper Tests:**

<img width="841" alt="Screenshot 2023-05-30 at 12 20 57 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/86d9d41f-5c7c-492e-8865-927207ab0ba9">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

no

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
