### PR TITLE
Convert ResourceCentreComponent - AB#15819

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed } from "vue";
 import { useRoute } from "vue-router";
 
 import ErrorCardComponent from "@/components/error/ErrorCardComponent.vue";
@@ -8,18 +8,12 @@ import FooterComponent from "@/components/site/FooterComponent.vue";
 import HeaderComponent from "@/components/site/HeaderComponent.vue";
 import IdleComponent from "@/components/site/IdleComponent.vue";
 import NotificationCentreComponent from "@/components/site/NotificationCentreComponent.vue";
+import ResourceCentreComponent from "@/components/site/ResourceCentreComponent.vue";
 import SidebarComponent from "@/components/site/SidebarComponent.vue";
 import { Path } from "@/constants/path";
-import ScreenWidth from "@/constants/screenWidth";
-import { useAppStore } from "@/stores/app";
 
 const route = useRoute();
-const appStore = useAppStore();
 
-const initialized = ref(false);
-const windowWidth = ref(0);
-
-const isMobile = computed<boolean>(() => appStore.isMobile);
 const hideErrorAlerts = computed(() =>
     currentPathMatches(Path.Root, Path.VaccineCard, Path.Queue, Path.Busy)
 );
@@ -30,6 +24,9 @@ const isCommunicationVisible = computed(
     () =>
         !currentPathMatches(Path.LoginCallback, Path.VaccineCard) &&
         !route.path.toLowerCase().startsWith(Path.PcrTest.toLowerCase())
+);
+const isResourceCentreAvailable = computed(() =>
+    currentPathMatches(Path.Dependents, Path.Reports, Path.Timeline)
 );
 
 const isFooterVisible = computed(
@@ -46,41 +43,10 @@ function currentPathMatches(...paths: string[]): boolean {
         (path) => route.path.toLowerCase() === path.toLowerCase()
     );
 }
-
-function initializeResizeListener(): void {
-    window.addEventListener("resize", onResize);
-    onResize();
-}
-
-function onResize(): void {
-    windowWidth.value = window.innerWidth;
-
-    if (windowWidth.value < ScreenWidth.Mobile) {
-        if (!isMobile.value) {
-            appStore.setIsMobile(true);
-        }
-    } else {
-        if (isMobile.value) {
-            appStore.setIsMobile(false);
-        }
-    }
-}
-
-onBeforeUnmount(() => {
-    window.removeEventListener("resize", onResize);
-});
-
-onMounted(async () => {
-    windowWidth.value = window.innerWidth;
-
-    await nextTick();
-    initializeResizeListener();
-    initialized.value = true;
-});
 </script>
 
 <template>
-    <v-app v-if="initialized">
+    <v-app>
         <HeaderComponent v-if="isHeaderVisible" />
         <SidebarComponent />
         <NotificationCentreComponent />
