### PR TITLE
Downgrade Mud Blazor 6.5.1 to 6.3.1 due to failing admin functional test failures

### DIFF
--- a/Apps/Admin/Client/Admin.Client.csproj
+++ b/Apps/Admin/Client/Admin.Client.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="7.0.0" />
         <PackageReference Include="Microsoft.Extensions.Primitives" Version="7.0.0" />
-        <PackageReference Include="MudBlazor" Version="6.5.0" />
+        <PackageReference Include="MudBlazor" Version="6.3.1" />
         <PackageReference Include="Refit" Version="6.3.2" />
         <PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
     </ItemGroup>

--- a/Apps/CommonUi/src/Common.Ui.csproj
+++ b/Apps/CommonUi/src/Common.Ui.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MudBlazor" Version="6.5.0" />
+    <PackageReference Include="MudBlazor" Version="6.3.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Fixes [AB#15792](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15792)

## Description

Downgrade Mud Blazor 6.5.1 (Dependabot Update) to 6.3.1 so that admin functional tests do not fail.

Note: this was previously rolled when 6.4.1 was introduced #5234

<img width="1274" alt="Screenshot 2023-06-29 at 1 04 50 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/5638c4c2-bad7-4b66-a449-5ea3eb47f35d">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
