### PR TITLE
Fix UTC/PST bug  in Admin Communication Tests for AB#15718

### DIFF
--- a/Apps/Admin/Client/Components/Communications/BroadcastDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/BroadcastDialog.razor.cs
@@ -122,7 +122,7 @@ public partial class BroadcastDialog : FluxorComponent
     {
         if (this.IsNewBroadcast)
         {
-            DateTime now = this.DateConversionService.ConvertTime(DateTime.Now);
+            DateTime now = this.DateConversionService.ConvertFromUtc(DateTime.UtcNow);
             DateTime tomorrow = now.AddDays(1);
             this.EffectiveDate = now.Date;
             this.EffectiveTime = now.TimeOfDay;

--- a/Apps/Admin/Client/Components/Communications/CommunicationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Communications/CommunicationDialog.razor.cs
@@ -101,7 +101,7 @@ public partial class CommunicationDialog : FluxorComponent
     {
         if (this.IsNewCommunication)
         {
-            DateTime now = this.DateConversionService.ConvertTime(DateTime.Now);
+            DateTime now = this.DateConversionService.ConvertFromUtc(DateTime.UtcNow);
             DateTime tomorrow = now.AddDays(1);
             this.EffectiveDate = now.Date;
             this.EffectiveTime = now.TimeOfDay;

--- a/Apps/Admin/Client/Services/DateConversionService.cs
+++ b/Apps/Admin/Client/Services/DateConversionService.cs
@@ -64,13 +64,5 @@ namespace HealthGateway.Admin.Client.Services
         {
             return utcDateTime == null ? fallbackString : DateFormatter.ToShortDateAndTime(this.ConvertFromUtc(utcDateTime.Value));
         }
-
-        /// <inheritdoc/>
-        public DateTime ConvertTime(DateTime dateTime)
-        {
-            return TimeZoneInfo.ConvertTime(
-                dateTime,
-                DateFormatter.GetLocalTimeZone(this.Configuration));
-        }
     }
 }

--- a/Apps/Admin/Client/Services/IDateConversionService.cs
+++ b/Apps/Admin/Client/Services/IDateConversionService.cs
@@ -44,12 +44,5 @@ namespace HealthGateway.Admin.Client.Services
         /// <param name="fallbackString">In the event utcDateTime is null, provide a fallback string to return.</param>
         /// <returns>The short formatted date and time string.</returns>
         public string ConvertToShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-");
-
-        /// <summary>
-        /// Converts datetime value to the system configured timezone.
-        /// </summary>
-        /// <param name="dateTime">A DateTime instance.</param>
-        /// <returns>A DateTime instance in the configured timezone.</returns>
-        public DateTime ConvertTime(DateTime dateTime);
     }
 }

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -1,11 +1,12 @@
 function getTodayPlusDaysDate(days) {
     let newDay = new Date(Date.now());
+    cy.log(`New day: ${newDay}`);
     newDay.setDate(newDay.getDate() + days);
+    cy.log(`New day plus ${days}: ${newDay}`);
 
     // Convert the date and time to a localized string
     const localizedDateString = newDay.toLocaleString("en-US", {
         timeZone: "America/Vancouver",
-        hour12: false,
     });
 
     // Parse the localized string to a Date object


### PR DESCRIPTION
# Fixes [AB#15718](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15718)

## Description

Cypress environment was UTC whereas, DEV and our local environments are PST.

- Reverted #5236 
- Fixed javascript bug to retrieve PST Date - failing after midnight producing NaN when converting to PST 
- Updated Admin Functional Test Pipeline to use PST for Cypress environment
- Updated CICD Release Pipeline to use PST for Cypress environment
- Updated Production Release Pipeline to use PST for Cypress environment

<img width="1069" alt="Screen Shot 2023-06-19 at 9 36 04 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/d481d325-d34f-4a9c-aec0-71afe2e79751">

**Functional Tests Passing in CICD Release - Ran 5:52 AM as UTC and PST on different days :**

<img width="2513" alt="Screenshot 2023-06-17 at 12 44 52 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/085e02ed-c0c3-4488-b244-0bb276e2e962">

**Admin Functional Test Pipeline Changes:**

<img width="2118" alt="Screenshot 2023-06-17 at 12 46 17 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/a488eb0c-143f-4ab3-9327-990b94b3a849">

**CICD Release Pipeline Changes:**

<img width="2473" alt="Screenshot 2023-06-17 at 12 47 08 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/36009ab4-5f47-4bbc-a360-4cb452215663">

**Production Release Pipeline Changes:**

<img width="2310" alt="Screenshot 2023-06-17 at 12 47 46 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/c79d9e18-463c-4470-bbc6-d7b2108970d3">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
