### PR TITLE
Migrate HgDatePickerComponent to vuetify AB#15741

### DIFF
--- a/Apps/WebClient/src/NewClientApp/package-lock.json
+++ b/Apps/WebClient/src/NewClientApp/package-lock.json
@@ -10,6 +10,7 @@
             "dependencies": {
                 "@vuelidate/core": "^2.0.2",
                 "@vuelidate/validators": "^2.0.2",
+                "@vuepic/vue-datepicker": "^5.3.0",
                 "axios": "^1.4.0",
                 "file-saver": "^2.0.5",
                 "keycloak-js": "^21.1.1",
@@ -77,6 +78,17 @@
             },
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+            "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+            "dependencies": {
+                "regenerator-runtime": "^0.13.11"
+            },
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/types": {
@@ -1167,6 +1179,21 @@
                 }
             }
         },
+        "node_modules/@vuepic/vue-datepicker": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-5.3.0.tgz",
+            "integrity": "sha512-eW5LRa3mH5klbRaKedG96/KY4EZC7ns+Zs7A+4guRBL+dQQthd8HV0xyS9nkI7hjr1K5zU+FQ3TOdo/oX5r3og==",
+            "dependencies": {
+                "date-fns": "^2.30.0",
+                "date-fns-tz": "^1.3.7"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "peerDependencies": {
+                "vue": ">=3.2.0"
+            }
+        },
         "node_modules/@vuetify/loader-shared": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-1.7.1.tgz",
@@ -1482,6 +1509,29 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
             "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        },
+        "node_modules/date-fns": {
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "dependencies": {
+                "@babel/runtime": "^7.21.0"
+            },
+            "engines": {
+                "node": ">=0.11"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/date-fns"
+            }
+        },
+        "node_modules/date-fns-tz": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+            "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+            "peerDependencies": {
+                "date-fns": ">=2.0.0"
+            }
         },
         "node_modules/de-indent": {
             "version": "1.0.2",
@@ -2916,6 +2966,11 @@
                 "node": ">=8.10.0"
             }
         },
+        "node_modules/regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+        },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3494,6 +3549,14 @@
             "version": "7.22.5",
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.5.tgz",
             "integrity": "sha512-DFZMC9LJUG9PLOclRC32G63UXwzqS2koQC8dkx+PLdmt1xSePYpbT/NbsrJy8Q/muXz7o/h/d4A7Fuyixm559Q=="
+        },
+        "@babel/runtime": {
+            "version": "7.22.5",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.5.tgz",
+            "integrity": "sha512-ecjvYlnAaZ/KVneE/OdKYBYfgXV3Ptu6zQWmgEF7vwKhQnvVS6bjMD2XYgj+SNvQ1GfK/pjgokfPkC/2CO8CuA==",
+            "requires": {
+                "regenerator-runtime": "^0.13.11"
+            }
         },
         "@babel/types": {
             "version": "7.22.5",
@@ -4149,6 +4212,15 @@
                 }
             }
         },
