### PR TITLE
Migrate HgCardComponent to vuetify AB#15545

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/views/HomeView.vue
@@ -485,7 +485,7 @@ watch(vaccineRecordState, () => {
                                     <hg-icon
                                         icon="ellipsis-v"
                                         size="medium"
-                                        data-testid="quick-link-menu-button"
+                                        data-testid="card-menu-button"
                                     />
                                 </template>
                                 <b-dropdown-item
@@ -533,7 +533,7 @@ watch(vaccineRecordState, () => {
                                     <hg-icon
                                         icon="ellipsis-v"
                                         size="medium"
-                                        data-testid="quick-link-menu-button"
+                                        data-testid="card-menu-button"
                                     />
                                 </template>
                                 <b-dropdown-item
@@ -581,7 +581,7 @@ watch(vaccineRecordState, () => {
                                     <hg-icon
                                         icon="ellipsis-v"
                                         size="medium"
-                                        data-testid="quick-link-menu-button"
+                                        data-testid="card-menu-button"
                                     />
                                 </template>
                                 <b-dropdown-item

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgButtonComponent.vue
@@ -58,7 +58,6 @@ const classes = computed(() => ({
         :variant="variantDetails.vuetifyVariant"
         :color="variantDetails.color"
         :class="classes"
-        :ripple="false"
     >
         <slot />
     </v-btn>
@@ -67,6 +66,5 @@ const classes = computed(() => ({
         :variant="variantDetails.vuetifyVariant"
         :color="variantDetails.color"
         :class="classes"
-        :ripple="false"
     />
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgCardComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgCardComponent.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { computed, useSlots } from "vue";
+import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
+
+interface Props {
+    title: string;
+}
+defineProps<Props>();
+
+const slots = useSlots();
+
+const hasIconSlot = computed<boolean>(() => {
+    return slots.icon !== undefined;
+});
+
+const hasActionIconSlot = computed<boolean>(() => {
+    return slots["action-icon"] !== undefined;
+});
+
+const hasMenuItemsSlot = computed<boolean>(() => {
+    return slots["menu-items"] !== undefined;
+});
+
+const hasDefaultSlot = computed<boolean>(() => {
+    return slots.default !== undefined;
+});
+</script>
+
+<template>
+    <v-card>
+        <template #title>
+            <v-row align="center" class="text-wrap">
+                <v-col v-if="hasIconSlot" class="flex-grow-0 d-flex py-5">
+                    <slot name="icon" />
+                </v-col>
+                <v-col data-testid="card-button-title" class="py-5">
+                    {{ title }}
+                </v-col>
+                <v-col v-if="hasActionIconSlot" class="flex-grow-0 d-flex pa-5">
+                    <slot name="action-icon" />
+                </v-col>
+                <v-col v-if="hasMenuItemsSlot" class="flex-grow-0 py-3">
+                    <v-menu location="bottom end">
+                        <template #activator="{ props }">
+                            <HgIconButtonComponent
+                                v-bind="props"
+                                icon="fas fa-ellipsis-vertical"
+                                aria-label="Menu"
+                                data-testid="card-menu-button"
+                                @click.stop.prevent
+                            />
+                        </template>
+                        <v-list>
+                            <slot name="menu-items" />
+                        </v-list>
+                    </v-menu>
+                </v-col>
+            </v-row>
+        </template>
+        <template #text v-if="hasDefaultSlot">
+            <slot name="default" />
+        </template>
+    </v-card>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgIconButtonComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgIconButtonComponent.vue
@@ -14,20 +14,8 @@ const hasSlot = computed(() => slots.default !== undefined);
 </script>
 
 <template>
-    <v-btn
-        v-if="hasSlot"
-        :icon="icon"
-        variant="flat"
-        class="bg-transparent"
-        :ripple="false"
-    >
+    <v-btn v-if="hasSlot" :icon="icon" variant="flat" class="bg-transparent">
         <slot />
     </v-btn>
-    <v-btn
-        v-else
-        :icon="icon"
-        variant="flat"
-        class="bg-transparent"
-        :ripple="false"
-    />
+    <v-btn v-else :icon="icon" variant="flat" class="bg-transparent" />
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
@@ -14,6 +14,11 @@ library.add(far, fas);
 
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
+    defaults: {
+        VIcon: {
+            style: "width: auto",
+        },
+    },
     icons: {
         defaultSet: "fa",
         aliases,

--- a/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
@@ -15,6 +15,9 @@ library.add(far, fas);
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
     defaults: {
+        global: {
+            ripple: false,
+        },
         VIcon: {
             style: "width: auto",
         },

--- a/Testing/functional/tests/cypress/integration/e2e/user/organDonorCardQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/organDonorCardQuickLink.js
@@ -4,7 +4,7 @@ const homePath = "/home";
 
 const addQuickLinkButtonSelector = "[data-testid=add-quick-link-button]";
 const addQuickLinkSubmitButtonSelector = "[data-testid=add-quick-link-btn]";
-const quickLinkMenuButtonSelector = "[data-testid=quick-link-menu-button]";
+const quickLinkMenuButtonSelector = "[data-testid=card-menu-button]";
 const quickLinkRemoveButtonSelector = "[data-testid=remove-quick-link-button]";
 const organDonorQuickLinkCardSelector =
     "[data-testid=organ-donor-registration-card]";

--- a/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
@@ -21,7 +21,7 @@ const addQuickLinkSubmitButtonSelector = "[data-testid=add-quick-link-btn]";
 const addQuickLinkModalTextSelector = "[data-testid=quick-link-modal-text]";
 const quickLinkCardSelector = "[data-testid=quick-link-card]";
 const cardButtonTitleSelector = "[data-testid=card-button-title]";
-const quickLinkMenuButtonSelector = "[data-testid=quick-link-menu-button]";
+const quickLinkMenuButtonSelector = "[data-testid=card-menu-button]";
 const quickLinkRemoveButtonSelector = "[data-testid=remove-quick-link-button]";
 
 function getQuickLinkCheckbox(module) {

--- a/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/vaccineCardQuickLink.js
@@ -4,7 +4,7 @@ const homePath = "/home";
 
 const addQuickLinkButtonSelector = "[data-testid=add-quick-link-button]";
 const addQuickLinkSubmitButtonSelector = "[data-testid=add-quick-link-btn]";
-const quickLinkMenuButtonSelector = "[data-testid=quick-link-menu-button]";
+const quickLinkMenuButtonSelector = "[data-testid=card-menu-button]";
 const quickLinkRemoveButtonSelector = "[data-testid=remove-quick-link-button]";
 const vaccineCardQuickLinkCardSelector = "[data-testid=bc-vaccine-card-card]";
 const vaccineCardAddQuickLinkCheckboxSelector =

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -281,7 +281,7 @@ function testRemoveQuickLinkError(statusCode = serverErrorStatusCode) {
     );
 
     getQuickLinkCard("Medications").within(() => {
-        cy.get("[data-testid=quick-link-menu-button]")
+        cy.get("[data-testid=card-menu-button]")
             .should("be.visible")
             .parent("a")
             .should("be.visible", "be.enabled")
@@ -314,7 +314,7 @@ function testHideVaccineCardQuickLinkError(statusCode = serverErrorStatusCode) {
     );
 
     cy.get("[data-testid=bc-vaccine-card-card]").within(() => {
-        cy.get("[data-testid=quick-link-menu-button]")
+        cy.get("[data-testid=card-menu-button]")
             .should("be.visible")
             .parent("a")
             .should("be.visible", "be.enabled")


### PR DESCRIPTION
# Implements [AB#15545](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15545)

## Description

- migrates HgCardComponent to vuetify
  - updates functional tests and old app to use the new generically named data-testid for the card menu button
  - fixes an issue with `<v-icon>` where icons could be cut off in some instances if they have a different width and height
- disables ripple effect globally, so it defaults to false rather than true and doesn't need to be toggled component by component

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![localhost-2023-06-21-170507](https://github.com/bcgov/healthgateway/assets/16570293/56f8cbc4-8c2e-49fb-9ee0-02de76ffeb56)

## Notes

There's no longer a need for HgCardButtonComponent, as HgCardComponents can receive appropriate styling when they are clickable (it's automatic when they have a `to` or `href` prop, but it can be manually assigned via the `link` prop, e.g. when assigning a click handler).  The `dense` prop is no longer needed as cards will adjust height automatically when there is no default slot content.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
