### PR TITLE
Fixed failing functional tests due to timezone and Mud Blazor release version

### DIFF
--- a/Apps/Admin/Client/Admin.Client.csproj
+++ b/Apps/Admin/Client/Admin.Client.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="7.0.0" />
-        <PackageReference Include="MudBlazor" Version="6.4.1" />
+        <PackageReference Include="MudBlazor" Version="6.3.1" />
         <PackageReference Include="Refit" Version="6.3.2" />
         <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
     </ItemGroup>

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -18,9 +18,9 @@ function getTodayPlusDaysDate(days) {
     const day = String(parsedDate.getDate()).padStart(2, "0");
 
     // Format the date to "yyyy-mm-dd" format
-    const today = `${year}-${month}-${day}`;
-    cy.log(`Today plus ${days} => ${today}`);
-    return today;
+    const dateString = `${year}-${month}-${day}`;
+    cy.log(`Today plus ${days} => ${dateString}`);
+    return dateString;
 }
 
 describe("Communications", () => {

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -1,8 +1,26 @@
 function getTodayPlusDaysDate(days) {
-    let ms = new Date(Date.now());
-    ms.setDate(ms.getDate() + days);
-    // yyyy-mm-dd
-    return ms.toISOString().substring(0, 10);
+    let newDay = new Date(Date.now());
+    newDay.setDate(newDay.getDate() + days);
+
+    // Convert the date and time to a localized string
+    const localizedDateString = newDay.toLocaleString("en-US", {
+        timeZone: "America/Vancouver",
+        hour12: false,
+    });
+
+    // Parse the localized string to a Date object
+    const parsedDate = new Date(localizedDateString);
+    cy.log(`Parsed date: ${parsedDate}`);
+
+    // Get the components: year, month, and day
+    const year = parsedDate.getFullYear();
+    const month = String(parsedDate.getMonth() + 1).padStart(2, "0");
+    const day = String(parsedDate.getDate()).padStart(2, "0");
+
+    // Format the date to "yyyy-mm-dd" format
+    const today = `${year}-${month}-${day}`;
+    cy.log(`Today plus ${days} => ${today}`);
+    return today;
 }
 
 describe("Communications", () => {

--- a/Apps/CommonUi/src/Common.Ui.csproj
+++ b/Apps/CommonUi/src/Common.Ui.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="6.4.1" />
+    <PackageReference Include="MudBlazor" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Fixes [AB#15718](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15718)

## Description

- Fixed expected date timezone issues for Communications functional tests.
- Rolled back MudBlazor release from 6.4.1 to 6.3.1 as this was causing AgentAccess, Feedback-Review and Communications to fail
- Removed timezone override in OpenShift DEV for Admin Server

**Note:** 

- If AgentAccess functional tests fails, make sure the provisioned user is removed from keycloak i.e., created successfully but was not removed.
- If Communications functional tests fail, make sure the created notification is removed i.e., created successfully but was not removed

**Communications:**

<img width="1048" alt="Screenshot 2023-06-14 at 3 07 23 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/8aaf8a06-f2b6-474c-b3d2-5b1b58b3310e">

**Feedback-Review:**

<img width="933" alt="Screenshot 2023-06-14 at 3 07 42 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/09def5aa-1592-46e1-ae20-16da846fb1bc">

**AgentAccess:**

<img width="972" alt="Screenshot 2023-06-14 at 3 07 33 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/1523bf61-9eae-474c-95ce-896ce51c6c97">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

NO

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
