### PR TITLE
Migrate IdleComponent to vuetify AB#15812

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -5,6 +5,7 @@ import { useRoute } from "vue-router";
 import ErrorCardComponent from "@/components/error/ErrorCardComponent.vue";
 import CommunicationComponent from "@/components/site/CommunicationComponent.vue";
 import HeaderComponent from "@/components/site/HeaderComponent.vue";
+import IdleComponent from "@/components/site/IdleComponent.vue";
 import SidebarComponent from "@/components/site/SidebarComponent.vue";
 import { Path } from "@/constants/path";
 import ScreenWidth from "@/constants/screenWidth";
@@ -78,5 +79,6 @@ onMounted(async () => {
                 <router-view />
             </v-container>
         </v-main>
+        <IdleComponent />
     </v-app>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/components/site/IdleComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/IdleComponent.vue
@@ -1,0 +1,60 @@
+﻿<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+
+import IdleDialogComponent from "@/components/site/IdleDialogComponent.vue";
+import { Path } from "@/constants/path";
+import router from "@/router";
+import { useAuthStore } from "@/stores/auth";
+import { useConfigStore } from "@/stores/config";
+import { IdleDetector } from "@/utility/idleDetector";
+
+const authStore = useAuthStore();
+const configStore = useConfigStore();
+
+const idleDialog = ref<InstanceType<typeof IdleDialogComponent>>();
+
+const timeBeforeIdle = computed(() => configStore.webConfig.timeouts.idle);
+const maxIdleDialogCountdown = computed(() => 60000);
+const idleDetector = computed(() =>
+    timeBeforeIdle.value > 0
+        ? new IdleDetector(
+              handleIsIdle,
+              timeBeforeIdle.value,
+              authStore.oidcIsAuthenticated
+          )
+        : undefined
+);
+
+function handleIsIdle(timeIdle: number): void {
+    if (!authStore.oidcIsAuthenticated) {
+        return;
+    }
+
+    const countdownTime = maxIdleDialogCountdown.value - timeIdle;
+    if (countdownTime <= 0) {
+        router.push(Path.Logout);
+    } else {
+        idleDialog.value?.showDialog(countdownTime);
+    }
+}
+
+watch(
+    () => authStore.oidcIsAuthenticated,
+    (value: boolean) => {
+        // enable idle detector when authenticated and disable when not
+        if (value) {
+            idleDetector.value?.enable();
+        } else {
+            idleDetector.value?.disable();
+        }
+    }
+);
+</script>
+
+<template>
+    <IdleDialogComponent
+        ref="idleDialog"
+        @response-received="idleDetector?.enable()"
+        @expired="router.push(Path.Logout)"
+    />
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/site/IdleComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/IdleComponent.vue
@@ -8,13 +8,14 @@ import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { IdleDetector } from "@/utility/idleDetector";
 
+const maxIdleDialogCountdown = 60000;
+
 const authStore = useAuthStore();
 const configStore = useConfigStore();
 
 const idleDialog = ref<InstanceType<typeof IdleDialogComponent>>();
 
 const timeBeforeIdle = computed(() => configStore.webConfig.timeouts.idle);
-const maxIdleDialogCountdown = computed(() => 60000);
 const idleDetector = computed(() =>
     timeBeforeIdle.value > 0
         ? new IdleDetector(
@@ -30,7 +31,7 @@ function handleIsIdle(timeIdle: number): void {
         return;
     }
 
-    const countdownTime = maxIdleDialogCountdown.value - timeIdle;
+    const countdownTime = maxIdleDialogCountdown - timeIdle;
     if (countdownTime <= 0) {
         router.push(Path.Logout);
     } else {

--- a/Apps/WebClient/src/NewClientApp/src/components/site/IdleDialogComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/IdleDialogComponent.vue
@@ -1,0 +1,104 @@
+﻿<script setup lang="ts">
+import { computed, ref } from "vue";
+
+import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
+import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
+import { useAppStore } from "@/stores/app";
+import { ReliableTimer } from "@/utility/reliableTimer";
+
+const emit = defineEmits<{
+    (e: "response-received"): void;
+    (e: "expired"): void;
+}>();
+
+defineExpose({ showDialog });
+
+const appStore = useAppStore();
+
+const intervalId = ref<ReturnType<typeof setInterval>>();
+const countdownTimer = ref<ReliableTimer>();
+const remainingTime = ref(Number.MAX_SAFE_INTEGER);
+
+const isVisible = computed(() => appStore.isIdle);
+const remainingSeconds = computed(() => Math.ceil(remainingTime.value / 1000));
+
+function setVisible(value: boolean): void {
+    appStore.setIsIdle(value);
+}
+
+function showDialog(countdownDuration: number): void {
+    if (isVisible.value) {
+        return;
+    }
+
+    intervalId.value = setInterval(update, 1000);
+    countdownTimer.value = new ReliableTimer(expire, countdownDuration);
+    countdownTimer.value.start();
+    update();
+
+    setVisible(true);
+}
+
+function update(): void {
+    if (countdownTimer.value === undefined) {
+        return;
+    }
+
+    remainingTime.value = countdownTimer.value.remainingTime;
+}
+
+function notifyNotIdle(): void {
+    emit("response-received");
+    hideDialog();
+}
+
+function expire(): void {
+    emit("expired");
+    hideDialog();
+}
+
+function hideDialog(): void {
+    setVisible(false);
+    clearInterval(intervalId.value);
+    countdownTimer.value?.cancel();
+}
+</script>
+
+<template>
+    <v-dialog
+        :model-value="isVisible"
+        data-testid="idleModal"
+        persistent
+        no-click-animation
+    >
+        <div class="d-flex justify-center">
+            <v-card max-width="700px">
+                <v-card-title class="bg-primary px-0">
+                    <v-toolbar
+                        title="Are you still there?"
+                        density="compact"
+                        color="primary"
+                    >
+                        <HgIconButtonComponent
+                            icon="close"
+                            @click="notifyNotIdle"
+                        />
+                    </v-toolbar>
+                </v-card-title>
+                <v-card-text class="text-body-1 pa-4">
+                    <p data-testid="idleModalText">
+                        You will be automatically logged out in
+                        {{ remainingSeconds }} seconds.
+                    </p>
+                </v-card-text>
+                <v-card-actions class="justify-end border-t-sm pa-4">
+                    <HgButtonComponent
+                        variant="primary"
+                        text="I'm here!"
+                        @click="notifyNotIdle"
+                    />
+                </v-card-actions>
+            </v-card>
+        </div>
+    </v-dialog>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/utility/idleDetector.ts
+++ b/Apps/WebClient/src/NewClientApp/src/utility/idleDetector.ts
@@ -17,12 +17,17 @@ export class IdleDetector {
 
     constructor(
         private isIdleCallback: (timeIdle: number) => void,
-        private timeBeforeIdle: number
+        private timeBeforeIdle: number,
+        startEnabled: boolean
     ) {
         this.idleTimer = new ReliableTimer(
             () => this.timerCallback(),
-            timeBeforeIdle
+            this.timeBeforeIdle
         );
+
+        if (startEnabled) {
+            this.enable();
+        }
     }
 
     public enable() {


### PR DESCRIPTION
# Implements [AB#15812](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15812)

## Description

- renames IdleComponent to IdleDialogComponent
  - updates component to emit events rather than store a callback function
- introduces new IdleComponent containing all the logic that was previously in app.vue

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
