### PR TITLE
Restrict BlockAccess feature on patient details page to AdminUser AB#15662

### DIFF
--- a/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor
+++ b/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor
@@ -12,7 +12,7 @@
                 hidden="@(!IsLoading)"
                 Color="Color.Primary"
                 Indeterminate="true"
-                data-testid="block-access-loader"/>
+                data-testid="block-access-loader" />
             <MudCardContent Class="d-flex">
                 <MudText Class="mt-2" Typo="Typo.subtitle1">
                     Dataset/Service Block
@@ -30,12 +30,13 @@
                                 Color="Color.Success"
                                 Checked="@IsBlocked(dataSource)"
                                 CheckedChanged="@(e => ToggleDataSource(dataSource))"
+                                ReadOnly="@(!CanEdit)"
                                 data-testid="@("block-access-switch-" + dataSource)" />
                         </MudItem>
                     }
                 </MudGrid>
             </MudCardContent>
-            @if (IsDirty)
+            @if (IsDirty && CanEdit)
             {
                 <MudCardContent Class="d-flex justify-end align-center">
                     <MudButton

--- a/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor.cs
+++ b/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor.cs
@@ -54,6 +54,13 @@ namespace HealthGateway.Admin.Client.Components.Support
         public bool IsLoading { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets a value indicating whether the component is editable.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public bool CanEdit { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the patient's hdid.
         /// </summary>
         [Parameter]

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -90,7 +90,7 @@
             </MudItem>
         </MudGrid>
         <MessageVerificationTable Data="@MessagingVerifications" IsLoading="@PatientSupportDetailsLoading" />
-        <DatasetAccessSection Data="@BlockedDataSources" IsLoading="@PatientSupportDetailsLoading" Hdid="@Hdid" />
+        <DatasetAccessSection Data="@BlockedDataSources" IsLoading="@PatientSupportDetailsLoading" Hdid="@Hdid" CanEdit="@CanEditDatasetAccess" />
         <AgentAuditHistory Title="Agent Reason History" AgentActions="@AgentAuditHistory" IsLoading="@PatientSupportDetailsLoading" />
     }
     else

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -18,8 +18,10 @@ namespace HealthGateway.Admin.Client.Pages
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
+    using HealthGateway.Admin.Client.Authorization;
     using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Client.Store.PatientSupport;
     using HealthGateway.Admin.Common.Constants;
@@ -28,6 +30,7 @@ namespace HealthGateway.Admin.Client.Pages
     using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Data.ViewModels;
     using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Authorization;
     using Microsoft.AspNetCore.WebUtilities;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Primitives;
@@ -54,6 +57,9 @@ namespace HealthGateway.Admin.Client.Pages
 
         [Inject]
         private IConfiguration Configuration { get; set; } = default!;
+
+        [Inject]
+        private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
 
         private bool PatientSupportDetailsLoading => this.PatientDetailsState.Value.IsLoading;
 
@@ -84,6 +90,17 @@ namespace HealthGateway.Admin.Client.Pages
         private DateTime? ProfileCreatedDateTime { get; set; }
 
         private DateTime? ProfileLastLoginDateTime { get; set; }
+
+        private bool CanEditDatasetAccess { get; set; }
+
+        /// <inheritdoc/>
+        protected override async Task OnInitializedAsync()
+        {
+            await base.OnInitializedAsync();
+
+            AuthenticationState state = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
+            this.CanEditDatasetAccess = state.User.IsInRole(Roles.Admin);
+        }
 
         /// <inheritdoc/>
         protected override void OnInitialized()

--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -105,6 +105,7 @@ namespace HealthGateway.Admin.Server.Controllers
         [Route("{hdid}/BlockAccess")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [Authorize(Roles = "AdminUser")]
         public async Task BlockAccess(string hdid, BlockAccessRequest request)
         {
             await this.supportService.BlockAccessAsync(hdid, request.DataSources, request.Reason).ConfigureAwait(true);

--- a/Apps/Admin/Tests/Functional/cypress.config.js
+++ b/Apps/Admin/Tests/Functional/cypress.config.js
@@ -19,6 +19,8 @@ module.exports = defineConfig({
             idir_password: "",
             keycloak_username: "blazoradmin",
             keycloak_password: "",
+            keycloak_reviewer_username: "blazorreviewer",
+            keycloak_reviewer_password: "",
             keycloak_unauthorized_username: "healthgateway",
         },
         trashAssetsBeforeRuns: true,

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details.cy.js
@@ -16,7 +16,7 @@ function checkAgentAuditHistory() {
     return cy.get("[data-testid=agent-audit-history-count]").invoke("text");
 }
 
-describe("Patient details message verification", () => {
+describe("Patient details page as admin", () => {
     beforeEach(() => {
         cy.login(
             Cypress.env("keycloak_username"),
@@ -59,6 +59,10 @@ describe("Patient details message verification", () => {
             .click();
 
         cy.get("[data-testid=block-access-switches]").should("be.visible");
+        cy.get(`[data-testid*="block-access-switch"]`).should(
+            "not.have.attr",
+            "readonly"
+        );
         cy.get("[data-testid=block-access-cancel]").should("not.exist");
         cy.get("[data-testid=block-access-save]").should("not.exist");
     });
@@ -186,5 +190,37 @@ describe("Patient details message verification", () => {
                 );
             });
         });
+    });
+});
+
+describe("Patient details page as reviewer", () => {
+    beforeEach(() => {
+        cy.login(
+            Cypress.env("keycloak_reviewer_username"),
+            Cypress.env("keycloak_reviewer_password"),
+            "/support"
+        );
+    });
+
+    // verify that the reviewer cannot use the block access controls
+    it("Verify block access readonly", () => {
+        performSearch("HDID", hdid);
+        cy.get("[data-testid=user-table]")
+            .find("tbody tr.mud-table-row")
+            .first()
+            .click();
+
+        cy.get(`[data-testid*="block-access-switch-"]`).each(($el) => {
+            // follow the mud tag structure to find the mud-readonly class
+            cy.wrap($el).parent().parent().should("have.class", "mud-readonly");
+        });
+
+        // Clicke any switch and check if the dirty state has exposed the save and cancel buttons
+        cy.get(`[data-testid=block-access-switch-${switchName}]`)
+            .should("exist")
+            .click();
+
+        cy.get("[data-testid=block-access-cancel]").should("not.exist");
+        cy.get("[data-testid=block-access-save]").should("not.exist");
     });
 });


### PR DESCRIPTION
# Fixes or Implements [AB#15662](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15662)

## Description
1. Restrict the BlockAccess feature to only user's with the role AdminUser
     - Everyone else will only have readonly versions of the controls.
     - Controller endpoint also checks for the AdminUser role.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

## UI Changes
Screen capture cannot show "unclickable" nature, however functional tests are used to check the variance in the controls.

## Notes
![image](https://github.com/bcgov/healthgateway/assets/19548348/f58efbfd-ad06-473e-9b5c-1f1fc92d2f6f)

New config value needs to be added for `keycloak_reviewer_username` and `keycloack_reviewer_password`.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
