### PR TITLE
Guard Dataset API Calls with BlockedAccess for AB#15457

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -56,6 +56,15 @@ namespace HealthGateway.AccountDataAccess.Patient
         Task<PatientQueryResult> Query(PatientQuery query, CancellationToken ct = default);
 
         /// <summary>
+        /// Returns true if data source can be accessed and false if it cannot.
+        /// </summary>
+        /// <param name="hdid">The hdid to query on.</param>
+        /// <param name="dataSource">The data source to check.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>The blocked access or null if not found.</returns>
+        Task<bool> CanAccessDataSourceAsync(string hdid, DataSource dataSource, CancellationToken ct = default);
+
+        /// <summary>
         /// Gets the blocked access record.
         /// </summary>
         /// <param name="hdid">The hdid to query on.</param>

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -85,6 +85,20 @@ namespace HealthGateway.AccountDataAccess.Patient
         }
 
         /// <inheritdoc/>
+        public async Task<bool> CanAccessDataSourceAsync(string hdid, DataSource dataSource, CancellationToken ct = default)
+        {
+            IEnumerable<DataSource> blockedDataSources = await this.GetDataSources(hdid, ct);
+            this.logger.LogDebug("Blocked data sources for hdid: {Hdid} - {DataSources}", hdid, blockedDataSources);
+
+            if (blockedDataSources.Any(ds => ds == dataSource))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <inheritdoc/>
         public async Task BlockAccess(BlockAccessCommand command, CancellationToken ct = default)
         {
             string authenticatedUserId = this.authenticationDelegate.FetchAuthenticatedUserId() ?? UserId.DefaultUser;

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -90,12 +90,7 @@ namespace HealthGateway.AccountDataAccess.Patient
             IEnumerable<DataSource> blockedDataSources = await this.GetDataSources(hdid, ct);
             this.logger.LogDebug("Blocked data sources for hdid: {Hdid} - {DataSources}", hdid, blockedDataSources);
 
-            if (blockedDataSources.Any(ds => ds == dataSource))
-            {
-                return false;
-            }
-
-            return true;
+            return !blockedDataSources.Contains(dataSource);
         }
 
         /// <inheritdoc/>

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -272,6 +272,44 @@ namespace AccountDataAccessTest
         }
 
         /// <summary>
+        /// Can access data source.
+        /// </summary>
+        /// <param name="dataSource">The data source to check for access.</param>
+        /// <param name="canAccessDataSource">The value indicates whether the data source can be accessed or not.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        [Theory]
+        [InlineData(DataSource.Note, true)]
+        [InlineData(DataSource.Medication, false)]
+        public async Task CanAccessDataSource(DataSource dataSource, bool canAccessDataSource)
+        {
+            // Arrange
+            string hdid = Hdid;
+
+            HashSet<DataSource> dataSources = new()
+            {
+                DataSource.Immunization,
+                DataSource.Medication,
+            };
+
+            BlockedAccess blockedAccess = new()
+            {
+                Hdid = hdid,
+                DataSources = new HashSet<DataSource>
+                {
+                    DataSource.Immunization, DataSource.Medication,
+                },
+            };
+
+            PatientRepository patientRepository = GetPatientRepository(blockedAccess, dataSources);
+
+            // Act
+            bool actual = await patientRepository.CanAccessDataSourceAsync(hdid, dataSource).ConfigureAwait(true);
+
+            // Verify
+            Assert.Equal(canAccessDataSource, actual);
+        }
+
+        /// <summary>
         /// Get blocked access by hdid.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>

--- a/Apps/ClinicalDocument/src/ClinicalDocument.csproj
+++ b/Apps/ClinicalDocument/src/ClinicalDocument.csproj
@@ -6,6 +6,7 @@
     <UserSecretsId>84e2fe9a-a1f5-4de7-bef6-4518a33fa8b9</UserSecretsId>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\..\Common\src\Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/ClinicalDocument/src/Startup.cs
+++ b/Apps/ClinicalDocument/src/Startup.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.ClinicalDocument
 {
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.AccountDataAccess;
     using HealthGateway.ClinicalDocument.Api;
     using HealthGateway.ClinicalDocument.Services;
     using HealthGateway.Common.Api;
@@ -72,15 +73,18 @@ namespace HealthGateway.ClinicalDocument
             services.AddAutoMapper(typeof(Startup));
 
             // Add Refit clients
-            PhsaConfigV2 phsaConfig = new();
-            this.startupConfig.Configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfig);
+            PhsaConfigV2 phsaConfigV2 = new();
+            this.startupConfig.Configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfigV2);
 
             services.AddRefitClient<IClinicalDocumentsApi>()
