### PR TITLE
Remove Facility from Diagnostic Imaging Card 

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/DiagnosticImagingTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/timeline/entryCard/DiagnosticImagingTimelineComponent.vue
@@ -102,10 +102,6 @@ function downloadFile(): void {
                     <strong>Health Authority: </strong>
                     <span>{{ entry.healthAuthority }}</span>
                 </div>
-                <div data-testid="diagnostic-imaging-facility">
-                    <strong>Facility: </strong>
-                    <span>{{ entry.organization }}</span>
-                </div>
             </div>
             <div class="mt-3">
                 <hg-button

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -27,7 +27,6 @@ describe("Diagnostic Imaging", () => {
         cy.get("[data-testid=diagnostic-imaging-health-authority").should(
             "be.visible"
         );
-        cy.get("[data-testid=diagnostic-imaging-facility").should("be.visible");
         cy.get("[data-testid=diagnostic-imaging-download-button").should(
             "be.visible"
         );


### PR DESCRIPTION
# Fixes or Implements [AB#15891](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15891)

## Removes facility from diagnostic imaging timeline card. 



## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
