### PR TITLE
Change date and time picker bindings to configuration time zone AB#15679

### DIFF
--- a/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor
+++ b/Apps/Admin/Client/Components/Communications/BroadcastsTable.razor
@@ -31,7 +31,7 @@
             </MudTableSortLabel>
         </MudTh>
         <MudTh>
-            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => ConvertToShortFormatFromUtc(x.ExpiryDate))">
+            <MudTableSortLabel SortBy="new Func<BroadcastRow, object>(x => ShortFormatFromUtc(x.ExpiryDate))">
                 Expires On
             </MudTableSortLabel>
         </MudTh>
@@ -46,8 +46,8 @@
     </HeaderContent>
     <RowTemplate>
         <MudTd data-testid="broadcast-table-subject" DataLabel="Subject">@context.Subject</MudTd>
-        <MudTd data-testid="broadcast-table-effective-date" DataLabel="Effective On">@ConvertToShortFormatFromUtc(context.EffectiveDate)</MudTd>
-        <MudTd data-testid="broadcast-table-expiry-date" DataLabel="Expires On">@ConvertToShortFormatFromUtc(context.ExpiryDate)</MudTd>
+        <MudTd data-testid="broadcast-table-effective-date" DataLabel="Effective On">@ShortFormatFromUtc(context.EffectiveDate)</MudTd>
+        <MudTd data-testid="broadcast-table-expiry-date" DataLabel="Expires On">@ShortFormatFromUtc(context.ExpiryDate)</MudTd>
         <MudTd data-testid="broadcast-table-action-type" DataLabel="Action Type">@context.ActionType</MudTd>
         <MudTd DataLabel="Actions" Style="text-align:right">
             <div>

--- a/Apps/Admin/Client/Components/Communications/CommunicationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/CommunicationDialog.razor.cs
@@ -21,6 +21,7 @@ using System.Threading.Tasks;
 using Fluxor;
 using Fluxor.Blazor.Web.Components;
 using HealthGateway.Admin.Client.Components.Common;
+using HealthGateway.Admin.Client.Services;
 using HealthGateway.Admin.Client.Store.Communications;
 using HealthGateway.Admin.Common.Models;
 using HealthGateway.Common.Data.Constants;
@@ -53,6 +54,9 @@ public partial class CommunicationDialog : FluxorComponent
 
     [Inject]
     private IState<CommunicationsState> CommunicationsState { get; set; } = default!;
+
+    [Inject]
+    private IDateConversionService DateConversionService { get; set; } = default!;
 
     private bool IsNewCommunication => this.Communication.Id == Guid.Empty;
 
@@ -97,7 +101,7 @@ public partial class CommunicationDialog : FluxorComponent
     {
         if (this.IsNewCommunication)
         {
-            DateTime now = DateTime.Now;
+            DateTime now = this.DateConversionService.ConvertFromUtc(DateTime.UtcNow);
             DateTime tomorrow = now.AddDays(1);
             this.EffectiveDate = now.Date;
             this.EffectiveTime = now.TimeOfDay;
@@ -106,10 +110,12 @@ public partial class CommunicationDialog : FluxorComponent
         }
         else
         {
-            this.EffectiveDate = this.Communication.EffectiveDateTime.ToLocalTime().Date;
-            this.EffectiveTime = this.Communication.EffectiveDateTime.ToLocalTime().TimeOfDay;
-            this.ExpiryDate = this.Communication.ExpiryDateTime.ToLocalTime().Date;
-            this.ExpiryTime = this.Communication.ExpiryDateTime.ToLocalTime().TimeOfDay;
+            DateTime effectiveDateTime = this.DateConversionService.ConvertFromUtc(this.Communication.EffectiveDateTime);
+            DateTime expiryDateTime = this.DateConversionService.ConvertFromUtc(this.Communication.ExpiryDateTime);
+            this.EffectiveDate = effectiveDateTime.Date;
+            this.EffectiveTime = effectiveDateTime.TimeOfDay;
+            this.ExpiryDate = expiryDateTime.Date;
+            this.ExpiryTime = expiryDateTime.TimeOfDay;
             this.HtmlContent = this.Communication.Text;
         }
     }

--- a/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor
+++ b/Apps/Admin/Client/Components/Communications/CommunicationsTable.razor
@@ -46,8 +46,8 @@
     <RowTemplate>
         <MudTd data-testid="comm-table-subject" DataLabel="Subject">@context.Subject</MudTd>
         <MudTd data-testid="comm-table-status" DataLabel="Status">@context.Status</MudTd>
-        <MudTd data-testid="comm-table-effective-date" DataLabel="Effective On">@ConvertToShortFormatFromUtc(context.EffectiveDate)</MudTd>
-        <MudTd data-testid="comm-table-expiry-date" DataLabel="Expires On">@ConvertToShortFormatFromUtc(context.ExpiryDate)</MudTd>
+        <MudTd data-testid="comm-table-effective-date" DataLabel="Effective On">@ShortFormatFromUtc(context.EffectiveDate)</MudTd>
+        <MudTd data-testid="comm-table-expiry-date" DataLabel="Expires On">@ShortFormatFromUtc(context.ExpiryDate)</MudTd>
         <MudTd DataLabel="Actions" Style="text-align:right">
             <div>
                 <MudTooltip Text="@(context.IsExpanded ? "Collapse" : "Expand")">

--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.Admin.Client
     using Fluxor;
     using HealthGateway.Admin.Client.Api;
     using HealthGateway.Admin.Client.Authorization;
+    using HealthGateway.Admin.Client.Services;
     using Microsoft.AspNetCore.Components;
     using Microsoft.AspNetCore.Components.Web;
     using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