-                .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl)
+                .ConfigureHttpClient(c => c.BaseAddress = phsaConfigV2.BaseUrl)
                 .AddHttpMessageHandler<AuthHeaderHandler>();
             services.AddRefitClient<IPersonalAccountsApi>()
-                .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl)
+                .ConfigureHttpClient(c => c.BaseAddress = phsaConfigV2.BaseUrl)
                 .AddHttpMessageHandler<AuthHeaderHandler>();
+
+            // Access patient repository
+            services.AddPatientRepositoryConfiguration(new AccountDataAccessConfiguration(phsaConfigV2.BaseUrl));
         }
 
         /// <summary>

--- a/Apps/Encounter/src/Encounter.csproj
+++ b/Apps/Encounter/src/Encounter.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\..\Common\src\Common.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/Encounter/src/Startup.cs
+++ b/Apps/Encounter/src/Startup.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Encounter
 {
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.AccountDataAccess;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
@@ -69,6 +70,12 @@ namespace HealthGateway.Encounter
             PhsaConfig phsaConfig = new();
             this.startupConfig.Configuration.Bind(PhsaConfig.ConfigurationSectionKey, phsaConfig);
 
+            PhsaConfigV2 phsaConfigV2 = new();
+            this.startupConfig.Configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfigV2);
+
+            // Access patient repository
+            services.AddPatientRepositoryConfiguration(new AccountDataAccessConfiguration(phsaConfigV2.BaseUrl));
+
             // Add auto mapper
             services.AddAutoMapper(typeof(Startup));
 
@@ -83,7 +90,6 @@ namespace HealthGateway.Encounter
             // Add API Clients
             services.AddRefitClient<IHospitalVisitApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
-
             OdrConfiguration.AddOdrRefitClient<IMspVisitApi>(services, this.startupConfig.Configuration);
         }
 

--- a/Apps/Encounter/src/appsettings.Development.json
+++ b/Apps/Encounter/src/appsettings.Development.json
@@ -38,5 +38,9 @@
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Encounter/src/appsettings.hgdev.json
+++ b/Apps/Encounter/src/appsettings.hgdev.json
@@ -23,5 +23,9 @@
     "RedisAuditing": true,
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Encounter/src/appsettings.hgmock.json
+++ b/Apps/Encounter/src/appsettings.hgmock.json
@@ -22,5 +22,9 @@
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Encounter/src/appsettings.hgpoc.json
+++ b/Apps/Encounter/src/appsettings.hgpoc.json
@@ -22,5 +22,9 @@
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Encounter/src/appsettings.hgtest.json
+++ b/Apps/Encounter/src/appsettings.hgtest.json
@@ -22,5 +22,9 @@
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-test.azurewebsites.net"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-test.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-test.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Encounter/src/appsettings.json
+++ b/Apps/Encounter/src/appsettings.json
@@ -75,5 +75,14 @@
         "BaseUrl": "https://phsahealthgatewayapi-prod.azurewebsites.net",
         "FetchSize": "25",
         "BackOffMilliseconds": "3000"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd.azure-api.net/healthgateway",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "Scope": "healthdata.read webalert.read patient_profile account.read",
+        "TokenCacheEnabled": true
     }
 }

--- a/Apps/Immunization/src/Immunization.csproj
+++ b/Apps/Immunization/src/Immunization.csproj
@@ -13,6 +13,7 @@
     <None Remove="Constants\" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\..\Common\src\Common.csproj" />
     <ProjectReference Include="..\..\CommonData\src\Common.Data.csproj">
       <GlobalPropertiesToRemove></GlobalPropertiesToRemove>

--- a/Apps/Immunization/src/Startup.cs
+++ b/Apps/Immunization/src/Startup.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Immunization
 {
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.AccountDataAccess;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.Models.PHSA;
@@ -79,6 +80,12 @@ namespace HealthGateway.Immunization
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
             services.AddRefitClient<IImmunizationPublicApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = phsaConfig.BaseUrl);
+
+            PhsaConfigV2 phsaConfigV2 = new();
+            this.startupConfig.Configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfigV2);
+
+            // Access patient repository
+            services.AddPatientRepositoryConfiguration(new AccountDataAccessConfiguration(phsaConfigV2.BaseUrl));
 
             services.AddAutoMapper(typeof(Startup));
         }

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -23,6 +23,10 @@
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true,

--- a/Apps/Immunization/src/appsettings.hgdev.json
+++ b/Apps/Immunization/src/appsettings.hgdev.json
@@ -13,6 +13,10 @@
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true

