### PR TITLE
Add DI Timeline Alert - AB#15886

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -320,6 +320,11 @@ const isOnlyImmunizationSelected = computed(
         selectedEntryTypes.value.size === 1 &&
         selectedEntryTypes.value.has(EntryType.Immunization)
 );
+const isOnlyDiagnosticImagingSelected = computed(
+    () =>
+        selectedEntryTypes.value.size === 1 &&
+        selectedEntryTypes.value.has(EntryType.DiagnosticImaging)
+);
 
 function clearFilter(label: string, value: string | undefined): void {
     let keyword = filter.value.keyword;
@@ -623,6 +628,23 @@ setPageFromDate(linearDate.value);
                     rel="noopener"
                     class="text-link"
                     >fill in this online form</a
+                >.
+            </v-alert>
+            <v-alert
+                v-else-if="isOnlyDiagnosticImagingSelected"
+                type="info"
+                data-testid="linear-timeline-diagnostic-imaging-disclaimer"
+                class="d-print-none mb-4"
+                closable
+                variant="outlined"
+                border
+            >
+                Most reports are available 10-14 days after your procedure.
+                <a
+                    href="https://www2.gov.bc.ca/gov/content/health/managing-your-health/health-gateway/guide#medicalimaging"
+                    target="_blank"
+                    rel="noopener"
+                    >Learn more</a
                 >.
             </v-alert>
             <div v-if="visibleTimelineEntries.length > 0" class="mb-4">


### PR DESCRIPTION
# Implements [AB#15886](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15886)

## Description

1. Add Vue 3 Timeline Alert when only diagnostic images are filtered


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/9a24fd8e-0e49-4941-9a42-91591c8bec2d)


## Notes
Functional tests for this feature is under UI folder, and will be addressed in [AB#15918](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15918)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
