### PR TITLE
Fix PST/UTC problem with admin analytics functional tests for AB#15796

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -1,28 +1,4 @@
-function getTodayPlusDaysDate(days) {
-    let newDay = new Date(Date.now());
-    cy.log(`New day: ${newDay}`);
-    newDay.setDate(newDay.getDate() + days);
-    cy.log(`New day plus ${days}: ${newDay}`);
-
-    // Convert the date and time to a localized string
-    const localizedDateString = newDay.toLocaleString("en-US", {
-        timeZone: "America/Vancouver",
-    });
-
-    // Parse the localized string to a Date object
-    const parsedDate = new Date(localizedDateString);
-    cy.log(`Parsed date: ${parsedDate}`);
-
-    // Get the components: year, month, and day
-    const year = parsedDate.getFullYear();
-    const month = String(parsedDate.getMonth() + 1).padStart(2, "0");
-    const day = String(parsedDate.getDate()).padStart(2, "0");
-
-    // Format the date to "yyyy-mm-dd" format
-    const dateString = `${year}-${month}-${day}`;
-    cy.log(`Today plus ${days} => ${dateString}`);
-    return dateString;
-}
+import { getTodayPlusDaysDate } from "../../utilities/sharedUtilities";
 
 describe("Communications", () => {
     beforeEach(() => {

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/analytics.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/analytics.cy.js
@@ -1,12 +1,9 @@
+import { getTodayPlusDaysDate } from "../../utilities/sharedUtilities";
+
 const timeout = 45000;
 
-function formatDate(date) {
-    // yyyy-mm-dd
-    return date.toISOString().substring(0, 10);
-}
-
 function getFileName(name) {
-    const today = formatDate(new Date());
+    const today = getTodayPlusDaysDate(0);
     const fileName = `${name}_export_${today}.csv`;
     cy.log(`File name: ${fileName}`);
     return fileName;
@@ -83,10 +80,8 @@ describe("System Analytics", () => {
             .should("be.visible")
             .click();
 
-        let lastMonth = new Date();
-        lastMonth.setDate(lastMonth.getDate() - 30);
-        const fromDate = formatDate(lastMonth);
-        const toDate = formatDate(new Date());
+        const fromDate = getTodayPlusDaysDate(-30);
+        const toDate = getTodayPlusDaysDate(0);
         const fileName = `YearOfBirthCounts_export_${fromDate}_to_${toDate}.csv`;
         cy.verifyDownload(fileName);
 

--- a/Apps/Admin/Tests/Functional/cypress/utilities/sharedUtilities.js
+++ b/Apps/Admin/Tests/Functional/cypress/utilities/sharedUtilities.js
@@ -2,3 +2,29 @@ export function getTableRows(tableSelector) {
     cy.get(tableSelector).should("be.visible");
     return cy.get(`${tableSelector} tbody`).find("tr.mud-table-row");
 }
+
+export function getTodayPlusDaysDate(days) {
+    let newDay = new Date(Date.now());
+    cy.log(`New day: ${newDay}`);
+    newDay.setDate(newDay.getDate() + days);
+    cy.log(`New day plus/minus ${days}: ${newDay}`);
+
+    // Convert the date and time to a localized string
+    const localizedDateString = newDay.toLocaleString("en-US", {
+        timeZone: "America/Vancouver",
+    });
+
+    // Parse the localized string to a Date object
+    const parsedDate = new Date(localizedDateString);
+    cy.log(`Parsed date: ${parsedDate}`);
+
+    // Get the components: year, month, and day
+    const year = parsedDate.getFullYear();
+    const month = String(parsedDate.getMonth() + 1).padStart(2, "0");
+    const day = String(parsedDate.getDate()).padStart(2, "0");
+
+    // Format the date to "yyyy-mm-dd" format
+    const dateString = `${year}-${month}-${day}`;
+    cy.log(`Today plus ${days} => ${dateString}`);
+    return dateString;
+}


### PR DESCRIPTION
# Fixes [AB#15796](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15796)

## Description

- Fixed analytics functional tests to use PST as expected date instead of UTC.
- Moved analytics functional tests from e2e to ui as these tests use fixtures
- Moved javascript function to get PST date to a common location
- Update communications functional tests to point to new location to access PST date

**Issue - expected date is PST converted to UTC:** See high lighted values.

<img width="1712" alt="Screenshot 2023-06-29 at 6 22 57 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/63ea6969-22ed-4685-8fbf-e57dfa619cfe">

**Analytics:**

<img width="805" alt="Screenshot 2023-06-29 at 6 21 05 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/a9a9c0ab-7879-4f73-9435-eceeaad0b147">

**Communications:**

<img width="1184" alt="Screenshot 2023-06-29 at 6 18 39 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/5fb6f4e5-db4f-4a45-8c37-361042ff277b">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
