### PR TITLE
Migrate ProfileView & VerifySmsDialogComponent to vuetify #15807

### DIFF
--- a/Apps/WebClient/src/NewClientApp/package-lock.json
+++ b/Apps/WebClient/src/NewClientApp/package-lock.json
@@ -8,6 +8,7 @@
             "name": "gateway-client",
             "version": "2.0.0-alpha",
             "dependencies": {
+                "@chenfengyuan/vue-countdown": "^2.1.1",
                 "@vuelidate/core": "^2.0.2",
                 "@vuelidate/validators": "^2.0.2",
                 "@vuepic/vue-datepicker": "^5.3.0",
@@ -104,6 +105,14 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@chenfengyuan/vue-countdown": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@chenfengyuan/vue-countdown/-/vue-countdown-2.1.1.tgz",
+            "integrity": "sha512-HARJ62AFyxrBH/nMzwuaHUd20waKLN07mjyo2+8YfVouALkFERNRabqt5i3lfp3OISHb2054lWgyaX9L60hdPw==",
+            "peerDependencies": {
+                "vue": "^3.0.0"
             }
         },
         "node_modules/@esbuild/android-arm": {
@@ -3610,6 +3619,12 @@
                 "@babel/helper-validator-identifier": "^7.22.5",
                 "to-fast-properties": "^2.0.0"
             }
