### PR TITLE
Extend UserProfile to house blocked datasets for AB#15456

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -17,14 +17,17 @@ namespace HealthGateway.AccountDataAccess.Patient
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.AccountDataAccess.Patient.Strategy;
     using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
@@ -32,12 +35,17 @@ namespace HealthGateway.AccountDataAccess.Patient
     /// </summary>
     internal class PatientRepository : IPatientRepository
     {
+        private const string BlockedAccessKey = "BlockedAccess";
+        private const string CacheTtlKey = "CacheTtl";
+        private readonly int blockedAccessCacheTtl;
+
         /// <summary>
         /// The injected logger delegate.
         /// </summary>
         private readonly ILogger<PatientRepository> logger;
         private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly IBlockedAccessDelegate blockedAccessDelegate;
+        private readonly ICacheProvider cacheProvider;
         private readonly PatientQueryFactory patientQueryFactory;
 
         /// <summary>
@@ -46,17 +54,23 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="logger">The service Logger.</param>
         /// <param name="blockedAccessDelegate">The injected blocked access delegate.</param>
         /// <param name="authenticationDelegate">The injected authentication delegate.</param>
+        /// <param name="cacheProvider">The injected cache provider.</param>
+        /// <param name="configuration">The Configuration to use.</param>
         /// <param name="patientQueryFactory">The injected patient query factory.</param>
         public PatientRepository(
             ILogger<PatientRepository> logger,
             IBlockedAccessDelegate blockedAccessDelegate,
             IAuthenticationDelegate authenticationDelegate,
+            ICacheProvider cacheProvider,
+            IConfiguration configuration,
             PatientQueryFactory patientQueryFactory)
         {
             this.logger = logger;
             this.blockedAccessDelegate = blockedAccessDelegate;
             this.authenticationDelegate = authenticationDelegate;
+            this.cacheProvider = cacheProvider;
             this.patientQueryFactory = patientQueryFactory;
+            this.blockedAccessCacheTtl = configuration.GetValue($"{BlockedAccessKey}:{CacheTtlKey}", 30);
         }
 
         /// <inheritdoc/>
@@ -119,7 +133,18 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <inheritdoc/>
         public async Task<IEnumerable<DataSource>> GetDataSources(string hdid, CancellationToken ct = default)
         {
-            return await this.blockedAccessDelegate.GetDataSourcesAsync(hdid).ConfigureAwait(true);
+            string blockedAccessCacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, hdid);
+            string message = $"Getting item from cache for key: {blockedAccessCacheKey}";
+            this.logger.LogDebug("{Message}", message);
+
+            return await this.cacheProvider.GetOrSetAsync(
+                blockedAccessCacheKey,
+                () =>
+                {
+                    Task<IEnumerable<DataSource>> dataSources = this.blockedAccessDelegate.GetDataSourcesAsync(hdid);
+                    return dataSources;
+                },
+                TimeSpan.FromMinutes(this.blockedAccessCacheTtl)) ?? Array.Empty<DataSource>();
         }
 
         private static string GetStrategy(string? hdid, PatientDetailSource source)

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -29,6 +29,7 @@ namespace HealthGateway.Admin.Tests.Services
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Admin.Tests.Utils;
+    using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.Models;
@@ -37,6 +38,7 @@ namespace HealthGateway.Admin.Tests.Services
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
     using Moq;
     using Xunit;
     using Address = HealthGateway.AccountDataAccess.Patient.Address;
@@ -634,7 +636,9 @@ namespace HealthGateway.Admin.Tests.Services
                 patientRepositoryMock.Object,
                 resourceDelegateDelegateMock.Object,
                 userProfileDelegateMock.Object,
