### PR TITLE
Apply default styling for p, ul, and ol elements AB#15773

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/assets/styles/_spacing.scss
+++ b/Apps/WebClient/src/NewClientApp/src/assets/styles/_spacing.scss
@@ -1,0 +1,6 @@
+:is(p, ol, ul):not(:last-child) {
+    margin-bottom: 1em;
+}
+:is(ol, ul) {
+    padding-left: 40px;
+}

--- a/Apps/WebClient/src/NewClientApp/src/assets/styles/main.scss
+++ b/Apps/WebClient/src/NewClientApp/src/assets/styles/main.scss
@@ -1,4 +1,5 @@
 @use "_fonts";
+@use "_spacing";
 
 @use "vuetify" with (
     $heading-font-family: (


### PR DESCRIPTION
# Implements [AB#15773](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15773)

## Description

Vuetify resets the styling on all elements, removing the default spacing between paragraphs and indentation for lists, so these had to be re-added.

- adds margins between paragraphs and lists
- indents lists

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
