### PR TITLE
Use action type instead of is external url check for AB#15899.

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/NotificationCentreComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/NotificationCentreComponent.vue
@@ -69,10 +69,7 @@ function handleClickNotificationAction(notification: Notification): void {
     } else if (notification.categoryName === bctOdrCategory) {
         router.push({ path: "/services" });
     } else {
-        const isExternal = isExternalUrl(notification.actionUrl);
-        logger.debug(`is External: ${isExternal}`);
-
-        if (isExternal) {
+        if (notification.actionType === NotificationActionType.ExternalLink) {
             // Open the external url in a new tab/window
             window.open(notification.actionUrl, "_blank");
         } else {
@@ -93,18 +90,6 @@ function handleClickNotificationAction(notification: Notification): void {
             }
         }
     }
-}
-
-function isExternalUrl(url: string): boolean {
-    const currentDomain = window.location.hostname;
-    logger.debug(`Domain: ${currentDomain}`);
-
-    // Create a regular expression to extract the domain from the URL.
-    const domainRegex = /^(?:https:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/im;
-    const match = url.match(domainRegex);
-    const urlDomain = match ? match[1] : "";
-    logger.debug(`URL Domain: ${urlDomain}`);
-    return urlDomain !== currentDomain;
 }
 
 function getEntryType(categoryName: string): EntryType | undefined {


### PR DESCRIPTION
# Fixes [AB#15899](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15899)

## Description

Custom isExternalUrl function is not required.  Use communication.actionType instead.

<img width="2543" alt="Screenshot 2023-08-05 at 10 08 23 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/6756db07-769c-4f55-a652-bf9b92010a8e">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