@@ -98,6 +99,8 @@ namespace HealthGateway.Admin.Client
                     .UseReduxDevTools(rdt => rdt.Name = "Health Gateway Admin"));
 
             builder.Services.AddBlazoredLocalStorage();
+
+            builder.Services.AddTransient<IDateConversionService, DateConversionService>();
 
             app[0] = builder.Build();
             await app[0].RunAsync().ConfigureAwait(true);

--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -100,7 +100,7 @@ namespace HealthGateway.Admin.Client
 
             builder.Services.AddBlazoredLocalStorage();
 
-            builder.Services.AddTransient<IDateConversionService, DateConversionService>();
+            builder.Services.AddSingleton<IDateConversionService, DateConversionService>();
 
             app[0] = builder.Build();
             await app[0].RunAsync().ConfigureAwait(true);

--- a/Apps/Admin/Client/Services/DateConversionService.cs
+++ b/Apps/Admin/Client/Services/DateConversionService.cs
@@ -1,0 +1,68 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Services
+{
+    using System;
+    using HealthGateway.Common.Data.Utils;
+    using Microsoft.Extensions.Configuration;
+
+    /// <summary>
+    /// Injectable service to provide data conversion methods.
+    /// </summary>
+    public class DateConversionService : IDateConversionService
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateConversionService"/> class.
+        /// </summary>
+        /// <param name="configuration">Injected application settings</param>
+        public DateConversionService(IConfiguration configuration)
+        {
+            this.Configuration = configuration;
+        }
+
+        private IConfiguration Configuration { get; }
+
+        /// <inheritdoc/>
+        public DateTime ConvertFromUtc(DateTime utcDateTime)
+        {
+            return TimeZoneInfo.ConvertTimeFromUtc(
+                utcDateTime,
+                DateFormatter.GetLocalTimeZone(this.Configuration));
+        }
+
+        /// <inheritdoc/>
+        public DateTime? ConvertFromUtc(DateTime? utcDateTime, bool returnNowIfNull = false)
+        {
+            if (utcDateTime != null)
+            {
+                return this.ConvertFromUtc(utcDateTime.Value);
+            }
+
+            if (returnNowIfNull)
+            {
+                return this.ConvertFromUtc(DateTime.UtcNow);
+            }
+
+            return null;
+        }
+
+        /// <inheritdoc/>
+        public string ConvertToShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-")
+        {
+            return utcDateTime == null ? fallbackString : DateFormatter.ToShortDateAndTime(this.ConvertFromUtc(utcDateTime.Value));
+        }
+    }
+}

--- a/Apps/Admin/Client/Services/IDateConversionService.cs
+++ b/Apps/Admin/Client/Services/IDateConversionService.cs
@@ -13,21 +13,29 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Admin.Client.Models
+namespace HealthGateway.Admin.Client.Services
 {
     using System;
-    using Fluxor.Blazor.Web.Components;
-    using HealthGateway.Admin.Client.Services;
-    using Microsoft.AspNetCore.Components;
 
     /// <summary>
-    /// A base record for table rows.
-    /// Provides common functionality for table rows. Such as DateTime conversions.
+    /// Injectable service to provide data conversion methods.
     /// </summary>
-    public abstract class BaseTableFluxorComponent : FluxorComponent
+    public interface IDateConversionService
     {
-        [Inject]
-        private IDateConversionService DateConversionService { get; set; } = default!;
+        /// <summary>
+        /// Converts UTC datetime values to the system configured timezone.
+        /// </summary>
+        /// <param name="utcDateTime">A UTC DateTime instance.</param>
+        /// <returns>A DateTime instance in the configured timezone.</returns>
+        public DateTime ConvertFromUtc(DateTime utcDateTime);
+
+        /// <summary>
+        /// Converts a nullable UTC datetime values to the system configured timezone.
+        /// </summary>
+        /// <param name="utcDateTime">Nullable utcDateTime</param>
+        /// <param name="returnNowIfNull">If utcDateTime is null, this flag can be used to return now.</param>
+        /// <returns>DateTime converted or null if returnNowIfNull is false else will return now.</returns>
+        public DateTime? ConvertFromUtc(DateTime? utcDateTime, bool returnNowIfNull = false);
 
         /// <summary>
         /// Converts UTC datetime values to the system configured timezone and formats to a short date and time.
@@ -35,9 +43,6 @@ namespace HealthGateway.Admin.Client.Models
         /// <param name="utcDateTime">A UTC DateTime instance.</param>
         /// <param name="fallbackString">In the event utcDateTime is null, provide a fallback string to return.</param>
         /// <returns>The short formatted date and time string.</returns>
-        protected string ShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-")
-        {
-            return this.DateConversionService.ConvertToShortFormatFromUtc(utcDateTime, fallbackString);
-        }
+        public string ConvertToShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-");
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#15679](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15679)

## Description

1. Move datetime conversion helper methods to a injectable service
2. Update  base table function to use the date conversion service.
3. Change bindings for the MudTimePicker and MudDatePicker to use date and time in the configured time zone.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

The image below shows the difference, used EST in my system and the response from Blazor was still configured to PST.
<img width="785" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/868f1cfd-bb47-48fe-ae9c-77361f31baaf">

## Notes
Functional tests passing:
![image](https://github.com/bcgov/healthgateway/assets/19548348/cbca4b27-d27c-4363-8fca-df30a5fdf590)

Unit tests passing:
![image](https://github.com/bcgov/healthgateway/assets/19548348/6cd50ae1-8c7e-4474-9191-e7b848af0cc1)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
