### PR TITLE
Fix expected forbidden 403 not shown for AB#15984.

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/index.ts
@@ -49,6 +49,10 @@ const HomeView = () =>
     import(
         /* webpackChunkName: "home" */ "@/components/private/home/HomeView.vue"
     );
+const IdirLoggedInView = () =>
+    import(
+        /* webpackChunkName: "idirLoggedIn" */ "@/components/error/IdirLoggedInView.vue"
+    );
 const LogoutCompleteView = () =>
     import(
         /* webpackChunkName: "logoutComplete" */ "@/components/authentication/LogoutCompleteView.vue"
@@ -167,6 +171,14 @@ const routes = [
             validStates: [UserState.registered],
             requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>
                 config.dependents.enabled && config.dependents.timelineEnabled,
+            requiresProcessedWaitlistTicket: true,
+        },
+    },
+    {
+        path: Path.IdirLoggedIn,
+        component: IdirLoggedInView,
+        meta: {
+            validStates: [UserState.invalidIdentityProvider],
             requiresProcessedWaitlistTicket: true,
         },
     },


### PR DESCRIPTION
# Fixes AB#15984

## Description

$03 Forbidden page is now shown when IDIR blocked.

<img width="1279" alt="Screenshot 2023-08-20 at 5 06 30 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/fc5d596f-63b8-460b-9b01-431ccc7584f2">

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