--- a/Apps/Immunization/src/appsettings.hgmock.json
+++ b/Apps/Immunization/src/appsettings.hgmock.json
@@ -13,6 +13,10 @@
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true

--- a/Apps/Immunization/src/appsettings.hgpoc.json
+++ b/Apps/Immunization/src/appsettings.hgpoc.json
@@ -13,6 +13,10 @@
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true

--- a/Apps/Immunization/src/appsettings.hgtest.json
+++ b/Apps/Immunization/src/appsettings.hgtest.json
@@ -13,6 +13,10 @@
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-test.azurewebsites.net"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-test.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-test.azure-api.net/healthgateway"
+    },
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -33,6 +33,15 @@
         "FetchSize": "25",
         "BackOffMilliseconds": "10000"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd.azure-api.net/healthgateway",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "Scope": "healthdata.read webalert.read patient_profile account.read",
+        "TokenCacheEnabled": true
+    },
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [

--- a/Apps/Laboratory/src/Laboratory.csproj
+++ b/Apps/Laboratory/src/Laboratory.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\..\Common\src\Common.csproj" />
     <ProjectReference Include="..\..\CommonData\src\Common.Data.csproj">
       <GlobalPropertiesToRemove></GlobalPropertiesToRemove>

--- a/Apps/Laboratory/src/Startup.cs
+++ b/Apps/Laboratory/src/Startup.cs
@@ -16,9 +16,11 @@
 namespace HealthGateway.Laboratory
 {
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.AccountDataAccess;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
+    using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Laboratory.Api;
     using HealthGateway.Laboratory.Factories;
     using HealthGateway.Laboratory.Models;
@@ -79,6 +81,12 @@ namespace HealthGateway.Laboratory
                 .ConfigureHttpClient(c => c.BaseAddress = labConfig.BaseUrl);
             services.AddRefitClient<ILaboratoryApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = labConfig.BaseUrl);
+
+            PhsaConfigV2 phsaConfigV2 = new();
+            this.startupConfig.Configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfigV2);
+
+            // Access patient repository
+            services.AddPatientRepositoryConfiguration(new AccountDataAccessConfiguration(phsaConfigV2.BaseUrl));
 
             services.AddAutoMapper(typeof(Startup));
         }

--- a/Apps/Laboratory/src/appsettings.Development.json
+++ b/Apps/Laboratory/src/appsettings.Development.json
@@ -32,5 +32,9 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Laboratory/src/appsettings.hgdev.json
+++ b/Apps/Laboratory/src/appsettings.hgdev.json
@@ -27,5 +27,9 @@
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
     "RedisAuditing": true
 }

--- a/Apps/Laboratory/src/appsettings.hgmock.json
+++ b/Apps/Laboratory/src/appsettings.hgmock.json
@@ -25,5 +25,9 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Laboratory/src/appsettings.hgpoc.json
+++ b/Apps/Laboratory/src/appsettings.hgpoc.json
@@ -25,5 +25,9 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Laboratory/src/appsettings.hgtest.json
+++ b/Apps/Laboratory/src/appsettings.hgtest.json
@@ -25,5 +25,9 @@
     },
     "PublicAuthentication": {
         "TokenUri": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-test.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-test.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Laboratory/src/appsettings.json
+++ b/Apps/Laboratory/src/appsettings.json
@@ -73,5 +73,14 @@
     },
     "AuthCache": {
         "TokenCacheExpireMinutes": "20"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd.azure-api.net/healthgateway",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "Scope": "healthdata.read webalert.read patient_profile account.read",
+        "TokenCacheEnabled": true
     }
 }

--- a/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
+++ b/Apps/Laboratory/test/unit/Mock/LaboratoryServiceMock.cs
@@ -18,9 +18,12 @@ namespace HealthGateway.LaboratoryTests.Mock
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using AutoMapper;
+    using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AccessManagement.Authentication.Models;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Laboratory.Factories;
@@ -51,6 +54,7 @@ namespace HealthGateway.LaboratoryTests.Mock
                 new Mock<ILogger<LaboratoryService>>().Object,
                 new Mock<ILaboratoryDelegateFactory>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
+                new Mock<IPatientRepository>().Object,
                 this.autoMapper);
         }
 
@@ -59,13 +63,18 @@ namespace HealthGateway.LaboratoryTests.Mock
         /// </summary>
         /// <param name="delegateResult">return object of the delegate service.</param>
         /// <param name="token">token needed for authentication.</param>