-                new Mock<IAuditRepository>().Object);
+                new Mock<IAuditRepository>().Object,
+                new Mock<ICacheProvider>().Object,
+                new Mock<ILogger<SupportService>>().Object);
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Common/src/CacheProviders/ICacheProvider.cs
+++ b/Apps/Common/src/CacheProviders/ICacheProvider.cs
@@ -24,6 +24,11 @@ namespace HealthGateway.Common.CacheProviders
     public interface ICacheProvider
     {
         /// <summary>
+        /// Key used to store cache for blocked access.
+        /// </summary>
+        public const string BlockedAccessCachePrefixKey = "BlockedAccess:Hdid:{0}";
+
+        /// <summary>
         /// Retrieves an item from the cache if available.
         /// </summary>
         /// <param name="key">The key to lookup.</param>

--- a/Apps/CommonData/src/ViewModels/UserProfileModel.cs
+++ b/Apps/CommonData/src/ViewModels/UserProfileModel.cs
@@ -18,7 +18,9 @@ namespace HealthGateway.Common.Data.ViewModels
     using System;
     using System.Collections.Generic;
     using System.ComponentModel.DataAnnotations.Schema;
+    using System.Linq;
     using System.Text.Json.Serialization;
+    using HealthGateway.Common.Data.Constants;
 
     /// <summary>
     /// Model that provides a user representation of an user profile database model.
@@ -113,5 +115,10 @@ namespace HealthGateway.Common.Data.ViewModels
         /// Gets the user preference.
         /// </summary>
         public IDictionary<string, UserPreferenceModel> Preferences { get; } = new Dictionary<string, UserPreferenceModel>();
+
+        /// <summary>
+        ///  Gets or sets the user's blocked data sources.
+        /// </summary>
+        public IEnumerable<DataSource> BlockedDataSources { get; set; } = Enumerable.Empty<DataSource>();
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/PatientRepositoryMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/PatientRepositoryMock.cs
@@ -1,0 +1,39 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.GatewayApiTests.Services.Test.Mock
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Common.Data.Constants;
+    using Moq;
+
+    /// <summary>
+    /// PatientRepositoryMock.
+    /// </summary>
+    public class PatientRepositoryMock : Mock<IPatientRepository>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PatientRepositoryMock"/> class.
+        /// </summary>
+        /// <param name="hdid">hdid.</param>
+        /// <param name="dataSources">A list of data sources.</param>
+        public PatientRepositoryMock(string hdid, IEnumerable<DataSource> dataSources)
+        {
+            this.Setup(s => s.GetDataSources(hdid, It.IsAny<CancellationToken>())).ReturnsAsync(dataSources);
+        }
+    }
+}

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -71,6 +71,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 LegalAgreementCode = LegalAgreementType.TermsOfService,
                 LegalText = "Mock Terms of Service",
             });
+
         private Mock<IPatientRepository> patientRepositoryMock = new();
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -18,12 +18,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
     using System;
     using System.Collections.Generic;
     using AutoMapper;
+    using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Delegates;
-    using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
@@ -34,6 +34,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;
+    using PatientModel = HealthGateway.Common.Models.PatientModel;
 
     /// <summary>
     /// UserProfileServiceTestMock class mock the UserProfileService.
@@ -70,6 +71,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 LegalAgreementCode = LegalAgreementType.TermsOfService,
                 LegalText = "Mock Terms of Service",
             });
+        private Mock<IPatientRepository> patientRepositoryMock = new();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileServiceMock"/> class.
@@ -104,7 +106,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 this.autoMapper,
                 this.authenticationDelegateMock.Object,
                 this.applicationSettingsDelegateMock.Object,
-                this.cacheProviderMock.Object);
+                this.cacheProviderMock.Object,
+                this.patientRepositoryMock.Object);
         }
 
         /// <summary>
@@ -123,6 +126,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                         It.IsAny<Func<T>>(),
                         It.IsAny<TimeSpan?>()))
                 .Returns(returnValue);
+            return this;
+        }
+
+        /// <summary>
+        /// Setup the <see cref="PatientRepositoryMock"/> that will be used for by the UserProfileService.
+        /// </summary>
+        /// <param name="hdid">User profile hdid to query and returned.</param>
+        /// <param name="dataSources">The mocked list of <see cref="DataSource"/> to be returned.</param>
+        /// <returns>UserProfileServiceMock.</returns>
+        public UserProfileServiceMock SetupPatientRepository(string hdid, IEnumerable<DataSource> dataSources)
+        {
+            this.patientRepositoryMock = new PatientRepositoryMock(hdid, dataSources);
             return this;
         }
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -199,6 +199,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
+            HashSet<DataSource> dataSources = new()
+            {
+                DataSource.Immunization,
+                DataSource.Medication,
+            };
+
             DbResult<UserProfile> readProfileDbResult = new()
             {
                 Payload = userProfile,
@@ -222,7 +228,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
                 .SetupLegalAgreementDelegateMock(legalAgreement)
-                .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, readProfileDbResult, userProfileDbResultUpdate: updatedProfileDbResult);
+                .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, readProfileDbResult, userProfileDbResultUpdate: updatedProfileDbResult)
+                .SetupPatientRepository(this.hdid, dataSources);
+
             IUserProfileService service = mockService.UserProfileServiceMockInstance();
             RequestResult<UserProfileModel> actualResult = service.UpdateAcceptedTerms(this.hdid, Guid.Empty);
 
@@ -230,6 +238,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (actualResult.ResultStatus == ResultType.Success)
             {
                 Assert.True(actualResult.ResourcePayload?.TermsOfServiceId == Guid.Empty);
+                Assert.Equal(dataSources, actualResult.ResourcePayload?.BlockedDataSources);
             }
         }
 
@@ -252,6 +261,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
+            HashSet<DataSource> dataSources = new()
+            {
+                DataSource.Immunization,
+                DataSource.Medication,
+            };
+
             PatientModel patientModel = new()
             {
                 Birthdate = DateTime.Now.AddYears(-20),
@@ -270,7 +285,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(localConfig))
                 .SetupUserProfileDelegateMockInsert(userProfile, userProfileDbResult)
                 .SetupCryptoDelegateMockGenerateKey("abc")
-                .SetupPatientServiceMockCustomPatient(this.hdid, patientModel);
+                .SetupPatientServiceMockCustomPatient(this.hdid, patientModel)
+                .SetupPatientRepository(this.hdid, dataSources);
 
             IUserProfileService service = mockService.UserProfileServiceMockInstance();
 
