### PR TITLE
Add scroll on timeline page change - AB#15994

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -152,6 +152,10 @@ const hasActiveFilter = computed(() => timelineStore.hasActiveFilter);
 const linearDate = computed(() => timelineStore.linearDate);
 const selectedDate = computed(() => timelineStore.selectedDate);
 const blockedDataSources = computed(() => userStore.blockedDataSources);
+const lowerPageStart = computed(() => (currentPage.value - 1) * pageSize + 1);
+const upperPageEnd = computed(() =>
+    Math.min(currentPage.value * pageSize, filteredTimelineEntries.value.length)
+);
 
 const filterLabels = computed(() => {
     const labels: [string, string][] = [];
@@ -504,6 +508,7 @@ function setPageFromDate(eventDate: IDateWrapper): boolean {
 }
 
 watch(currentPage, () => {
+    window.scrollTo(0, 0);
     // Handle the current page being beyond the max number of pages
     if (currentPage.value > numberOfPages.value) {
         currentPage.value = numberOfPages.value;
@@ -588,7 +593,8 @@ setPageFromDate(linearDate.value);
                 data-testid="timeline-record-count"
                 class="text-body-1"
             >
-                Displaying {{ visibleTimelineEntries.length }} out of
+                Displaying
+                {{ lowerPageStart }} to {{ upperPageEnd }} out of
                 {{ filteredTimelineEntries.length }} records
             </p>
             <v-alert


### PR DESCRIPTION
improve records displayed text to give indication of location

# Fixes [AB#15994](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15994)

## Description
1. Scroll to top when timeline page is changed.
2. Add more location detail to the record message to the top of the timeline component, there is no indication what data is currently on display without scrolling to the pagination controls.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
https://github.com/bcgov/healthgateway/assets/19548348/eafb781e-f07a-46d0-b8ba-fb9f1cd1a6cd

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