-        public LaboratoryServiceMock(RequestResult<PhsaResult<List<PhsaCovid19Order>>> delegateResult, string token)
+        /// <param name="canAccessDataSource">The value indicates whether the data source can be accessed or not.</param>
+        public LaboratoryServiceMock(RequestResult<PhsaResult<List<PhsaCovid19Order>>> delegateResult, string token, bool canAccessDataSource = true)
         {
+            Mock<IPatientRepository> patientRepository = new();
+            patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(canAccessDataSource);
+
             this.laboratoryService = new LaboratoryService(
                 this.configuration,
                 new Mock<ILogger<LaboratoryService>>().Object,
                 new LaboratoryDelegateFactoryMock(new LaboratoryDelegateMock(delegateResult)).Object,
                 GetMockAuthDelegate(token),
+                patientRepository.Object,
                 this.autoMapper);
         }
 
@@ -81,6 +90,7 @@ namespace HealthGateway.LaboratoryTests.Mock
                 new Mock<ILogger<LaboratoryService>>().Object,
                 new LaboratoryDelegateFactoryMock(new LaboratoryDelegateMock(delegateResult)).Object,
                 GetMockAuthDelegate(token),
+                new Mock<IPatientRepository>().Object,
                 this.autoMapper);
         }
 
@@ -96,6 +106,7 @@ namespace HealthGateway.LaboratoryTests.Mock
                 new Mock<ILogger<LaboratoryService>>().Object,
                 new LaboratoryDelegateFactoryMock(new LaboratoryDelegateMock(delegateResult, token)).Object,
                 GetMockAuthDelegate(token),
+                new Mock<IPatientRepository>().Object,
                 this.autoMapper);
         }
 
@@ -104,13 +115,18 @@ namespace HealthGateway.LaboratoryTests.Mock
         /// </summary>
         /// <param name="delegateResult">return object of the delegate service.</param>
         /// <param name="token">token needed for authentication.</param>
-        public LaboratoryServiceMock(RequestResult<PhsaResult<PhsaLaboratorySummary>> delegateResult, string token)
+        /// <param name="canAccessDataSource">The value indicates whether the data source can be accessed or not.</param>
+        public LaboratoryServiceMock(RequestResult<PhsaResult<PhsaLaboratorySummary>> delegateResult, string token, bool canAccessDataSource = true)
         {
+            Mock<IPatientRepository> patientRepository = new();
+            patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(canAccessDataSource);
+
             this.laboratoryService = new LaboratoryService(
                 this.configuration,
                 new Mock<ILogger<LaboratoryService>>().Object,
                 new LaboratoryDelegateFactoryMock(new LaboratoryDelegateMock(delegateResult)).Object,
                 GetMockAuthDelegate(token),
+                patientRepository.Object,
                 this.autoMapper);
         }
 
@@ -140,7 +156,7 @@ namespace HealthGateway.LaboratoryTests.Mock
 
         private static IAuthenticationDelegate GetMockAuthDelegate(string token)
         {
-            JwtModel jwt = new JwtModel()
+            JwtModel jwt = new()
             {
                 AccessToken = token,
             };

--- a/Apps/Medication/src/Medication.csproj
+++ b/Apps/Medication/src/Medication.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\..\Common\src\Common.csproj" />
     <ProjectReference Include="..\..\Database\src\Database.csproj" />
   </ItemGroup>

--- a/Apps/Medication/src/Startup.cs
+++ b/Apps/Medication/src/Startup.cs
@@ -17,10 +17,12 @@
 namespace HealthGateway.Medication
 {
     using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.AccountDataAccess;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
     using HealthGateway.Common.Delegates;
+    using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Medication.Api;
     using HealthGateway.Medication.Delegates;
@@ -101,6 +103,12 @@ namespace HealthGateway.Medication
             this.startupConfig.Configuration.Bind(Config.SalesforceConfigSectionKey, sfConfig);
             services.AddRefitClient<ISpecialAuthorityApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = sfConfig.Endpoint);
+
+            PhsaConfigV2 phsaConfigV2 = new();
+            this.startupConfig.Configuration.Bind(PhsaConfigV2.ConfigurationSectionKey, phsaConfigV2);
+
+            // Access patient repository
+            services.AddPatientRepositoryConfiguration(new AccountDataAccessConfiguration(phsaConfigV2.BaseUrl));
 
             OdrConfiguration.AddOdrRefitClient<IOdrApi>(services, this.startupConfig.Configuration);
         }

--- a/Apps/Medication/src/appsettings.Development.json
+++ b/Apps/Medication/src/appsettings.Development.json
@@ -31,5 +31,9 @@
         "Enabled": true,
         "ConsoleEnabled": true,
         "ZipkinUri": "http://localhost:9411/api/v2/spans"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Medication/src/appsettings.hgdev.json
