### PR TITLE
Migrate HgButtonComponent to vuetify AB#15712

### DIFF
--- a/Apps/WebClient/src/NewClientApp/package-lock.json
+++ b/Apps/WebClient/src/NewClientApp/package-lock.json
@@ -25,6 +25,10 @@
             },
             "devDependencies": {
                 "@babel/types": "^7.21.4",
+                "@fortawesome/fontawesome-svg-core": "^6.4.0",
+                "@fortawesome/free-regular-svg-icons": "^6.4.0",
+                "@fortawesome/free-solid-svg-icons": "^6.4.0",
+                "@fortawesome/vue-fontawesome": "^3.0.3",
                 "@types/luxon": "^3.3.0",
                 "@types/node": "^18.15.0",
                 "@types/throttle-debounce": "^5.0.0",
@@ -35,6 +39,7 @@
                 "eslint": "^8.0.0",
                 "eslint-plugin-vue": "^9.0.0",
                 "prettier": "^2.8.8",
+                "sass": "^1.63.4",
                 "typescript": "^5.0.0",
                 "vite": "^4.2.0",
                 "vite-plugin-vuetify": "^1.0.0",
@@ -468,6 +473,65 @@
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+            "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/fontawesome-svg-core": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+            "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-regular-svg-icons": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+            "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+            "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+            "dev": true,
+            "hasInstallScript": true,
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/vue-fontawesome": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz",
+            "integrity": "sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==",
+            "dev": true,
+            "peerDependencies": {
+                "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+                "vue": ">= 3.0.0 < 4"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
@@ -1173,6 +1237,19 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "devOptional": true,
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -1228,6 +1305,15 @@
                 }
             ]
         },
+        "node_modules/binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -1248,7 +1334,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "fill-range": "^7.0.1"
             },
@@ -1279,6 +1365,45 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "devOptional": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://paulmillr.com/funding/"
+                }
+            ],
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "devOptional": true,
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/color-convert": {
@@ -1782,7 +1907,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -1999,6 +2124,12 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/immutable": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+            "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+            "devOptional": true
+        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -2040,11 +2171,23 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "devOptional": true,
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2053,7 +2196,7 @@
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -2065,7 +2208,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=0.12.0"
             }
@@ -2324,6 +2467,15 @@
             "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
+        "node_modules/normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "devOptional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -2458,7 +2610,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
+            "devOptional": true,
             "engines": {
                 "node": ">=8.6"
             },
@@ -2690,6 +2842,18 @@
                 }
             ]
         },
+        "node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "devOptional": true,
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2766,6 +2930,23 @@
             ],
             "dependencies": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "node_modules/sass": {
+            "version": "1.63.4",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.4.tgz",
+            "integrity": "sha512-Sx/+weUmK+oiIlI+9sdD0wZHsqpbgQg8wSwSnGBjwb5GwqFhYNwwnI+UWZtLjKvKyFlKkatRK235qQ3mokyPoQ==",
+            "devOptional": true,
+            "dependencies": {
+                "chokidar": ">=3.0.0 <4.0.0",
+                "immutable": "^4.0.0",
+                "source-map-js": ">=0.6.2 <2.0.0"
+            },
+            "bin": {
+                "sass": "sass.js"
+            },
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/semver": {
@@ -2884,7 +3065,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -3438,6 +3619,46 @@
             "integrity": "sha512-6SWlXpWU5AvId8Ac7zjzmIOqMOba/JWY8XZ4A7q7Gn1Vlfg/SFFIlrtHXt9nPn4op9ZPAkl91Jao+QQv3r/ukw==",
             "dev": true
         },