@@ -285,6 +301,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (dbStatus == DbStatusCode.Created && registration == RegistrationStatus.Open)
             {
                 Assert.Equal(ResultType.Success, actualResult.ResultStatus);
+                Assert.Equal(dataSources, actualResult.ResourcePayload?.BlockedDataSources);
             }
 
             if (dbStatus == DbStatusCode.Error && registration == RegistrationStatus.Closed)
@@ -553,6 +570,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 TermsOfServiceId = this.termsOfServiceGuid,
             };
 
+            HashSet<DataSource> dataSources = new()
+            {
+                DataSource.Immunization,
+                DataSource.Medication,
+            };
+
             DbResult<UserProfile> userProfileDbResult = new()
             {
                 Payload = userProfile,
@@ -566,7 +589,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
                 .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
-                .SetupEmailQueueServiceMock(false);
+                .SetupEmailQueueServiceMock(false)
+                .SetupPatientRepository(this.hdid, dataSources);
 
             IUserProfileService service = mockService.UserProfileServiceMockInstance();
 
@@ -576,6 +600,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResourcePayload?.ClosedDateTime);
+            Assert.Equal(dataSources, actualResult.ResourcePayload?.BlockedDataSources);
         }
 
         /// <summary>
@@ -672,6 +697,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
+            HashSet<DataSource> dataSources = new()
+            {
+                DataSource.Immunization,
+                DataSource.Medication,
+            };
+
             DbResult<UserProfile> userProfileDbResult = new()
             {
                 Payload = userProfile,
@@ -686,7 +717,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
                 .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
-                .SetupEmailQueueServiceMock(false);
+                .SetupEmailQueueServiceMock(false)
+                .SetupPatientRepository(this.hdid, dataSources);
 
             IUserProfileService service = mockService.UserProfileServiceMockInstance();
 
@@ -696,6 +728,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Null(actualResult.ResourcePayload?.ClosedDateTime);
+            Assert.Equal(dataSources, actualResult.ResourcePayload?.BlockedDataSources);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -133,9 +133,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Status = DbStatusCode.Read,
             };
 
+            HashSet<DataSource> dataSources = new()
+            {
+                DataSource.Immunization,
+                DataSource.Medication,
+            };
+
             UserProfileModel expected = UserProfileMapUtils.CreateFromDbModel(userProfile, Guid.Empty, MapperUtil.InitializeAutoMapper());
             UserProfileServiceMock mockService = new(GetIConfigurationRoot(null));
             mockService.SetupGetOrSetCache<DateTime?>(lastTourChangeDateTime, $"{TourApplicationSettings.Application}:{TourApplicationSettings.Component}")
+                .SetupPatientRepository(this.hdid, dataSources)
                 .SetupUserProfileDelegateMockGetUpdateAndHistory(this.hdid, userProfile, userProfileDbResult, userProfileHistoryDbResult)
                 .SetupLegalAgreementDelegateMock(termsOfService)
                 .SetupPatientServiceMockCustomPatient(this.hdid, patientModel)
@@ -157,6 +164,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Assert.Equal(userProfileHistoryMinus1.LastLoginDateTime, actualResult.ResourcePayload?.LastLoginDateTimes[1]);
                 Assert.Equal(userProfileHistoryMinus2.LastLoginDateTime, actualResult.ResourcePayload?.LastLoginDateTimes[2]);
                 Assert.Equal(expectedHasTourChanged, actualResult.ResourcePayload?.HasTourUpdated);
+                Assert.Equal(dataSources, actualResult.ResourcePayload?.BlockedDataSources);
             }
 
             if (dBStatus == DbStatusCode.Error)

--- a/Apps/Patient/src/appsettings.json
+++ b/Apps/Patient/src/appsettings.json
@@ -54,5 +54,8 @@
         "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
         "Scope": "healthdata.read webalert.read patient_profile account.read patientidentity.read",
         "TokenCacheEnabled": true
+    },
+    "BlockedAccess": {
+        "CacheTTL": 30
     }
 }


### PR DESCRIPTION
# Implements [AB#15456](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15456)

## Description

Updated Patient Repository GetDataSource to use cache if it exists and if it doesn't retrieve from database
Updated Support Service GetPatientSupportDetailsAsync to invalidate cache and get most up to date data from database for blocked data sources
Updated unit tests for PatientRepositoryTests and UserProfileServiceTests
Updated appsettings to store configuration cache to live value for blocked access data source values

**Redis Cache:**

<img width="2092" alt="Screenshot 2023-06-05 at 6 09 16 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/f129de20-7ebd-47fe-8a8c-984701962fdf">


**Web Client User 

<img width="2532" alt="Screenshot 2023-06-05 at 6 06 58 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/758a14cc-1a98-47f6-8e72-e497f33e5f05">
Profile:**


**Unit tests:**

<img width="1271" alt="Screenshot 2023-06-05 at 6 33 26 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/9398cd63-c55b-423a-ae00-d00661c3ac22">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
