### PR TITLE
Convert Waitlist Views - AB#15816

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
@@ -15,10 +15,11 @@ if (!waitlistStore.tooBusy) {
     <v-row justify="center" class="mt-12">
         <v-col cols="12" md="8" lg="6" xl="4">
             <v-alert
-                show
                 type="error"
                 data-testid="too-many-tickets"
                 class="mb-12 text-center"
+                variant="outlined"
+                border
                 text="Can’t access Health Gateway. Please try again later."
             />
             <v-img

--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { computed } from "vue";
 import { useRouter } from "vue-router";
 
 import { useWaitlistStore } from "@/stores/waitlist";
@@ -7,9 +6,7 @@ import { useWaitlistStore } from "@/stores/waitlist";
 const router = useRouter();
 const waitlistStore = useWaitlistStore();
 
-const tooBusy = computed<boolean>(() => waitlistStore.tooBusy);
-
-if (!tooBusy.value) {
+if (!waitlistStore.tooBusy) {
     router.push({ path: "/" });
 }
 </script>

--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRouter } from "vue-router";
+
+import { useWaitlistStore } from "@/stores/waitlist";
+
+const router = useRouter();
+const waitlistStore = useWaitlistStore();
+
+const tooBusy = computed<boolean>(() => waitlistStore.tooBusy);
+
+// if (!tooBusy.value) {
+//     router.push({ path: "/" });
+// }
+</script>
+
+<template>
+    <v-row justify="center" class="mt-12">
+        <v-col cols="12" md="8" lg="6" xl="4">
+            <v-alert
+                show
+                type="error"
+                data-testid="too-many-tickets"
+                class="mb-12 text-center"
+                text="Can’t access Health Gateway. Please try again later."
+            />
+            <v-img
+                src="@/assets/images/queue/error.png"
+                data-testid="queue-error-image"
+                alt="Queue full image"
+                max-height="300px"
+            />
+        </v-col>
+    </v-row>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueFullView.vue
@@ -9,9 +9,9 @@ const waitlistStore = useWaitlistStore();
 
 const tooBusy = computed<boolean>(() => waitlistStore.tooBusy);
 
-// if (!tooBusy.value) {
-//     router.push({ path: "/" });
-// }
+if (!tooBusy.value) {
+    router.push({ path: "/" });
+}
 </script>
 
 <template>

--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueView.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+import { useConfigStore } from "@/stores/config";
+import { useWaitlistStore } from "@/stores/waitlist";
+
+const route = useRoute();
+const router = useRouter();
+const configStore = useConfigStore();
+const waitlistStore = useWaitlistStore();
+
+const ticketIsProcessed = computed(() => waitlistStore.ticketIsProcessed);
+
+const queuePosition = computed(() => waitlistStore.ticket?.queuePosition);
+
+function redirect(): void {
+    const path = route.query.redirect ? route.query.redirect.toString() : "/";
+    router.push({ path });
+}
+
+watch(ticketIsProcessed, (value: boolean) => {
+    if (value) {
+        redirect();
+    }
+});
+
+if (
+    !configStore.webConfig.featureToggleConfiguration.waitingQueue.enabled ||
+    !waitlistStore.ticket ||
+    waitlistStore.ticketIsProcessed
+) {
+    redirect();
+}
+</script>
+
+<template>
+    <v-row justify="center" class="mt-12">
+        <v-col cols="12" md="8" lg="6" xl="4" class="text-center">
+            <v-img
+                src="@/assets/images/queue/waiting.png"
+                data-testid="queue-image"
+                alt="Queue waiting image"
+                max-height="200px"
+            />
+            <p class="my-4 text-body-1">
+                Health Gateway is busier than normal at this moment. We have
+                placed you in a queue.
+            </p>
+            <h2 v-if="queuePosition !== undefined" class="mt-4 text-h5">
+                <span class="mb-3">Your position in the queue: </span>
+                <span data-testid="queue-position">{{ queuePosition }}</span>
+            </h2>
+        </v-col>
+    </v-row>
+</template>

--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueView.vue
@@ -11,7 +11,6 @@ const configStore = useConfigStore();
 const waitlistStore = useWaitlistStore();
 
 const ticketIsProcessed = computed(() => waitlistStore.ticketIsProcessed);
-
 const queuePosition = computed(() => waitlistStore.ticket?.queuePosition);
 
 function redirect(): void {

--- a/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/waitlist/QueueView.vue
@@ -46,10 +46,15 @@ if (
                 Health Gateway is busier than normal at this moment. We have
                 placed you in a queue.
             </p>
-            <h2 v-if="queuePosition !== undefined" class="mt-4 text-h5">
-                <span class="mb-3">Your position in the queue: </span>
-                <span data-testid="queue-position">{{ queuePosition }}</span>
-            </h2>
+            <div v-if="queuePosition !== undefined" class="mt-4">
+                <h2 class="mb-4 text-h5">Your position in the queue:</h2>
+                <p
+                    class="font-weight-bold text-h5"
+                    data-testid="queue-position"
+                >
+                    {{ queuePosition }}
+                </p>
+            </div>
         </v-col>
     </v-row>
 </template>

--- a/Apps/WebClient/src/NewClientApp/src/router/beforeEachGuard.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/beforeEachGuard.ts
@@ -5,13 +5,16 @@
 } from "vue-router";
 
 import { Path } from "@/constants/path";
+import { TicketStatus } from "@/constants/ticketStatus";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { Ticket } from "@/models/ticket";
 import { UserState } from "@/router/index";
 import { ILogger } from "@/services/interfaces";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { useUserStore } from "@/stores/user";
+import { useWaitlistStore } from "@/stores/waitlist";
 
 function getDefaultPath(
     currentUserState: UserState,
@@ -122,7 +125,7 @@ export const beforeEachGuard: NavigationGuard = async (
     );
 
     if (waitlistIsEnabled && metaRequiresProcessedWaitlistTicket) {
-        // redirectWhenTicketIsInvalid(to, next); // TODO: implement
+        await redirectWhenTicketIsInvalid(to, next);
     }
 
     await authStore.checkStatus();
@@ -157,3 +160,43 @@ export const beforeEachGuard: NavigationGuard = async (
 
     next({ path: defaultPath });
 };
+
+function ticketIsValid(ticket: Ticket | undefined): boolean {
+    if (ticket?.status !== TicketStatus.Processed) {
+        return false;
+    }
+
+    const now = new Date().getTime();
+    return now < ticket.tokenExpires * 1000;
+}
+
+async function redirectWhenTicketIsInvalid(
+    to: RouteLocationNormalizedLoaded,
+    next: NavigationGuardNext
+) {
+    const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
+    const waitlistStore = useWaitlistStore();
+
+    let ticket = waitlistStore.ticket;
+    try {
+        if (ticketIsValid(ticket)) {
+            logger.debug(`Router - check existing Processed ticket`);
+            await waitlistStore.scheduleCheckIn();
+        } else if (ticket?.status === TicketStatus.Queued) {
+            logger.debug(`Router - check existing Queued ticket`);
+            await waitlistStore.scheduleCheckIn(undefined, true);
+            next({ path: Path.Queue, query: { redirect: to.path } });
+            return;
+        } else {
+            ticket = await waitlistStore.getTicket();
+            if (!ticketIsValid(ticket)) {
+                next({ path: Path.Queue, query: { redirect: to.path } });
+                return;
+            }
+        }
+    } catch {
+        // redirect to busy page if new ticket could not be retrieved
+        next({ path: Path.Busy, query: { redirect: to.path } });
+        return;
+    }
+}

--- a/Apps/WebClient/src/NewClientApp/src/router/beforeEachGuard.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/beforeEachGuard.ts
@@ -181,10 +181,10 @@ async function redirectWhenTicketIsInvalid(
     try {
         if (ticketIsValid(ticket)) {
             logger.debug(`Router - check existing Processed ticket`);
-            await waitlistStore.scheduleCheckIn();
+            waitlistStore.scheduleCheckIn();
         } else if (ticket?.status === TicketStatus.Queued) {
             logger.debug(`Router - check existing Queued ticket`);
-            await waitlistStore.scheduleCheckIn(undefined, true);
+            waitlistStore.scheduleCheckIn(undefined, true);
             next({ path: Path.Queue, query: { redirect: to.path } });
             return;
         } else {

--- a/Apps/WebClient/src/NewClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/index.ts
@@ -89,6 +89,14 @@ const ValidateEmailView = () =>
     import(
         /* webpackChunkName: "validateEmail" */ "@/components/private/validate-email/ValidateEmailView.vue"
     );
+const QueueView = () =>
+    import(
+        /* webpackChunkName: "queue" */ "@/components/public/waitlist/QueueView.vue"
+    );
+const QueueFullView = () =>
+    import(
+        /* webpackChunkName: "queueFull" */ "@/components/public/waitlist/QueueFullView.vue"
+    );
 
 export enum UserState {
     offline = "offline",
@@ -287,6 +295,20 @@ const routes = [
         meta: {
             validStates: [UserState.registered],
             requiresProcessedWaitlistTicket: true,
+        },
+    },
+    {
+        path: Path.Queue,
+        component: QueueView,
+        meta: {
+            stateless: true,
+        },
+    },
+    {
+        path: Path.Busy,
+        component: QueueFullView,
+        meta: {
+            stateless: true,
         },
     },
     {


### PR DESCRIPTION
# Fixes or Implements [AB#15816](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15816)

## Description
1. QueueFullView
2. QueueView
    * I could have done this without the container, however for consistency I decided to add the v-row and v-col.
4. Refine Waitlist store to better exposed the data from the store
    * Was one of the first store's I converted and added unnecessary abstraction.
 5. Reintroduced the waitlist checking code in the before navigation guard.


## Testing
- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes
The vue2 implementation of these views centers the content vertically and horizontally. However the Vue 3 views that we display some message such as the AppErrorView and LogoutComplete all display the content at the top. I've maintained this approach and have not bothered aligning vertically.

<img width="322" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/a1a04161-5a15-4a9a-b227-cf228c242a2f">

<img width="385" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/270bca10-8260-41d0-b4cf-8cd64beb93a0">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
