### PR TITLE
AppTour and Rating components - AB#15749

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -24,7 +24,7 @@ const isHeaderVisible = computed(
 
 <template>
     <v-app>
-        <HeaderComponent v-if="isHeaderVisible" class="d-print-none" />
+        <HeaderComponent v-if="isHeaderVisible" />
         <v-main>
             <router-view />
         </v-main>

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
@@ -98,6 +98,7 @@ function hideModal(): void {
 function next(): void {
     slideIndex.value++;
 }
+
 function previous(): void {
     slideIndex.value--;
 }
@@ -142,23 +143,18 @@ function previous(): void {
                             transition="scroll-x-reverse-transition"
                         />
                     </v-carousel>
+                    <div v-if="currentSlide" class="pa-4">
+                        <h3 class="text-h6 font-weight-bold">
+                            {{ currentSlide.title }}
+                        </h3>
+                        <p v-if="currentSlide.description" class="text-body-1">
+                            {{ currentSlide.description }}
+                        </p>
+                    </div>
                 </v-card-text>
                 <template #actions>
                     <v-container>
-                        <v-row v-if="currentSlide">
-                            <v-col>
-                                <h3 class="text-h6 font-weight-bold">
-                                    {{ currentSlide.title }}
-                                </h3>
-                                <p
-                                    v-if="currentSlide.description"
-                                    class="text-body-1"
-                                >
-                                    {{ currentSlide.description }}
-                                </p>
-                            </v-col>
-                        </v-row>
-                        <v-row v-if="isFirstSlide" class="mt-4">
+                        <v-row v-if="isFirstSlide">
                             <v-col cols="3">
                                 <HgButtonComponent
                                     variant="link"
@@ -176,10 +172,7 @@ function previous(): void {
                                 />
                             </v-col>
                         </v-row>
-                        <v-row
-                            v-else-if="!isFirstSlide && !isFinalSlide"
-                            class="mt-3"
-                        >
+                        <v-row v-else-if="!isFirstSlide && !isFinalSlide">
                             <v-col>
                                 <HgButtonComponent
                                     variant="link"
@@ -204,16 +197,14 @@ function previous(): void {
                                 />
                             </v-col>
                         </v-row>
-                        <v-row v-else class="mt-6">
-                            <v-col class="d-flex justify-center">
-                                <HgButtonComponent
-                                    variant="primary"
-                                    data-testid="app-tour-done"
-                                    @click="hideModal"
-                                    text="Done"
-                                />
-                            </v-col>
-                        </v-row>
+                        <div class="d-flex justify-center" v-else>
+                            <HgButtonComponent
+                                variant="primary"
+                                data-testid="app-tour-done"
+                                @click="hideModal"
+                                text="Done"
+                            />
+                        </div>
                     </v-container>
                 </template>
             </v-card>

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
@@ -120,7 +120,7 @@ function previous(): void {
                     color="red"
                     :model-value="highlightTourChangeIndicator"
                 >
-                    <v-icon icon="fas fa-lightbulb" />
+                    <v-icon icon="lightbulb" />
                 </v-badge>
             </HgIconButtonComponent>
         </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
@@ -123,7 +123,7 @@ function previous(): void {
                 </v-badge>
             </HgIconButtonComponent>
         </template>
-        <v-row align="center" justify="center" no-gutters>
+        <v-row justify="center" no-gutters>
             <v-card max-width="675px">
                 <v-card-text class="pa-0 mh-50">
                     <v-carousel

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
@@ -1,0 +1,222 @@
+﻿<script setup lang="ts">
+import { computed, ref } from "vue";
+import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
+import HgButtonComponent from "@/components/shared/HgButtonComponent.vue";
+import { VCarousel } from "vuetify/components";
+import { useDisplay } from "vuetify";
+
+interface Props {
+    highlightTourChangeIndicator: boolean;
+}
+defineProps<Props>();
+
+interface TourSlide {
+    // Title to be displayed for the slide.
+    title: string;
+    // Description to be displayed for the slide.
+    description?: string;
+    // Image or Gif to be displayed for the slide.
+    imageUri: string;
+    // Optional alt text for the image.
+    imageAlt?: string;
+}
+
+const desktopSlides: TourSlide[] = [
+    {
+        title: "App Tour",
+        description:
+            "Take this brief tour to learn how to use Health Gateway. You can always get here again by clicking the light bulb.",
+        imageUri: new URL(
+            "@/assets/images/tour/web/at-intro.png",
+            import.meta.url
+        ).href,
+        imageAlt: "App tour start splash",
+    },
+    {
+        title: "Add a Quick Link",
+        description:
+            "Add a quick link to easily access a health record type from your home screen.",
+        imageUri: new URL(
+            "@/assets/images/tour/web/at-quick-link.png",
+            import.meta.url
+        ).href,
+        imageAlt: "Quick link web demo",
+    },
+    {
+        title: "Filter your Timeline records",
+        description:
+            "Filter by health record type, date or keyword to find what you need.",
+        imageUri: new URL(
+            "@/assets/images/tour/web/at-filter.png",
+            import.meta.url
+        ).href,
+        imageAlt: "Timeline filter web demo",
+    },
+    {
+        title: "Notifications centre",
+        description:
+            "You'll be notified of updates to the app and your health records.",
+        imageUri: new URL(
+            "@/assets/images/tour/web/at-notifications-web.png",
+            import.meta.url
+        ).href,
+        imageAlt: "Notifications centre web demo",
+    },
+];
+
+const { mdAndUp } = useDisplay();
+
+const slideIndex = ref(0);
+const isVisible = ref(false);
+
+const slides = computed<TourSlide[]>(() => {
+    // (MOBILE) Requires new assets for mobile, currently returning only the desktopSlides
+    //    1. Reimplement checks for store's isMobile getter
+    //    2. Introduce mobileSlides array
+    //    3. Uncomment return statement below, naturally remove the current return desktopSlides.
+    // return this.isMobile ? mobileSlides : desktopSlides;
+    return desktopSlides;
+});
+
+const currentSlide = computed<TourSlide | undefined>(() => {
+    return slides.value.length > 0 ? slides.value[slideIndex.value] : undefined;
+});
+
+const isFinalSlide = computed<boolean>(() => {
+    return slideIndex.value === slides.value.length - 1;
+});
+
+const isFirstSlide = computed<boolean>(() => {
+    return slideIndex.value === 0;
+});
+
+function hideModal(): void {
+    slideIndex.value = 0;
+    isVisible.value = false;
+}
+
+function next(): void {
+    slideIndex.value++;
+}
+function previous(): void {
+    slideIndex.value--;
+}
+</script>
+
+<template>
+    <v-dialog
+        id="app-tour"
+        v-model="isVisible"
+        body-class="p-0"
+        content-class="overflow-hidden"
+        size="lg"
+        persistent
+        no-click-animation
+    >
+        <template v-slot:activator="{ props }">
+            <HgIconButtonComponent v-bind="props" data-testid="app-tour-button">
+                <v-badge
+                    color="red"
+                    :model-value="highlightTourChangeIndicator"
+                >
+                    <v-icon icon="fas fa-lightbulb" />
+                </v-badge>
+            </HgIconButtonComponent>
+        </template>
+        <v-row align="center" justify="center" no-gutters>
+            <v-card max-width="675px">
+                <v-card-text class="pa-0 mh-50">
+                    <v-carousel
+                        id="tourCarousel"
+                        v-model="slideIndex"
+                        :continuous="false"
+                        :show-arrows="false"
+                        hide-delimiter-background
+                        :height="mdAndUp ? 480 : 250"
+                    >
+                        <v-carousel-item
+                            v-for="slide in slides"
+                            :key="slide.title"
+                            :src="slide.imageUri"
+                            :alt="slide.imageAlt ?? slide.title"
+                            transition="scroll-x-reverse-transition"
+                        />
+                    </v-carousel>
+                </v-card-text>
+                <template #actions>
+                    <v-container>
+                        <v-row v-if="currentSlide">
+                            <v-col>
+                                <h3 class="text-h6 font-weight-bold">
+                                    {{ currentSlide.title }}
+                                </h3>
+                                <p
+                                    v-if="currentSlide.description"
+                                    class="text-body-1"
+                                >
+                                    {{ currentSlide.description }}
+                                </p>
+                            </v-col>
+                        </v-row>
+                        <v-row v-if="isFirstSlide" class="mt-4">
+                            <v-col cols="3">
+                                <HgButtonComponent
+                                    variant="link"
+                                    data-testid="app-tour-skip"
+                                    @click="hideModal"
+                                    text="Skip"
+                                />
+                            </v-col>
+                            <v-col cols="6" class="d-flex justify-center">
+                                <HgButtonComponent
+                                    variant="primary"
+                                    data-testid="app-tour-start"
+                                    @click="next()"
+                                    text="Start App Tour"
+                                />
+                            </v-col>
+                        </v-row>
+                        <v-row
+                            v-else-if="!isFirstSlide && !isFinalSlide"
+                            class="mt-3"
+                        >
+                            <v-col>
+                                <HgButtonComponent
+                                    variant="link"
+                                    data-testid="app-tour-skip"
+                                    @click="hideModal"
+                                    text="Skip"
+                                />
+                            </v-col>
+                            <v-col class="d-flex justify-end">
+                                <HgButtonComponent
+                                    data-testid="app-tour-back"
+                                    variant="secondary"
+                                    @click="previous()"
+                                    text="Back"
+                                />
+                                <HgButtonComponent
+                                    variant="primary"
+                                    class="ml-4"
+                                    data-testid="app-tour-next"
+                                    @click="next()"
+                                    text="Next"
+                                />
+                            </v-col>
+                        </v-row>
+                        <v-row v-else class="mt-6">
+                            <v-col class="d-flex justify-center">
+                                <HgButtonComponent
+                                    variant="primary"
+                                    data-testid="app-tour-done"
+                                    @click="hideModal"
+                                    text="Done"
+                                />
+                            </v-col>
+                        </v-row>
+                    </v-container>
+                </template>
+            </v-card>
+        </v-row>
+    </v-dialog>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/AppTourComponent.vue
@@ -172,7 +172,7 @@ function previous(): void {
                                     variant="primary"
                                     data-testid="app-tour-start"
                                     @click="next()"
-                                    text="Start App Tour"
+                                    text="Start Tour"
                                 />
                             </v-col>
                         </v-row>

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import type { WebClientConfiguration } from "@/models/configData";
+import { ILogger, IUserRatingService } from "@/services/interfaces";
+import SnowPlow from "@/utility/snowPlow";
+import HgButtonComponent from "@/components/shared/HgButtonComponent.vue";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { useConfigStore } from "@/stores/config";
+
+const emit = defineEmits<{
+    (e: "on-close"): void;
+}>();
+
+defineExpose({
+    showModal,
+    hideModal,
+});
+
+const question =
+    "Did the Health Gateway improve your access to health information today? Please provide a rating.";
+
+const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+const ratingService = container.get<IUserRatingService>(
+    SERVICE_IDENTIFIER.UserRatingService
+);
+
+const configStore = useConfigStore();
+
+const ratingValue = ref(0);
+const isVisible = ref(false);
+
+function showModal(): void {
+    isVisible.value = true;
+    setTimeout(() => {
+        if (isVisible.value) {
+            handleRating(0, true);
+        }
+    }, Number(configStore.webConfig.timeouts.logoutRedirect));
+}
+
+function hideModal(): void {
+    isVisible.value = false;
+}
+
+function handleRating(value: number, skip = false): void {
+    logger.debug(
+        `submitting rating: ratingValue = ${value}, skip = ${skip} ...`
+    );
+    ratingService
+        .submitRating({ ratingValue: value, skip })
+        .then(() => {
+            if (skip) {
+                SnowPlow.trackEvent({
+                    action: "submit_app_rating",
+                    text: "skip",
+                });
+            } else {
+                SnowPlow.trackEvent({
+                    action: "submit_app_rating",
+                    text: value.toString(),
+                });
+            }
+            logger.debug(`submitRating with success.`);
+        })
+        .catch((err: unknown) =>
+            logger.error(`submitRating with error: ${err}`)
+        )
+        .finally(() => {
+            hideModal();
+            emit("on-close");
+        });
+}
+</script>
+
+<template>
+    <div>
+        <v-dialog
+            id="rating-modal"
+            ref="rating-modal"
+            v-model="isVisible"
+            data-modal="rating"
+            data-testid="ratingModal"
+            persistent
+            no-click-animation
+        >
+            <v-card>
+                <template #title>
+                    <h1 class="text-h6 font-weight-bold text-center">Rating</h1>
+                </template>
+                <v-row class="text-center">
+                    <v-col data-testid="ratingModalQuestionText">
+                        {{ question }}
+                    </v-col>
+                </v-row>
+                <v-row class="text-center px-2 pt-3">
+                    <v-col>
+                        <v-rating
+                            v-model="ratingValue"
+                            data-testid="formRating"
+                            color="orange"
+                            class="mb-2"
+                            no-border
+                            size="large"
+                            @change="handleRating(ratingValue)"
+                        ></v-rating>
+                    </v-col>
+                </v-row>
+                <template #actions>
+                    <v-row>
+                        <v-col>
+                            <HgButtonComponent
+                                id="skipButton"
+                                data-testid="ratingModalSkipBtn"
+                                variant="secondary"
+                                @click="handleRating(0, true)"
+                                text="Skip"
+                            />
+                        </v-col>
+                    </v-row>
+                </template>
+            </v-card>
+        </v-dialog>
+    </div>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { ref } from "vue";
 
-import type { WebClientConfiguration } from "@/models/configData";
 import { ILogger, IUserRatingService } from "@/services/interfaces";
 import SnowPlow from "@/utility/snowPlow";
 import HgButtonComponent from "@/components/shared/HgButtonComponent.vue";

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
@@ -77,7 +77,6 @@ function handleRating(value: number | string, skip = false): void {
 <template>
     <v-dialog
         id="rating-modal"
-        ref="rating-modal"
         v-model="isVisible"
         data-modal="rating"
         data-testid="ratingModal"

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
@@ -44,12 +44,12 @@ function hideModal(): void {
     isVisible.value = false;
 }
 
-function handleRating(value: number, skip = false): void {
+function handleRating(value: number | string, skip = false): void {
     logger.debug(
         `submitting rating: ratingValue = ${value}, skip = ${skip} ...`
     );
     ratingService
-        .submitRating({ ratingValue: value, skip })
+        .submitRating({ ratingValue: Number(value), skip })
         .then(() => {
             if (skip) {
                 SnowPlow.trackEvent({

--- a/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/modal/RatingComponent.vue
@@ -75,52 +75,49 @@ function handleRating(value: number, skip = false): void {
 </script>
 
 <template>
-    <div>
-        <v-dialog
-            id="rating-modal"
-            ref="rating-modal"
-            v-model="isVisible"
-            data-modal="rating"
-            data-testid="ratingModal"
-            persistent
-            no-click-animation
-        >
-            <v-card>
-                <template #title>
-                    <h1 class="text-h6 font-weight-bold text-center">Rating</h1>
-                </template>
-                <v-row class="text-center">
-                    <v-col data-testid="ratingModalQuestionText">
+    <v-dialog
+        id="rating-modal"
+        ref="rating-modal"
+        v-model="isVisible"
+        data-modal="rating"
+        data-testid="ratingModal"
+        persistent
+        no-click-animation
+    >
+        <v-row no-gutters justify="center">
+            <v-card max-width="600px">
+                <v-card-title class="bg-primary text-white">
+                    <h1 class="text-h5 font-weight-bold">Rating</h1>
+                </v-card-title>
+                <v-card-text class="pa-3">
+                    <p
+                        class="text-body-1 text-center"
+                        data-testid="ratingModalQuestionText"
+                    >
                         {{ question }}
-                    </v-col>
-                </v-row>
-                <v-row class="text-center px-2 pt-3">
-                    <v-col>
+                    </p>
+                    <div class="d-flex justify-center">
                         <v-rating
                             v-model="ratingValue"
                             data-testid="formRating"
                             color="orange"
                             class="mb-2"
-                            no-border
+                            hover
                             size="large"
-                            @change="handleRating(ratingValue)"
-                        ></v-rating>
-                    </v-col>
-                </v-row>
-                <template #actions>
-                    <v-row>
-                        <v-col>
-                            <HgButtonComponent
-                                id="skipButton"
-                                data-testid="ratingModalSkipBtn"
-                                variant="secondary"
-                                @click="handleRating(0, true)"
-                                text="Skip"
-                            />
-                        </v-col>
-                    </v-row>
-                </template>
+                            @update:modelValue="handleRating"
+                        />
+                    </div>
+                </v-card-text>
+                <v-card-actions class="justify-end border-t-sm">
+                    <HgButtonComponent
+                        id="skipButton"
+                        data-testid="ratingModalSkipBtn"
+                        variant="secondary"
+                        @click="handleRating(0, true)"
+                        text="Skip"
+                    />
+                </v-card-actions>
             </v-card>
-        </v-dialog>
-    </div>
+        </v-row>
+    </v-dialog>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
@@ -10,6 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
+import AppTourComponent from "@/components/modal/AppTourComponent.vue";
 import RatingComponent from "@/components/modal/RatingComponent.vue";
 import HgButtonComponent from "@/components/shared/HgButtonComponent.vue";
 import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
@@ -27,7 +28,6 @@ import { useAuthStore } from "@/stores/auth";
 import { useNotificationStore } from "@/stores/notification";
 import { useNavbarStore } from "@/stores/navbar";
 import { useAppStore } from "@/stores/app";
-import AppTourComponent from "@/components/modal/AppTourComponent.vue";
 
 library.add(faBars, faSignInAlt, faSignOutAlt, faTimes, faUser, faLightbulb);
 

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
@@ -1,13 +1,4 @@
 <script setup lang="ts">
-import { library } from "@fortawesome/fontawesome-svg-core";
-import {
-    faBars,
-    faLightbulb,
-    faSignInAlt,
-    faSignOutAlt,
-    faTimes,
-    faUser,
-} from "@fortawesome/free-solid-svg-icons";
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
 import AppTourComponent from "@/components/modal/AppTourComponent.vue";
@@ -28,8 +19,6 @@ import { useAuthStore } from "@/stores/auth";
 import { useNotificationStore } from "@/stores/notification";
 import { useNavbarStore } from "@/stores/navbar";
 import { useAppStore } from "@/stores/app";
-
-library.add(faBars, faSignInAlt, faSignOutAlt, faTimes, faUser, faLightbulb);
 
 const sidebarId = "notification-centre-sidebar";
 const headerScrollThreshold = 100;

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
@@ -10,8 +10,7 @@ import {
 } from "@fortawesome/free-solid-svg-icons";
 import { computed, nextTick, onUnmounted, ref, watch } from "vue";
 
-// import AppTourComponent from "@/components/modal/AppTourComponent.vue";
-// import RatingComponent from "@/components/modal/RatingComponent.vue";
+import RatingComponent from "@/components/modal/RatingComponent.vue";
 import HgButtonComponent from "@/components/shared/HgButtonComponent.vue";
 import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
 import type { WebClientConfiguration } from "@/models/configData";
@@ -50,8 +49,7 @@ const notificationButtonClicked = ref(false);
 const hasViewedTour = ref(false);
 const isScrollNearBottom = ref(false);
 
-// const ratingComponent = ref<InstanceType<typeof RatingComponent>>();
-// const appTourComponent = ref<InstanceType<typeof AppTourComponent>>();
+const ratingComponent = ref<InstanceType<typeof RatingComponent>>();
 
 const isMobileWidth = computed<boolean>(() => appStore.isMobile);
 
@@ -225,20 +223,14 @@ function setHeaderState(isOpen: boolean): void {
 
 function handleLogoutClick(): void {
     if (isValidIdentityProvider.value) {
-        // showRating(); // TODO: Reintroduce with rating component
-        processLogout();
+        showRating();
     } else {
         processLogout();
     }
 }
 
-function handleShowTourClick(): void {
-    hasViewedTour.value = true;
-    // appTourComponent.value?.showModal();
-}
-
 function showRating(): void {
-    // ratingComponent.value?.showModal();
+    ratingComponent.value?.showModal();
 }
 
 function processLogout(): void {
@@ -277,7 +269,7 @@ nextTick(() => {
 <template>
     <v-app-bar
         :scroll-behavior="!isHeaderShown ? 'hide' : undefined"
-        class="border-b-md border-accent border-opacity-100"
+        class="border-b-md border-accent border-opacity-100 d-print-none"
         color="primary"
         :scroll-threshold="headerScrollThreshold"
     >
@@ -352,9 +344,8 @@ nextTick(() => {
             prepend-icon="fas fa-sign-in-alt"
             data-testid="loginBtn"
             to="/login"
-        >
-            Log In
-        </HgButtonComponent>
+            text="Log In"
+        />
         <HgButtonComponent
             v-else-if="isLogOutButtonShown"
             variant="secondary"
@@ -366,6 +357,5 @@ nextTick(() => {
             Log Out
         </HgButtonComponent>
     </v-app-bar>
-    <!--    <RatingComponent ref="ratingComponent" @on-close="processLogout()" />-->
-    <!--    <AppTourComponent ref="appTourComponent" />-->
+    <RatingComponent ref="ratingComponent" @on-close="processLogout()" />
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
@@ -28,6 +28,7 @@ import { useAuthStore } from "@/stores/auth";
 import { useNotificationStore } from "@/stores/notification";
 import { useNavbarStore } from "@/stores/navbar";
 import { useAppStore } from "@/stores/app";
+import AppTourComponent from "@/components/modal/AppTourComponent.vue";
 
 library.add(faBars, faSignInAlt, faSignOutAlt, faTimes, faUser, faLightbulb);
 
@@ -295,15 +296,10 @@ nextTick(() => {
             />
         </router-link>
         <v-spacer />
-        <HgIconButtonComponent
+        <AppTourComponent
             v-if="isAppTourAvailable"
-            @click="handleShowTourClick"
-            data-testid="app-tour-button"
-        >
-            <v-badge color="red" :model-value="highlightTourChangeIndicator">
-                <v-icon icon="fas fa-lightbulb" />
-            </v-badge>
-        </HgIconButtonComponent>
+            :highlight-tour-change-indicator="highlightTourChangeIndicator"
+        />
         <HgIconButtonComponent
             v-if="isNotificationCentreAvailable"
             @click="notificationButtonClicked = true"


### PR DESCRIPTION
# Implements [AB#15749](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15749)

## Description
1. Convert AppTourComponent
2. Convert RatingComponent


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
### AppTour Desktop:
![image](https://github.com/bcgov/healthgateway/assets/19548348/92cd0545-8979-42a6-bb09-5853efbc2fc8)

### AppTour Mobile:
height must be a fixed height for vuetify carousel to work without breaking transitions.

The slight "bleed" around the image change from the top to the sides pending on the width of the screens so there isn't a perfect solution for mobile, this seems to be a frustrating aspect of v-img. Can revisit this with native <img> later once Mandad has explored the implementation.
![image](https://github.com/bcgov/healthgateway/assets/19548348/124988ec-0e21-49ee-ba3d-18ba09527ac1)

### Rating Desktop:
![image](https://github.com/bcgov/healthgateway/assets/19548348/1714de52-20f7-4050-b9d6-ea8647605e8d)

### Rating Mobile:
![image](https://github.com/bcgov/healthgateway/assets/19548348/aa8779db-d0a1-4b22-bac2-d52ca48cdfdd)


## Notes
v-dialog, doesn't natively provide a card like structure so one must define your own structure, a straight row with a card directly within worked well, there may be a better layout option but did not invest more time into it for a marginal improvement.


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
