### PR TITLE
Use midnight pacific time not utc on default date values for AB#15718

### DIFF
--- a/Apps/Admin/Client/Components/Communications/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/BroadcastDialog.razor.cs
@@ -157,8 +157,6 @@ public partial class BroadcastDialog : FluxorComponent
         {
             this.Broadcast.ActionUrl = null;
         }
-
-        Console.WriteLine($"Scheduled Date UTC: {this.Broadcast.ScheduledDateUtc}");
     }
 
     private void HandleClickCancel()

--- a/Apps/Admin/Client/Components/Communications/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/BroadcastDialog.razor.cs
@@ -122,7 +122,7 @@ public partial class BroadcastDialog : FluxorComponent
     {
         if (this.IsNewBroadcast)
         {
-            DateTime now = this.DateConversionService.ConvertFromUtc(DateTime.UtcNow);
+            DateTime now = this.DateConversionService.ConvertTime(DateTime.Now);
             DateTime tomorrow = now.AddDays(1);
             this.EffectiveDate = now.Date;
             this.EffectiveTime = now.TimeOfDay;
@@ -157,6 +157,8 @@ public partial class BroadcastDialog : FluxorComponent
         {
             this.Broadcast.ActionUrl = null;
         }
+
+        Console.WriteLine($"Scheduled Date UTC: {this.Broadcast.ScheduledDateUtc}");
     }
 
     private void HandleClickCancel()

--- a/Apps/Admin/Client/Components/Communications/CommunicationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/CommunicationDialog.razor.cs
@@ -101,7 +101,7 @@ public partial class CommunicationDialog : FluxorComponent
     {
         if (this.IsNewCommunication)
         {
-            DateTime now = this.DateConversionService.ConvertFromUtc(DateTime.UtcNow);
+            DateTime now = this.DateConversionService.ConvertTime(DateTime.Now);
             DateTime tomorrow = now.AddDays(1);
             this.EffectiveDate = now.Date;
             this.EffectiveTime = now.TimeOfDay;

--- a/Apps/Admin/Client/Services/DateConversionService.cs
+++ b/Apps/Admin/Client/Services/DateConversionService.cs
@@ -64,5 +64,13 @@ namespace HealthGateway.Admin.Client.Services
         {
             return utcDateTime == null ? fallbackString : DateFormatter.ToShortDateAndTime(this.ConvertFromUtc(utcDateTime.Value));
         }
+
+        /// <inheritdoc/>
+        public DateTime ConvertTime(DateTime dateTime)
+        {
+            return TimeZoneInfo.ConvertTime(
+                dateTime,
+                DateFormatter.GetLocalTimeZone(this.Configuration));
+        }
     }
 }

--- a/Apps/Admin/Client/Services/IDateConversionService.cs
+++ b/Apps/Admin/Client/Services/IDateConversionService.cs
@@ -44,5 +44,12 @@ namespace HealthGateway.Admin.Client.Services
         /// <param name="fallbackString">In the event utcDateTime is null, provide a fallback string to return.</param>
         /// <returns>The short formatted date and time string.</returns>
         public string ConvertToShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-");
+
+        /// <summary>
+        /// Converts datetime value to the system configured timezone.
+        /// </summary>
+        /// <param name="dateTime">A DateTime instance.</param>
+        /// <returns>A DateTime instance in the configured timezone.</returns>
+        public DateTime ConvertTime(DateTime dateTime);
     }
 }


### PR DESCRIPTION
# Fixes [AB#15718](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15718)

## Description

Their reason why there was a date discrepancy when running functional tests at 6:30 am was because the default date being used in the date picker was based on a UTC value and then converted back to PST.  

Example, when running the admin functional tests at 6:30 AM, the date picker uses UTC Now and then converts it PST for the default dates it uses for effective and expiry dates.

So UTC June 15 at 6:36 AM is actually June 14 11:36 PM in PST.

As a result, changed both Communication and Broadcast Dialogs to use PST as the default when initializing the date picker.

**See the screenshot.  You will notice the notifications were created the day before.**

<img width="1350" alt="Screenshot 2023-06-15 at 1 49 17 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/d00eec85-e76e-497b-9ef8-ce8a1e609d12">

**Communication functional tests:**

<img width="2099" alt="Screenshot 2023-06-15 at 1 43 03 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/9afff223-cea2-4a30-9ee2-4199dfab35e9">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