+++ b/Apps/Medication/src/appsettings.hgdev.json
@@ -20,5 +20,9 @@
         "Enabled": true,
         "ConsoleEnabled": true
     },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
     "RedisAuditing": true
 }

--- a/Apps/Medication/src/appsettings.hgmock.json
+++ b/Apps/Medication/src/appsettings.hgmock.json
@@ -19,5 +19,9 @@
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Medication/src/appsettings.hgpoc.json
+++ b/Apps/Medication/src/appsettings.hgpoc.json
@@ -19,5 +19,9 @@
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Medication/src/appsettings.hgtest.json
+++ b/Apps/Medication/src/appsettings.hgtest.json
@@ -19,5 +19,9 @@
     "OpenTelemetry": {
         "Enabled": true,
         "ConsoleEnabled": true
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd-test.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd-test.azure-api.net/healthgateway"
     }
 }

--- a/Apps/Medication/src/appsettings.json
+++ b/Apps/Medication/src/appsettings.json
@@ -82,5 +82,14 @@
     },
     "AuthCache": {
         "TokenCacheExpireMinutes": "20"
+    },
+    "PhsaV2": {
+        "TokenBaseUrl": "https://phsa-ccd.azure-api.net/identity",
+        "BaseUrl": "https://phsa-ccd.azure-api.net/healthgateway",
+        "ClientId": "****",
+        "ClientSecret": "****",
+        "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "Scope": "healthdata.read webalert.read patient_profile account.read",
+        "TokenCacheEnabled": true
     }
 }

--- a/Apps/Patient/src/Mappings/PatientDataAccessMappings.cs
+++ b/Apps/Patient/src/Mappings/PatientDataAccessMappings.cs
@@ -17,11 +17,12 @@ namespace HealthGateway.Patient.Mappings
 {
     using System;
     using AutoMapper;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Patient.Constants;
     using HealthGateway.Patient.Services;
     using HealthGateway.PatientDataAccess;
-    using DiagnosticImagingExam = HealthGateway.Patient.Services.DiagnosticImagingExam;
-    using OrganDonorRegistration = HealthGateway.Patient.Services.OrganDonorRegistration;
+    using DiagnosticImagingExam = HealthGateway.PatientDataAccess.DiagnosticImagingExam;
+    using OrganDonorRegistration = HealthGateway.PatientDataAccess.OrganDonorRegistration;
 
     /// <summary>
     /// Patient data access mappings.
@@ -46,6 +47,17 @@ namespace HealthGateway.Patient.Mappings
                     });
             this.CreateMap<HealthData, PatientData>()
                 .ConvertUsing<PatientDataConverter>();
+            this.CreateMap<PatientDataType, DataSource>()
+                .ConvertUsing(
+                    (source, destination, context) =>
+                    {
+                        return source switch
+                        {
+                            PatientDataType.OrganDonorRegistrationStatus => DataSource.OrganDonorRegistration,
+                            PatientDataType.DiagnosticImaging => DataSource.DiagnosticImaging,
+                            _ => throw new NotImplementedException($"Mapping for {source} is not implemented"),
+                        };
+                    });
         }
 
 #pragma warning disable SA1600
@@ -56,8 +68,8 @@ namespace HealthGateway.Patient.Mappings
             {
                 return source switch
                 {
-                    PatientDataAccess.OrganDonorRegistration hd => context.Mapper.Map<OrganDonorRegistration>(hd),
-                    PatientDataAccess.DiagnosticImagingExam hd => context.Mapper.Map<DiagnosticImagingExam>(hd),
+                    OrganDonorRegistration hd => context.Mapper.Map<Services.OrganDonorRegistration>(hd),
+                    DiagnosticImagingExam hd => context.Mapper.Map<Services.DiagnosticImagingExam>(hd),
                     _ => throw new NotImplementedException($"{source.GetType().Name} is not mapped to {nameof(PatientData)}"),
                 };
             }


### PR DESCRIPTION
# Implements [AB#15457](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15457)

## Description

Guarding API calls for the following datasets:

- ClinicalDocument,
- Immunization
- SpecialAuthorityRequest
- Covid19TestResult
- LabResult
- HealthVisit
- HospitalVisit
- Medication,
- Note
- DiagnosticImaging
- OrganDonorRegistration

Added to and updated existing unit tests.

<img width="1263" alt="Screenshot 2023-06-08 at 10 51 50 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/6e5654f7-b627-4274-84d6-09dc0d3bdeb1">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
