### PR TITLE
Set communications page date and times to PST

### DIFF
--- a/Apps/Admin/Client/Components/AgentAudit/AgentAuditHistory.razor.cs
+++ b/Apps/Admin/Client/Components/AgentAudit/AgentAuditHistory.razor.cs
@@ -52,7 +52,7 @@ namespace HealthGateway.Admin.Client.Components.AgentAudit
         /// Gets or sets the application's configuration.
         /// </summary>
         [Inject]
-        public IConfiguration Configuration { get; set; } = default!;
+        private IConfiguration Configuration { get; set; } = default!;
 
         private int[] PageSizes { get; } = { 5, 10, 15 };
 

--- a/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor
@@ -1,5 +1,4 @@
-@using HealthGateway.Common.Data.Utils
-@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+@inherits HealthGateway.Admin.Client.Models.BaseTableFluxorComponent
 
 <MudTable Class="mt-3"
           Items="@Rows"
@@ -47,8 +46,8 @@
     </HeaderContent>
     <RowTemplate>
         <MudTd data-testid="broadcast-table-subject" DataLabel="Subject">@context.Subject</MudTd>
-        <MudTd data-testid="broadcast-table-effective-date" DataLabel="Effective On">@DateFormatter.ToShortDateAndTime(context.EffectiveDate)</MudTd>
-        <MudTd data-testid="broadcast-table-expiry-date" DataLabel="Expires On">@context.ExpiryDate</MudTd>
+        <MudTd data-testid="broadcast-table-effective-date" DataLabel="Effective On">@ConvertToShortFormatFromUtc(context.EffectiveDate)</MudTd>
+        <MudTd data-testid="broadcast-table-expiry-date" DataLabel="Expires On">@ConvertToShortFormatFromUtc(context.ExpiryDate)</MudTd>
         <MudTd data-testid="broadcast-table-action-type" DataLabel="Action Type">@context.ActionType</MudTd>
         <MudTd DataLabel="Actions" Style="text-align:right">
             <div>

--- a/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor
@@ -31,7 +31,7 @@
             </MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => x.ExpiryDate)">
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => ConvertToShortFormatFromUtc(x.ExpiryDate))">
                 Expires On
             </MudTableSortLabel>
         </MudTh>

--- a/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor.cs
@@ -24,14 +24,13 @@ namespace HealthGateway.Admin.Client.Components.Communications
     using HealthGateway.Admin.Client.Models;
     using HealthGateway.Admin.Client.Store.Broadcasts;
     using HealthGateway.Admin.Client.Utils;
-    using HealthGateway.Common.Data.Utils;
     using Microsoft.AspNetCore.Components;
     using MudBlazor;
 
     /// <summary>
     /// Backing logic for the BroadcastsTable component.
     /// </summary>