+        "@fortawesome/fontawesome-common-types": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.0.tgz",
+            "integrity": "sha512-HNii132xfomg5QVZw0HwXXpN22s7VBHQBv9CeOu9tfJnhsWQNd2lmTNi8CSrnw5B+5YOmzu1UoPAyxaXsJ6RgQ==",
+            "dev": true
+        },
+        "@fortawesome/fontawesome-svg-core": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
+            "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
+            "dev": true,
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            }
+        },
+        "@fortawesome/free-regular-svg-icons": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.4.0.tgz",
+            "integrity": "sha512-ZfycI7D0KWPZtf7wtMFnQxs8qjBXArRzczABuMQqecA/nXohquJ5J/RCR77PmY5qGWkxAZDxpnUFVXKwtY/jPw==",
+            "dev": true,
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            }
+        },
+        "@fortawesome/free-solid-svg-icons": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.0.tgz",
+            "integrity": "sha512-kutPeRGWm8V5dltFP1zGjQOEAzaLZj4StdQhWVZnfGFCvAPVvHh8qk5bRrU4KXnRRRNni5tKQI9PBAdI6MP8nQ==",
+            "dev": true,
+            "requires": {
+                "@fortawesome/fontawesome-common-types": "6.4.0"
+            }
+        },
+        "@fortawesome/vue-fontawesome": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@fortawesome/vue-fontawesome/-/vue-fontawesome-3.0.3.tgz",
+            "integrity": "sha512-KCPHi9QemVXGMrfuwf3nNnNo129resAIQWut9QTAMXmXqL2ErABC6ohd2yY5Ipq0CLWNbKHk8TMdTXL/Zf3ZhA==",
+            "dev": true,
+            "requires": {}
+        },
         "@humanwhocodes/config-array": {
             "version": "0.11.10",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.10.tgz",
@@ -3920,6 +4141,16 @@
                 "color-convert": "^2.0.1"
             }
         },
+        "anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "devOptional": true,
+            "requires": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            }
+        },
         "argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3958,6 +4189,12 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
         },
+        "binary-extensions": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
+            "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
+            "devOptional": true
+        },
         "boolbase": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -3978,7 +4215,7 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
             "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "fill-range": "^7.0.1"
             }
@@ -3997,6 +4234,33 @@
             "requires": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
+            }
+        },
+        "chokidar": {
+            "version": "3.5.3",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "devOptional": true,
+            "requires": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "fsevents": "~2.3.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "devOptional": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                }
             }
         },
         "color-convert": {
@@ -4380,7 +4644,7 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
             "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "to-regex-range": "^5.0.1"
             }
@@ -4525,6 +4789,12 @@
             "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
             "dev": true
         },
+        "immutable": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.0.tgz",
+            "integrity": "sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==",
+            "devOptional": true
+        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -4557,17 +4827,26 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "devOptional": true,
+            "requires": {
+                "binary-extensions": "^2.0.0"
+            }
+        },
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-            "dev": true
+            "devOptional": true
         },
         "is-glob": {
             "version": "4.0.3",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -4576,7 +4855,7 @@
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true
+            "devOptional": true
         },
         "is-path-inside": {
             "version": "3.0.3",
@@ -4767,6 +5046,12 @@
             "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
             "dev": true
         },
