### PR TITLE
Removed offset from query for AB#14194

### DIFF
--- a/Apps/JobScheduler/src/Tasks/CopyEmailToMessagingVerification.cs
+++ b/Apps/JobScheduler/src/Tasks/CopyEmailToMessagingVerification.cs
@@ -61,7 +61,7 @@ namespace HealthGateway.JobScheduler.Tasks
                     email => this.dbContext.MessagingVerification.Any(msgVerification => msgVerification.EmailId == email.Id && msgVerification.EmailAddress == null))
                 .OrderBy(e => e.Id);
 
-            List<Email> emails = query.Skip(offset).Take(this.batchSize).ToList();
+            List<Email> emails = query.Take(this.batchSize).ToList();
             this.logger.LogInformation("The number of emails to copy from Email.To to MessagingVerification.EmailAddress: {Emails}", emails.Count);
             int processed = 0;
 
@@ -79,7 +79,7 @@ namespace HealthGateway.JobScheduler.Tasks
                 this.logger.LogInformation("Saved message verification changes after {Processed} email(s) processed", processed);
 
                 offset += this.batchSize;
-                emails = query.Skip(offset).Take(this.batchSize).ToList();
+                emails = query.Take(this.batchSize).ToList();
             }
 
             this.logger.LogInformation("Performing Task {Name} finished", this.GetType().Name);


### PR DESCRIPTION
# Fixes [AB#14194](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14194)

## Description

Removed offset from query that was introduced in #5251

Removing offset will allow the job to re-query properly in the while loop.  The email query looks for email addresses being null.  But when looping through messaging verifications, the job will update the email address with a value.  Because of this the offset will not work.

The screenshot console logging shows an example where the batch size is 1.  It queries 1 record and processes it.  It then queries again for another record and processes it.  It does one final query at the end where it finds nothing to process.

<img width="2556" alt="Screenshot 2023-06-19 at 10 17 47 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/0f0e53d1-7f5b-43d5-a4fe-bed0723a2ede">

<img width="2521" alt="Screenshot 2023-06-19 at 10 18 14 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/e2594367-47c5-4747-b2e7-0d7e77459c2e">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