-    public partial class BroadcastsTable : FluxorComponent
+    public partial class BroadcastsTable : BaseTableFluxorComponent
     {
         /// <summary>
         /// Gets or sets the data with which to populate the table.
@@ -94,8 +93,8 @@ namespace HealthGateway.Admin.Client.Components.Communications
             {
                 this.Id = model.Id;
                 this.Subject = model.CategoryName;
-                this.EffectiveDate = model.ScheduledDateUtc.ToLocalTime();
-                this.ExpiryDate = model.ExpirationDateUtc == null ? "-" : DateFormatter.ToShortDateAndTime(model.ExpirationDateUtc.Value.ToLocalTime());
+                this.EffectiveDate = model.ScheduledDateUtc;
+                this.ExpiryDate = model.ExpirationDateUtc;
                 this.ActionType = BroadcastUtility.FormatActionType(model.ActionType);
                 this.Text = model.DisplayText;
                 this.IsExpanded = model.IsExpanded;
@@ -107,7 +106,7 @@ namespace HealthGateway.Admin.Client.Components.Communications
 
             public DateTime EffectiveDate { get; }
 
-            public string ExpiryDate { get; }
+            public DateTime? ExpiryDate { get; }
 
             public string ActionType { get; }
 

--- a/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor
+++ b/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor
@@ -1,5 +1,4 @@
-@using HealthGateway.Common.Data.Utils
-@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+@inherits HealthGateway.Admin.Client.Models.BaseTableFluxorComponent
 
 <MudTable Class="mt-3"
           Items="@Rows"
@@ -47,8 +46,8 @@
     <RowTemplate>
         <MudTd data-testid="comm-table-subject" DataLabel="Subject">@context.Subject</MudTd>
         <MudTd data-testid="comm-table-status" DataLabel="Status">@context.Status</MudTd>
-        <MudTd data-testid="comm-table-effective-date" DataLabel="Effective On">@DateFormatter.ToShortDateAndTime(context.EffectiveDate)</MudTd>
-        <MudTd data-testid="comm-table-expiry-date" DataLabel="Expires On">@context.ExpiryDate</MudTd>
+        <MudTd data-testid="comm-table-effective-date" DataLabel="Effective On">@ConvertToShortFormatFromUtc(context.EffectiveDate)</MudTd>
+        <MudTd data-testid="comm-table-expiry-date" DataLabel="Expires On">@ConvertToShortFormatFromUtc(context.ExpiryDate)</MudTd>
         <MudTd DataLabel="Actions" Style="text-align:right">
             <div>
                 <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">

--- a/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor.cs
@@ -20,17 +20,15 @@ namespace HealthGateway.Admin.Client.Components.Communications
     using System.Linq;
     using System.Threading.Tasks;
     using Fluxor;
-    using Fluxor.Blazor.Web.Components;
     using HealthGateway.Admin.Client.Models;
     using HealthGateway.Admin.Client.Store.Communications;
-    using HealthGateway.Common.Data.Utils;
     using Microsoft.AspNetCore.Components;
     using MudBlazor;
 
     /// <summary>
     /// Backing logic for the CommunicationsTable component.
     /// </summary>
-    public partial class CommunicationsTable : FluxorComponent
+    public partial class CommunicationsTable : BaseTableFluxorComponent
     {
         /// <summary>
         /// Gets or sets the data with which to populate the table.
@@ -94,8 +92,8 @@ namespace HealthGateway.Admin.Client.Components.Communications
                 this.Id = model.Id;
                 this.Subject = model.Subject;
                 this.Status = model.CommunicationStatusCode.ToString();
-                this.EffectiveDate = model.EffectiveDateTime.ToLocalTime();
-                this.ExpiryDate = DateFormatter.ToShortDateAndTime(model.ExpiryDateTime.ToLocalTime());
+                this.EffectiveDate = model.EffectiveDateTime;
+                this.ExpiryDate = model.ExpiryDateTime;
                 this.Text = (MarkupString)model.Text;
                 this.IsExpanded = model.IsExpanded;
             }
@@ -108,7 +106,7 @@ namespace HealthGateway.Admin.Client.Components.Communications
 
             public DateTime EffectiveDate { get; init; }
 
-            public string ExpiryDate { get; init; }
+            public DateTime? ExpiryDate { get; init; }
 
             public MarkupString Text { get; init; }
 

--- a/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor.cs
@@ -106,7 +106,7 @@ namespace HealthGateway.Admin.Client.Components.Communications
 
             public DateTime EffectiveDate { get; init; }
 
-            public DateTime? ExpiryDate { get; init; }
+            public DateTime ExpiryDate { get; init; }
 
             public MarkupString Text { get; init; }
 

--- a/Apps/Admin/Client/Models/BaseTableFluxorComponent.cs
+++ b/Apps/Admin/Client/Models/BaseTableFluxorComponent.cs
@@ -1,0 +1,56 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Models
+{
+    using System;
+    using Fluxor.Blazor.Web.Components;
+    using HealthGateway.Common.Data.Utils;
+    using Microsoft.AspNetCore.Components;
+    using Microsoft.Extensions.Configuration;
+
+    /// <summary>
+    /// A base record for table rows.
+    /// Provides common functionality for table rows. Such as DateTime conversions.
+    /// </summary>
+    public abstract class BaseTableFluxorComponent : FluxorComponent
+    {
+        [Inject]
+        private IConfiguration Configuration { get; set; } = default!;
+
+        /// <summary>
+        /// Converts UTC datetime values to the system configured timezone.
+        /// </summary>
+        /// <param name="utcDateTime">A UTC DateTime instance.</param>
+        /// <returns>A DateTime instance in the configured timezone.</returns>
+        protected DateTime ConvertFromUtc(DateTime utcDateTime)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(
+                utcDateTime,
+                DateFormatter.GetLocalTimeZone(this.Configuration));
+        }
+
+        /// <summary>
+        /// Converts UTC datetime values to the system configured timezone and formats to a short date and time.
+        /// </summary>
+        /// <param name="utcDateTime">A UTC DateTime instance.</param>
+        /// <param name="fallbackString">In the event utcDateTime is null, provide a fallback string to return.</param>
+        /// <returns>The short formatted date and time string.</returns>
+        protected string ConvertToShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-")
+        {
+            return utcDateTime == null ? fallbackString : DateFormatter.ToShortDateAndTime(this.ConvertFromUtc(utcDateTime.Value));
+        }
+    }
+}


### PR DESCRIPTION
# Fixes or Implements [AB#15558](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15558)

## Description

1. Add BaseTableFluxourComponent to centralise date time conversion methods for table components.
2. Consume conversion methods in the broadcast and communications table.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## Notes
UI remains unchanged and the time zone for the date conversions are centralised through the application's configuration.


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
