### PR TITLE
Add timeline alert for Diagnostic Imaging

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/TimelineComponent.vue
@@ -329,6 +329,11 @@ const isOnlyImmunizationSelected = computed(
         selectedEntryTypes.value.size === 1 &&
         selectedEntryTypes.value.has(EntryType.Immunization)
 );
+const isOnlyDiagnosticImagingSelected = computed(
+    () =>
+        selectedEntryTypes.value.size === 1 &&
+        selectedEntryTypes.value.has(EntryType.DiagnosticImaging)
+);
 const showContentPlaceholders = computed(() => {
     if (selectedEntryTypes.value.size > 0) {
         return selectedDatasetsAreLoading.value;
@@ -760,6 +765,29 @@ fetchTimelineData();
                             target="_blank"
                             rel="noopener"
                             >fill in this online form</a
+                        >.
+                    </span>
+                </b-alert>
+            </div>
+            <div
+                v-show="isOnlyDiagnosticImagingSelected"
+                id="linear-timeline-diagnostic-imaging-disclaimer"
+                class="pb-2"
+            >
+                <b-alert
+                    show
+                    variant="info"
+                    class="mt-0 mb-1"
+                    data-testid="linear-timeline-diagnostic-imaging-disclaimer-alert"
+                >
+                    <span>
+                        Most reports are available 10-14 days after your
+                        procedure.
+                        <a
+                            href="https://www2.gov.bc.ca/gov/content/health/managing-your-health/health-gateway/guide#medicalimaging"
+                            target="_blank"
+                            rel="noopener"
+                            >Learn more</a
                         >.
                     </span>
                 </b-alert>

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -26,6 +26,10 @@ describe("Filters", () => {
                     name: "immunization",
                     enabled: true,
                 },
+                {
+                    name: "diagnosticImaging",
+                    enabled: true,
+                },
             ],
         });
         cy.login(
@@ -37,7 +41,7 @@ describe("Filters", () => {
     });
 
     it("Verify filtered record count", () => {
-        const unfilteredRecordsMessage = "Displaying 25 out of 34 records";
+        const unfilteredRecordsMessage = "Displaying 25 out of 43 records";
 
         cy.get("[data-testid=timeline-record-count]").contains(
             unfilteredRecordsMessage
@@ -128,6 +132,31 @@ describe("Filters", () => {
 
         cy.get(
             "[data-testid=timeline-clinical-document-disclaimer-alert]"
+        ).should("not.be.visible");
+    });
+
+    it("Verify diagnostic imaging record alert appears when only imaging reports is selected", () => {
+        cy.get(
+            "[data-testid=linear-timeline-diagnostic-imaging-disclaimer-alert]"
+        ).should("not.be.visible");
+
+        cy.get("[data-testid=filterDropdown]").click();
+        cy.get("[data-testid=DiagnosticImaging-filter]").click({
+            force: true,
+        });
+        cy.get("[data-testid=btnFilterApply]").click();
+        cy.get("[data-testid=btnFilterApply]").should("not.exist");
+
+        cy.get(
+            "[data-testid=linear-timeline-diagnostic-imaging-disclaimer-alert]"
+        ).should("be.visible");
+
+        cy.get("[data-testid=filterDropdown]").click();
+        cy.get("[data-testid=HealthVisit-filter]").click({ force: true });
+        cy.get("[data-testid=btnFilterApply]").click();
+
+        cy.get(
+            "[data-testid=linear-timeline-diagnostic-imaging-disclaimer-alert]"
         ).should("not.be.visible");
     });
 });


### PR DESCRIPTION
# Fixes or Implements [AB#15884](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15884)

## Description

1. Add timeline alert when only diagnostic imaging is selected.
2. Add functional test for alert.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
<img width="875" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/87242da5-2c45-4e4a-8d0c-dc49fe4b6e0f">

<img width="878" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/d1ec9074-26ac-4df8-b8d1-645f6172d32a">

<img width="877" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/b8f7778b-7043-4016-82ec-e8b0674cc3c4">

## Notes

<img width="322" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/cf1ad541-7354-4838-8f72-c9dc8a5dfb6b">


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
