### PR TITLE
Align e2e and ui notificationCentre Cypress tests to Vue 3 for AB#15985

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/notificationCentre.js
@@ -3,6 +3,8 @@ const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 
 describe("Notification Centre", () => {
     beforeEach(() => {
+        cy.intercept("GET", "**/Notification/*").as("getNotification");
+
         cy.configureSettings({
             notificationCentre: {
                 enabled: true,
@@ -17,6 +19,9 @@ describe("Notification Centre", () => {
     });
 
     it("Get notifications", () => {
+        // Wait for request to complete
+        cy.wait("@getNotification");
+
         cy.get("[data-testid=notification-centre-button]")
             .should("be.visible", "be.enabled")
             .click();

--- a/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
@@ -40,45 +40,35 @@ describe("Notification Centre", () => {
 
     it("Dismiss individual notification", () => {
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get(
-            "[data-testid=notification-" + notificationIdOne + "-action-button]"
-        ).should("be.visible");
-        cy.get(
-            "[data-testid=notification-" +
-                notificationIdOne +
-                "-dismiss-button]"
+            `[data-testid=notification-${notificationIdOne}-action-button]`
         ).should("be.visible");
 
         cy.get(
-            "[data-testid=notification-" + notificationIdTwo + "-action-button]"
+            `[data-testid=notification-${notificationIdOne}-dismiss-button]`
+        ).should("be.visible");
+
+        cy.get(
+            `[data-testid=notification-${notificationIdTwo}-action-button]`
         ).should("not.exist");
-        cy.get(
-            "[data-testid=notification-" +
-                notificationIdTwo +
-                "-dismiss-button]"
-        )
-            .should("be.visible")
-            .should("be.enabled")
+
+        cy.get(`[data-testid=notification-${notificationIdTwo}-dismiss-button]`)
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdOne +
-                "-dismiss-button]"
+            `[data-testid=notification-${notificationIdOne}-dismiss-button]`
         ).should("be.visible");
+
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdTwo +
-                "-dismiss-button]"
+            `[data-testid=notification-${notificationIdTwo}-dismiss-button]`
         ).should("not.exist");
 
         cy.get("[data-testid=notification-centre-close-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
         cy.get("[data-testid=notification-centre-close-button]").should(
             "not.be.visible"
@@ -87,45 +77,37 @@ describe("Notification Centre", () => {
 
     it("Dismiss all notifications", () => {
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
+        cy.get(`[data-testid=notification-${notificationIdOne}-dismiss-button]`)
+            .scrollIntoView()
+            .should("be.visible");
+
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdOne +
-                "-dismiss-button]"
-        ).should("be.visible");
-        cy.get(
-            "[data-testid=notification-" +
-                notificationIdTwo +
-                "-dismiss-button]"
+            `[data-testid=notification-${notificationIdTwo}-dismiss-button]`
         ).should("be.visible");
 
         cy.get("[data-testid=notification-centre-dismiss-all-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdOne +
-                "-dismiss-button]"
+            `[data-testid=notification-${notificationIdOne}-dismiss-button]`
         ).should("not.exist");
+
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdTwo +
-                "-dismiss-button]"
+            `[data-testid=notification-${notificationIdTwo}-dismiss-button]`
         ).should("not.exist");
+
         cy.get("[data-testid=notification-centre-button]").click();
         cy.get("[data-testid=notification-centre-dismiss-all-button]").should(
             "not.exist"
         );
 
         cy.get("[data-testid=notification-centre-close-button]")
-            .should("be.visible")
-            .should("be.enabled")
-            .click();
+            .should("be.visible", "be.enabled")
+            .click({ force: true });
         cy.get("[data-testid=notification-centre-close-button]").should(
             "not.be.visible"
         );
@@ -165,13 +147,12 @@ describe("Notification Badge", () => {
             .contains("3");
 
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get("[data-testid=notification-centre-close-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .scrollIntoView()
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get("[data-testid=notification-centre-button]").should(
@@ -209,7 +190,7 @@ describe("Categorized web alerts", () => {
             fixture: "NotificationService/notifications.json",
         });
 
-        cy.intercept("GET", `**/Immunization?hdid*`, {
+        cy.intercept("GET", `**/Immunization?hdid=*`, {
             fixture: "ImmunizationService/immunization.json",
         });
 
@@ -223,17 +204,11 @@ describe("Categorized web alerts", () => {
 
     it("Web alert category to pre-filtered timeline", () => {
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
-        cy.get(
-            "[data-testid=notification-" +
-                notificationIdImms +
-                "-action-button]"
-        )
-            .should("be.visible")
-            .should("be.enabled")
+        cy.get(`[data-testid=notification-${notificationIdImms}-action-button]`)
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.location("pathname").should("eq", timelinePath);
@@ -242,17 +217,14 @@ describe("Categorized web alerts", () => {
 
     it("Web alert category to services", () => {
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdBctOdr +
-                "-action-button]"
+            `[data-testid=notification-${notificationIdBctOdr}-action-button]`
         )
-            .should("be.visible")
-            .should("be.enabled")
+            .scrollIntoView()
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.location("pathname").should("eq", servicesPath);
@@ -260,17 +232,13 @@ describe("Categorized web alerts", () => {
 
     it("Web alert category to other internal link", () => {
         cy.get("[data-testid=notification-centre-button]")
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.get(
-            "[data-testid=notification-" +
-                notificationIdOtherInternal +
-                "-action-button]"
+            `[data-testid=notification-${notificationIdOtherInternal}-action-button]`
         )
-            .should("be.visible")
-            .should("be.enabled")
+            .should("be.visible", "be.enabled")
             .click();
 
         cy.location("pathname").should("eq", reportsPath);


### PR DESCRIPTION
# Implements [AB#15985](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15985)

## Description

Updated e2e notificationCentre test to Vue 3
- Call to PHSA notification is slow so added wait on endpoint to finish before checking on button

Updated ui notificationCentre test to Vue 3
- Updated intercept to ensure fixture is being used
- Updated string concatenation to use string interpolation
- Combined be.visiable and be.enabled into one should
- Added cypress recommendations to use force click true and scroll into view

<img width="1021" alt="Screenshot 2023-08-21 at 2 18 17 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/0c02b41f-4375-4c00-92a0-c21b1fbdb76a">

<img width="1109" alt="Screenshot 2023-08-21 at 2 17 33 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/239f1b3e-9ba6-4565-ba44-a854b68ad57a">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
