### PR TITLE
Convert SidebarComponent to Vue 3 for AB#15786

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import HeaderComponent from "@/components/navmenu/HeaderComponent.vue";
+import SidebarComponent from "@/components/navmenu/SidebarComponent.vue";
 import { useRoute } from "vue-router";
 import { computed } from "vue";
 import { useAppStore } from "@/stores/app";
@@ -25,6 +26,7 @@ const isHeaderVisible = computed(
 <template>
     <v-app>
         <HeaderComponent v-if="isHeaderVisible" class="d-print-none" />
+        <SidebarComponent class="d-print-none" />
         <v-main>
             <router-view />
         </v-main>

--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -2,14 +2,18 @@
 import HeaderComponent from "@/components/navmenu/HeaderComponent.vue";
 import SidebarComponent from "@/components/navmenu/SidebarComponent.vue";
 import { useRoute } from "vue-router";
-import { computed } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
 import { useAppStore } from "@/stores/app";
+import ScreenWidth from "@/constants/screenWidth";
 
 const loginCallbackPath = "/logincallback";
 const vaccineCardPath = "/vaccinecard";
 
 const route = useRoute();
 const appStore = useAppStore();
+
+const initialized = ref(false);
+const windowWidth = ref(0);
 
 function currentPathMatches(...paths: string[]): boolean {
     const currentPath = route.path.toLowerCase();
@@ -21,6 +25,43 @@ const isHeaderVisible = computed(
         appStore.appError === undefined &&
         !currentPathMatches(loginCallbackPath, vaccineCardPath)
 );
+
+const isMobile = computed<boolean>(() => appStore.isMobile);
+
+function initializeResizeListener(): void {
+    window.addEventListener("resize", onResize);
+    onResize();
+}
+
+function onResize(): void {
+    windowWidth.value = window.innerWidth;
+
+    if (windowWidth.value < ScreenWidth.Mobile) {
+        if (!isMobile.value) {
+            setIsMobile(true);
+        }
+    } else {
+        if (isMobile.value) {
+            setIsMobile(false);
+        }
+    }
+}
+
+function setIsMobile(isMobile: boolean): void {
+    appStore.setIsMobile(isMobile);
+}
+
+onMounted(async () => {
+    windowWidth.value = window.innerWidth;
+
+    await nextTick();
+    initializeResizeListener();
+    initialized.value = true;
+});
+
+onBeforeUnmount(() => {
+    window.removeEventListener("resize", onResize);
+});
 </script>
 
 <template>

--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -51,6 +51,10 @@ function setIsMobile(isMobile: boolean): void {
     appStore.setIsMobile(isMobile);
 }
 
+onBeforeUnmount(() => {
+    window.removeEventListener("resize", onResize);
+});
+
 onMounted(async () => {
     windowWidth.value = window.innerWidth;
 
@@ -58,16 +62,12 @@ onMounted(async () => {
     initializeResizeListener();
     initialized.value = true;
 });
-
-onBeforeUnmount(() => {
-    window.removeEventListener("resize", onResize);
-});
 </script>
 
 <template>
     <v-app>
         <HeaderComponent v-if="isHeaderVisible" class="d-print-none" />
-        <SidebarComponent class="d-print-none" />
+        <SidebarComponent />
         <v-main>
             <router-view />
         </v-main>

--- a/Apps/WebClient/src/NewClientApp/src/components/dependent/DependentViewSelectorComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/dependent/DependentViewSelectorComponent.vue
@@ -1,0 +1,4 @@
+<script setup lang="ts"></script>
+<template>
+    <h1>dependents</h1>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/HeaderComponent.vue
@@ -17,7 +17,7 @@ import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue
 import type { WebClientConfiguration } from "@/models/configData";
 import { DateWrapper, StringISODateTime } from "@/models/dateWrapper";
 import Notification from "@/models/notification";
-import User, { OidcUserInfo } from "@/models/user";
+import User from "@/models/user";
 import { ILogger } from "@/services/interfaces";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
@@ -78,10 +78,6 @@ const userLastLoginDateTime = computed<StringISODateTime | undefined>(
     () => userStore.lastLoginDateTime
 );
 
-const oidcUserInfo = computed<OidcUserInfo | undefined>(
-    () => userStore.oidcUserInfo
-);
-
 const userIsRegistered = computed<boolean>(() => userStore.userIsRegistered);
 
 const userIsActive = computed<boolean>(() => userStore.userIsActive);
@@ -89,26 +85,6 @@ const userIsActive = computed<boolean>(() => userStore.userIsActive);
 const patientRetrievalFailed = computed<boolean>(
     () => userStore.patientRetrievalFailed
 );
-
-const userName = computed<string>(() =>
-    oidcUserInfo.value === undefined
-        ? ""
-        : `${oidcUserInfo.value.given_name} ${oidcUserInfo.value.family_name}`
-);
-
-const userInitials = computed<string>(() => {
-    const first = oidcUserInfo.value?.given_name;
-    const last = oidcUserInfo.value?.family_name;
-    if (first && last) {
-        return first.charAt(0) + last.charAt(0);
-    } else if (first) {
-        return first.charAt(0);
-    } else if (last) {
-        return last.charAt(0);
-    } else {
-        return "?";
-    }
-});
 
 const isPcrTest = computed<boolean>(() =>
     route.path.toLowerCase().startsWith("/pcrtest")
@@ -323,14 +299,14 @@ nextTick(() => {
                 data-testid="headerDropdownBtn"
             >
                 <v-avatar data-testid="profileButtonInitials" color="info">
-                    {{ userInitials }}
+                    {{ userStore.userInitials }}
                 </v-avatar>
             </HgIconButtonComponent>
             <v-menu activator="#menuBtnLogout">
                 <v-list>
                     <v-list-item
                         data-testid="profileUserName"
-                        :title="userName"
+                        :title="userStore.userName"
                     />
                     <v-divider />
                     <v-list-item

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/SidebarComponent.vue
@@ -1,0 +1,143 @@
+<script setup lang="ts">
+import { computed, nextTick, onMounted } from "vue";
+
+import { useNavbarStore } from "@/stores/navbar";
+import { useUserStore } from "@/stores/user";
+import { useAuthStore } from "@/stores/auth";
+import { useConfigStore } from "@/stores/config";
+import { useRoute } from "vue-router";
+import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
+
+const route = useRoute();
+
+const authStore = useAuthStore();
+const configStore = useConfigStore();
+const navbarStore = useNavbarStore();
+const userStore = useUserStore();
+
+const isQueuePage = computed(
+    () =>
+        route.path.toLowerCase() === "/queue" ||
+        route.path.toLowerCase() === "/busy"
+);
+
+const isSidebarAvailable = computed(
+    () =>
+        !configStore.isOffline &&
+        authStore.oidcIsAuthenticated &&
+        userStore.isValidIdentityProvider &&
+        userStore.userIsRegistered &&
+        userStore.userIsActive &&
+        !userStore.patientRetrievalFailed &&
+        !isQueuePage.value
+);
+
+const isDependentEnabled = computed(
+    () => configStore.webConfig.featureToggleConfiguration.dependents.enabled
+);
+
+const isServicesEnabled = computed(
+    () => configStore.webConfig.featureToggleConfiguration.services.enabled
+);
+
+onMounted(async () => {
+    await nextTick();
+});
+</script>
+
+<template>
+    <div v-if="isSidebarAvailable" class="wrapper">
+        <v-navigation-drawer
+            :rail="!navbarStore.isSidebarOpen"
+            color="primary"
+            permanent
+        >
+            <v-list density="compact" nav>
+                <v-list-item
+                    title="Home"
+                    to="/home"
+                    data-testid="menu-btn-home-link"
+                >
+                    <template #prepend>
+                        <div
+                            class="nav-list-item-icon mr-8 d-flex justify-center"
+                        >
+                            <v-icon icon="fas fa-house" />
+                        </div>
+                    </template>
+                </v-list-item>
+                <v-list-item
+                    title="Timeline"
+                    to="/timeline"
+                    data-testid="menu-btn-time-line-link"
+                >
+                    <template #prepend>
+                        <div
+                            class="nav-list-item-icon mr-8 d-flex justify-center"
+                        >
+                            <v-icon icon="fas fa-box-archive" />
+                        </div>
+                    </template>
+                </v-list-item>
+                <v-list-item
+                    title="COVID-19"
+                    to="/covid19"
+                    data-testid="menu-btn-covid19-link"
+                >
+                    <template #prepend>
+                        <div
+                            class="nav-list-item-icon mr-8 d-flex justify-center"
+                        >
+                            <v-icon icon="fas fa-circle-check" />
+                        </div>
+                    </template>
+                </v-list-item>
+                <v-list-item
+                    v-show="isDependentEnabled && userStore.userIsActive"
+                    title="Dependents"
+                    to="/dependents"
+                    data-testid="menu-btn-dependents-link"
+                >
+                    <template #prepend>
+                        <div
+                            class="nav-list-item-icon mr-8 d-flex justify-center"
+                        >
+                            <v-icon icon="fas fa-user-group" />
+                        </div>
+                    </template>
+                </v-list-item>
+                <v-list-item
+                    v-show="isServicesEnabled && userStore.userIsActive"
+                    prepend-icon="fas fa-hand-holding-medical"
+                    title="Services"
+                    to="/services"
+                    data-testid="menu-btn-dependents-link"
+                >
+                    <template #prepend>
+                        <div
+                            class="nav-list-item-icon mr-8 d-flex justify-center"
+                        >
+                            <v-icon icon="fas fa-hand-holding-medical" />
+                        </div>
+                    </template>
+                </v-list-item>
+            </v-list>
+            <template #append>
+                <HgIconButtonComponent
+                    :icon="
+                        navbarStore.isSidebarOpen
+                            ? 'fas fa-angle-double-left'
+                            : 'fas fa-angle-double-right'
+                    "
+                    @click="navbarStore.toggleSidebar"
+                />
+            </template>
+        </v-navigation-drawer>
+    </div>
+</template>
+
+<style scoped>
+.nav-list-item-icon {
+    width: 1.5em;
+}
+</style>

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/SidebarComponent.vue
@@ -7,6 +7,7 @@ import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { useRoute } from "vue-router";
 import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
+import { OidcUserInfo } from "@/models/user";
 
 const route = useRoute();
 
@@ -40,6 +41,30 @@ const isServicesEnabled = computed(
     () => configStore.webConfig.featureToggleConfiguration.services.enabled
 );
 
+const oidcUserInfo = computed<OidcUserInfo | undefined>(
+    () => userStore.oidcUserInfo
+);
+
+const userInitials = computed<string>(() => {
+    const first = oidcUserInfo.value?.given_name;
+    const last = oidcUserInfo.value?.family_name;
+    if (first && last) {
+        return first.charAt(0) + last.charAt(0);
+    } else if (first) {
+        return first.charAt(0);
+    } else if (last) {
+        return last.charAt(0);
+    } else {
+        return "?";
+    }
+});
+
+const userName = computed<string>(() =>
+    oidcUserInfo.value === undefined
+        ? ""
+        : `${oidcUserInfo.value.given_name} ${oidcUserInfo.value.family_name}`
+);
+
 onMounted(async () => {
     await nextTick();
 });
@@ -52,6 +77,31 @@ onMounted(async () => {
             color="primary"
             permanent
         >
+            <v-list-item
+                :title="userName"
+                nav
+                @click="navbarStore.toggleSidebar"
+            >
+                <template #prepend>
+                    <div class="nav-list-item-icon mr-8 d-flex justify-center">
+                        <HgIconButtonComponent
+                            id="sidenavbar-profile"
+                            data-testid="sidenavbar-profile-btn"
+                        >
+                            <v-avatar
+                                data-testid="sidenavbar-profile-initials"
+                                color="info"
+                            >
+                                {{ userInitials }}
+                            </v-avatar>
+                        </HgIconButtonComponent>
+                    </div>
+                </template>
+                <template #append>
+                    <v-icon icon="fas fa-angle-double-left" />
+                </template>
+            </v-list-item>
+            <v-divider></v-divider>
             <v-list density="compact" nav>
                 <v-list-item
                     title="Home"
@@ -122,16 +172,6 @@ onMounted(async () => {
                     </template>
                 </v-list-item>
             </v-list>
-            <template #append>
-                <HgIconButtonComponent
-                    :icon="
-                        navbarStore.isSidebarOpen
-                            ? 'fas fa-angle-double-left'
-                            : 'fas fa-angle-double-right'
-                    "
-                    @click="navbarStore.toggleSidebar"
-                />
-            </template>
         </v-navigation-drawer>
     </div>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/navmenu/SidebarComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/navmenu/SidebarComponent.vue
@@ -7,7 +7,6 @@ import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { useRoute } from "vue-router";
 import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
-import { OidcUserInfo } from "@/models/user";
 import { useAppStore } from "@/stores/app";
 
 const route = useRoute();
@@ -28,9 +27,6 @@ const isDependentEnabled = computed(
 const isServicesEnabled = computed(
     () => configStore.webConfig.featureToggleConfiguration.services.enabled
 );
-const oidcUserInfo = computed<OidcUserInfo | undefined>(
-    () => userStore.oidcUserInfo
-);
 
 const isQueuePage = computed(
     () =>
@@ -47,26 +43,6 @@ const isSidebarAvailable = computed(
         userStore.userIsActive &&
         !userStore.patientRetrievalFailed &&
         !isQueuePage.value
-);
-
-const userInitials = computed<string>(() => {
-    const first = oidcUserInfo.value?.given_name;
-    const last = oidcUserInfo.value?.family_name;
-    if (first && last) {
-        return first.charAt(0) + last.charAt(0);
-    } else if (first) {
-        return first.charAt(0);
-    } else if (last) {
-        return last.charAt(0);
-    } else {
-        return "?";
-    }
-});
-
-const userName = computed<string>(() =>
-    oidcUserInfo.value === undefined
-        ? ""
-        : `${oidcUserInfo.value.given_name} ${oidcUserInfo.value.family_name}`
 );
 
 const visibleOnMobile = computed({
@@ -97,21 +73,23 @@ function dismiss() {
         :temporary="isMobile"
         :rail="isMobile ? false : collapsedOnDesktop"
         color="primary"
+        class="d-print-none"
         @click.stop="collapsedOnDesktop = false"
         @update:model-value="visibleOnMobile = false"
     >
-        <v-list-item :title="userName" nav>
+        <v-list-item :title="userStore.userName" nav>
             <template #prepend>
                 <v-avatar
                     data-testid="sidenavbar-profile-initials"
                     color="info"
                 >
-                    {{ userInitials }}
+                    {{ userStore.userInitials }}
                 </v-avatar>
             </template>
             <template #append>
                 <HgIconButtonComponent
                     icon="fas fa-chevron-left"
+                    data-testid="sidenavbar-dismiss-btn"
                     @click.stop="dismiss"
                 />
             </template>

--- a/Apps/WebClient/src/NewClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/index.ts
@@ -6,6 +6,12 @@ import {
 import { beforeEachGuard } from "@/router/beforeEachGuard";
 import { afterEachHook } from "@/router/afterEachHook";
 
+const Covid19View = () =>
+    import(/* webpackChunkName: "covid19" */ "@/views/Covid19View.vue");
+const DependentViewSelectorComponent = () =>
+    import(
+        /* webpackChunkName: "dependents" */ "@/components/dependent/DependentViewSelectorComponent.vue"
+    );
 const LandingView = () =>
     import(/* webpackChunkName: "landing" */ "@/views/LandingView.vue");
 const LoginView = () =>
@@ -42,9 +48,15 @@ const ReleaseNotesView = () =>
     import(
         /* webpackChunkName: "releaseNotes" */ "@/views/ReleaseNotesView.vue"
     );
+const ServicesView = () =>
+    import(/* webpackChunkName: "services" */ "@/views/ServicesView.vue");
+const UserTimelineView = () =>
+    import(/* webpackChunkName: "timeline" */ "@/views/UserTimelineView.vue");
 
 export enum RouterPath {
     ACCEPT_TERMS_OF_SERVICE_PATH = "/acceptTermsOfService",
+    COVID19_PATH = "/covid19",
+    DEPENDENTS_PATH = "/dependents",
     HOME_PATH = "/home",
     IDIR_LOGGED_IN_PATH = "/idirLoggedIn",
     LOGIN_PATH = "/login",
@@ -61,6 +73,7 @@ export enum RouterPath {
     QUEUE_PATH = "/queue",
     QUEUE_FULL_PATH = "/busy",
     RELEASE_NOTES_PATH = "/release-notes",
+    SERVICES_PATH = "/services",
 }
 
 export enum UserState {
@@ -88,6 +101,22 @@ const routes = [
                 UserState.offline,
             ],
             requiresProcessedWaitlistTicket: false,
+        },
+    },
+    {
+        path: RouterPath.COVID19_PATH,
+        component: Covid19View,
+        meta: {
+            validStates: [UserState.registered],
+            requiresProcessedWaitlistTicket: true,
+        },
+    },
+    {
+        path: RouterPath.DEPENDENTS_PATH,
+        component: DependentViewSelectorComponent,
+        meta: {
+            validStates: [UserState.registered],
+            requiresProcessedWaitlistTicket: true,
         },
     },
     {
@@ -163,6 +192,22 @@ const routes = [
         path: RouterPath.RELEASE_NOTES_PATH,
         name: "ReleaseNotes",
         component: ReleaseNotesView,
+    },
+    {
+        path: RouterPath.SERVICES_PATH,
+        component: ServicesView,
+        meta: {
+            validStates: [UserState.registered],
+            requiresProcessedWaitlistTicket: true,
+        },
+    },
+    {
+        path: RouterPath.TIMELINE_PATH,
+        component: UserTimelineView,
+        meta: {
+            validStates: [UserState.registered],
+            requiresProcessedWaitlistTicket: true,
+        },
     },
     {
         path: "/*",

--- a/Apps/WebClient/src/NewClientApp/src/stores/navbar.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/navbar.ts
@@ -11,7 +11,7 @@ export const useNavbarStore = defineStore("navbar", () => {
     const appStore = useAppStore();
 
     const isSidebarOpenField = ref<boolean>();
-    const isSidebarAnimating = ref<boolean>(false);
+
     const isHeaderShown = ref<boolean>(true);
 
     const isSidebarOpen = computed(
@@ -19,24 +19,8 @@ export const useNavbarStore = defineStore("navbar", () => {
     );
 
     function toggleSidebar() {
-        logger.verbose(
-            `useNavbarStore:toggleSidebar - SidebarOpenField: ${isSidebarOpenField.value} - Mobile: ${appStore.isMobile}`
-        );
-        isSidebarOpenField.value =
-            isSidebarOpenField.value === undefined
-                ? appStore.isMobile
-                    ? false
-                    : appStore.isMobile
-                : !isSidebarOpenField.value;
-        logger.verbose(
-            `useNavbarStore:toggleSidebar - set SidebarOpenField: ${isSidebarOpenField.value}`
-        );
-        isSidebarAnimating.value = true;
-    }
-
-    function setSidebarStoppedAnimating() {
-        logger.verbose(`useNavbarStore:setSidebarStoppedAnimating`);
-        isSidebarAnimating.value = false;
+        logger.verbose(`useNavbarStore:toggleSidebar`);
+        isSidebarOpenField.value = !isSidebarOpenField.value;
     }
 
     function setHeaderState(isOpen: boolean) {
@@ -46,10 +30,8 @@ export const useNavbarStore = defineStore("navbar", () => {
 
     return {
         isSidebarOpen,
-        isSidebarAnimating,
         isHeaderShown,
         toggleSidebar,
-        setSidebarStoppedAnimating,
         setHeaderState,
     };
 });

--- a/Apps/WebClient/src/NewClientApp/src/stores/navbar.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/navbar.ts
@@ -14,11 +14,23 @@ export const useNavbarStore = defineStore("navbar", () => {
     const isSidebarAnimating = ref<boolean>(false);
     const isHeaderShown = ref<boolean>(true);
 
-    const isSidebarOpen = computed(() => isSidebarOpenField.value ?? !appStore.isMobile);
+    const isSidebarOpen = computed(
+        () => isSidebarOpenField.value ?? !appStore.isMobile
+    );
 
     function toggleSidebar() {
-        logger.verbose(`useNavbarStore:setSidebarState`);
-        isSidebarOpenField.value = !isSidebarOpenField.value;
+        logger.verbose(
+            `useNavbarStore:toggleSidebar - SidebarOpenField: ${isSidebarOpenField.value} - Mobile: ${appStore.isMobile}`
+        );
+        isSidebarOpenField.value =
+            isSidebarOpenField.value === undefined
+                ? appStore.isMobile
+                    ? false
+                    : appStore.isMobile
+                : !isSidebarOpenField.value;
+        logger.verbose(
+            `useNavbarStore:toggleSidebar - set SidebarOpenField: ${isSidebarOpenField.value}`
+        );
         isSidebarAnimating.value = true;
     }
 

--- a/Apps/WebClient/src/NewClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/user.ts
@@ -94,6 +94,26 @@ export const useUserStore = defineStore("user", () => {
         return status.value === LoadStatus.REQUESTED;
     });
 
+    const userInitials = computed(() => {
+        const first = oidcUserInfo.value?.given_name;
+        const last = oidcUserInfo.value?.family_name;
+        if (first && last) {
+            return first.charAt(0) + last.charAt(0);
+        } else if (first) {
+            return first.charAt(0);
+        } else if (last) {
+            return last.charAt(0);
+        } else {
+            return "?";
+        }
+    });
+
+    const userName = computed(() =>
+        oidcUserInfo.value === undefined
+            ? ""
+            : `${oidcUserInfo.value.given_name} ${oidcUserInfo.value.family_name}`
+    );
+
     function setOidcUserInfo(userInfo: OidcUserInfo) {
         user.value.hdid = userInfo.hdid;
         oidcUserInfo.value = userInfo;
@@ -426,6 +446,8 @@ export const useUserStore = defineStore("user", () => {
         patient,
         patientRetrievalFailed,
         isLoading,
+        userInitials,
+        userName,
         createProfile,
         retrieveProfile,
         updateUserEmail,

--- a/Apps/WebClient/src/NewClientApp/src/views/Covid19View.vue
+++ b/Apps/WebClient/src/NewClientApp/src/views/Covid19View.vue
@@ -1,0 +1,4 @@
+<script setup lang="ts"></script>
+<template>
+    <h1>COVID-19</h1>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/views/ServicesView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/views/ServicesView.vue
@@ -1,0 +1,5 @@
+﻿<script setup lang="ts"></script>
+
+<template>
+    <h1>services</h1>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/views/UserTimelineView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/views/UserTimelineView.vue
@@ -1,0 +1,5 @@
+<script setup lang="ts"></script>
+
+<template>
+    <h1>timeline</h1>
+</template>


### PR DESCRIPTION
# Implements [AB#15786](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15786)

## Description

- Converted Sidebar Component to Vue 3
- Created placeholders for Dependent View, Service View, Timeline View and Covid19 View
- Updated Routes to include Dependent, Service, Timeline and Covid19 views
- Updated nabber store so that Sidebar Component can toggle open and close properly
- Update App Vue to include SidebarComponent

**Desktop:**

<img width="2552" alt="Screenshot 2023-06-29 at 5 45 05 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/0f36c0f5-9c21-4850-b5a6-147ddb6b0d48">

<img width="2550" alt="Screenshot 2023-06-29 at 5 45 14 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/de878d9d-c659-4061-aa0f-0b8146ce77fc">


**Mobile:**

<img width="1281" alt="Screenshot 2023-06-29 at 5 46 13 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/3405c2a7-6e65-47b6-bf13-f9e5a064c354">

<img width="1286" alt="Screenshot 2023-06-29 at 5 46 22 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/2f6ca6cb-c23b-470d-8646-1943f7124a8e">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

Yes

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
