### PR TITLE
Migrate PageTitleComponent to vuetify AB#15736

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
@@ -15,41 +15,58 @@ const props = withDefaults(defineProps<Props>(), {
 type HgButtonVariant = "primary" | "secondary" | "link";
 
 interface HgButtonVariantDetails {
+    inverseVariant: HgButtonVariant;
     vuetifyVariant: "flat" | "outlined" | "text";
     color: string;
+    bgColor?: string;
 }
 
 const variants = new Map<HgButtonVariant, HgButtonVariantDetails>();
 variants.set("primary", {
+    inverseVariant: "secondary",
     vuetifyVariant: "flat",
     color: "primary",
 });
 variants.set("secondary", {
+    inverseVariant: "primary",
     vuetifyVariant: "outlined",
     color: "primary",
+    bgColor: "white",
 });
 variants.set("link", {
+    inverseVariant: "link",
     vuetifyVariant: "text",
     color: "link",
 });
 
 const slots = useSlots();
 
-const vuetifyVariant = computed(
-    () => variants.get(props.variant)?.vuetifyVariant
-);
-const color = computed(() => variants.get(props.variant)?.color);
 const hasSlot = computed(() => slots.default !== undefined);
+const variantDetails = computed(() => {
+    const details = variants.get(props.variant)!;
+    return props.inverse ? variants.get(details.inverseVariant)! : details;
+});
+const bgColor = computed(() => variantDetails.value.bgColor);
+const classes = computed(() => ({
+    [`bg-${bgColor.value}`]: Boolean(bgColor.value),
+}));
 </script>
 
 <template>
     <v-btn
         v-if="hasSlot"
-        :variant="vuetifyVariant"
-        :color="color"
+        :variant="variantDetails.vuetifyVariant"
+        :color="variantDetails.color"
+        :class="classes"
         :ripple="false"
     >
         <slot />
     </v-btn>
-    <v-btn v-else :variant="vuetifyVariant" :color="color" :ripple="false" />
+    <v-btn
+        v-else
+        :variant="variantDetails.vuetifyVariant"
+        :color="variantDetails.color"
+        :class="classes"
+        :ripple="false"
+    />
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, useSlots } from "vue";
 
 interface Props {
     variant?: HgButtonVariant;
@@ -33,14 +33,23 @@ variants.set("link", {
     color: "link",
 });
 
+const slots = useSlots();
+
 const vuetifyVariant = computed(
     () => variants.get(props.variant)?.vuetifyVariant
 );
 const color = computed(() => variants.get(props.variant)?.color);
+const hasSlot = computed(() => slots.default !== undefined);
 </script>
 
 <template>
-    <v-btn :variant="vuetifyVariant" :color="color" :ripple="false">
+    <v-btn
+        v-if="hasSlot"
+        :variant="vuetifyVariant"
+        :color="color"
+        :ripple="false"
+    >
         <slot />
     </v-btn>
+    <v-btn v-else :variant="vuetifyVariant" :color="color" :ripple="false" />
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgIconButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgIconButtonComponent.vue
@@ -1,10 +1,33 @@
 <script setup lang="ts">
+import { computed, useSlots } from "vue";
+
 interface Props {
-    icon: string;
+    icon: string | boolean;
 }
-defineProps<Props>();
+withDefaults(defineProps<Props>(), {
+    icon: true,
+});
+
+const slots = useSlots();
+
+const hasSlot = computed(() => slots.default !== undefined);
 </script>
 
 <template>
-    <v-btn :icon="icon" variant="flat" class="bg-transparent" :ripple="false" />
+    <v-btn
+        v-if="hasSlot"
+        :icon="icon"
+        variant="flat"
+        class="bg-transparent"
+        :ripple="false"
+    >
+        <slot />
+    </v-btn>
+    <v-btn
+        v-else
+        :icon="icon"
+        variant="flat"
+        class="bg-transparent"
+        :ripple="false"
+    />
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/PageTitleComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/PageTitleComponent.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { computed, useSlots } from "vue";
+
+interface Props {
+    title: string;
+}
+defineProps<Props>();
+
+const slots = useSlots();
+
+const hasPrependSlot = computed(() => slots.prepend !== undefined);
+const hasAppendSlot = computed(() => slots.append !== undefined);
+</script>
+
+<template>
+    <div id="pageTitle">
+        <v-row dense justify="end" align="center">
+            <v-col v-if="hasPrependSlot" class="flex-grow-0">
+                <slot name="prepend" />
+            </v-col>
+            <v-col>
+                <h1 id="subject" class="text-primary">
+                    {{ title }}
+                </h1>
+            </v-col>
+            <v-col v-if="hasAppendSlot" class="flex-grow-0">
+                <slot name="append" />
+            </v-col>
+        </v-row>
+        <v-divider
+            class="border-opacity-100 my-2"
+            color="primary"
+            :thickness="2"
+        />
+    </div>
+</template>


### PR DESCRIPTION
# Implements [AB#15736](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15736)

## Description

- migrates PageTitleComponent to vuetify [AB#15736](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15736)
- improves button components
  - extends icon button component to support slot content or icon prop
    - slot content is needed when the button needs to display a badge on the icon or an avatar
  - extends button component to support text prop or slot content
    - most of our usages won't require slot content any longer and can just use the text prop
  - fixes secondary button variant to include white background
  - introduces inverse prop for usage on dark backgrounds

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![127 0 0 1-2023-06-20-131436](https://github.com/bcgov/healthgateway/assets/16570293/98655b05-676f-49c6-b38c-d5355e40474f)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