+        },
+        "@chenfengyuan/vue-countdown": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@chenfengyuan/vue-countdown/-/vue-countdown-2.1.1.tgz",
+            "integrity": "sha512-HARJ62AFyxrBH/nMzwuaHUd20waKLN07mjyo2+8YfVouALkFERNRabqt5i3lfp3OISHb2054lWgyaX9L60hdPw==",
+            "requires": {}
         },
         "@esbuild/android-arm": {
             "version": "0.17.19",

--- a/Apps/WebClient/src/NewClientApp/package.json
+++ b/Apps/WebClient/src/NewClientApp/package.json
@@ -9,6 +9,7 @@
         "lint": "eslint src --fix"
     },
     "dependencies": {
+        "@chenfengyuan/vue-countdown": "^2.1.1",
         "@vuelidate/core": "^2.0.2",
         "@vuelidate/validators": "^2.0.2",
         "@vuepic/vue-datepicker": "^5.3.0",

--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -73,7 +73,7 @@ onMounted(async () => {
         <SidebarComponent />
         <v-main>
             <CommunicationComponent v-if="isCommunicationVisible" />
-            <v-container>
+            <v-container class="pt-6">
                 <ErrorCardComponent v-if="!hideErrorAlerts" />
                 <router-view />
             </v-container>

--- a/Apps/WebClient/src/NewClientApp/src/assets/styles/_spacing.scss
+++ b/Apps/WebClient/src/NewClientApp/src/assets/styles/_spacing.scss
@@ -1,6 +1,7 @@
 :is(p, ol, ul):not(:last-child) {
     margin-bottom: 1em;
 }
+
 :is(ol, ul) {
     padding-left: 40px;
 }

--- a/Apps/WebClient/src/NewClientApp/src/assets/styles/_visibility.scss
+++ b/Apps/WebClient/src/NewClientApp/src/assets/styles/_visibility.scss
@@ -1,0 +1,7 @@
+.visible {
+    visibility: visible;
+}
+
+.invisible {
+    visibility: hidden;
+}

--- a/Apps/WebClient/src/NewClientApp/src/assets/styles/main.scss
+++ b/Apps/WebClient/src/NewClientApp/src/assets/styles/main.scss
@@ -1,5 +1,6 @@
 @use "_fonts";
 @use "_spacing";
+@use "_visibility";
 
 @use "vuetify" with (
     $heading-font-family: (

--- a/Apps/WebClient/src/NewClientApp/src/components/common/DisplayFieldComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/common/DisplayFieldComponent.vue
@@ -9,10 +9,10 @@ defineProps<Props>();
 </script>
 
 <template>
-    <div class="text-body-1">
+    <p class="text-body-1">
         <span :class="nameClass">{{ name }}: </span>
         <span :class="valueClass" v-bind="$attrs">
             {{ value }}
         </span>
-    </div>
+    </p>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/common/PageTitleComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/common/PageTitleComponent.vue
@@ -13,7 +13,7 @@ const hasAppendSlot = computed(() => slots.append !== undefined);
 </script>
 
 <template>
-    <div id="pageTitle">
+    <div id="pageTitle" class="mb-4">
         <v-row dense justify="end" align="center">
             <v-col v-if="hasPrependSlot" class="flex-grow-0">
                 <slot name="prepend" />

--- a/Apps/WebClient/src/NewClientApp/src/components/common/SectionHeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/common/SectionHeaderComponent.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+interface Props {
+    title: string;
+}
+defineProps<Props>();
+</script>
+
+<template>
+    <h3 class="text-subtitle-1 font-weight-bold mb-2 d-flex align-center">
+        <span>{{ title }}</span>
+        <slot name="append" />
+    </h3>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/error/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/error/ErrorCardComponent.vue
@@ -67,7 +67,7 @@ async function copyToClipboard() {
         :title="errorTitle"
         type="error"
         data-testid="errorBanner"
-        class="d-print-none"
+        class="d-print-none mb-4"
         closable
         variant="outlined"
         border

--- a/Apps/WebClient/src/NewClientApp/src/components/private/home/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/home/AddQuickLinkComponent.vue
@@ -238,7 +238,7 @@ function hideModal(): void {
                         />
                     </v-toolbar>
                 </v-card-title>
-                <v-card-text class="pa-3">
+                <v-card-text class="pa-4">
                     <TooManyRequestsComponent location="addQuickLinkModal" />
                     <v-alert
                         v-if="bannerError"
@@ -321,7 +321,7 @@ function hideModal(): void {
                         color="primary"
                     />
                 </v-card-text>
-                <v-card-actions class="justify-end border-t-sm">
+                <v-card-actions class="justify-end border-t-sm pa-4">
                     <HgButtonComponent
                         data-testid="cancel-add-quick-link-btn"
                         variant="secondary"

--- a/Apps/WebClient/src/NewClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/home/HomeView.vue
@@ -335,7 +335,7 @@ watch(vaccineRecordState, () => {
         data-testid="incomplete-profile-banner"
         closable
         type="info"
-        class="d-print-none my-3"
+        class="d-print-none mb-4"
         title="Verify Contact Information"
         variant="outlined"
         border
@@ -361,7 +361,7 @@ watch(vaccineRecordState, () => {
         title="Looks like you're in a different timezone."
         text="Heads up: your health records are recorded and displayed in
                 Pacific Time."
-        class="d-print-none my-3"
+        class="d-print-none mb-4"
         variant="outlined"
         border
     />

--- a/Apps/WebClient/src/NewClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/home/HomeView.vue
@@ -71,8 +71,8 @@ const vaccineRecordResultMessage = computed(
 const unverifiedEmail = computed(
     () => !user.value.verifiedEmail && user.value.hasEmail
 );
-const unverifiedSMS = computed(
-    () => !user.value.verifiedSMS && user.value.hasSMS
+const unverifiedSms = computed(
+    () => !user.value.verifiedSms && user.value.hasSms
 );
 const isPacificTime = computed(() => {
     const isDaylightSavings = new DateWrapper().isInDST();
@@ -331,7 +331,7 @@ watch(vaccineRecordState, () => {
         :text="vaccineRecordStatusMessage"
     />
     <v-alert
-        v-if="unverifiedEmail || unverifiedSMS"
+        v-if="unverifiedEmail || unverifiedSms"
         data-testid="incomplete-profile-banner"
         closable
         type="info"

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/ActiveUserProfileComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/ActiveUserProfileComponent.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
+import UserProfileAddressComponent from "@/components/private/profile/UserProfileAddressComponent.vue";
+import UserProfileEmailComponent from "@/components/private/profile/UserProfileEmailComponent.vue";
+import UserProfileManageAccountComponent from "@/components/private/profile/UserProfileManageAccountComponent.vue";
+import UserProfileSmsComponent from "@/components/private/profile/UserProfileSmsComponent.vue";
+import { DateWrapper } from "@/models/dateWrapper";
+import { useUserStore } from "@/stores/user";
+
+const emit = defineEmits<{
+    (e: "email-updated", value: string): void;
+}>();
+
+const userStore = useUserStore();
+
+const formattedLoginDateTimes = computed(() =>
+    userStore.user.lastLoginDateTimes.map((time) =>
+        new DateWrapper(time, { isUtc: true }).format("yyyy-MMM-dd, t")
+    )
+);
+</script>
+
+<template>
+    <SectionHeaderComponent title="Full Name" />
+    <p data-testid="fullName">{{ userStore.userName }}</p>
+    <SectionHeaderComponent title="Personal Health Number" />
+    <p data-testid="PHN">
+        {{ userStore.patient.personalHealthNumber }}
+    </p>
+    <UserProfileEmailComponent @email-updated="emit('email-updated', $event)" />
+    <UserProfileSmsComponent />
+    <UserProfileAddressComponent />
+    <SectionHeaderComponent title="Login History" />
+    <ul id="lastLoginDate" class="text-body-1">
+        <li
+            v-for="(item, index) in formattedLoginDateTimes"
+            :key="index"
+            data-testid="lastLoginDateItem"
+        >
+            {{ item }}
+        </li>
+    </ul>
+    <UserProfileManageAccountComponent />
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/InactiveUserProfileComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/InactiveUserProfileComponent.vue
@@ -13,12 +13,13 @@ import { ResultError } from "@/models/errors";
 import { ILogger } from "@/services/interfaces";
 import { useConfigStore } from "@/stores/config";
 import { useErrorStore } from "@/stores/error";
+import { useLoadingStore } from "@/stores/loading";
 import { useUserStore } from "@/stores/user";
-import PromiseUtility from "@/utility/promiseUtility";
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const configStore = useConfigStore();
 const errorStore = useErrorStore();
+const loadingStore = useLoadingStore();
 const userStore = useUserStore();
 
 const timeForDeletion = ref(-1);
@@ -42,7 +43,9 @@ const timeForDeletionString = computed(() => {
 });
 
 function recoverAccount(): void {
-    PromiseUtility.withLoader(
+    loadingStore.applyLoader(
+        Loader.UserProfile,
+        "recoverAccount",
         userStore.recoverUserAccount().catch((err: ResultError) => {
             logger.error(err.resultMessage);
             if (err.statusCode === 429) {
@@ -54,9 +57,7 @@ function recoverAccount(): void {
                     undefined
                 );
             }
-        }),
-        Loader.UserProfile,
-        "recoverAccount"
+        })
     );
 }
 

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/InactiveUserProfileComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/InactiveUserProfileComponent.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { Duration, DurationUnit } from "luxon";
+import { computed, ref } from "vue";
+
+import DisplayFieldComponent from "@/components/common/DisplayFieldComponent.vue";
+import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
+import { ErrorSourceType } from "@/constants/errorType";
+import { Loader } from "@/constants/loader";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { DateWrapper } from "@/models/dateWrapper";
+import { ResultError } from "@/models/errors";
+import { ILogger } from "@/services/interfaces";
+import { useConfigStore } from "@/stores/config";
+import { useErrorStore } from "@/stores/error";
+import { useUserStore } from "@/stores/user";
+import PromiseUtility from "@/utility/promiseUtility";
+
+const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+const configStore = useConfigStore();
+const errorStore = useErrorStore();
+const userStore = useUserStore();
+
+const timeForDeletion = ref(-1);
+const intervalHandler = ref(0);
+
+const timeForDeletionString = computed(() => {
+    if (userStore.userIsActive) {
+        return "";
+    }
+
+    const duration = Duration.fromMillis(timeForDeletion.value);
+    const units: DurationUnit[] = ["day", "hour", "minute", "second"];
+    for (const unit of units) {
+        const amount = Math.floor(duration.as(unit));
+        if (amount > 1) {
+            return `${amount} ${unit}s`;
+        }
+    }
+
+    return "Your account will be closed imminently";
+});
+
+function recoverAccount(): void {
+    PromiseUtility.withLoader(
+        userStore.recoverUserAccount().catch((err: ResultError) => {
+            logger.error(err.resultMessage);
+            if (err.statusCode === 429) {
+                errorStore.setTooManyRequestsError("page");
+            } else {
+                errorStore.addCustomError(
+                    `Unable to recover ${ErrorSourceType.Profile}`,
+                    ErrorSourceType.Profile,
+                    undefined
+                );
+            }
+        }),
+        Loader.UserProfile,
+        "recoverAccount"
+    );
+}
+
+function calculateTimeForDeletion(): void {
+    if (userStore.userIsActive) {
+        return undefined;
+    }
+
+    let endDate = new DateWrapper(userStore.user.closedDateTime);
+    endDate = endDate.add({ hour: configStore.webConfig.hoursForDeletion });
+    timeForDeletion.value = endDate.diff(new DateWrapper()).milliseconds;
+}
+
+calculateTimeForDeletion();
+intervalHandler.value = window.setInterval(
+    () => calculateTimeForDeletion(),
+    1000
+);
+</script>
+
+<template>
+    <v-alert
+        data-testid="emailOptOutMessage"
+        class="pt-0"
+        type="error"
+        variant="text"
+        icon="exclamation-triangle"
+        title="Account marked for removal"
+        text="Your account has been deactivated. If you wish to recover your account,
+                click on the “Recover Account” button before the time expires."
+    />
+    <DisplayFieldComponent
+        name="Time remaining for deletion"
+        :value="timeForDeletionString"
+    />
+    <HgButtonComponent
+        id="recoverAccountCancelBtn"
+        data-testid="recoverAccountCancelBtn"
+        variant="primary"
+        text="Recover Account"
+        @click="recoverAccount"
+    />
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/ProfileView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/ProfileView.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { faExclamationTriangle } from "@fortawesome/free-solid-svg-icons";
+import { computed, ref } from "vue";
+import { VSkeletonLoader } from "vuetify/labs/VSkeletonLoader";
+
+import LoadingComponent from "@/components/common/LoadingComponent.vue";
+import PageTitleComponent from "@/components/common/PageTitleComponent.vue";
+import ActiveUserProfileComponent from "@/components/private/profile/ActiveUserProfileComponent.vue";
+import InactiveUserProfileComponent from "@/components/private/profile/InactiveUserProfileComponent.vue";
+import BreadcrumbComponent from "@/components/site/BreadcrumbComponent.vue";
+import { Loader } from "@/constants/loader";
+import BreadcrumbItem from "@/models/breadcrumbItem";
+import { useLoadingStore } from "@/stores/loading";
+import { useUserStore } from "@/stores/user";
+
+library.add(faExclamationTriangle);
+
+const breadcrumbItems: BreadcrumbItem[] = [
+    {
+        text: "Profile",
+        to: "/profile",
+        active: true,
+        dataTestId: "breadcrumb-profile",
+    },
+];
+
+const loadingStore = useLoadingStore();
+const userStore = useUserStore();
+
+const showCheckEmailAlert = ref(false);
+
+const isLoading = computed(() => loadingStore.isLoading(Loader.UserProfile));
+</script>
+
+<template>
+    <BreadcrumbComponent :items="breadcrumbItems" />
+    <LoadingComponent :is-loading="isLoading" />
+    <v-alert
+        v-if="userStore.userIsActive && showCheckEmailAlert"
+        data-testid="verifyEmailTxt"
+        class="d-print-none mb-4"
+        closable
+        type="info"
+        variant="outlined"
+        border
+        title="Please check your email"
+        text="Please check your email for an email verification link. If you
+            didn't receive one, please check your junk mail."
+        @click:close="showCheckEmailAlert = false"
+    />
+    <PageTitleComponent title="Profile" />
+    <v-skeleton-loader
+        v-if="isLoading"
+        type="heading, text, heading, paragraph"
+    />
+    <div v-show="!isLoading">
+        <ActiveUserProfileComponent
+            v-if="userStore.userIsActive"
+            @email-updated="showCheckEmailAlert = Boolean($event)"
+        />
+        <InactiveUserProfileComponent v-else />
+    </div>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileAddressComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileAddressComponent.vue
@@ -109,8 +109,7 @@ const postalAddressLabel = computed(() =>
             target="_blank"
             rel="noopener"
             >here</a
-        >
-        <span>.</span>
+        >.
     </div>
     <div v-if="!isSameAddress" class="mb-4 text-body-1">
         If either of these addresses is incorrect, update them
@@ -119,8 +118,7 @@ const postalAddressLabel = computed(() =>
             target="_blank"
             rel="noopener"
             >here</a
-        >
-        <span>.</span>
+        >.
     </div>
     <div v-if="!hasAddress" class="mb-4 text-body-1">
         To add an address, visit
@@ -129,7 +127,6 @@ const postalAddressLabel = computed(() =>
             target="_blank"
             rel="noopener"
             >this page</a
-        >
-        <span>.</span>
+        >.
     </div>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileAddressComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileAddressComponent.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
+import { useUserStore } from "@/stores/user";
+
+const userStore = useUserStore();
+
+const physicalAddress = computed(() => userStore.patient.physicalAddress);
+const postalAddress = computed(() => userStore.patient.postalAddress);
+const hasAddress = computed(
+    () => Boolean(physicalAddress.value) || Boolean(postalAddress.value)
+);
+const isSameAddress = computed(() => {
+    if (!physicalAddress.value || !postalAddress.value) {
+        return !hasAddress.value;
+    }
+
+    const arrayEqual = (a: string[], b: string[]) =>
+        a.length === b.length && a.every((v, i) => v === b[i]);
+
+    const streetLinesMatch = arrayEqual(
+        postalAddress.value.streetLines,
+        physicalAddress.value.streetLines
+    );
+    const cityMatches =
+        postalAddress.value.city === physicalAddress.value?.city;
+    const stateMatches =
+        postalAddress.value.state === physicalAddress.value?.state;
+    const postalCodeMatches =
+        postalAddress.value.postalCode === physicalAddress.value?.postalCode;
+
+    return streetLinesMatch && cityMatches && stateMatches && postalCodeMatches;
+});
+const postalAddressLabel = computed(() =>
+    !isSameAddress.value || (physicalAddress.value && !postalAddress.value)
+        ? "Mailing Address"
+        : "Address"
+);
+</script>
+
+<template>
+    <div class="mb-4">
+        <SectionHeaderComponent
+            data-testid="postal-address-label"
+            :title="postalAddressLabel"
+        />
+        <div
+            v-if="postalAddress"
+            data-testid="postal-address-div"
+            class="text-body-1"
+        >
+            <div
+                v-for="(item, index) in postalAddress.streetLines"
+                :key="index"
+            >
+                {{ item }}
+            </div>
+            <div>
+                {{ postalAddress.city }}, {{ postalAddress.state }},
+                {{ postalAddress.postalCode }}
+            </div>
+        </div>
+        <div
+            v-else
+            data-testid="no-postal-address-text"
+            class="text-body-1 font-italic"
+        >
+            No address on record
+        </div>
+    </div>
+    <div
+        v-if="!isSameAddress"
+        data-testid="physical-address-section"
+        class="mb-4"
+    >
+        <SectionHeaderComponent
+            data-testid="physical-address-label"
+            title="Physical Address"
+        />
+        <div
+            v-if="physicalAddress"
+            data-testid="physical-address-div"
+            class="text-body-1"
+        >
+            <div
+                v-for="(item, index) in physicalAddress.streetLines"
+                :key="index"
+            >
+                {{ item }}
+            </div>
+            <div>
+                {{ physicalAddress.city }}, {{ physicalAddress.state }},
+                {{ physicalAddress.postalCode }}
+            </div>
+        </div>
+        <div
+            v-else
+            data-testid="no-physical-address-text"
+            class="text-body-1 font-italic"
+        >
+            No address on record
+        </div>
+    </div>
+    <div v-if="hasAddress && isSameAddress" class="mb-4 text-body-1">
+        If this address is incorrect, update it
+        <a
+            href="https://www.addresschange.gov.bc.ca/"
+            target="_blank"
+            rel="noopener"
+            >here</a
+        >
+        <span>.</span>
+    </div>
+    <div v-if="!isSameAddress" class="mb-4 text-body-1">
+        If either of these addresses is incorrect, update them
+        <a
+            href="https://www.addresschange.gov.bc.ca/"
+            target="_blank"
+            rel="noopener"
+            >here</a
+        >
+        <span>.</span>
+    </div>
+    <div v-if="!hasAddress" class="mb-4 text-body-1">
+        To add an address, visit
+        <a
+            href="https://www.addresschange.gov.bc.ca/"
+            target="_blank"
+            rel="noopener"
+            >this page</a
+        >
+        <span>.</span>
+    </div>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -1,0 +1,214 @@
+<script setup lang="ts">
+import useVuelidate from "@vuelidate/core";
+import {
+    email as emailValidator,
+    helpers,
+    not,
+    sameAs,
+} from "@vuelidate/validators";
+import { computed, ref, watch } from "vue";
+
+import DisplayFieldComponent from "@/components/common/DisplayFieldComponent.vue";
+import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
+import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
+import { ErrorSourceType, ErrorType } from "@/constants/errorType";
+import { Loader } from "@/constants/loader";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { isTooManyRequestsError } from "@/models/errors";
+import { ILogger } from "@/services/interfaces";
+import { useErrorStore } from "@/stores/error";
+import { useUserStore } from "@/stores/user";
+import PromiseUtility from "@/utility/promiseUtility";
+import ValidationUtil from "@/utility/validationUtil";
+
+const emit = defineEmits<{
+    (e: "email-updated", value: string): void;
+}>();
+
+const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+const errorStore = useErrorStore();
+const userStore = useUserStore();
+
+const isEmailEditable = ref(false);
+const inputValue = ref(userStore.user.email);
+
+const email = computed(() => userStore.user.email);
+const emailVerified = computed(() => userStore.user.verifiedEmail);
+const emailVerificationSent = computed(() => userStore.user.verifiedEmail);
+const inputErrorMessages = computed(() =>
+    !isEmailEditable.value
+        ? []
+        : ValidationUtil.getErrorMessages(v$.value.inputValue)
+);
+const validations = computed(() => ({
+    inputValue: {
+        newEmail: helpers.withMessage(
+            "New email must be different from the previous one",
+            not(sameAs(email))
+        ),
+        email: helpers.withMessage("Valid email is required", emailValidator),
+    },
+}));
+
+const v$ = useVuelidate(validations, { inputValue });
+
+function makeEmailEditable(): void {
+    isEmailEditable.value = true;
+    v$.value.inputValue.$touch();
+}
+
+function cancelEmailEdit(): void {
+    isEmailEditable.value = false;
+    inputValue.value = email.value;
+    v$.value.$reset();
+}
+
+function saveEmailEdit(): void {
+    v$.value.$touch();
+    if (v$.value.inputValue.$invalid !== true) {
+        logger.debug(`saveEmailEdit: ${inputValue.value}`);
+        sendUserEmailUpdate();
+    }
+}
+
+function sendUserEmailUpdate(): void {
+    PromiseUtility.withLoader(
+        userStore
+            .updateUserEmail(inputValue.value)
+            .then(() => {
+                userStore
+                    .retrieveProfile()
+                    .then(() => {
+                        isEmailEditable.value = false;
+                        v$.value.$reset();
+                        emit("email-updated", email.value);
+                    })
+                    .catch((error) => {
+                        if (isTooManyRequestsError(error)) {
+                            errorStore.setTooManyRequestsWarning("page");
+                        } else {
+                            errorStore.addError(
+                                ErrorType.Retrieve,
+                                ErrorSourceType.Profile,
+                                undefined
+                            );
+                        }
+                    });
+            })
+            .catch((err) => {
+                logger.error(err);
+                if (err.statusCode === 429) {
+                    errorStore.setTooManyRequestsError("page");
+                } else {
+                    errorStore.addError(
+                        ErrorType.Update,
+                        ErrorSourceType.Profile,
+                        undefined
+                    );
+                }
+            }),
+        Loader.UserProfile,
+        "updateUserEmail"
+    );
+}
+
+watch(email, (value) => (inputValue.value = value));
+</script>
+
+<template>
+    <SectionHeaderComponent title="Email Address">
+        <template #append>
+            <HgButtonComponent
+                id="editEmail"
+                data-testid="editEmailBtn"
+                class="ml-2"
+                :class="{ invisible: isEmailEditable }"
+                variant="link"
+                text="Edit"
+                @click="makeEmailEditable"
+            />
+        </template>
+    </SectionHeaderComponent>
+    <v-sheet :max-width="400">
+        <v-text-field
+            v-model.trim="inputValue"
+            :class="{ 'mb-4': inputErrorMessages.length > 0 }"
+            type="email"
+            clearable
+            label="Email Address"
+            :placeholder="isEmailEditable ? 'Your email address' : 'Empty'"
+            persistent-placeholder
+            :disabled="!isEmailEditable"
+            :error-messages="inputErrorMessages"
+            @blur="v$.inputValue.$touch()"
+        />
+    </v-sheet>
+    <div v-if="isEmailEditable" class="mb-4">
+        <v-alert
+            v-if="!inputValue && email"
+            data-testid="emailOptOutMessage"
+            class="text-center pt-0"
+            type="error"
+            variant="text"
+            icon="exclamation-triangle"
+            text="Removing your email address will disable future email
+                communications from the Health Gateway."
+        />
+        <HgButtonComponent
+            id="editEmailCancelBtn"
+            data-testid="editEmailCancelBtn"
+            class="mr-2"
+            variant="secondary"
+            text="Cancel"
+            @click="cancelEmailEdit"
+        />
+        <HgButtonComponent
+            id="editEmailSaveBtn"
+            data-testid="editEmailSaveBtn"
+            class="mx-2"
+            variant="primary"
+            text="Save"
+            :disabled="
+                inputValue === email ||
+                !ValidationUtil.isValid(v$.inputValue, undefined, false)
+            "
+            @click="saveEmailEdit"
+        />
+    </div>
+    <template v-else>
+        <div id="emailStatus" data-testid="emailStatus" class="mb-4">
+            <DisplayFieldComponent
+                v-if="emailVerified"
+                name="Status"
+                value="Verified"
+                value-class="text-success"
+                data-testid="emailStatusVerified"
+            />
+            <DisplayFieldComponent
+                v-else-if="!email"
+                name="Status"
+                value="Opted Out"
+                value-class="text-medium-emphasis"
+                data-testid="emailStatusOptedOut"
+            />
+            <DisplayFieldComponent
+                v-else
+                name="Status"
+                value="Not Verified"
+                value-class="text-error"
+                data-testid="emailStatusNotVerified"
+            />
+        </div>
+        <HgButtonComponent
+            v-if="!emailVerified && email"
+            id="resendEmail"
+            data-testid="resendEmailBtn"
+            class="mb-4"
+            variant="secondary"
+            text="Resend Verification"
+            :disabled="emailVerificationSent"
+            @click="sendUserEmailUpdate"
+        />
+    </template>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -18,8 +18,8 @@ import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { isTooManyRequestsError } from "@/models/errors";
 import { ILogger } from "@/services/interfaces";
 import { useErrorStore } from "@/stores/error";
+import { useLoadingStore } from "@/stores/loading";
 import { useUserStore } from "@/stores/user";
-import PromiseUtility from "@/utility/promiseUtility";
 import ValidationUtil from "@/utility/validationUtil";
 
 const emit = defineEmits<{
@@ -28,6 +28,7 @@ const emit = defineEmits<{
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const errorStore = useErrorStore();
+const loadingStore = useLoadingStore();
 const userStore = useUserStore();
 
 const isEmailEditable = ref(false);
@@ -73,7 +74,9 @@ function saveEmailEdit(): void {
 }
 
 function sendUserEmailUpdate(): void {
-    PromiseUtility.withLoader(
+    loadingStore.applyLoader(
+        Loader.UserProfile,
+        "updateUserEmail",
         userStore
             .updateUserEmail(inputValue.value)
             .then(() => {
@@ -107,9 +110,7 @@ function sendUserEmailUpdate(): void {
                         undefined
                     );
                 }
-            }),
-        Loader.UserProfile,
-        "updateUserEmail"
+            })
     );
 }
 

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileManageAccountComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileManageAccountComponent.vue
@@ -10,17 +10,20 @@ import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { ResultError } from "@/models/errors";
 import { ILogger } from "@/services/interfaces";
 import { useErrorStore } from "@/stores/error";
+import { useLoadingStore } from "@/stores/loading";
 import { useUserStore } from "@/stores/user";
-import PromiseUtility from "@/utility/promiseUtility";
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const errorStore = useErrorStore();
+const loadingStore = useLoadingStore();
 const userStore = useUserStore();
 
 const showCloseWarning = ref(false);
 
 function closeAccount(): void {
-    PromiseUtility.withLoader(
+    loadingStore.applyLoader(
+        Loader.UserProfile,
+        "closeAccount",
         userStore
             .closeUserAccount()
             .then(() => (showCloseWarning.value = false))
@@ -35,9 +38,7 @@ function closeAccount(): void {
                         undefined
                     );
                 }
-            }),
-        Loader.UserProfile,
-        "closeAccount"
+            })
     );
 }
 </script>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileManageAccountComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileManageAccountComponent.vue
@@ -1,0 +1,90 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
+import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
+import { ErrorSourceType } from "@/constants/errorType";
+import { Loader } from "@/constants/loader";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { ResultError } from "@/models/errors";
+import { ILogger } from "@/services/interfaces";
+import { useErrorStore } from "@/stores/error";
+import { useUserStore } from "@/stores/user";
+import PromiseUtility from "@/utility/promiseUtility";
+
+const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+const errorStore = useErrorStore();
+const userStore = useUserStore();
+
+const showCloseWarning = ref(false);
+
+function closeAccount(): void {
+    PromiseUtility.withLoader(
+        userStore
+            .closeUserAccount()
+            .then(() => (showCloseWarning.value = false))
+            .catch((err: ResultError) => {
+                logger.error(err.resultMessage);
+                if (err.statusCode === 429) {
+                    errorStore.setTooManyRequestsError("page");
+                } else {
+                    errorStore.addCustomError(
+                        `Unable to close ${ErrorSourceType.Profile}`,
+                        ErrorSourceType.Profile,
+                        undefined
+                    );
+                }
+            }),
+        Loader.UserProfile,
+        "closeAccount"
+    );
+}
+</script>
+
+<template>
+    <SectionHeaderComponent title="Manage Account" />
+    <HgButtonComponent
+        v-if="!showCloseWarning"
+        id="recoverAccountShowCloseWarningBtn"
+        data-testid="recoverAccountShowCloseWarningBtn"
+        variant="link"
+        color="error"
+        text="Delete My Account"
+        @click="showCloseWarning = true"
+    />
+    <template v-else>
+        <v-card variant="text">
+            <template #text>
+                <v-alert
+                    class="pa-0"
+                    type="error"
+                    variant="text"
+                    icon="exclamation-triangle"
+                    text="Your account will be marked for removal, preventing
+                        you from accessing your information on the Health
+                        Gateway. After a set period of time it will be
+                        removed permanently."
+                />
+            </template>
+            <template #actions>
+                <v-spacer />
+                <HgButtonComponent
+                    id="closeAccountCancelBtn"
+                    data-testid="closeAccountCancelBtn"
+                    class="mr-2"
+                    variant="secondary"
+                    text="Cancel"
+                    @click="showCloseWarning = false"
+                />
+                <HgButtonComponent
+                    id="closeAccountBtn"
+                    data-testid="closeAccountBtn"
+                    color="error"
+                    text="Delete Account"
+                    @click="closeAccount"
+                />
+            </template>
+        </v-card>
+    </template>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileSmsComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileSmsComponent.vue
@@ -1,0 +1,272 @@
+<script setup lang="ts">
+import useVuelidate from "@vuelidate/core";
+import { helpers, not, sameAs } from "@vuelidate/validators";
+import { Mask, MaskaDetail, vMaska } from "maska";
+import { computed, ref, watch } from "vue";
+
+import DisplayFieldComponent from "@/components/common/DisplayFieldComponent.vue";
+import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
+import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
+import VerifySmsDialogComponent from "@/components/private/profile/VerifySmsDialogComponent.vue";
+import { ErrorSourceType, ErrorType } from "@/constants/errorType";
+import { Loader } from "@/constants/loader";
+import ValidationRegEx from "@/constants/validationRegEx";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { DateWrapper } from "@/models/dateWrapper";
+import { isTooManyRequestsError } from "@/models/errors";
+import { IUserProfileService } from "@/services/interfaces";
+import { useErrorStore } from "@/stores/error";
+import { useUserStore } from "@/stores/user";
+import PhoneUtil from "@/utility/phoneUtil";
+import PromiseUtility from "@/utility/promiseUtility";
+import ValidationUtil from "@/utility/validationUtil";
+
+const maskString = "(###) ###-####";
+const mask = new Mask({ mask: maskString });
+const maskOptions = {
+    mask: maskString,
+    onMaska: (detail: MaskaDetail) => (rawValue.value = detail.unmasked),
+};
+
+const userProfileService = container.get<IUserProfileService>(
+    SERVICE_IDENTIFIER.UserProfileService
+);
+const errorStore = useErrorStore();
+const userStore = useUserStore();
+
+const isSmsEditable = ref(false);
+
+const verified = computed(() => userStore.user.verifiedSms);
+const rawStoreValue = computed(() => userStore.user.sms);
+const maskedStoreValue = computed(() => mask.masked(rawStoreValue.value));
+
+const rawValue = ref(rawStoreValue.value);
+const maskedValue = ref(maskedStoreValue.value);
+
+const verifySmsModal = ref<InstanceType<typeof VerifySmsDialogComponent>>();
+
+const inputErrorMessages = computed(() =>
+    !isSmsEditable.value
+        ? []
+        : ValidationUtil.getErrorMessages(v$.value.rawValue)
+);
+const validations = computed(() => ({
+    rawValue: {
+        newSMSNumber: helpers.withMessage(
+            "New SMS number must be different from the previous one",
+            not(sameAs(rawStoreValue))
+        ),
+        sms: helpers.withMessage(
+            "Valid SMS number is required",
+            helpers.withAsync(validPhoneNumberFormat)
+        ),
+    },
+}));
+
+const v$ = useVuelidate(validations, { rawValue });
+
+async function validPhoneNumberFormat(
+    value: string
+): Promise<boolean | undefined> {
+    if (value === rawStoreValue.value || !value) {
+        return true;
+    }
+
+    if (!ValidationRegEx.PhoneNumberMasked.test(value)) {
+        return false;
+    }
+
+    const phoneNumber = PhoneUtil.stripPhoneMask(value);
+    return await PromiseUtility.withMinimumDelay(
+        userProfileService.isPhoneNumberValid(phoneNumber),
+        500
+    );
+}
+
+function makeSmsEditable(): void {
+    isSmsEditable.value = true;
+    v$.value.rawValue.$touch();
+}
+
+function cancelSmsEdit(): void {
+    isSmsEditable.value = false;
+    maskedValue.value = maskedStoreValue.value;
+}
+
+function saveSmsEdit(): void {
+    v$.value.$touch();
+    if (v$.value.rawValue.$invalid !== true) {
+        updateSms();
+    }
+}
+
+function updateSms(): void {
+    // Reset timer when user submits their SMS number
+    userStore.updateSmsResendDateTime(new DateWrapper());
+
+    // Send update to backend
+    PromiseUtility.withLoader(
+        userProfileService
+            .updateSmsNumber(userStore.user.hdid, rawValue.value)
+            .then(refreshProfile)
+            .then(() => {
+                isSmsEditable.value = false;
+                v$.value.$reset();
+
+                if (rawStoreValue.value) {
+                    verifySms();
+                }
+            })
+            .catch((error) => {
+                if (isTooManyRequestsError(error)) {
+                    errorStore.setTooManyRequestsError("page");
+                } else {
+                    errorStore.addError(
+                        ErrorType.Update,
+                        ErrorSourceType.Profile,
+                        undefined
+                    );
+                }
+            }),
+        Loader.UserProfile,
+        "updateSms"
+    );
+}
+
+function verifySms(): void {
+    verifySmsModal.value?.showModal();
+}
+
+function handleSmsVerified(): void {
+    PromiseUtility.withLoader(
+        refreshProfile(),
+        Loader.UserProfile,
+        "verifySms"
+    );
+}
+
+function refreshProfile(): Promise<void> {
+    return userStore.retrieveProfile().catch((error) => {
+        if (isTooManyRequestsError(error)) {
+            errorStore.setTooManyRequestsWarning("page");
+        } else {
+            errorStore.addError(
+                ErrorType.Retrieve,
+                ErrorSourceType.Profile,
+                undefined
+            );
+        }
+    });
+}
+
+watch(maskedStoreValue, (value) => (maskedValue.value = value));
+</script>
+
+<template>
+    <SectionHeaderComponent title="Cell Number (SMS notifications)">
+        <template #append>
+            <HgButtonComponent
+                data-testid="editSMSBtn"
+                class="ml-2"
+                :class="{ invisible: isSmsEditable }"
+                variant="link"
+                text="Edit"
+                @click="makeSmsEditable"
+            />
+        </template>
+    </SectionHeaderComponent>
+    <v-sheet :max-width="400">
+        <v-text-field
+            v-model="maskedValue"
+            v-maska:[maskOptions]
+            data-testid="smsNumberInput"
+            :class="{ 'mb-4': inputErrorMessages.length > 0 }"
+            type="tel"
+            maxlength="14"
+            clearable
+            label="Cell Number"
+            :placeholder="isSmsEditable ? 'Your phone number' : 'Empty'"
+            persistent-placeholder
+            :disabled="!isSmsEditable"
+            :error-messages="inputErrorMessages"
+        >
+            <template #append-inner>
+                <v-progress-circular
+                    v-if="v$.rawValue.$pending"
+                    color="info"
+                    indeterminate
+                    size="24"
+                />
+            </template>
+        </v-text-field>
+    </v-sheet>
+    <div v-if="isSmsEditable" class="mb-4">
+        <v-alert
+            v-if="!rawValue && rawStoreValue"
+            data-testid="smsOptOutMessage"
+            class="pt-0"
+            type="error"
+            variant="text"
+            icon="exclamation-triangle"
+            text="Removing your phone number will disable future SMS communications
+                from the Health Gateway."
+        />
+        <HgButtonComponent
+            data-testid="cancelSMSEditBtn"
+            class="mr-2"
+            variant="secondary"
+            text="Cancel"
+            @click="cancelSmsEdit"
+        />
+        <HgButtonComponent
+            data-testid="saveSMSEditBtn"
+            class="mx-2"
+            variant="primary"
+            text="Save"
+            :disabled="
+                rawValue === rawStoreValue ||
+                !ValidationUtil.isValid(v$.rawValue)
+            "
+            @click="saveSmsEdit"
+        />
+    </div>
+    <template v-else>
+        <div data-testid="smsStatus" class="mb-4">
+            <DisplayFieldComponent
+                v-if="verified"
+                name="Status"
+                value="Verified"
+                value-class="text-success"
+                data-testid="smsStatusVerified"
+            />
+            <DisplayFieldComponent
+                v-else-if="!rawStoreValue"
+                name="Status"
+                value="Opted Out"
+                value-class="text-medium-emphasis"
+                data-testid="smsStatusOptedOut"
+            />
+            <DisplayFieldComponent
+                v-else
+                name="Status"
+                value="Not Verified"
+                value-class="text-error"
+                data-testid="smsStatusNotVerified"
+            />
+        </div>
+        <HgButtonComponent
+            v-if="!verified && rawStoreValue"
+            data-testid="verifySMSBtn"
+            class="mb-4"
+            variant="secondary"
+            text="Verify"
+            @click="verifySms"
+        />
+    </template>
+    <VerifySmsDialogComponent
+        ref="verifySmsModal"
+        :sms-number="rawStoreValue"
+        @verified="handleSmsVerified"
+    />
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileSmsComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileSmsComponent.vue
@@ -17,6 +17,7 @@ import { DateWrapper } from "@/models/dateWrapper";
 import { isTooManyRequestsError } from "@/models/errors";
 import { IUserProfileService } from "@/services/interfaces";
 import { useErrorStore } from "@/stores/error";
+import { useLoadingStore } from "@/stores/loading";
 import { useUserStore } from "@/stores/user";
 import PhoneUtil from "@/utility/phoneUtil";
 import PromiseUtility from "@/utility/promiseUtility";
@@ -33,6 +34,7 @@ const userProfileService = container.get<IUserProfileService>(
     SERVICE_IDENTIFIER.UserProfileService
 );
 const errorStore = useErrorStore();
+const loadingStore = useLoadingStore();
 const userStore = useUserStore();
 
 const isSmsEditable = ref(false);
@@ -106,7 +108,9 @@ function updateSms(): void {
     userStore.updateSmsResendDateTime(new DateWrapper());
 
     // Send update to backend
-    PromiseUtility.withLoader(
+    loadingStore.applyLoader(
+        Loader.UserProfile,
+        "updateSms",
         userProfileService
             .updateSmsNumber(userStore.user.hdid, rawValue.value)
             .then(refreshProfile)
@@ -128,9 +132,7 @@ function updateSms(): void {
                         undefined
                     );
                 }
-            }),
-        Loader.UserProfile,
-        "updateSms"
+            })
     );
 }
 
@@ -139,11 +141,7 @@ function verifySms(): void {
 }
 
 function handleSmsVerified(): void {
-    PromiseUtility.withLoader(
-        refreshProfile(),
-        Loader.UserProfile,
-        "verifySms"
-    );
+    loadingStore.applyLoader(Loader.UserProfile, "verifySms", refreshProfile());
 }
 
 function refreshProfile(): Promise<void> {

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
@@ -1,0 +1,276 @@
+﻿<script setup lang="ts">
+import VueCountdown from "@chenfengyuan/vue-countdown";
+import { Mask } from "maska";
+import { computed, ComputedRef, ref, watch } from "vue";
+
+import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
+import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
+import LoadingComponent from "@/components/common/LoadingComponent.vue";
+import TooManyRequestsComponent from "@/components/error/TooManyRequestsComponent.vue";
+import { ErrorSourceType, ErrorType } from "@/constants/errorType";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { DateWrapper, IDateWrapper } from "@/models/dateWrapper";
+import { isTooManyRequestsError, ResultError } from "@/models/errors";
+import { ILogger, IUserProfileService } from "@/services/interfaces";
+import { useConfigStore } from "@/stores/config";
+import { useErrorStore } from "@/stores/error";
+import { useUserStore } from "@/stores/user";
+
+interface Props {
+    smsNumber: string;
+}
+const props = defineProps<Props>();
+
+const emit = defineEmits<{
+    (e: "verified"): void;
+}>();
+
+defineExpose({ showModal });
+
+const mask = new Mask({ mask: "(###) ###-####" });
+
+const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+const userProfileService = container.get<IUserProfileService>(
+    SERVICE_IDENTIFIER.UserProfileService
+);
+const configStore = useConfigStore();
+const errorStore = useErrorStore();
+const userStore = useUserStore();
+
+const tooManyRetries = ref(false);
+const allowRetry = ref(false);
+const smsVerificationSent = ref(false);
+const smsVerificationCode = ref("");
+const isVisible = ref(false);
+const isLoading = ref(false);
+const validationError = ref(false);
+const unexpectedError = ref(false);
+
+const smsResendDateTime: ComputedRef<IDateWrapper | undefined> = computed(
+    () => userStore.smsResendDateTime
+);
+const user = computed(() => userStore.user);
+const maskedSmsNumber = computed(() => mask.masked(props.smsNumber));
+const errorMessages = computed(() =>
+    validationError.value ? ["Invalid verification code. Try again."] : []
+);
+
+function showModal(): void {
+    getTimeout();
+    isVisible.value = true;
+}
+
+function hideModal(): void {
+    isVisible.value = false;
+}
+
+function setResendTimeout(): void {
+    if (smsResendDateTime.value === undefined) {
+        allowRetry.value = true;
+        return;
+    }
+
+    const smsTimeWhenEnabled = smsResendDateTime.value.add({
+        minutes: configStore.webConfig.timeouts.resendSMS,
+    });
+
+    const now = new DateWrapper();
+    allowRetry.value = smsTimeWhenEnabled.isBefore(now);
+    if (!allowRetry.value) {
+        const millisecondsToExpire = smsTimeWhenEnabled.diff(now).milliseconds;
+        setTimeout(() => (allowRetry.value = true), millisecondsToExpire);
+    }
+}
+
+function verifySms(): void {
+    smsVerificationCode.value = smsVerificationCode.value.replace(/\D/g, "");
+    isLoading.value = true;
+    userProfileService
+        .validateSms(user.value.hdid, smsVerificationCode.value)
+        .then((result) => {
+            validationError.value = !result;
+            if (!validationError.value) {
+                hideModal();
+                emit("verified");
+            }
+        })
+        .catch((err: ResultError) => {
+            logger.error(err.resultMessage);
+            if (err.statusCode === 429) {
+                errorStore.setTooManyRequestsError("verifySmsModal");
+            } else {
+                unexpectedError.value = true;
+            }
+        })
+        .finally(() => {
+            smsVerificationCode.value = "";
+            isLoading.value = false;
+        });
+}
+
+function sendUserSmsUpdate(): void {
+    smsVerificationSent.value = true;
+    userStore.updateSmsResendDateTime(new DateWrapper());
+    userProfileService
+        .updateSmsNumber(user.value.hdid, props.smsNumber)
+        .then(() => setTimeout(() => (smsVerificationSent.value = false), 5000))
+        .catch((error) => {
+            if (isTooManyRequestsError(error)) {
+                errorStore.setTooManyRequestsWarning("page");
+            } else {
+                errorStore.addError(
+                    ErrorType.Update,
+                    ErrorSourceType.Profile,
+                    undefined
+                );
+            }
+        });
+}
+
+function getTimeout(): number {
+    let resendTime: IDateWrapper;
+    if (!smsResendDateTime.value) {
+        const now = new DateWrapper();
+        userStore.updateSmsResendDateTime(now);
+        resendTime = now;
+    } else {
+        resendTime = smsResendDateTime.value;
+    }
+    resendTime = resendTime.add(
+        configStore.webConfig.timeouts.resendSMS * 60 * 1000
+    );
+    return resendTime.diff(new DateWrapper()).milliseconds;
+}
+
+function onVerificationChange(): void {
+    if (smsVerificationCode.value.length >= 6) {
+        verifySms();
+    }
+}
+
+watch(smsResendDateTime, () => setResendTimeout());
+
+setResendTimeout();
+</script>
+
+<template>
+    <LoadingComponent :is-loading="isLoading" />
+    <v-dialog
+        v-model="isVisible"
+        data-testid="verifySMSModal"
+        persistent
+        no-click-animation
+    >
+        <div class="d-flex justify-center">
+            <v-card :loading="isLoading" max-width="300px">
+                <template #loader="{ isActive }">
+                    <v-progress-linear
+                        :active="isActive"
+                        color="accent"
+                        indeterminate
+                    />
+                </template>
+                <v-card-title class="bg-primary px-0">
+                    <v-toolbar
+                        title="Phone Verification"
+                        density="compact"
+                        color="primary"
+                    >
+                        <HgIconButtonComponent
+                            data-testid="messageModalCloseButton"
+                            icon="close"
+                            @click="hideModal"
+                        />
+                    </v-toolbar>
+                </v-card-title>
+                <v-card-text class="text-body-1 pa-4">
+                    <TooManyRequestsComponent location="verifySmsModal" />
+                    <v-alert
+                        v-if="unexpectedError"
+                        data-testid="verifySMSModalUnexpectedErrorText"
+                        class="d-print-none pa-0"
+                        variant="text"
+                        type="error"
+                    >
+                        An unexpected error has occurred. Please try refreshing
+                        your browser or try again later.
+                    </v-alert>
+                    <div
+                        v-else-if="tooManyRetries"
+                        data-testid="verifySMSModalErrorAttemptsText"
+                        class="text-center"
+                    >
+                        Too many failed attempts.
+                    </div>
+                    <div
+                        v-else
+                        data-testid="verifySMSModalText"
+                        class="text-center"
+                    >
+                        <p class="text-body-1">
+                            Enter the verification code sent to
+                            <span class="font-weight-bold">
+                                {{ maskedSmsNumber }}
+                            </span>
+                        </p>
+                        <v-text-field
+                            v-model="smsVerificationCode"
+                            data-testid="verifySMSModalCodeInput"
+                            label="Verification Code"
+                            maxlength="6"
+                            :disabled="isLoading"
+                            :error-messages="errorMessages"
+                            @update:model-value="onVerificationChange"
+                        />
+                    </div>
+                </v-card-text>
+                <v-card-actions
+                    class="border-t-sm pa-4"
+                    :class="{
+                        'justify-center': !unexpectedError,
+                        'justify-end': unexpectedError,
+                    }"
+                >
+                    <HgButtonComponent
+                        v-if="unexpectedError"
+                        variant="primary"
+                        text="OK"
+                        @click.prevent="hideModal"
+                    />
+                    <HgButtonComponent
+                        v-else-if="tooManyRetries"
+                        id="resendSMSVerification"
+                        variant="link"
+                        block
+                        text="Send New Code"
+                        :disabled="smsVerificationSent"
+                        @click="sendUserSmsUpdate"
+                    />
+                    <VueCountdown
+                        v-else-if="!allowRetry"
+                        v-slot="{ minutes, seconds }"
+                        :time="getTimeout()"
+                    >
+                        Your code has been sent. You can resend after
+                        <span data-testid="countdownText">
+                            {{ minutes > 0 ? minutes + "m" : "" }}
+                            {{ seconds }}s.
+                        </span>
+                    </VueCountdown>
+                    <div v-else>
+                        <span>Didn't receive a code?</span>
+                        <HgButtonComponent
+                            id="resendSMSVerification"
+                            class="ml-2"
+                            variant="link"
+                            text="Resend"
+                            :disabled="smsVerificationSent"
+                            @click="sendUserSmsUpdate"
+                        />
+                    </div>
+                </v-card-actions>
+            </v-card>
+        </div>
+    </v-dialog>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/services/ServicesView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/services/ServicesView.vue
@@ -60,7 +60,7 @@ if (isOrganDonorServiceEnabled.value) {
         <v-col
             v-if="!patientDataAreLoading && isOrganDonorServiceEnabled"
             :cols="getGridCols"
-            class="pa-3"
+            class="pa-4"
         >
             <OrganDonorDetailsCard :hdid="hdid" />
         </v-col>

--- a/Apps/WebClient/src/NewClientApp/src/components/public/landing/LandingView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/landing/LandingView.vue
@@ -142,15 +142,15 @@ function selectPreviewDevice(previewDevice: PreviewDevice): void {
 </script>
 
 <template>
-    <v-container v-if="isOffline" class="landing-container pt-10 text-center">
+    <div v-if="isOffline" class="pa-4 text-center">
         <h1 class="text-primary text-h4 font-weight-bold mb-6">
             The site is offline for maintenance
         </h1>
         <p data-testid="offlineMessage" class="text-body-1">
             {{ offlineMessage }}
         </p>
-    </v-container>
-    <v-container v-else class="landing-container pt-10">
+    </div>
+    <div v-else class="pa-4">
         <v-row justify="start" align="start">
             <v-col lg="5">
                 <h1 class="mb-6 text-primary text-h4 font-weight-bold">
@@ -419,14 +419,10 @@ function selectPreviewDevice(previewDevice: PreviewDevice): void {
                 </a>
             </v-col>
         </v-row>
-    </v-container>
+    </div>
 </template>
 
 <style lang="scss" scoped>
-.landing-container {
-    max-width: 1140px;
-}
-
 .device-preview {
     max-height: 212px;
 

--- a/Apps/WebClient/src/NewClientApp/src/components/site/BreadcrumbComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/BreadcrumbComponent.vue
@@ -37,7 +37,7 @@ const displayBreadcrumbs = computed(
     <v-breadcrumbs
         v-if="displayBreadcrumbs"
         data-testid="breadcrumbs"
-        class="pt-0 pb-0"
+        class="py-0 mb-4"
         aria-label="Breadcrumb Nav"
     >
         <template v-for="(item, index) in allBreadcrumbItems" :key="item.text">

--- a/Apps/WebClient/src/NewClientApp/src/components/site/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/HeaderComponent.vue
@@ -276,6 +276,7 @@ nextTick(() => {
             <HgIconButtonComponent
                 id="menuBtnLogout"
                 data-testid="headerDropdownBtn"
+                class="mx-2"
             >
                 <v-avatar data-testid="profileButtonInitials" color="info">
                     {{ userStore.userInitials }}

--- a/Apps/WebClient/src/NewClientApp/src/components/site/ProtectiveWordComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/ProtectiveWordComponent.vue
@@ -86,7 +86,7 @@ function handleClose(): void {
                         />
                     </v-toolbar>
                 </v-card-title>
-                <v-card-text class="text-body-1 pa-3">
+                <v-card-text class="text-body-1 pa-4">
                     <v-text-field
                         id="protectiveWord-input"
                         v-model="protectiveWord"

--- a/Apps/WebClient/src/NewClientApp/src/components/site/RatingComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/RatingComponent.vue
@@ -84,10 +84,14 @@ function handleRating(value: number | string, skip = false): void {
     >
         <div class="d-flex justify-center">
             <v-card max-width="600px">
-                <v-card-title class="bg-primary text-white">
-                    <h1 class="text-h5 font-weight-bold">Rating</h1>
+                <v-card-title class="bg-primary text-white px-0">
+                    <v-toolbar
+                        title="Rating"
+                        density="compact"
+                        color="primary"
+                    />
                 </v-card-title>
-                <v-card-text class="pa-3">
+                <v-card-text class="pa-4">
                     <p
                         class="text-body-1 text-center"
                         data-testid="ratingModalQuestionText"
@@ -99,14 +103,13 @@ function handleRating(value: number | string, skip = false): void {
                             v-model="ratingValue"
                             data-testid="formRating"
                             color="orange"
-                            class="mb-2"
                             hover
                             size="large"
                             @update:model-value="handleRating"
                         />
                     </div>
                 </v-card-text>
-                <v-card-actions class="justify-end border-t-sm">
+                <v-card-actions class="justify-end border-t-sm pa-4">
                     <HgButtonComponent
                         id="skipButton"
                         data-testid="ratingModalSkipBtn"

--- a/Apps/WebClient/src/NewClientApp/src/constants/loader.ts
+++ b/Apps/WebClient/src/NewClientApp/src/constants/loader.ts
@@ -1,0 +1,3 @@
+export const enum Loader {
+    UserProfile = "UserProfile",
+}

--- a/Apps/WebClient/src/NewClientApp/src/models/user.ts
+++ b/Apps/WebClient/src/NewClientApp/src/models/user.ts
@@ -6,10 +6,12 @@ import type { UserPreference } from "@/models/userPreference";
 export default class User {
     public hdid = "";
     public acceptedTermsOfService = false;
+    public email = "";
     public hasEmail = false;
     public verifiedEmail = false;
-    public hasSMS = false;
-    public verifiedSMS = false;
+    public sms = "";
+    public hasSms = false;
+    public verifiedSms = false;
     public hasTermsOfServiceUpdated = false;
     public lastLoginDateTime?: StringISODateTime;
     public lastLoginDateTimes: StringISODateTime[] = [];

--- a/Apps/WebClient/src/NewClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/index.ts
@@ -114,6 +114,8 @@ const routes = [
         component: DependentViewSelectorComponent,
         meta: {
             validStates: [UserState.registered],
+            requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>
+                config.dependents.enabled,
             requiresProcessedWaitlistTicket: true,
         },
     },
@@ -199,8 +201,17 @@ const routes = [
     },
     {
         path: Path.ReleaseNotes,
-        name: "ReleaseNotes",
         component: ReleaseNotesView,
+        meta: {
+            validStates: [
+                UserState.unauthenticated,
+                UserState.invalidIdentityProvider,
+                UserState.noPatient,
+                UserState.registered,
+                UserState.pendingDeletion,
+            ],
+            requiresProcessedWaitlistTicket: false,
+        },
     },
     {
         path: Path.Reports,
@@ -219,9 +230,9 @@ const routes = [
         },
     },
     {
-        path: "/*",
-        redirect: "/not-found",
-    }, // Not found; Will catch all other paths not covered previously
+        path: "/*", // will catch all other paths not covered previously
+        redirect: Path.NotFound,
+    },
 ];
 
 function scrollBehaviour(
@@ -243,6 +254,6 @@ const router = createRouter({
 });
 
 router.beforeEach(beforeEachGuard);
-
 router.afterEach(afterEachHook);
+
 export default router;

--- a/Apps/WebClient/src/NewClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/index.ts
@@ -29,6 +29,10 @@ const LoginCallbackView = () =>
     import(
         /* webpackChunkName: "loginCallback" */ "@/components/authentication/LoginCallbackView.vue"
     );
+const ProfileView = () =>
+    import(
+        /* webpackChunkName: profile" */ "@/components/private/profile/ProfileView.vue"
+    );
 const RegistrationView = () =>
     import(
         /* webpackChunkName: "registration" */ "@/components/private/registration/RegistrationView.vue"
@@ -125,6 +129,19 @@ const routes = [
         component: HomeView,
         meta: {
             validStates: [UserState.registered],
+            requiresProcessedWaitlistTicket: true,
+        },
+    },
+    {
+        path: Path.Profile,
+        name: "Profile",
+        component: ProfileView,
+        meta: {
+            validStates: [
+                UserState.registered,
+                UserState.pendingDeletion,
+                UserState.acceptTermsOfService,
+            ],
             requiresProcessedWaitlistTicket: true,
         },
     },

--- a/Apps/WebClient/src/NewClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/NewClientApp/src/services/interfaces.ts
@@ -134,9 +134,9 @@ export interface IUserProfileService {
         hdid: string,
         inviteKey: string
     ): Promise<RequestResult<boolean>>;
-    validateSMS(hdid: string, digit: string): Promise<boolean>;
+    validateSms(hdid: string, digit: string): Promise<boolean>;
     updateEmail(hdid: string, email: string): Promise<boolean>;
-    updateSMSNumber(hdid: string, smsNumber: string): Promise<boolean>;
+    updateSmsNumber(hdid: string, smsNumber: string): Promise<boolean>;
     updateUserPreference(
         hdid: string,
         userPreference: UserPreference

--- a/Apps/WebClient/src/NewClientApp/src/services/restUserProfileService.ts
+++ b/Apps/WebClient/src/NewClientApp/src/services/restUserProfileService.ts
@@ -229,7 +229,7 @@ export class RestUserProfileService implements IUserProfileService {
         );
     }
 
-    public validateSMS(hdid: string, digit: string): Promise<boolean> {
+    public validateSms(hdid: string, digit: string): Promise<boolean> {
         return new Promise((resolve, reject) =>
             this.http
                 .get<RequestResult<boolean>>(
@@ -244,7 +244,7 @@ export class RestUserProfileService implements IUserProfileService {
                 })
                 .catch((err: HttpError) => {
                     this.logger.error(
-                        `Error in RestUserProfileService.validateSMS()`
+                        `Error in RestUserProfileService.validateSms()`
                     );
                     reject(
                         ErrorTranslator.internalNetworkError(
@@ -282,7 +282,7 @@ export class RestUserProfileService implements IUserProfileService {
         });
     }
 
-    public updateSMSNumber(hdid: string, smsNumber: string): Promise<boolean> {
+    public updateSmsNumber(hdid: string, smsNumber: string): Promise<boolean> {
         return new Promise((resolve, reject) => {
             const headers: Dictionary<string> = {};
             headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
@@ -296,7 +296,7 @@ export class RestUserProfileService implements IUserProfileService {
                 .then(() => resolve(true))
                 .catch((err: HttpError) => {
                     this.logger.error(
-                        `Error in RestUserProfileService.updateSMSNumber()`
+                        `Error in RestUserProfileService.updateSmsNumber()`
                     );
                     reject(
                         ErrorTranslator.internalNetworkError(

--- a/Apps/WebClient/src/NewClientApp/src/stores/loading.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/loading.ts
@@ -1,0 +1,42 @@
+﻿import { defineStore } from "pinia";
+import { ref } from "vue";
+
+import { Loader } from "@/constants/loader";
+
+export const useLoadingStore = defineStore("loading", () => {
+    const state = ref(new Map<Loader, Set<string>>());
+
+    function isLoading(location: Loader): boolean {
+        return (state.value.get(location)?.size ?? 0) > 0;
+    }
+
+    function setIsLoading(
+        value: boolean,
+        loader: Loader,
+        reason = "default"
+    ): void {
+        const reasons = state.value.get(loader) ?? new Set<string>();
+        if (value) {
+            reasons.add(reason);
+        } else {
+            reasons.delete(reason);
+        }
+
+        if (reasons.size > 0) {
+            state.value.set(loader, reasons);
+        } else {
+            clearIsLoading(loader);
+        }
+    }
+
+    function clearIsLoading(location: Loader): void {
+        state.value.delete(location);
+    }
+
+    return {
+        state,
+        isLoading,
+        setIsLoading,
+        clearIsLoading,
+    };
+});

--- a/Apps/WebClient/src/NewClientApp/src/stores/loading.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/loading.ts
@@ -33,10 +33,20 @@ export const useLoadingStore = defineStore("loading", () => {
         state.value.delete(location);
     }
 
+    function applyLoader<T>(
+        loader: Loader,
+        reason: string,
+        promise: Promise<T>
+    ): void {
+        setIsLoading(true, loader, reason);
+        promise.finally(() => setIsLoading(false, loader, reason));
+    }
+
     return {
         state,
         isLoading,
         setIsLoading,
         clearIsLoading,
+        applyLoader,
     };
 });

--- a/Apps/WebClient/src/NewClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/user.ts
@@ -9,7 +9,7 @@ import {
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
-import { DateWrapper } from "@/models/dateWrapper";
+import { DateWrapper, IDateWrapper } from "@/models/dateWrapper";
 import { ResultError } from "@/models/errors";
 import Patient from "@/models/patient";
 import { QuickLink } from "@/models/quickLink";
@@ -41,7 +41,7 @@ export const useUserStore = defineStore("user", () => {
 
     const user = ref(new User());
     const oidcUserInfo = ref<OidcUserInfo>();
-    const smsResendDateTime = ref<DateWrapper>();
+    const smsResendDateTime = ref<IDateWrapper>();
     const error = ref<unknown>();
     const statusMessage = ref("");
     const status = ref(LoadStatus.NONE);
@@ -162,10 +162,12 @@ export const useUserStore = defineStore("user", () => {
             : undefined;
         user.value.preferences = userProfile ? userProfile.preferences : {};
         user.value.blockedDataSources = userProfile?.blockedDataSources ?? [];
+        user.value.email = userProfile?.email ?? "";
         user.value.hasEmail = Boolean(userProfile?.email);
         user.value.verifiedEmail = userProfile?.isEmailVerified === true;
-        user.value.hasSMS = Boolean(userProfile?.smsNumber);
-        user.value.verifiedSMS = userProfile?.isSMSNumberVerified === true;
+        user.value.sms = userProfile?.smsNumber ?? "";
+        user.value.hasSms = Boolean(userProfile?.smsNumber);
+        user.value.verifiedSms = userProfile?.isSMSNumberVerified === true;
         user.value.hasTourUpdated = userProfile?.hasTourUpdated === true;
 
         logger.verbose(`User: ${JSON.stringify(user.value)}`);
@@ -173,7 +175,7 @@ export const useUserStore = defineStore("user", () => {
         setLoadedStatus(patient.value.hdid !== undefined);
     }
 
-    function updateSMSResendDateTime(date: DateWrapper) {
+    function updateSmsResendDateTime(date: IDateWrapper) {
         smsResendDateTime.value = date;
         setLoadedStatus();
     }
@@ -450,7 +452,7 @@ export const useUserStore = defineStore("user", () => {
         createProfile,
         retrieveProfile,
         updateUserEmail,
-        updateSMSResendDateTime,
+        updateSmsResendDateTime,
         setUserPreference,
         updateQuickLinks,
         validateEmail,

--- a/Apps/WebClient/src/NewClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/user.ts
@@ -370,9 +370,7 @@ export const useUserStore = defineStore("user", () => {
     function closeUserAccount(): Promise<void> {
         return userProfileService
             .closeAccount(user.value.hdid)
-            .then((userProfile) => {
-                setProfileUserData(userProfile);
-            })
+            .then(retrieveProfile)
             .catch((resultError: ResultError) => {
                 setUserError(resultError.resultMessage);
                 throw resultError;
@@ -382,12 +380,7 @@ export const useUserStore = defineStore("user", () => {
     function recoverUserAccount(): Promise<void> {
         return userProfileService
             .recoverAccount(user.value.hdid)
-            .then((userProfile) => {
-                logger.debug(
-                    `recoverUserAccount: ${JSON.stringify(userProfile)}`
-                );
-                setProfileUserData(userProfile);
-            })
+            .then(retrieveProfile)
             .catch((resultError: ResultError) => {
                 setUserError(resultError.resultMessage);
                 throw resultError;

--- a/Apps/WebClient/src/NewClientApp/src/utility/promiseUtility.ts
+++ b/Apps/WebClient/src/NewClientApp/src/utility/promiseUtility.ts
@@ -1,3 +1,6 @@
+import { Loader } from "@/constants/loader";
+import { useLoadingStore } from "@/stores/loading";
+
 export default abstract class PromiseUtility {
     /**
      * Wraps a promise so it won't return or reject until a minimum amount of time has elapsed.
@@ -30,5 +33,27 @@ export default abstract class PromiseUtility {
      */
     public static delay(milliseconds: number): Promise<unknown> {
         return new Promise((resolve) => setTimeout(resolve, milliseconds));
+    }
+
+    /**
+     * Wraps a promise so a loader is enabled beforehand and disabled afterward.
+     * @param promise The provided Promise.
+     * @param loader A loader to invoke.
+     * @param reason A reason for invoking the loader.
+     * @returns A new Promise.
+     */
+    public static async withLoader<T>(
+        promise: Promise<T>,
+        loader: Loader,
+        reason?: string
+    ): Promise<T> {
+        const loadingStore = useLoadingStore();
+
+        try {
+            loadingStore.setIsLoading(true, loader, reason);
+            return await promise;
+        } finally {
+            loadingStore.setIsLoading(false, loader, reason);
+        }
     }
 }

--- a/Apps/WebClient/src/NewClientApp/src/utility/promiseUtility.ts
+++ b/Apps/WebClient/src/NewClientApp/src/utility/promiseUtility.ts
@@ -1,6 +1,3 @@
-import { Loader } from "@/constants/loader";
-import { useLoadingStore } from "@/stores/loading";
-
 export default abstract class PromiseUtility {
     /**
      * Wraps a promise so it won't return or reject until a minimum amount of time has elapsed.
@@ -33,27 +30,5 @@ export default abstract class PromiseUtility {
      */
     public static delay(milliseconds: number): Promise<unknown> {
         return new Promise((resolve) => setTimeout(resolve, milliseconds));
-    }
-
-    /**
-     * Wraps a promise so a loader is enabled beforehand and disabled afterward.
-     * @param promise The provided Promise.
-     * @param loader A loader to invoke.
-     * @param reason A reason for invoking the loader.
-     * @returns A new Promise.
-     */
-    public static async withLoader<T>(
-        promise: Promise<T>,
-        loader: Loader,
-        reason?: string
-    ): Promise<T> {
-        const loadingStore = useLoadingStore();
-
-        try {
-            loadingStore.setIsLoading(true, loader, reason);
-            return await promise;
-        } finally {
-            loadingStore.setIsLoading(false, loader, reason);
-        }
     }
 }


### PR DESCRIPTION
# Implements [AB#15807](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15807)

## Description

- improves spacing for page content, titles, and cards
- adds visible and invisible CSS classes for toggling element visibility
- fixes meta props in dependent and release note routes
- avoids relying on incomplete profile returned from close/recover account
- adds SectionHeaderComponent for simple headers on pages
- migrates ProfileView and VerifySmsDialogComponent to vuetify
  - splits ProfileView into ActiveUserProfileComponent and InactiveUserProfileComponent
  - ActiveUserProfileComponent is further split into UserProfileEmailComponent, UserProfileSmsComponent, UserProfileAddressComponent, and UserProfileManageAccountComponent

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
