### PR TITLE
Add Procedure Description Back to Diagnostic Imaging Timeline 

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/DiagnosticImagingTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/DiagnosticImagingTimelineComponent.vue
@@ -98,6 +98,10 @@ function downloadFile(): void {
                     <strong>Body Part: </strong>
                     <span>{{ entry.bodyPart }}</span>
                 </div>
+                <div data-testid="diagnostic-imaging-procedure-description">
+                    <strong>Description: </strong>
+                    <span>{{ entry.procedureDescription }}</span>
+                </div>
                 <div data-testid="diagnostic-imaging-health-authority">
                     <strong>Health Authority: </strong>
                     <span>{{ entry.healthAuthority }}</span>

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -24,6 +24,9 @@ describe("Diagnostic Imaging", () => {
         cy.get("[data-testid=diagnostic-imaging-body-part").should(
             "be.visible"
         );
+        cy.get("[data-testid=diagnostic-imaging-procedure-description").should(
+            "be.visible"
+        );
         cy.get("[data-testid=diagnostic-imaging-health-authority").should(
             "be.visible"
         );


### PR DESCRIPTION
# Fixes or Implements [AB#15753](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15753)

## Add back procedure description to diagnostic imaging timeline card. 



## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