+        "@vuepic/vue-datepicker": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@vuepic/vue-datepicker/-/vue-datepicker-5.3.0.tgz",
+            "integrity": "sha512-eW5LRa3mH5klbRaKedG96/KY4EZC7ns+Zs7A+4guRBL+dQQthd8HV0xyS9nkI7hjr1K5zU+FQ3TOdo/oX5r3og==",
+            "requires": {
+                "date-fns": "^2.30.0",
+                "date-fns-tz": "^1.3.7"
+            }
+        },
         "@vuetify/loader-shared": {
             "version": "1.7.1",
             "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-1.7.1.tgz",
@@ -4377,6 +4449,20 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
             "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
+        },
+        "date-fns": {
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+            "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+            "requires": {
+                "@babel/runtime": "^7.21.0"
+            }
+        },
+        "date-fns-tz": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-1.3.8.tgz",
+            "integrity": "sha512-qwNXUFtMHTTU6CFSFjoJ80W8Fzzp24LntbjFFBgL/faqds4e5mo9mftoRLgr3Vi1trISsg4awSpYVsOQCRnapQ==",
+            "requires": {}
         },
         "de-indent": {
             "version": "1.0.2",
@@ -5379,6 +5465,11 @@
             "requires": {
                 "picomatch": "^2.2.1"
             }
+        },
+        "regenerator-runtime": {
+            "version": "0.13.11",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+            "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
         },
         "resolve-from": {
             "version": "4.0.0",

--- a/Apps/WebClient/src/NewClientApp/package.json
+++ b/Apps/WebClient/src/NewClientApp/package.json
@@ -11,6 +11,7 @@
     "dependencies": {
         "@vuelidate/core": "^2.0.2",
         "@vuelidate/validators": "^2.0.2",
+        "@vuepic/vue-datepicker": "^5.3.0",
         "axios": "^1.4.0",
         "file-saver": "^2.0.5",
         "keycloak-js": "^21.1.1",

--- a/Apps/WebClient/src/NewClientApp/src/components/shared/HgDatePickerComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/shared/HgDatePickerComponent.vue
@@ -1,0 +1,154 @@
+<script setup lang="ts">
+import "@vuepic/vue-datepicker/dist/main.css";
+
+import { useVuelidate } from "@vuelidate/core";
+import { helpers } from "@vuelidate/validators";
+import VueDatePicker from "@vuepic/vue-datepicker";
+import { vMaska } from "maska";
+import { computed, ref, watch } from "vue";
+
+import HgIconButtonComponent from "@/components/shared/HgIconButtonComponent.vue";
+import { DateWrapper, IDateWrapper } from "@/models/dateWrapper";
+import ValidationUtil from "@/utility/validationUtil";
+
+interface Props {
+    modelValue?: string;
+    label?: string;
+    state?: boolean;
+    errorMessages?: string[];
+    minDate?: IDateWrapper;
+    maxDate?: IDateWrapper;
+}
+const props = withDefaults(defineProps<Props>(), {
+    modelValue: "",
+    label: "Date",
+    state: undefined,
+    errorMessages: () => [],
+    minDate: () => new DateWrapper("1900-01-01"),
+    maxDate: () => new DateWrapper("2099-12-31"),
+});
+
+const emit = defineEmits<{
+    (e: "update:model-value", value: string): void;
+    (e: "validity-updated", value: boolean): void;
+    (e: "blur"): void;
+}>();
+
+const maskOptions = {
+    mask: "####-@@@-##",
+    eager: true,
+    postProcess: (value: string) => value.toUpperCase(),
+};
+
+const internalValue = ref(props.modelValue);
+
+const datePickerValue = computed<string>({
+    get() {
+        return props.modelValue;
+    },
+    set(value: string) {
+        emit("update:model-value", value);
+        notifyTouched(true);
+    },
+});
+const textFieldValue = computed<string>({
+    get() {
+        return internalValue.value;
+    },
+    set(value: string) {
+        internalValue.value = value ? value : "";
+        const convertedValue =
+            internalState.value === false || !internalValue.value
+                ? ""
+                : toIsoFormat(internalValue.value);
+
+        if (convertedValue !== props.modelValue) {
+            emit("update:model-value", convertedValue);
+        }
+        notifyTouched();
+    },
+});
+const internalState = computed(() =>
+    ValidationUtil.isValid(v$.value.textFieldValue)
+);
+const internalErrorMessages = computed(() =>
+    ValidationUtil.getErrorMessages(v$.value.textFieldValue)
+);
+const validations = computed(() => ({
+    textFieldValue: {
+        date: helpers.withMessage("Invalid date", validateDateFormat),
+    },
+}));
+
+const v$ = useVuelidate(validations, { textFieldValue });
+
+function fromIsoFormat(value: string): string {
+    return new DateWrapper(value).format().toUpperCase();
+}
+
+function toIsoFormat(value: string): string {
+    return DateWrapper.fromStringFormat(value).toISODate();
+}
+
+function validateDateFormat(value: string): boolean {
+    return value ? DateWrapper.fromStringFormat(value).isValid() : true;
+}
+
+function notifyTouched(fromDatePicker?: boolean): void {
+    const valid = fromDatePicker ? true : internalState.value === true;
+
+    emit("blur");
+    emit("validity-updated", valid);
+}
+
+watch(
+    () => props.modelValue,
+    (value) => {
+        internalValue.value = fromIsoFormat(value);
+    }
+);
+</script>
+
+<template>
+    <v-text-field
+        v-model="v$.textFieldValue.$model"
+        v-maska:[maskOptions]
+        clearable
+        type="text"
+        :label="label"
+        :placeholder="DateWrapper.defaultFormat.toUpperCase()"
+        :error="internalState === false || state === false"
+        :error-messages="internalErrorMessages.concat(errorMessages)"
+        @blur="notifyTouched"
+    >
+        <template #append>
+            <VueDatePicker
+                v-model="datePickerValue"
+                :max-date="maxDate.toJSDate()"
+                :enable-time-picker="false"
+                model-type="format"
+                format="yyyy-MM-dd"
+                auto-apply
+                month-name-format="long"
+                six-weeks="append"
+                :offset="16"
+                calendar-cell-class-name="rounded-circle"
+            >
+                <template #trigger>
+                    <HgIconButtonComponent icon="fas fa-calendar" />
+                </template>
+            </VueDatePicker>
+        </template>
+    </v-text-field>
+</template>
+
+<style lang="scss">
+.dp__theme_light {
+    --dp-text-color: rgba(
+        var(--v-theme-on-background),
+        var(--v-high-emphasis-opacity)
+    );
+    --dp-primary-color: rgb(var(--v-theme-focus));
+    --dp-primary-text-color: rgb(var(--v-theme-on-focus));
+}
+</style>

--- a/Apps/WebClient/src/NewClientApp/src/models/dateWrapper.ts
+++ b/Apps/WebClient/src/NewClientApp/src/models/dateWrapper.ts
@@ -72,6 +72,12 @@ export interface IDateWrapper {
     fromEpoch(): number;
 
     /**
+     * Determines if the date is valid.
+     * @returns true if the date is valid.
+     */
+    isValid(): boolean;
+
+    /**
      * Gets the year.
      * @returns Calendar year
      */
@@ -339,6 +345,11 @@ export class DateWrapper implements IDateWrapper {
     /** {@inheritDoc IDateWrapper.fromEpoch} */
     public fromEpoch(): number {
         return this.internalDate.valueOf();
+    }
+
+    /** {@inheritDoc IDateWrapper.isValid} */
+    public isValid(): boolean {
+        return this.internalDate.isValid;
     }
 
     /** {@inheritDoc IDateWrapper.year} */

--- a/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
@@ -1,18 +1,13 @@
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
-
-// Plugins
-import vuetify from "@/plugins/vuetify";
-import pinia from "@/stores";
-import router from "@/router";
-
-// Types
 import type { App } from "vue";
-import { vMaska } from "maska";
+
+import vuetify from "@/plugins/vuetify";
+import router from "@/router";
+import pinia from "@/stores";
 
 export function registerInitialPlugins(app: App) {
     app.use(vuetify).use(pinia);
-    app.component("font-awesome-icon", FontAwesomeIcon);
-    app.directive("maska", vMaska);
+    app.component("FontAwesomeIcon", FontAwesomeIcon);
 }
 
 export function registerRouterPlugin(app: App) {

--- a/Apps/WebClient/src/NewClientApp/src/utility/validationUtil.ts
+++ b/Apps/WebClient/src/NewClientApp/src/utility/validationUtil.ts
@@ -1,4 +1,5 @@
 import { BaseValidation } from "@vuelidate/core";
+import { unref } from "vue";
 
 const PHNsigDigits = [2, 4, 8, 5, 10, 9, 7, 3];
 
@@ -50,5 +51,21 @@ export default abstract class ValidationUtil {
         return untouched && ignoreUntouched
             ? undefined
             : !validator.$invalid && !validator.$pending;
+    }
+
+    /**
+     * Returns the error messages associated with failed validation rules on a validator.
+     * @param validator The validator for a parameter.
+     * @param ignoreUntouched Determines whether untouched parameters should be ignored when retrieving error messages (defaults to true).
+     * @returns an empty array if the parameter is untouched (and ignoreUntouched is true), otherwise an array containing the error messages associated with all failed validation rules on the validator.
+     */
+    public static getErrorMessages(
+        validator: BaseValidation,
+        ignoreUntouched = true
+    ): string[] {
+        const errors = ignoreUntouched
+            ? validator.$errors
+            : validator.$silentErrors;
+        return errors.map((e) => unref(e.$message));
     }
 }


### PR DESCRIPTION
# Implements [AB#15741](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15741)

## Description

- adds vue3datepicker package
- removes global registration of vMaska directive, since it can easily be used only where it's needed

[Vuetify Migration Guide Link](https://github.com/bcgov/healthgateway/wiki/Vuetify:-DatePickerComponent)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