+        "normalize-path": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "devOptional": true
+        },
         "nth-check": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -4865,7 +5150,7 @@
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true
+            "devOptional": true
         },
         "pinia": {
             "version": "2.1.3",
@@ -4990,6 +5275,15 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
+        "readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "devOptional": true,
+            "requires": {
+                "picomatch": "^2.2.1"
+            }
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -5032,6 +5326,17 @@
             "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
+            }
+        },
+        "sass": {
+            "version": "1.63.4",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.4.tgz",
+            "integrity": "sha512-Sx/+weUmK+oiIlI+9sdD0wZHsqpbgQg8wSwSnGBjwb5GwqFhYNwwnI+UWZtLjKvKyFlKkatRK235qQ3mokyPoQ==",
+            "devOptional": true,
+            "requires": {
+                "chokidar": ">=3.0.0 <4.0.0",
+                "immutable": "^4.0.0",
+                "source-map-js": ">=0.6.2 <2.0.0"
             }
         },
         "semver": {
@@ -5114,7 +5419,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-            "dev": true,
+            "devOptional": true,
             "requires": {
                 "is-number": "^7.0.0"
             }

--- a/Apps/WebClient/src/NewClientApp/package.json
+++ b/Apps/WebClient/src/NewClientApp/package.json
@@ -26,6 +26,10 @@
     },
     "devDependencies": {
         "@babel/types": "^7.21.4",
+        "@fortawesome/fontawesome-svg-core": "^6.4.0",
+        "@fortawesome/free-regular-svg-icons": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^6.4.0",
+        "@fortawesome/vue-fontawesome": "^3.0.3",
         "@types/luxon": "^3.3.0",
         "@types/node": "^18.15.0",
         "@types/throttle-debounce": "^5.0.0",
@@ -36,6 +40,7 @@
         "eslint": "^8.0.0",
         "eslint-plugin-vue": "^9.0.0",
         "prettier": "^2.8.8",
+        "sass": "^1.63.4",
         "typescript": "^5.0.0",
         "vite": "^4.2.0",
         "vite-plugin-vuetify": "^1.0.0",

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
@@ -15,29 +15,24 @@ const props = withDefaults(defineProps<Props>(), {
 type HgButtonVariant = "primary" | "secondary" | "link";
 
 interface HgButtonVariantDetails {
-    className: string;
     vuetifyVariant: "flat" | "outlined" | "text";
     color: string;
 }
 
 const variants = new Map<HgButtonVariant, HgButtonVariantDetails>();
 variants.set("primary", {
-    className: "hg-primary",
     vuetifyVariant: "flat",
     color: "primary",
 });
 variants.set("secondary", {
-    className: "hg-secondary",
     vuetifyVariant: "outlined",
     color: "primary",
 });
 variants.set("link", {
-    className: "hg-link",
     vuetifyVariant: "text",
     color: "link",
 });
 
-const className = computed(() => variants.get(props.variant)?.className);
 const vuetifyVariant = computed(
     () => variants.get(props.variant)?.vuetifyVariant
 );
@@ -45,13 +40,7 @@ const color = computed(() => variants.get(props.variant)?.color);
 </script>
 
 <template>
-    <v-btn
-        :variant="vuetifyVariant"
-        class="hg-button"
-        :class="className"
-        :color="color"
-        :ripple="false"
-    >
+    <v-btn :variant="vuetifyVariant" :color="color" :ripple="false">
         <slot />
     </v-btn>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+interface Props {
+    variant?: HgButtonVariant;
+    size?: string;
+    inverse?: boolean;
+}
+const props = withDefaults(defineProps<Props>(), {
+    variant: "primary",
+    size: "",
+    inverse: false,
+});
+
+type HgButtonVariant = "primary" | "secondary" | "link";
+
+interface HgButtonVariantDetails {
+    className: string;
+    vuetifyVariant: "flat" | "outlined" | "text";
+    color: string;
+}
+
+const variants = new Map<HgButtonVariant, HgButtonVariantDetails>([
+    [
+        "primary",
+        { className: "hg-primary", vuetifyVariant: "flat", color: "primary" },
+    ],
+    [
+        "secondary",
+        {
+            className: "hg-secondary",
+            vuetifyVariant: "outlined",
+            color: "primary",
+        },
+    ],
+    ["link", { className: "hg-link", vuetifyVariant: "text", color: "link" }],
+]);
+
+variants.set("primary", {
+    className: "hg-primary",
+    vuetifyVariant: "flat",
+    color: "primary",
+});
+variants.set("secondary", {
+    className: "hg-secondary",
+    vuetifyVariant: "outlined",
+    color: "primary",
+});
+variants.set("link", {
+    className: "hg-link",
+    vuetifyVariant: "text",
+    color: "link",
+});
+
+const className = computed(() => variants.get(props.variant)?.className);
+const vuetifyVariant = computed(
+    () => variants.get(props.variant)?.vuetifyVariant
+);
+const color = computed(() => variants.get(props.variant)?.color);
+</script>
+
+<template>
+    <v-btn
+        :variant="vuetifyVariant"
+        class="hg-button"
+        :class="className"
+        :color="color"
+        :ripple="false"
+    >
+        <slot />
+    </v-btn>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
@@ -20,22 +20,7 @@ interface HgButtonVariantDetails {
     color: string;
 }
 
-const variants = new Map<HgButtonVariant, HgButtonVariantDetails>([
-    [
-        "primary",
-        { className: "hg-primary", vuetifyVariant: "flat", color: "primary" },
-    ],
-    [
-        "secondary",
-        {
-            className: "hg-secondary",
-            vuetifyVariant: "outlined",
-            color: "primary",
-        },
-    ],
-    ["link", { className: "hg-link", vuetifyVariant: "text", color: "link" }],
-]);
-
+const variants = new Map<HgButtonVariant, HgButtonVariantDetails>();
 variants.set("primary", {
     className: "hg-primary",
     vuetifyVariant: "flat",

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgIconButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgIconButtonComponent.vue
@@ -1,0 +1,10 @@
+<script setup lang="ts">
+interface Props {
+    icon: string;
+}
+defineProps<Props>();
+</script>
+
+<template>
+    <v-btn :icon="icon" variant="flat" class="bg-transparent" :ripple="false" />
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
@@ -1,8 +1,4 @@
-/**
- * plugins/index.ts
- *
- * Included in `./src/main.ts`
- */
+import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 
 // Plugins
 import { loadFonts } from "@/plugins/webfontloader";
@@ -16,4 +12,5 @@ import type { App } from "vue";
 export function registerPlugins(app: App) {
     loadFonts();
     app.use(vuetify).use(router).use(pinia);
+    app.component("font-awesome-icon", FontAwesomeIcon);
 }

--- a/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
@@ -1,8 +1,7 @@
-/**
- * plugins/vuetify.ts
- *
- * Framework documentation: https://vuetifyjs.com`
- */
+import { aliases, fa } from "vuetify/iconsets/fa-svg";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { far } from "@fortawesome/free-regular-svg-icons";
+import { fas } from "@fortawesome/free-solid-svg-icons";
 
 // Styles
 import "@mdi/font/css/materialdesignicons.css";
@@ -11,14 +10,33 @@ import "vuetify/styles";
 // Composables
 import { createVuetify } from "vuetify";
 
+library.add(far, fas);
+
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
+    icons: {
+        defaultSet: "fa",
+        aliases,
+        sets: {
+            fa,
+        },
+    },
     theme: {
         themes: {
             light: {
                 colors: {
-                    primary: "#1867C0",
-                    secondary: "#5CBBF6",
+                    background: "#ffffff",
+                    surface: "#ffffff",
+                    primary: "#003366",
+                    secondary: "#38598a",
+                    success: "#2e8540",
+                    // warning: "",
+                    error: "#d8292f",
+                    info: "#0092f1",
+                    // custom colours below
+                    accent: "#fcba19",
+                    link: "#1a5a96",
+                    focus: "#3b99fc",
                 },
             },
         },


### PR DESCRIPTION
# Implements [AB#15712](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15712)

## Description

- initializes vuetify theme and font-awesome icons
- migrates HgButtonComponent to vuetify
  - splits into HgButtonComponent and HgIconButtonComponent
  - see migration guides:
    - [hg-button (HgButtonComponent)](https://github.com/bcgov/healthgateway/wiki/Vuetify:-hg‐button-(HgButtonComponent))
    - [hg-button (HgIconButtonComponent)](https://github.com/bcgov/healthgateway/wiki/Vuetify:-hg‐button-(HgIconButtonComponent))

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/444f2e70-41ff-4fde-b853-462dc4b6e30c)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
