### PR TITLE
Migrate StatusLabelComponent to vuetify AB#15739

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/shared/DisplayFieldComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/DisplayFieldComponent.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+interface Props {
+    name: string;
+    value: string;
+    nameClass?: string;
+    valueClass?: string;
+}
+defineProps<Props>();
+</script>
+
+<template>
+    <div class="text-body-1">
+        <span :class="nameClass">{{ name }}: </span>
+        <span :class="valueClass" v-bind="$attrs">
+            {{ value }}
+        </span>
+    </div>
+</template>


### PR DESCRIPTION
# Implements [AB#15739](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15739)

## Description

Migrates StatusLabelComponent to vuetify, making it more generic and renaming to DisplayFieldComponent.

[Vuetify Migration Guide Link](https://github.com/bcgov/healthgateway/wiki/Vuetify:-status%E2%80%90label-(StatusLabelComponent))

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
