### PR TITLE
Convert vaccination status store to VUE 3.0 for AB#15709

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/stores/healthVisits.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/healthVisits.ts
@@ -15,7 +15,7 @@ import { ResultError } from "@/models/errors";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { useErrorStore } from "@/stores/error";
 
-const defaultHealthVisitState: HealthVisitState = {
+const defaultHealthVisitState = {
     data: [],
     status: LoadStatus.NONE,
     statusMessage: "",

--- a/Apps/WebClient/src/NewClientApp/src/stores/healthVisits.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/healthVisits.ts
@@ -15,7 +15,7 @@ import { ResultError } from "@/models/errors";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { useErrorStore } from "@/stores/error";
 
-const defaultHealthVisitState = {
+const defaultHealthVisitState: HealthVisitState = {
     data: [],
     status: LoadStatus.NONE,
     statusMessage: "",

--- a/Apps/WebClient/src/NewClientApp/src/stores/note.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/note.ts
@@ -111,15 +111,12 @@ export const useNoteStore = defineStore("note", () => {
                     if (result.resultStatus === ResultType.Success) {
                         setNotesLoaded(result.resourcePayload);
                     } else {
-                        logger.error(
-                            `Notes retrieval failed! ${JSON.stringify(result)}`
-                        );
                         if (result.resultError) {
-                            logger.error(
-                                `Notes retrieval failed - result error: ${result.resultError}`
-                            );
                             throw result.resultError;
                         }
+                        logger.warn(
+                            `Notes retrieval failed! ${JSON.stringify(result)}`
+                        );
                     }
                 })
                 .catch((error: ResultError) => {

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
@@ -306,12 +306,6 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
         function retrieveAuthenticatedVaccineRecord(
             hdid: string
         ): Promise<void> {
-            const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-            const vaccinationStatusService =
-                container.get<IVaccinationStatusService>(
-                    SERVICE_IDENTIFIER.VaccinationStatusService
-                );
-
             logger.debug(`Retrieving authenticated vaccination record`);
             setAuthenticatedVaccineRecordRequested(hdid);
 

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
@@ -14,7 +14,7 @@ import { useErrorStore } from "@/stores/error";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
-export const useVaccinationStatusStore = defineStore(
+export const useVaccinationStatusAuthenticatedStore = defineStore(
     "vaccinationStatusAuthenticated",
     () => {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
@@ -1,0 +1,387 @@
+import { ActionType } from "@/constants/actionType";
+import { ErrorSourceType, ErrorType } from "@/constants/errorType";
+import { ResultType } from "@/constants/resulttype";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import CovidVaccineRecord from "@/models/covidVaccineRecord";
+import { DateWrapper } from "@/models/dateWrapper";
+import { ResultError } from "@/models/errors";
+import { LoadStatus } from "@/models/storeOperations";
+import VaccinationStatus from "@/models/vaccinationStatus";
+import VaccineRecordState from "@/models/vaccineRecordState";
+import { ILogger, IVaccinationStatusService } from "@/services/interfaces";
+import { useErrorStore } from "@/stores/error";
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+export const useVaccinationStatusStore = defineStore(
+    "vaccinationStatusAuthenticated",
+    () => {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        const vaccinationStatusService =
+            container.get<IVaccinationStatusService>(
+                SERVICE_IDENTIFIER.VaccinationStatusService
+            );
+
+        const errorStore = useErrorStore();
+
+        const defaultVaccineRecordState: VaccineRecordState = {
+            hdid: "",
+            download: false,
+            status: LoadStatus.NONE,
+            statusMessage: "",
+            resultMessage: "",
+        };
+
+        interface AuthenticatedVaccinationStatus {
+            vaccinationStatus?: VaccinationStatus;
+            error?: ResultError;
+            status: LoadStatus;
+            statusMessage: string;
+        }
+
+        // Refs
+        const authenticatedVaccination = ref<AuthenticatedVaccinationStatus>({
+            vaccinationStatus: undefined,
+            error: undefined,
+            status: LoadStatus.NONE,
+            statusMessage: "",
+        });
+
+        const authenticatedVaccinationRecordStates = ref(
+            new Map<string, VaccineRecordState>()
+        );
+
+        // Computed
+        const authenticatedVaccinationStatus = computed(
+            () => authenticatedVaccination.value.vaccinationStatus
+        );
+
+        const authenticatedIsLoading = computed(
+            () => authenticatedVaccination.value.status === LoadStatus.REQUESTED
+        );
+
+        const authenticatedError = computed(
+            () => authenticatedVaccination.value.error
+        );
+
+        const authenticatedStatusMessage = computed(
+            () => authenticatedVaccination.value.statusMessage
+        );
+
+        // Mutations
+        // Authenticated Vaccination Status
+        function setAuthenticatedRequested() {
+            authenticatedVaccination.value.error = undefined;
+            authenticatedVaccination.value.status = LoadStatus.REQUESTED;
+            authenticatedVaccination.value.statusMessage = "";
+        }
+
+        function setAuthenticatedVaccinationStatus(
+            vaccinationStatus: VaccinationStatus
+        ) {
+            authenticatedVaccination.value.vaccinationStatus = {
+                ...vaccinationStatus,
+                issueddate: new DateWrapper().toISO(),
+            };
+            authenticatedVaccination.value.status = LoadStatus.LOADED;
+            authenticatedVaccination.value.statusMessage = "";
+        }
+
+        function setAuthenticatedVaccinationStatusError(error: ResultError) {
+            authenticatedVaccination.value.vaccinationStatus = undefined;
+            authenticatedVaccination.value.error = error;
+            authenticatedVaccination.value.status = LoadStatus.ERROR;
+            authenticatedVaccination.value.statusMessage = "";
+        }
+
+        function setAuthenticatedVaccinationStatusMessage(
+            statusMessage: string
+        ) {
+            authenticatedVaccination.value.statusMessage = statusMessage;
+        }
+
+        // Authenticated Vaccination Record
+        function setAuthenticatedVaccineRecordRequested(hdid: string) {
+            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const nextState: VaccineRecordState = {
+                ...currentState,
+                record: undefined,
+                download: true,
+                error: undefined,
+                status: LoadStatus.REQUESTED,
+                statusMessage: "",
+                resultMessage: "",
+            };
+            setAuthenticatedVaccineRecordState(hdid, nextState);
+        }
+
+        function setAuthenticatedVaccinationRecord(
+            hdid: string,
+            record: CovidVaccineRecord
+        ) {
+            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const nextState: VaccineRecordState = {
+                ...currentState,
+                record,
+                error: undefined,
+                status: LoadStatus.LOADED,
+                statusMessage: "",
+            };
+            setAuthenticatedVaccineRecordState(hdid, nextState);
+        }
+
+        function setAuthenticatedVaccinationRecordError(
+            hdid: string,
+            error: ResultError
+        ) {
+            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const nextState: VaccineRecordState = {
+                ...currentState,
+                record: undefined,
+                error,
+                status: LoadStatus.ERROR,
+                statusMessage: "",
+            };
+            setAuthenticatedVaccineRecordState(hdid, nextState);
+        }
+
+        function setAuthenticatedVaccineRecordStatusMessage(
+            hdid: string,
+            statusMessage: string
+        ) {
+            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const nextState: VaccineRecordState = {
+                ...currentState,
+                statusMessage,
+            };
+            setAuthenticatedVaccineRecordState(hdid, nextState);
+        }
+
+        function setAuthenticatedVaccineRecordResultMessage(
+            hdid: string,
+            resultMessage: string
+        ) {
+            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const nextState: VaccineRecordState = {
+                ...currentState,
+                resultMessage,
+            };
+            setAuthenticatedVaccineRecordState(hdid, nextState);
+        }
+
+        function setAuthenticatedVaccineRecordDownload(
+            hdid: string,
+            download: boolean
+        ) {
+            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const nextState: VaccineRecordState = {
+                ...currentState,
+                download,
+            };
+            setAuthenticatedVaccineRecordState(hdid, nextState);
+        }
+
+        // Mutation Helpers
+        function getAuthenticatedVaccineRecordState(
+            hdid: string
+        ): VaccineRecordState {
+            return (
+                authenticatedVaccinationRecordStates.value.get(hdid) ?? {
+                    ...defaultVaccineRecordState,
+                    hdid,
+                }
+            );
+        }
+
+        function setAuthenticatedVaccineRecordState(
+            hdid: string,
+            vaccineRecordState: VaccineRecordState
+        ) {
+            authenticatedVaccinationRecordStates.value.set(
+                hdid,
+                vaccineRecordState
+            );
+        }
+
+        // Action Helpers
+        function handleAuthenticatedError(
+            error: ResultError,
+            errorType: ErrorType
+        ) {
+            logger.error(`ERROR: ${JSON.stringify(error)}`);
+            setAuthenticatedVaccinationStatusError(error);
+
+            if (error.statusCode === 429) {
+                errorStore.setTooManyRequestsWarning("page");
+            } else {
+                errorStore.addError(
+                    errorType,
+                    ErrorSourceType.VaccineCard,
+                    error.traceId
+                );
+            }
+        }
+
+        function handleAuthenticatedPdfError(
+            hdid: string,
+            error: ResultError,
+            errorType: ErrorType
+        ) {
+            logger.error(`ERROR: ${JSON.stringify(error)}`);
+            setAuthenticatedVaccinationRecordError(hdid, error);
+
+            if (error.statusCode === 429) {
+                errorStore.setTooManyRequestsWarning("vaccineCardComponent");
+            } else {
+                if (error.actionCode === ActionType.Invalid) {
+                    setAuthenticatedVaccineRecordResultMessage(
+                        hdid,
+                        "No records found"
+                    );
+                } else {
+                    errorStore.addError(
+                        errorType,
+                        ErrorSourceType.VaccineCard,
+                        error.traceId
+                    );
+                }
+            }
+        }
+
+        // Actions
+        function retrieveAuthenticatedVaccineStatus(
+            hdid: string
+        ): Promise<void> {
+            if (authenticatedVaccination.value.status === LoadStatus.LOADED) {
+                logger.debug(
+                    `Authenticated vaccination status found stored, not querying!`
+                );
+                return Promise.resolve();
+            } else {
+                logger.debug(`Retrieving authenticated vaccination status`);
+                setAuthenticatedRequested();
+                return vaccinationStatusService
+                    .getAuthenticatedVaccineStatus(hdid)
+                    .then((result) => {
+                        const payload = result.resourcePayload;
+                        if (result.resultStatus === ResultType.Success) {
+                            setAuthenticatedVaccinationStatus(payload);
+                        } else if (
+                            result.resultError?.actionCode ===
+                                ActionType.Refresh &&
+                            !payload.loaded &&
+                            payload.retryin > 0
+                        ) {
+                            logger.info(
+                                "Authenticated vaccination status not loaded"
+                            );
+                            setAuthenticatedVaccinationStatusMessage(
+                                "Please wait a moment while we retrieve your proof of vaccination."
+                            );
+                            setTimeout(() => {
+                                logger.info(
+                                    "Re-querying for authenticated proof of vaccination"
+                                );
+                                retrieveAuthenticatedVaccineStatus(hdid);
+                            }, payload.retryin);
+                        } else {
+                            if (result.resultError) {
+                                throw result.resultError;
+                            }
+                            logger.warn(
+                                `Authenticated vaccination status retrieval failed! ${JSON.stringify(
+                                    result
+                                )}`
+                            );
+                        }
+                    })
+                    .catch((error: ResultError) => {
+                        handleAuthenticatedError(error, ErrorType.Retrieve);
+                        throw error;
+                    });
+            }
+        }
+
+        function retrieveAuthenticatedVaccineRecord(
+            hdid: string
+        ): Promise<void> {
+            const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+            const vaccinationStatusService =
+                container.get<IVaccinationStatusService>(
+                    SERVICE_IDENTIFIER.VaccinationStatusService
+                );
+
+            logger.debug(`Retrieving authenticated vaccination record`);
+            setAuthenticatedVaccineRecordRequested(hdid);
+
+            return vaccinationStatusService
+                .getAuthenticatedVaccineRecord(hdid)
+                .then((result) => {
+                    const payload = result.resourcePayload;
+                    if (result.resultStatus === ResultType.Success) {
+                        logger.info("Authenticated vaccination record loaded");
+                        setAuthenticatedVaccinationRecord(hdid, payload);
+                    } else if (
+                        result.resultError?.actionCode === ActionType.Refresh &&
+                        !payload.loaded &&
+                        payload.retryin > 0
+                    ) {
+                        logger.info(
+                            "Authenticated vaccination record not loaded but will try again"
+                        );
+                        setAuthenticatedVaccineRecordStatusMessage(
+                            hdid,
+                            "Please wait a moment while we download your proof of vaccination."
+                        );
+                        setTimeout(() => {
+                            logger.info(
+                                "Re-querying for downloading the authenticated vaccination record"
+                            );
+                            retrieveAuthenticatedVaccineRecord(hdid);
+                        }, payload.retryin);
+                    } else {
+                        if (result.resultError) {
+                            throw result.resultError;
+                        }
+                        logger.warn(
+                            `Authenticated vaccination record retrieval failed! ${JSON.stringify(
+                                result
+                            )}`
+                        );
+                    }
+                })
+                .catch((error: ResultError) => {
+                    logger.error(
+                        "Authenticated vaccination record not loaded due to unexpected error"
+                    );
+                    handleAuthenticatedPdfError(
+                        hdid,
+                        error,
+                        ErrorType.Retrieve
+                    );
+                });
+        }
+
+        function authenticatedVaccineRecordState(
+            hdid: string
+        ): VaccineRecordState {
+            return getAuthenticatedVaccineRecordState(hdid);
+        }
+
+        function stopAuthenticatedVaccineRecordDownload(hdid: string) {
+            setAuthenticatedVaccineRecordDownload(hdid, false);
+        }
+
+        return {
+            authenticatedVaccinationStatus,
+            authenticatedIsLoading,
+            authenticatedError,
+            authenticatedStatusMessage,
+            retrieveAuthenticatedVaccineStatus,
+            retrieveAuthenticatedVaccineRecord,
+            authenticatedVaccineRecordState,
+            stopAuthenticatedVaccineRecordDownload,
+        };
+    }
+);

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusAuthenticated.ts
@@ -33,77 +33,74 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             resultMessage: "",
         };
 
-        interface AuthenticatedVaccinationStatus {
-            vaccinationStatus?: VaccinationStatus;
+        interface Vaccination {
+            data?: VaccinationStatus;
             error?: ResultError;
             status: LoadStatus;
             statusMessage: string;
         }
 
         // Refs
-        const authenticatedVaccination = ref<AuthenticatedVaccinationStatus>({
-            vaccinationStatus: undefined,
+        const vaccination = ref<Vaccination>({
+            data: undefined,
             error: undefined,
             status: LoadStatus.NONE,
             statusMessage: "",
         });
 
-        const authenticatedVaccinationRecordStates = ref(
-            new Map<string, VaccineRecordState>()
-        );
+        const vaccineRecordStates = ref(new Map<string, VaccineRecordState>());
 
         // Computed
-        const authenticatedVaccinationStatus = computed(
-            () => authenticatedVaccination.value.vaccinationStatus
+        // Vaccination Status
+        const vaccinationStatus = computed(() => vaccination.value.data);
+
+        const vaccinationStatusIsLoading = computed(
+            () => vaccination.value.status === LoadStatus.REQUESTED
         );
 
-        const authenticatedIsLoading = computed(
-            () => authenticatedVaccination.value.status === LoadStatus.REQUESTED
+        const vaccinationStatusError = computed(() => vaccination.value.error);
+
+        const vaccinationStatusStatusMessage = computed(
+            () => vaccination.value.statusMessage
         );
 
-        const authenticatedError = computed(
-            () => authenticatedVaccination.value.error
-        );
-
-        const authenticatedStatusMessage = computed(
-            () => authenticatedVaccination.value.statusMessage
-        );
-
-        // Mutations
-        // Authenticated Vaccination Status
-        function setAuthenticatedRequested() {
-            authenticatedVaccination.value.error = undefined;
-            authenticatedVaccination.value.status = LoadStatus.REQUESTED;
-            authenticatedVaccination.value.statusMessage = "";
+        // Getters
+        // Vaccine Records
+        function vaccineRecordState(hdid: string): VaccineRecordState {
+            return getVaccineRecordState(hdid);
         }
 
-        function setAuthenticatedVaccinationStatus(
-            vaccinationStatus: VaccinationStatus
-        ) {
-            authenticatedVaccination.value.vaccinationStatus = {
+        // Mutations
+        // Vaccination Status
+        function setVaccinationStatusRequested() {
+            vaccination.value.error = undefined;
+            vaccination.value.status = LoadStatus.REQUESTED;
+            vaccination.value.statusMessage = "";
+        }
+
+        function setVaccinationStatus(vaccinationStatus: VaccinationStatus) {
+            vaccination.value.data = {
                 ...vaccinationStatus,
                 issueddate: new DateWrapper().toISO(),
             };
-            authenticatedVaccination.value.status = LoadStatus.LOADED;
-            authenticatedVaccination.value.statusMessage = "";
+            vaccination.value.status = LoadStatus.LOADED;
+            vaccination.value.statusMessage = "";
         }
 
-        function setAuthenticatedVaccinationStatusError(error: ResultError) {
-            authenticatedVaccination.value.vaccinationStatus = undefined;
-            authenticatedVaccination.value.error = error;
-            authenticatedVaccination.value.status = LoadStatus.ERROR;
-            authenticatedVaccination.value.statusMessage = "";
+        function setVaccinationStatusError(error: ResultError) {
+            vaccination.value.data = undefined;
+            vaccination.value.error = error;
+            vaccination.value.status = LoadStatus.ERROR;
+            vaccination.value.statusMessage = "";
         }
 
-        function setAuthenticatedVaccinationStatusMessage(
-            statusMessage: string
-        ) {
-            authenticatedVaccination.value.statusMessage = statusMessage;
+        function setVaccinationStatusStatusMessage(statusMessage: string) {
+            vaccination.value.statusMessage = statusMessage;
         }
 
-        // Authenticated Vaccination Record
-        function setAuthenticatedVaccineRecordRequested(hdid: string) {
-            const currentState = getAuthenticatedVaccineRecordState(hdid);
+        // Vaccination Record
+        function setVaccineRecordRequested(hdid: string) {
+            const currentState = getVaccineRecordState(hdid);
             const nextState: VaccineRecordState = {
                 ...currentState,
                 record: undefined,
@@ -116,11 +113,8 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             setAuthenticatedVaccineRecordState(hdid, nextState);
         }
 
-        function setAuthenticatedVaccinationRecord(
-            hdid: string,
-            record: CovidVaccineRecord
-        ) {
-            const currentState = getAuthenticatedVaccineRecordState(hdid);
+        function setVaccineRecord(hdid: string, record: CovidVaccineRecord) {
+            const currentState = getVaccineRecordState(hdid);
             const nextState: VaccineRecordState = {
                 ...currentState,
                 record,
@@ -131,11 +125,8 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             setAuthenticatedVaccineRecordState(hdid, nextState);
         }
 
-        function setAuthenticatedVaccinationRecordError(
-            hdid: string,
-            error: ResultError
-        ) {
-            const currentState = getAuthenticatedVaccineRecordState(hdid);
+        function setVaccineRecordError(hdid: string, error: ResultError) {
+            const currentState = getVaccineRecordState(hdid);
             const nextState: VaccineRecordState = {
                 ...currentState,
                 record: undefined,
@@ -146,11 +137,11 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             setAuthenticatedVaccineRecordState(hdid, nextState);
         }
 
-        function setAuthenticatedVaccineRecordStatusMessage(
+        function setVaccineRecordStatusMessage(
             hdid: string,
             statusMessage: string
         ) {
-            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const currentState = getVaccineRecordState(hdid);
             const nextState: VaccineRecordState = {
                 ...currentState,
                 statusMessage,
@@ -158,11 +149,11 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             setAuthenticatedVaccineRecordState(hdid, nextState);
         }
 
-        function setAuthenticatedVaccineRecordResultMessage(
+        function setVaccineRecordResultMessage(
             hdid: string,
             resultMessage: string
         ) {
-            const currentState = getAuthenticatedVaccineRecordState(hdid);
+            const currentState = getVaccineRecordState(hdid);
             const nextState: VaccineRecordState = {
                 ...currentState,
                 resultMessage,
@@ -170,11 +161,8 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             setAuthenticatedVaccineRecordState(hdid, nextState);
         }
 
-        function setAuthenticatedVaccineRecordDownload(
-            hdid: string,
-            download: boolean
-        ) {
-            const currentState = getAuthenticatedVaccineRecordState(hdid);
+        function setVaccineRecordDownload(hdid: string, download: boolean) {
+            const currentState = getVaccineRecordState(hdid);
             const nextState: VaccineRecordState = {
                 ...currentState,
                 download,
@@ -183,11 +171,9 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
         }
 
         // Mutation Helpers
-        function getAuthenticatedVaccineRecordState(
-            hdid: string
-        ): VaccineRecordState {
+        function getVaccineRecordState(hdid: string): VaccineRecordState {
             return (
-                authenticatedVaccinationRecordStates.value.get(hdid) ?? {
+                vaccineRecordStates.value.get(hdid) ?? {
                     ...defaultVaccineRecordState,
                     hdid,
                 }
@@ -198,10 +184,7 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             hdid: string,
             vaccineRecordState: VaccineRecordState
         ) {
-            authenticatedVaccinationRecordStates.value.set(
-                hdid,
-                vaccineRecordState
-            );
+            vaccineRecordStates.value.set(hdid, vaccineRecordState);
         }
 
         // Action Helpers
@@ -210,7 +193,7 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             errorType: ErrorType
         ) {
             logger.error(`ERROR: ${JSON.stringify(error)}`);
-            setAuthenticatedVaccinationStatusError(error);
+            setVaccinationStatusError(error);
 
             if (error.statusCode === 429) {
                 errorStore.setTooManyRequestsWarning("page");
@@ -229,16 +212,13 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             errorType: ErrorType
         ) {
             logger.error(`ERROR: ${JSON.stringify(error)}`);
-            setAuthenticatedVaccinationRecordError(hdid, error);
+            setVaccineRecordError(hdid, error);
 
             if (error.statusCode === 429) {
                 errorStore.setTooManyRequestsWarning("vaccineCardComponent");
             } else {
                 if (error.actionCode === ActionType.Invalid) {
-                    setAuthenticatedVaccineRecordResultMessage(
-                        hdid,
-                        "No records found"
-                    );
+                    setVaccineRecordResultMessage(hdid, "No records found");
                 } else {
                     errorStore.addError(
                         errorType,
@@ -250,23 +230,21 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
         }
 
         // Actions
-        function retrieveAuthenticatedVaccineStatus(
-            hdid: string
-        ): Promise<void> {
-            if (authenticatedVaccination.value.status === LoadStatus.LOADED) {
+        function retrieveVaccinationStatus(hdid: string): Promise<void> {
+            if (vaccination.value.status === LoadStatus.LOADED) {
                 logger.debug(
                     `Authenticated vaccination status found stored, not querying!`
                 );
                 return Promise.resolve();
             } else {
                 logger.debug(`Retrieving authenticated vaccination status`);
-                setAuthenticatedRequested();
+                setVaccinationStatusRequested();
                 return vaccinationStatusService
                     .getAuthenticatedVaccineStatus(hdid)
                     .then((result) => {
                         const payload = result.resourcePayload;
                         if (result.resultStatus === ResultType.Success) {
-                            setAuthenticatedVaccinationStatus(payload);
+                            setVaccinationStatus(payload);
                         } else if (
                             result.resultError?.actionCode ===
                                 ActionType.Refresh &&
@@ -276,14 +254,14 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
                             logger.info(
                                 "Authenticated vaccination status not loaded"
                             );
-                            setAuthenticatedVaccinationStatusMessage(
+                            setVaccinationStatusStatusMessage(
                                 "Please wait a moment while we retrieve your proof of vaccination."
                             );
                             setTimeout(() => {
                                 logger.info(
                                     "Re-querying for authenticated proof of vaccination"
                                 );
-                                retrieveAuthenticatedVaccineStatus(hdid);
+                                retrieveVaccinationStatus(hdid);
                             }, payload.retryin);
                         } else {
                             if (result.resultError) {
@@ -303,11 +281,9 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
             }
         }
 
-        function retrieveAuthenticatedVaccineRecord(
-            hdid: string
-        ): Promise<void> {
+        function retrieveVaccineRecord(hdid: string): Promise<void> {
             logger.debug(`Retrieving authenticated vaccination record`);
-            setAuthenticatedVaccineRecordRequested(hdid);
+            setVaccineRecordRequested(hdid);
 
             return vaccinationStatusService
                 .getAuthenticatedVaccineRecord(hdid)
@@ -315,7 +291,7 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
                     const payload = result.resourcePayload;
                     if (result.resultStatus === ResultType.Success) {
                         logger.info("Authenticated vaccination record loaded");
-                        setAuthenticatedVaccinationRecord(hdid, payload);
+                        setVaccineRecord(hdid, payload);
                     } else if (
                         result.resultError?.actionCode === ActionType.Refresh &&
                         !payload.loaded &&
@@ -324,7 +300,7 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
                         logger.info(
                             "Authenticated vaccination record not loaded but will try again"
                         );
-                        setAuthenticatedVaccineRecordStatusMessage(
+                        setVaccineRecordStatusMessage(
                             hdid,
                             "Please wait a moment while we download your proof of vaccination."
                         );
@@ -332,7 +308,7 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
                             logger.info(
                                 "Re-querying for downloading the authenticated vaccination record"
                             );
-                            retrieveAuthenticatedVaccineRecord(hdid);
+                            retrieveVaccineRecord(hdid);
                         }, payload.retryin);
                     } else {
                         if (result.resultError) {
@@ -357,25 +333,19 @@ export const useVaccinationStatusAuthenticatedStore = defineStore(
                 });
         }
 
-        function authenticatedVaccineRecordState(
-            hdid: string
-        ): VaccineRecordState {
-            return getAuthenticatedVaccineRecordState(hdid);
-        }
-
-        function stopAuthenticatedVaccineRecordDownload(hdid: string) {
-            setAuthenticatedVaccineRecordDownload(hdid, false);
+        function stopVaccineRecordDownload(hdid: string) {
+            setVaccineRecordDownload(hdid, false);
         }
 
         return {
-            authenticatedVaccinationStatus,
-            authenticatedIsLoading,
-            authenticatedError,
-            authenticatedStatusMessage,
-            retrieveAuthenticatedVaccineStatus,
-            retrieveAuthenticatedVaccineRecord,
-            authenticatedVaccineRecordState,
-            stopAuthenticatedVaccineRecordDownload,
+            vaccinationStatus,
+            vaccinationStatusIsLoading,
+            vaccinationStatusError,
+            vaccinationStatusStatusMessage,
+            vaccineRecordState,
+            retrieveVaccinationStatus,
+            retrieveVaccineRecord,
+            stopVaccineRecordDownload,
         };
     }
 );

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusPublic.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusPublic.ts
@@ -23,137 +23,126 @@ export const useVaccinationStatusPublicStore = defineStore(
 
         const errorStore = useErrorStore();
 
-        interface PublicVaccinationStatus {
-            vaccinationStatus?: VaccinationStatus;
+        interface Vaccination {
+            data?: VaccinationStatus;
             error?: CustomBannerError;
             status: LoadStatus;
             statusMessage: string;
         }
 
-        interface PublicVaccinationRecord {
-            vaccinationRecord?: CovidVaccineRecord;
+        interface VaccinationRecord {
+            data?: CovidVaccineRecord;
             error?: CustomBannerError;
             status: LoadStatus;
             statusMessage: string;
         }
 
         // Refs
-        const publicVaccination = ref<PublicVaccinationStatus>({
-            vaccinationStatus: undefined,
+        const vaccination = ref<Vaccination>({
+            data: undefined,
             error: undefined,
             status: LoadStatus.NONE,
             statusMessage: "",
         });
 
-        const publicVaccinationRecord = ref<PublicVaccinationRecord>({
-            vaccinationRecord: undefined,
+        const vaccinationRecord = ref<VaccinationRecord>({
+            data: undefined,
             error: undefined,
             status: LoadStatus.NONE,
             statusMessage: "",
         });
 
         // Computed
-        // Public Vaccination Status
-        const publicVaccinationStatus = computed(
-            () => publicVaccination.value.vaccinationStatus
+        // Vaccination Status
+        const vaccinationStatus = computed(() => vaccination.value.data);
+
+        const vaccinationStatusIsLoading = computed(
+            () => vaccination.value.status === LoadStatus.REQUESTED
         );
 
-        const publicIsLoading = computed(
-            () => publicVaccination.value.status === LoadStatus.REQUESTED
+        const vaccinationStatusError = computed(() => vaccination.value.error);
+
+        const vaccinationStatusStatusMessage = computed(
+            () => vaccination.value.statusMessage
         );
 
-        const publicError = computed(() => publicVaccination.value.error);
+        // Vaccine Record
+        const vaccineRecord = computed(() => vaccinationRecord.value.data);
 
-        const publicStatusMessage = computed(
-            () => publicVaccination.value.statusMessage
+        const vaccineRecordIsLoading = computed(
+            () => vaccinationRecord.value.status === LoadStatus.REQUESTED
         );
 
-        // Public Vaccination Record
-        const publicVaccineRecord = computed(
-            () => publicVaccinationRecord.value.vaccinationRecord
+        const vaccineRecordError = computed(
+            () => vaccinationRecord.value.error
         );
 
-        const publicVaccineRecordIsLoading = computed(
-            () => publicVaccinationRecord.value.status === LoadStatus.REQUESTED
-        );
-
-        const publicVaccineRecordError = computed(
-            () => publicVaccinationRecord.value.error
-        );
-
-        const publicVaccineRecordStatusMessage = computed(
-            () => publicVaccinationRecord.value.statusMessage
+        const vaccineRecordStatusMessage = computed(
+            () => vaccinationRecord.value.statusMessage
         );
 
         // Mutations
-        // Public Vaccination Status
-        function setPublicVaccinationRequested() {
-            publicVaccination.value.error = undefined;
-            publicVaccination.value.status = LoadStatus.REQUESTED;
-            publicVaccination.value.statusMessage = "";
+        // Vaccination Status
+        function setVaccinationStatusRequested() {
+            vaccination.value.error = undefined;
+            vaccination.value.status = LoadStatus.REQUESTED;
+            vaccination.value.statusMessage = "";
         }
 
-        function setPublicVaccinationStatus(
-            vaccinationStatus: VaccinationStatus
-        ) {
-            publicVaccination.value.vaccinationStatus = {
+        function setVaccinationStatus(vaccinationStatus: VaccinationStatus) {
+            vaccination.value.data = {
                 ...vaccinationStatus,
                 issueddate: new DateWrapper().toISO(),
             };
-            publicVaccination.value.status = LoadStatus.LOADED;
-            publicVaccination.value.statusMessage = "";
+            vaccination.value.status = LoadStatus.LOADED;
+            vaccination.value.statusMessage = "";
         }
 
-        function setPublicVaccinationStatusError(
+        function setVaccinationStatusError(
             error: CustomBannerError | undefined
         ) {
-            publicVaccination.value.vaccinationStatus = undefined;
-            publicVaccination.value.error = error;
-            publicVaccination.value.status = LoadStatus.ERROR;
-            publicVaccination.value.statusMessage = "";
+            vaccination.value.data = undefined;
+            vaccination.value.error = error;
+            vaccination.value.status = LoadStatus.ERROR;
+            vaccination.value.statusMessage = "";
         }
 
-        function setPublicVaccinationStatusMessage(statusMessage: string) {
-            publicVaccination.value.statusMessage = statusMessage;
+        function setVaccinationStatusStatusMessage(statusMessage: string) {
+            vaccination.value.statusMessage = statusMessage;
         }
 
-        // Public Vaccination Record
-        function setPublicVaccinationRecordRequested() {
-            publicVaccinationRecord.value.status = LoadStatus.REQUESTED;
-            publicVaccinationRecord.value.statusMessage = "";
-            publicVaccinationRecord.value.error = undefined;
+        // Vaccination Record
+        function setVaccinationRecordRequested() {
+            vaccinationRecord.value.status = LoadStatus.REQUESTED;
+            vaccinationRecord.value.statusMessage = "";
+            vaccinationRecord.value.error = undefined;
         }
 
-        function setPublicVaccinationRecord(
-            covidVaccineRecord: CovidVaccineRecord
-        ) {
-            publicVaccinationRecord.value.vaccinationRecord =
-                covidVaccineRecord;
-            publicVaccinationRecord.value.status = LoadStatus.LOADED;
-            publicVaccinationRecord.value.statusMessage = "";
-            publicVaccinationRecord.value.error = undefined;
+        function setVaccinationRecord(covidVaccineRecord: CovidVaccineRecord) {
+            vaccinationRecord.value.data = covidVaccineRecord;
+            vaccinationRecord.value.status = LoadStatus.LOADED;
+            vaccinationRecord.value.statusMessage = "";
+            vaccinationRecord.value.error = undefined;
         }
 
-        function setPublicVaccinationRecordError(
+        function setVaccinationRecordError(
             error: CustomBannerError | undefined
         ) {
-            publicVaccinationRecord.value.error = error;
-            publicVaccinationRecord.value.status = LoadStatus.ERROR;
+            vaccinationRecord.value.error = error;
+            vaccinationRecord.value.status = LoadStatus.ERROR;
         }
 
-        function setPublicVaccinationRecordStatusMessage(
-            statusMessage: string
-        ) {
-            publicVaccinationRecord.value.statusMessage = statusMessage;
+        function setVaccinationRecordStatusMessage(statusMessage: string) {
+            vaccinationRecord.value.statusMessage = statusMessage;
         }
 
         // Helpers
-        function handlePublicError(error: ResultError) {
+        function handleError(error: ResultError) {
             logger.error(`ERROR: ${JSON.stringify(error)}`);
 
             if (error.statusCode === 429) {
                 errorStore.setTooManyRequestsWarning("publicVaccineCard");
-                setPublicVaccinationStatusError(undefined);
+                setVaccinationStatusError(undefined);
             } else {
                 const customBannerError: CustomBannerError = {
                     title: "Our Apologies",
@@ -165,7 +154,7 @@ export const useVaccinationStatusPublicStore = defineStore(
                     customBannerError.title = "Data Mismatch";
                     customBannerError.description = error.resultMessage;
                 }
-                setPublicVaccinationStatusError(customBannerError);
+                setVaccinationStatusError(customBannerError);
             }
         }
 
@@ -174,45 +163,45 @@ export const useVaccinationStatusPublicStore = defineStore(
 
             if (error.statusCode === 429) {
                 errorStore.setTooManyRequestsWarning("vaccineCardComponent");
-                setPublicVaccinationRecordError(undefined);
+                setVaccinationRecordError(undefined);
             } else {
                 const customBannerError: CustomBannerError = {
                     title: "Our Apologies",
                     description:
                         "We've found an issue and the Health Gateway team is working hard to fix it.",
                 };
-                setPublicVaccinationRecordError(customBannerError);
+                setVaccinationRecordError(customBannerError);
             }
         }
 
         // Actions
-        function retrievePublicVaccineStatus(
+        function retrieveVaccinationStatus(
             phn: string,
             dateOfBirth: StringISODate,
             dateOfVaccine: StringISODate
         ): Promise<void> {
             logger.debug(`Retrieving public vaccination status`);
-            setPublicVaccinationRequested();
+            setVaccinationStatusRequested();
             return vaccinationStatusService
                 .getPublicVaccineStatus(phn, dateOfBirth, dateOfVaccine)
                 .then((result) => {
                     const payload = result.resourcePayload;
                     if (result.resultStatus === ResultType.Success) {
-                        setPublicVaccinationStatus(payload);
+                        setVaccinationStatus(payload);
                     } else if (
                         result.resultError?.actionCode === ActionType.Refresh &&
                         !payload.loaded &&
                         payload.retryin > 0
                     ) {
                         logger.info("Public vaccination status not loaded");
-                        setPublicVaccinationStatusMessage(
+                        setVaccinationStatusStatusMessage(
                             "Please wait a moment while we retrieve your proof of vaccination."
                         );
                         setTimeout(() => {
                             logger.info(
                                 "Re-querying for public vaccination status"
                             );
-                            retrievePublicVaccineStatus(
+                            retrieveVaccinationStatus(
                                 phn,
                                 dateOfBirth,
                                 dateOfVaccine
@@ -223,38 +212,38 @@ export const useVaccinationStatusPublicStore = defineStore(
                     }
                 })
                 .catch((error: ResultError) => {
-                    handlePublicError(error);
+                    handleError(error);
                     throw error;
                 });
         }
 
-        function retrievePublicVaccineRecord(
+        function retrieveVaccinationRecord(
             phn: string,
             dateOfBirth: StringISODate,
             dateOfVaccine: StringISODate
         ): Promise<void> {
             logger.debug(`Retrieving public vaccination record`);
-            setPublicVaccinationRecordRequested();
+            setVaccinationRecordRequested();
             return vaccinationStatusService
                 .getPublicVaccineStatusPdf(phn, dateOfBirth, dateOfVaccine)
                 .then((result) => {
                     const payload = result.resourcePayload;
                     if (result.resultStatus === ResultType.Success) {
-                        setPublicVaccinationRecord(payload);
+                        setVaccinationRecord(payload);
                     } else if (
                         result.resultError?.actionCode === ActionType.Refresh &&
                         !payload.loaded &&
                         payload.retryin > 0
                     ) {
                         logger.info("Public vaccination proof not loaded");
-                        setPublicVaccinationRecordStatusMessage(
+                        setVaccinationRecordStatusMessage(
                             "Please wait a moment while we download your proof of vaccination."
                         );
                         setTimeout(() => {
                             logger.info(
                                 "Re-querying for public proof of vaccination"
                             );
-                            retrievePublicVaccineRecord(
+                            retrieveVaccinationRecord(
                                 phn,
                                 dateOfBirth,
                                 dateOfVaccine
@@ -270,16 +259,16 @@ export const useVaccinationStatusPublicStore = defineStore(
         }
 
         return {
-            publicVaccinationStatus,
-            publicIsLoading,
-            publicError,
-            publicStatusMessage,
-            publicVaccineRecord,
-            publicVaccineRecordIsLoading,
-            publicVaccineRecordError,
-            publicVaccineRecordStatusMessage,
-            retrievePublicVaccineStatus,
-            retrievePublicVaccineRecord,
+            vaccinationStatus,
+            vaccinationStatusIsLoading,
+            vaccinationStatusError,
+            vaccinationStatusStatusMessage,
+            vaccineRecord,
+            vaccineRecordIsLoading,
+            vaccineRecordError,
+            vaccineRecordStatusMessage,
+            retrieveVaccinationStatus,
+            retrieveVaccinationRecord,
         };
     }
 );

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusPublic.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusPublic.ts
@@ -1,0 +1,285 @@
+import { ActionType } from "@/constants/actionType";
+import { ResultType } from "@/constants/resulttype";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import CovidVaccineRecord from "@/models/covidVaccineRecord";
+import { DateWrapper, StringISODate } from "@/models/dateWrapper";
+import { CustomBannerError, ResultError } from "@/models/errors";
+import { LoadStatus } from "@/models/storeOperations";
+import VaccinationStatus from "@/models/vaccinationStatus";
+import { ILogger, IVaccinationStatusService } from "@/services/interfaces";
+import { useErrorStore } from "@/stores/error";
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+
+export const useVaccinationStatusStore = defineStore(
+    "vaccinationStatusPublic",
+    () => {
+        const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+        const vaccinationStatusService =
+            container.get<IVaccinationStatusService>(
+                SERVICE_IDENTIFIER.VaccinationStatusService
+            );
+
+        const errorStore = useErrorStore();
+
+        interface PublicVaccinationStatus {
+            vaccinationStatus?: VaccinationStatus;
+            error?: CustomBannerError;
+            status: LoadStatus;
+            statusMessage: string;
+        }
+
+        interface PublicVaccinationRecord {
+            vaccinationRecord?: CovidVaccineRecord;
+            error?: CustomBannerError;
+            status: LoadStatus;
+            statusMessage: string;
+        }
+
+        // Refs
+        const publicVaccination = ref<PublicVaccinationStatus>({
+            vaccinationStatus: undefined,
+            error: undefined,
+            status: LoadStatus.NONE,
+            statusMessage: "",
+        });
+
+        const publicVaccinationRecord = ref<PublicVaccinationRecord>({
+            vaccinationRecord: undefined,
+            error: undefined,
+            status: LoadStatus.NONE,
+            statusMessage: "",
+        });
+
+        // Computed
+        // Public Vaccination Status
+        const publicVaccinationStatus = computed(
+            () => publicVaccination.value.vaccinationStatus
+        );
+
+        const publicIsLoading = computed(
+            () => publicVaccination.value.status === LoadStatus.REQUESTED
+        );
+
+        const publicError = computed(() => publicVaccination.value.error);
+
+        const publicStatusMessage = computed(
+            () => publicVaccination.value.statusMessage
+        );
+
+        // Public Vaccination Record
+        const publicVaccineRecord = computed(
+            () => publicVaccinationRecord.value.vaccinationRecord
+        );
+
+        const publicVaccineRecordIsLoading = computed(
+            () => publicVaccinationRecord.value.status === LoadStatus.REQUESTED
+        );
+
+        const publicVaccineRecordError = computed(
+            () => publicVaccinationRecord.value.error
+        );
+
+        const publicVaccineRecordStatusMessage = computed(
+            () => publicVaccinationRecord.value.statusMessage
+        );
+
+        // Mutations
+        // Public Vaccination Status
+        function setPublicVaccinationRequested() {
+            publicVaccination.value.error = undefined;
+            publicVaccination.value.status = LoadStatus.REQUESTED;
+            publicVaccination.value.statusMessage = "";
+        }
+
+        function setPublicVaccinationStatus(
+            vaccinationStatus: VaccinationStatus
+        ) {
+            publicVaccination.value.vaccinationStatus = {
+                ...vaccinationStatus,
+                issueddate: new DateWrapper().toISO(),
+            };
+            publicVaccination.value.status = LoadStatus.LOADED;
+            publicVaccination.value.statusMessage = "";
+        }
+
+        function setPublicVaccinationStatusError(
+            error: CustomBannerError | undefined
+        ) {
+            publicVaccination.value.vaccinationStatus = undefined;
+            publicVaccination.value.error = error;
+            publicVaccination.value.status = LoadStatus.ERROR;
+            publicVaccination.value.statusMessage = "";
+        }
+
+        function setPublicVaccinationStatusMessage(statusMessage: string) {
+            publicVaccination.value.statusMessage = statusMessage;
+        }
+
+        // Public Vaccination Record
+        function setPublicVaccinationRecordRequested() {
+            publicVaccinationRecord.value.status = LoadStatus.REQUESTED;
+            publicVaccinationRecord.value.statusMessage = "";
+            publicVaccinationRecord.value.error = undefined;
+        }
+
+        function setPublicVaccinationRecord(
+            covidVaccineRecord: CovidVaccineRecord
+        ) {
+            publicVaccinationRecord.value.vaccinationRecord =
+                covidVaccineRecord;
+            publicVaccinationRecord.value.status = LoadStatus.LOADED;
+            publicVaccinationRecord.value.statusMessage = "";
+            publicVaccinationRecord.value.error = undefined;
+        }
+
+        function setPublicVaccinationRecordError(
+            error: CustomBannerError | undefined
+        ) {
+            publicVaccinationRecord.value.error = error;
+            publicVaccinationRecord.value.status = LoadStatus.ERROR;
+        }
+
+        function setPublicVaccinationRecordStatusMessage(
+            statusMessage: string
+        ) {
+            publicVaccinationRecord.value.statusMessage = statusMessage;
+        }
+
+        // Helpers
+        function handlePublicError(error: ResultError) {
+            logger.error(`ERROR: ${JSON.stringify(error)}`);
+
+            if (error.statusCode === 429) {
+                errorStore.setTooManyRequestsWarning("publicVaccineCard");
+                setPublicVaccinationStatusError(undefined);
+            } else {
+                const customBannerError: CustomBannerError = {
+                    title: "Our Apologies",
+                    description:
+                        "We've found an issue and the Health Gateway team is working hard to fix it.",
+                };
+
+                if (error.actionCode === ActionType.DataMismatch) {
+                    customBannerError.title = "Data Mismatch";
+                    customBannerError.description = error.resultMessage;
+                }
+                setPublicVaccinationStatusError(customBannerError);
+            }
+        }
+
+        function handlePdfError(error: ResultError) {
+            logger.error(`ERROR: ${JSON.stringify(error)}`);
+
+            if (error.statusCode === 429) {
+                errorStore.setTooManyRequestsWarning("vaccineCardComponent");
+                setPublicVaccinationRecordError(undefined);
+            } else {
+                const customBannerError: CustomBannerError = {
+                    title: "Our Apologies",
+                    description:
+                        "We've found an issue and the Health Gateway team is working hard to fix it.",
+                };
+                setPublicVaccinationRecordError(customBannerError);
+            }
+        }
+
+        // Actions
+        function retrievePublicVaccineStatus(
+            phn: string,
+            dateOfBirth: StringISODate,
+            dateOfVaccine: StringISODate
+        ): Promise<void> {
+            logger.debug(`Retrieving public vaccination status`);
+            setPublicVaccinationRequested();
+            return vaccinationStatusService
+                .getPublicVaccineStatus(phn, dateOfBirth, dateOfVaccine)
+                .then((result) => {
+                    const payload = result.resourcePayload;
+                    if (result.resultStatus === ResultType.Success) {
+                        setPublicVaccinationStatus(payload);
+                    } else if (
+                        result.resultError?.actionCode === ActionType.Refresh &&
+                        !payload.loaded &&
+                        payload.retryin > 0
+                    ) {
+                        logger.info("Public vaccination status not loaded");
+                        setPublicVaccinationStatusMessage(
+                            "Please wait a moment while we retrieve your proof of vaccination."
+                        );
+                        setTimeout(() => {
+                            logger.info(
+                                "Re-querying for public vaccination status"
+                            );
+                            retrievePublicVaccineStatus(
+                                phn,
+                                dateOfBirth,
+                                dateOfVaccine
+                            );
+                        }, payload.retryin);
+                    } else {
+                        throw result.resultError;
+                    }
+                })
+                .catch((error: ResultError) => {
+                    handlePublicError(error);
+                    throw error;
+                });
+        }
+
+        function retrievePublicVaccineRecord(
+            phn: string,
+            dateOfBirth: StringISODate,
+            dateOfVaccine: StringISODate
+        ): Promise<void> {
+            logger.debug(`Retrieving public vaccination record`);
+            setPublicVaccinationRecordRequested();
+            return vaccinationStatusService
+                .getPublicVaccineStatusPdf(phn, dateOfBirth, dateOfVaccine)
+                .then((result) => {
+                    const payload = result.resourcePayload;
+                    if (result.resultStatus === ResultType.Success) {
+                        setPublicVaccinationRecord(payload);
+                    } else if (
+                        result.resultError?.actionCode === ActionType.Refresh &&
+                        !payload.loaded &&
+                        payload.retryin > 0
+                    ) {
+                        logger.info("Public vaccination proof not loaded");
+                        setPublicVaccinationRecordStatusMessage(
+                            "Please wait a moment while we download your proof of vaccination."
+                        );
+                        setTimeout(() => {
+                            logger.info(
+                                "Re-querying for public proof of vaccination"
+                            );
+                            retrievePublicVaccineRecord(
+                                phn,
+                                dateOfBirth,
+                                dateOfVaccine
+                            );
+                        }, payload.retryin);
+                    } else {
+                        throw result.resultError;
+                    }
+                })
+                .catch((error: ResultError) => {
+                    handlePdfError(error);
+                });
+        }
+
+        return {
+            publicVaccinationStatus,
+            publicIsLoading,
+            publicError,
+            publicStatusMessage,
+            publicVaccineRecord,
+            publicVaccineRecordIsLoading,
+            publicVaccineRecordError,
+            publicVaccineRecordStatusMessage,
+            retrievePublicVaccineStatus,
+            retrievePublicVaccineRecord,
+        };
+    }
+);

--- a/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusPublic.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/vaccinationStatusPublic.ts
@@ -12,7 +12,7 @@ import { useErrorStore } from "@/stores/error";
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 
-export const useVaccinationStatusStore = defineStore(
+export const useVaccinationStatusPublicStore = defineStore(
     "vaccinationStatusPublic",
     () => {
         const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);


### PR DESCRIPTION
# Implements [AB#15709](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15709)

## Description

- Created vaccinationStatusAuthenticated store from old vaccinationStatus store
- Created vaccinationStatusPublic store from old vaccinationStatus store
- Kept getter/computed and action names the same
- Updated log message in Note store to match all other stores

**Note:** Reason for naming vaccinationStatusAuthenticated and vaccinationStatusPublic was to keep the files next to one another - If this is not wanted, suggest a new name for those files.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