@@ -90,6 +56,7 @@ onMounted(async () => {
                 <ErrorCardComponent v-if="!hideErrorAlerts" />
                 <router-view />
             </v-container>
+            <ResourceCentreComponent v-if="isResourceCentreAvailable" />
         </v-main>
         <IdleComponent />
         <FooterComponent v-if="isFooterVisible" :order="-1" />

--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -50,7 +50,7 @@ function currentPathMatches(...paths: string[]): boolean {
         <HeaderComponent v-if="isHeaderVisible" />
         <SidebarComponent />
         <NotificationCentreComponent />
-        <v-main>
+        <v-main class="position-relative">
             <CommunicationComponent v-if="isCommunicationVisible" />
             <v-container class="pt-6">
                 <ErrorCardComponent v-if="!hideErrorAlerts" />

--- a/Apps/WebClient/src/NewClientApp/src/components/site/FooterComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/FooterComponent.vue
@@ -19,7 +19,6 @@ const isFooterShown = computed(
             !userStore.isValidIdentityProvider ||
             userStore.userIsRegistered)
 );
-
 const isFooterFixed = computed(() => !appStore.isMobile);
 </script>
 

--- a/Apps/WebClient/src/NewClientApp/src/components/site/FooterComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/FooterComponent.vue
@@ -2,6 +2,7 @@
 import { computed } from "vue";
 
 import { Path } from "@/constants/path";
+import { useAppStore } from "@/stores/app";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { useUserStore } from "@/stores/user";
@@ -9,18 +10,26 @@ import { useUserStore } from "@/stores/user";
 const authStore = useAuthStore();
 const configStore = useConfigStore();
 const userStore = useUserStore();
+const appStore = useAppStore();
 
-const isFooterShown = computed<boolean>(
+const isFooterShown = computed(
     () =>
         !configStore.isOffline &&
         (!authStore.oidcIsAuthenticated ||
             !userStore.isValidIdentityProvider ||
             userStore.userIsRegistered)
 );
+
+const isFooterFixed = computed(() => !appStore.isMobile);
 </script>
 
 <template>
-    <v-footer v-if="isFooterShown" data-testid="footer" color="primary" app>
+    <v-footer
+        v-if="isFooterShown"
+        data-testid="footer"
+        color="primary"
+        :app="isFooterFixed"
+    >
         <v-row class="pa-2">
             <v-col class="flex-grow-0" cols="12" md="auto">
                 <a

--- a/Apps/WebClient/src/NewClientApp/src/components/site/FooterComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/FooterComponent.vue
@@ -36,7 +36,7 @@ const isFooterFixed = computed(() => !appStore.isMobile);
                     data-testid="footer-terms-of-service-link"
                     class="text-white"
                 >
-                    Terms of service
+                    Terms of Service
                 </a>
             </v-col>
             <v-col class="flex-grow-0" cols="12" md="auto">

--- a/Apps/WebClient/src/NewClientApp/src/components/site/HeaderComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/HeaderComponent.vue
@@ -16,7 +16,6 @@ import { useNavbarStore } from "@/stores/navbar";
 import { useNotificationStore } from "@/stores/notification";
 import { useUserStore } from "@/stores/user";
 
-const sidebarId = "notification-centre-sidebar";
 const headerScrollThreshold = 100;
 
 const appStore = useAppStore();

--- a/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
@@ -21,8 +21,8 @@ const appStore = useAppStore();
                     v-bind="props"
                     icon="question"
                     size="large"
-                    elevation="2"
-                    color="secondary"
+                    elevation="8"
+                    color="info"
                 />
             </template>
             <v-list>

--- a/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
+import { Path } from "@/constants/path";
 import { useAppStore } from "@/stores/app";
 
 const appStore = useAppStore();
@@ -37,7 +38,7 @@ const appStore = useAppStore();
                     target="_blank"
                     title="FAQ"
                 />
-                <v-list-item to="/release-notes" title="Release Notes" />
+                <v-list-item :to="Path.ReleaseNotes" title="Release Notes" />
             </v-list>
         </v-menu>
     </div>

--- a/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
@@ -8,24 +8,28 @@ const appStore = useAppStore();
 <template>
     <div
         data-testid="hg-resource-centre"
-        class="resource-centre-position text-right pa-4"
-        :class="{ mobile: appStore.isMobile }"
+        class="pa-4"
+        :class="
+            appStore.isMobile
+                ? 'resource-centre-position--mobile'
+                : 'resource-centre-position'
+        "
     >
         <v-menu location="top">
             <template #activator="{ props }">
                 <HgIconButtonComponent
                     v-bind="props"
                     icon="question"
-                    size="x-large"
+                    size="large"
                     elevation="2"
                     color="secondary"
                 />
             </template>
             <v-list>
                 <v-list-item>
-                    <v-list-title class="font-weight-bold"
-                        >Resource Centre</v-list-title
-                    >
+                    <v-list-item-title class="font-weight-bold">
+                        Resource Centre
+                    </v-list-item-title>
                 </v-list-item>
                 <v-divider />
                 <v-list-item
@@ -41,10 +45,11 @@ const appStore = useAppStore();
 
 <style scoped lang="scss">
 .resource-centre-position {
-    position: fixed;
+    position: absolute;
     bottom: 56px;
     right: 0;
-    &.mobile {
+    &--mobile {
+        @extend .resource-centre-position;
         bottom: 0;
     }
 }

--- a/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/ResourceCentreComponent.vue
@@ -1,0 +1,51 @@
+<script setup lang="ts">
+import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
+import { useAppStore } from "@/stores/app";
+
+const appStore = useAppStore();
+</script>
+
+<template>
+    <div
+        data-testid="hg-resource-centre"
+        class="resource-centre-position text-right pa-4"
+        :class="{ mobile: appStore.isMobile }"
+    >
+        <v-menu location="top">
+            <template #activator="{ props }">
+                <HgIconButtonComponent
+                    v-bind="props"
+                    icon="question"
+                    size="x-large"
+                    elevation="2"
+                    color="secondary"
+                />
+            </template>
+            <v-list>
+                <v-list-item>
+                    <v-list-title class="font-weight-bold"
+                        >Resource Centre</v-list-title
+                    >
+                </v-list-item>
+                <v-divider />
+                <v-list-item
+                    href="https://www2.gov.bc.ca/gov/content?id=FE8BA7F9F1F0416CB2D24CF71C4BAF80"
+                    target="_blank"
+                    title="FAQ"
+                />
+                <v-list-item to="/release-notes" title="Release Notes" />
+            </v-list>
+        </v-menu>
+    </div>
+</template>
+
+<style scoped lang="scss">
+.resource-centre-position {
+    position: fixed;
+    bottom: 56px;
+    right: 0;
+    &.mobile {
+        bottom: 0;
+    }
+}
+</style>

--- a/Apps/WebClient/src/NewClientApp/src/components/site/SidebarComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/SidebarComponent.vue
@@ -29,13 +29,11 @@ const isDependentEnabled = computed(
 const isServicesEnabled = computed(
     () => configStore.webConfig.featureToggleConfiguration.services.enabled
 );
-
 const isQueuePage = computed(
     () =>
         route.path.toLowerCase() === "/queue" ||
         route.path.toLowerCase() === "/busy"
 );
-
 const isSidebarAvailable = computed(
     () =>
         !configStore.isOffline &&

--- a/Apps/WebClient/src/NewClientApp/src/constants/screenWidth.ts
+++ b/Apps/WebClient/src/NewClientApp/src/constants/screenWidth.ts
@@ -1,3 +1,0 @@
-export default abstract class ScreenWidth {
-    public static Mobile = 768;
-}

--- a/Apps/WebClient/src/NewClientApp/src/stores/app.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/app.ts
@@ -1,19 +1,18 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
+import { computed, ref } from "vue";
+import { useDisplay } from "vuetify";
 
 import { AppErrorType } from "@/constants/errorType";
 
 export const useAppStore = defineStore("app", () => {
+    const display = useDisplay();
+
     const appError = ref<AppErrorType>();
-    const isMobile = ref(false);
     const isIdle = ref(false);
 
+    const isMobile = computed(() => !display.mdAndUp.value);
     function setAppError(errorType: AppErrorType): void {
         appError.value = errorType;
-    }
-
-    function setIsMobile(value: boolean) {
-        isMobile.value = value;
     }
 
     function setIsIdle(value: boolean) {
@@ -25,7 +24,6 @@ export const useAppStore = defineStore("app", () => {
         isMobile,
         isIdle,
         setAppError,
-        setIsMobile,
         setIsIdle,
     };
 });


### PR DESCRIPTION
# Implements [AB#15819](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15819)

## Description

1. Convert ResourceCentreComponent to vue3
3. Improve the isMobile detection from original fixed width determined by Bootstrap to Vuetify's useDisplay.
4. Improved Footer's structure but toggling between fixed and end-of-page configurations to improve Mobile's UI.
5. Header and sidebar component has some clean up.
6. Changed v-main on App.vue to position relative to allow for better absolute placement.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/e8ff3bc6-4437-4f3c-ae00-f1305e1d4dfc)

![image](https://github.com/bcgov/healthgateway/assets/19548348/40cfef40-563a-4ea7-9139-4ea211cda5c3)

![image](https://github.com/bcgov/healthgateway/assets/19548348/3cb0927b-44f7-41a4-b969-5d185300bef4)

Not a perfect example of the footer improvement but it shows what it looked like:
![image](https://github.com/bcgov/healthgateway/assets/19548348/ab62daf1-64aa-4008-898d-c0d9a964a84c)

The footer regardless of the content in the main view would be covered by the footer. The reason this is a bad example is timeline being empty is covering the content but it shows what it did look like.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
