### PR TITLE
Move router initialization to explicit method - AB#15861

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/site/IdleComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/IdleComponent.vue
@@ -1,9 +1,9 @@
 ﻿<script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { useRouter } from "vue-router";
 
 import IdleDialogComponent from "@/components/site/IdleDialogComponent.vue";
 import { Path } from "@/constants/path";
-import router from "@/router";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { IdleDetector } from "@/utility/idleDetector";
@@ -12,6 +12,7 @@ const maxIdleDialogCountdown = 60000;
 
 const authStore = useAuthStore();
 const configStore = useConfigStore();
+const router = useRouter();
 
 const idleDialog = ref<InstanceType<typeof IdleDialogComponent>>();
 

--- a/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
@@ -11,5 +11,6 @@ export function registerInitialPlugins(app: App) {
 }
 
 export function registerRouterPlugin(app: App) {
-    app.use(initializeRouter());
+    const router = initializeRouter();
+    app.use(router);
 }

--- a/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/index.ts
@@ -2,7 +2,7 @@ import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 import type { App } from "vue";
 
 import vuetify from "@/plugins/vuetify";
-import router from "@/router";
+import initializeRouter from "@/router";
 import pinia from "@/stores";
 
 export function registerInitialPlugins(app: App) {
@@ -11,5 +11,5 @@ export function registerInitialPlugins(app: App) {
 }
 
 export function registerRouterPlugin(app: App) {
-    app.use(router);
+    app.use(initializeRouter());
 }

--- a/Apps/WebClient/src/NewClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/NewClientApp/src/router/index.ts
@@ -417,13 +417,16 @@ function scrollBehaviour(
     }
 }
 
-const router = createRouter({
-    history: createWebHistory(process.env.BASE_URL),
-    routes,
-    scrollBehavior: scrollBehaviour,
-});
+function initializeRouter() {
+    const router = createRouter({
+        history: createWebHistory(process.env.BASE_URL),
+        routes,
+        scrollBehavior: scrollBehaviour,
+    });
 
-router.beforeEach(beforeEachGuard);
-router.afterEach(afterEachHook);
+    router.beforeEach(beforeEachGuard);
+    router.afterEach(afterEachHook);
+    return router;
+}
 
-export default router;
+export default initializeRouter;


### PR DESCRIPTION
# Fixes [AB#15861](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15861)

## Description
1. Create the router with createWebHistory after inititialising keycloak.
2. Updatied the idle component to use `useRouter` to get the router for the navigation to logout.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes



## Notes
The crux of the issue is well documented here:
https://github.com/keycloak/keycloak/issues/14742


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
