### PR TITLE
Use const for max-date prop on Date picker - AB#15963

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/public/pcr-test-kit-registration/PcrTestKitRegistrationForm.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/pcr-test-kit-registration/PcrTestKitRegistrationForm.vue
@@ -67,6 +67,8 @@ interface ISelectOption {
     value: unknown;
 }
 
+const currentDate = new DateWrapper();
+
 const testTakenMinutesAgoOptions: ISelectOption[] = [
     { value: -1, title: "Time" },
     { value: 5, title: "Just now" },
@@ -524,7 +526,7 @@ if (!props.serialNumber) {
                             label="Date of Birth"
                             data-testid="dob-input"
                             class="mb-2"
-                            :max-date="new DateWrapper()"
+                            :max-date="currentDate"
                             :error-messages="
                                 ValidationUtil.getErrorMessages(v$.dob)
                             "

--- a/Apps/WebClient/src/NewClientApp/src/components/public/vaccine-card/VaccineCardView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/vaccine-card/VaccineCardView.vue
@@ -32,6 +32,8 @@ const phnMaskaOptions = {
     eager: true,
 };
 
+const currentDate = new DateWrapper();
+
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
 const appStore = useAppStore();
@@ -401,7 +403,7 @@ watch(vaccineRecord, (value) => {
                                 v-model="dateOfBirth"
                                 label="Date of Birth"
                                 data-testid="dateOfBirthInput"
-                                :max-date="new DateWrapper()"
+                                :max-date="currentDate"
                                 :error-messages="
                                     ValidationUtil.getErrorMessages(
                                         v$.dateOfBirth
@@ -421,7 +423,7 @@ watch(vaccineRecord, (value) => {
                             <HgDatePickerComponent
                                 id="dateOfVaccine"
                                 v-model="dateOfVaccine"
-                                :max-date="new DateWrapper()"
+                                :max-date="currentDate"
                                 label="Date of Vaccine (Any Dose)"
                                 data-testid="dateOfVaccineInput"
                                 :error-messages="


### PR DESCRIPTION
# Fixes [AB#15963](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15963)

## Description
1. Use of new DateWrapper for HgDatePicker min-date and max-date doesn't work when compiled for production.
    * No instances of min-date


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
/pcrtest
![image](https://github.com/bcgov/healthgateway/assets/19548348/80ba8a11-4297-4777-a570-ba99811af4ee)

/vaccinecard
![image](https://github.com/bcgov/healthgateway/assets/19548348/cb347e7c-84f9-4eed-bf50-05f518915aff)



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
