### PR TITLE
Migrate LoadingComponent to vuetify AB#15735

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/LoadingComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/LoadingComponent.vue
@@ -82,7 +82,7 @@ onUnmounted(() => {
             </template>
         </LoadingOverlay>
         <div v-else>
-            <div class="spinner" data-testid="timelineLoading">
+            <div class="spinner" data-testid="loadingSpinner">
                 <div id="first" class="double-bounce">
                     <hg-icon icon="pills" size="large" />
                 </div>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/LoadingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/LoadingComponent.vue
@@ -1,0 +1,27 @@
+﻿<script setup lang="ts">
+interface Props {
+    isLoading: boolean;
+    text?: string;
+}
+withDefaults(defineProps<Props>(), {
+    text: undefined,
+});
+</script>
+
+<template>
+    <v-overlay
+        class="align-center justify-center"
+        :model-value="isLoading"
+        :persistent="true"
+    >
+        <div class="d-flex flex-column align-center">
+            <v-progress-circular
+                indeterminate
+                color="primary"
+                size="64"
+                data-testid="loadingSpinner"
+            />
+            <p class="mt-4">{{ text }}</p>
+        </div>
+    </v-overlay>
+</template>

--- a/Testing/functional/tests/cypress/integration/ui/report/immunizationReport.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/immunizationReport.js
@@ -37,8 +37,8 @@ describe("Immunization History Report", () => {
 
     it("Validate Immunization Loading", () => {
         cy.get("[data-testid=reportType]").select("Immunizations");
-        cy.get("[data-testid=timelineLoading]").should("be.visible");
-        cy.get("[data-testid=timelineLoading]").should("not.be.visible");
+        cy.get("[data-testid=loadingSpinner]").should("be.visible");
+        cy.get("[data-testid=loadingSpinner]").should("not.be.visible");
     });
 
     it("Validate Immunization History Report", () => {


### PR DESCRIPTION
# Implements [AB#15735](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15735)

## Description

Migrates LoadingComponent to vuetify:

- now located in /components/shared (rather than /components)
- all custom styling is removed, leaving support only for displaying or not displaying a message

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/eda627ba-32a7-4a98-a138-01520ae8fb74)

## Notes

- Two data-testids were consolidated together, so the functional test and corresponding old version of the component were also updated to ensure a seamless transition.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
