### PR TITLE
Remove Body Part from Diagnostic Imaging Card 

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/DiagnosticImagingTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/DiagnosticImagingTimelineComponent.vue
@@ -94,10 +94,6 @@ function downloadFile(): void {
     >
         <div slot="details-body">
             <div class="my-2">
-                <div data-testid="diagnostic-imaging-body-part">
-                    <strong>Body Part: </strong>
-                    <span>{{ entry.bodyPart }}</span>
-                </div>
                 <div data-testid="diagnostic-imaging-procedure-description">
                     <strong>Description: </strong>
                     <span>{{ entry.procedureDescription }}</span>

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -21,9 +21,6 @@ describe("Diagnostic Imaging", () => {
     it("Validate Card Details", () => {
         cy.get("[data-testid=diagnosticimagingTitle]").should("be.visible");
         cy.get("[data-testid=entryCardDetailsTitle").first().click();
-        cy.get("[data-testid=diagnostic-imaging-body-part").should(
-            "be.visible"
-        );
         cy.get("[data-testid=diagnostic-imaging-procedure-description").should(
             "be.visible"
         );


### PR DESCRIPTION
# Fixes or Implements AB#15880

## Remove body part from imaging report card. 



## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
