### PR TITLE
Fix breaking timeline record count tests - AB#16008

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -332,6 +332,7 @@ const recordCountMessage = computed(() =>
         ? "Displaying 1 out of 1 records"
         : `Displaying ${lowerPageStart.value} to ${upperPageEnd.value} out of ${filteredTimelineEntries.value.length} records`
 );
+
 function clearFilter(label: string, value: string | undefined): void {
     let keyword = filter.value.keyword;
     let startDate = filter.value.startDate;

--- a/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -327,7 +327,11 @@ const isOnlyDiagnosticImagingSelected = computed(
         selectedEntryTypes.value.size === 1 &&
         selectedEntryTypes.value.has(EntryType.DiagnosticImaging)
 );
-
+const recordCountMessage = computed(() =>
+    filteredTimelineEntries.value.length === 1
+        ? "Displaying 1 out of 1 records"
+        : `Displaying ${lowerPageStart.value} to ${upperPageEnd.value} out of ${filteredTimelineEntries.value.length} records`
+);
 function clearFilter(label: string, value: string | undefined): void {
     let keyword = filter.value.keyword;
     let startDate = filter.value.startDate;
@@ -593,9 +597,7 @@ setPageFromDate(linearDate.value);
                 data-testid="timeline-record-count"
                 class="text-body-1"
             >
-                Displaying
-                {{ lowerPageStart }} to {{ upperPageEnd }} out of
-                {{ filteredTimelineEntries.length }} records
+                {{ recordCountMessage }}
             </p>
             <v-alert
                 v-if="isOnlyClinicalDocumentSelected"

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/pagination.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/pagination.js
@@ -25,7 +25,7 @@ describe("Pagination", () => {
     it("Count Records", () => {
         cy.get("[data-testid=timelineCard]").then(($cards) => {
             cy.get("[data-testid=timeline-record-count]").contains(
-                `Displaying ${$cards.length} out of `
+                `Displaying 1 to ${$cards.length} out of `
             );
         });
     });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -37,10 +37,11 @@ describe("Filters", () => {
     });
 
     it("Verify filtered record count", () => {
-        const unfilteredRecordsMessage = "Displaying 25 out of 34 records";
+        const recordDisplayMessage = (lower, upper, total) =>
+            `Displaying ${lower} to ${upper} out of ${total} records`;
 
         cy.get("[data-testid=timeline-record-count]").contains(
-            unfilteredRecordsMessage
+            recordDisplayMessage(1, 25, 34)
         );
 
         cy.get("[data-testid=filterDropdown]").click();
@@ -50,7 +51,7 @@ describe("Filters", () => {
         cy.get("[data-testid=immunizationTitle]").should("be.visible");
 
         cy.get("[data-testid=timeline-record-count]").contains(
-            "Displaying 9 out of 9 records"
+            recordDisplayMessage(1, 9, 9)
         );
 
         cy.contains("[data-testid=filter-label]", "Immunizations").within(
@@ -60,7 +61,7 @@ describe("Filters", () => {
         );
 
         cy.get("[data-testid=timeline-record-count]").contains(
-            unfilteredRecordsMessage
+            recordDisplayMessage(1, 25, 34)
         );
 
         cy.get("[data-testid=filterDropdown]").click();
@@ -83,7 +84,7 @@ describe("Filters", () => {
 
         cy.get("[data-testid=clear-filters-button]").click();
         cy.get("[data-testid=timeline-record-count]").contains(
-            unfilteredRecordsMessage
+            recordDisplayMessage(1, 25, 34)
         );
     });
 

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -16,7 +16,7 @@ function checkPopoverIsVisible() {
 const recordDisplayMessage = (lower, upper, total) =>
     `Displaying ${lower} to ${upper} out of ${total} records`;
 
-describe.skip("Laboratory Orders", () => {
+describe("Laboratory Orders", () => {
     beforeEach(() => {
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
             fixture: "LaboratoryService/laboratoryOrders.json",
@@ -289,7 +289,7 @@ describe("Laboratory Orders Refresh", () => {
     });
 });
 
-describe.skip("Laboratory Orders Queued", () => {
+describe("Laboratory Orders Queued", () => {
     beforeEach(() => {
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
             fixture: "LaboratoryService/laboratoryOrdersQueued.json",

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -80,122 +80,122 @@ describe("Laboratory Orders", () => {
                 cy.document()
                     .find("[data-testid=result-info-popover]")
                     .should("exist");
-
-                cy.log("Verifying partial status");
-                cy.get("[data-testid=laboratoryResultTable]").within(() => {
-                    cy.contains("td", "Alanine Aminotransferase Test")
-                        .parent("tr")
-                        .within(() => {
-                            // Check the Name Column
-                            cy.get("td:nth-child(1)").then(($name) => {
-                                const name = $name.text().trim();
-                                cy.log(name);
-                                expect(name).equal(
-                                    "Alanine Aminotransferase Test"
-                                );
-                            });
-                            // Check the Result Column
-                            cy.get("td:nth-child(2)").then(($result) => {
-                                const result = $result.text().trim();
-                                cy.log(result);
-                                expect(result).equal("Pending");
-                            });
-                            // Check the Status Column
-                            cy.get("td:nth-child(3)").then(($status) => {
-                                const status = $status.text().trim();
-                                cy.log(status);
-                                expect(status).equal("Pending");
-                            });
-                            // Check the Status Popover
-                            checkPopoverIsVisible();
-                        });
-
-                    cy.contains(
-                        "td",
-                        "Creatinine & Glomerular Filtration Rate Predicted Panel"
-                    )
-                        .parent("tr")
-                        .within(() => {
-                            // Check the Name Column
-                            cy.get("td:nth-child(1)").then(($name) => {
-                                const name = $name.text().trim();
-                                cy.log(name);
-                                expect(name).equal(
-                                    "Creatinine & Glomerular Filtration Rate Predicted Panel"
-                                );
-                            });
-                            // Check the Result Column
-                            cy.get("td:nth-child(2)").then(($result) => {
-                                const result = $result.text().trim();
-                                cy.log(result);
-                                expect(result).equal("Out of Range");
-                            });
-                            // Check the Status Column
-                            cy.get("td:nth-child(3)").then(($status) => {
-                                const status = $status.text().trim();
-                                cy.log(status);
-                                expect(status).equal("Completed");
-                            });
-                            // Check the Status Popover
-                            checkPopoverIsVisible();
-                        });
-
-                    cy.contains("td", "Glucose Random")
-                        .parent("tr")
-                        .within(() => {
-                            // Check the Name Column
-                            cy.get("td:nth-child(1)").then(($name) => {
-                                const name = $name.text().trim();
-                                cy.log(name);
-                                expect(name).equal("Glucose Random");
-                            });
-                            // Check the Result Column
-                            cy.get("td:nth-child(2)").then(($result) => {
-                                const result = $result.text().trim();
-                                cy.log(result);
-                                expect(result).equal("In Range");
-                            });
-                            // Check the Status Column
-                            cy.get("td:nth-child(3)").then(($status) => {
-                                const status = $status.text().trim();
-                                cy.log(status);
-                                expect(status).equal("Completed");
-                            });
-                            // Check the Status Popover
-                            checkPopoverIsVisible();
-                        });
-
-                    cy.contains("td", "CBC & Differential")
-                        .parent("tr")
-                        .within(() => {
-                            // Check the Name Column
-                            cy.get("td:nth-child(1)").then(($name) => {
-                                const name = $name.text().trim();
-                                cy.log(name);
-                                expect(name).equal("CBC & Differential");
-                            });
-                            // Check the Result Column
-                            cy.get("td:nth-child(2)").then(($result) => {
-                                const result = $result.text().trim();
-                                cy.log(result);
-                                expect(result).equal("Cancelled");
-                            });
-                            // Check the Status Column
-                            cy.get("td:nth-child(3)").then(($status) => {
-                                const status = $status.text().trim();
-                                cy.log(status);
-                                expect(status).equal("Cancelled");
-                            });
-                            // Check the Status Popover
-                            checkPopoverIsVisible();
-                        });
-                });
-
-                cy.get("[data-testid=backBtn]").click({ force: true });
             });
 
-        cy.log("Verifying collection date");
+        cy.get("[data-testid=backBtn]").click({ force: true });
+    });
 
+    it("Should have a valid result table", () => {
+        cy.get("[data-testid=timelineCard]").last().scrollIntoView().click();
+        cy.get("[data-testid=laboratoryResultTable]").within(() => {
+            cy.contains("td", "Alanine Aminotransferase Test")
+                .parent("tr")
+                .within(() => {
+                    // Check the Name Column
+                    cy.get("td:nth-child(1)").then(($name) => {
+                        const name = $name.text().trim();
+                        cy.log(name);
+                        expect(name).equal("Alanine Aminotransferase Test");
+                    });
+                    // Check the Result Column
+                    cy.get("td:nth-child(2)").then(($result) => {
+                        const result = $result.text().trim();
+                        cy.log(result);
+                        expect(result).equal("Pending");
+                    });
+                    // Check the Status Column
+                    cy.get("td:nth-child(3)").then(($status) => {
+                        const status = $status.text().trim();
+                        cy.log(status);
+                        expect(status).equal("Pending");
+                    });
+                    // Check the Status Popover
+                    checkPopoverIsVisible();
+                });
+
+            cy.contains(
+                "td",
+                "Creatinine & Glomerular Filtration Rate Predicted Panel"
+            )
+                .parent("tr")
+                .within(() => {
+                    // Check the Name Column
+                    cy.get("td:nth-child(1)").then(($name) => {
+                        const name = $name.text().trim();
+                        cy.log(name);
+                        expect(name).equal(
+                            "Creatinine & Glomerular Filtration Rate Predicted Panel"
+                        );
+                    });
+                    // Check the Result Column
+                    cy.get("td:nth-child(2)").then(($result) => {
+                        const result = $result.text().trim();
+                        cy.log(result);
+                        expect(result).equal("Out of Range");
+                    });
+                    // Check the Status Column
+                    cy.get("td:nth-child(3)").then(($status) => {
+                        const status = $status.text().trim();
+                        cy.log(status);
+                        expect(status).equal("Completed");
+                    });
+                    // Check the Status Popover
+                    checkPopoverIsVisible();
+                });
+
+            cy.contains("td", "Glucose Random")
+                .parent("tr")
+                .within(() => {
+                    // Check the Name Column
+                    cy.get("td:nth-child(1)").then(($name) => {
+                        const name = $name.text().trim();
+                        cy.log(name);
+                        expect(name).equal("Glucose Random");
+                    });
+                    // Check the Result Column
+                    cy.get("td:nth-child(2)").then(($result) => {
+                        const result = $result.text().trim();
+                        cy.log(result);
+                        expect(result).equal("In Range");
+                    });
+                    // Check the Status Column
+                    cy.get("td:nth-child(3)").then(($status) => {
+                        const status = $status.text().trim();
+                        cy.log(status);
+                        expect(status).equal("Completed");
+                    });
+                    // Check the Status Popover
+                    checkPopoverIsVisible();
+                });
+
+            cy.contains("td", "CBC & Differential")
+                .parent("tr")
+                .within(() => {
+                    // Check the Name Column
+                    cy.get("td:nth-child(1)").then(($name) => {
+                        const name = $name.text().trim();
+                        cy.log(name);
+                        expect(name).equal("CBC & Differential");
+                    });
+                    // Check the Result Column
+                    cy.get("td:nth-child(2)").then(($result) => {
+                        const result = $result.text().trim();
+                        cy.log(result);
+                        expect(result).equal("Cancelled");
+                    });
+                    // Check the Status Column
+                    cy.get("td:nth-child(3)").then(($status) => {
+                        const status = $status.text().trim();
+                        cy.log(status);
+                        expect(status).equal("Cancelled");
+                    });
+                    // Check the Status Popover
+                    checkPopoverIsVisible();
+                });
+        });
+    });
+
+    it("Should have valid collection dates", () => {
         // Validate collection date time when not null in json
         cy.get("[data-testid=timelineCard]").eq(6).scrollIntoView().click();
         cy.get("#entry-details-modal")

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -13,7 +13,10 @@ function checkPopoverIsVisible() {
         });
 }
 
-describe("Laboratory Orders", () => {
+const recordDisplayMessage = (lower, upper, total) =>
+    `Displaying ${lower} to ${upper} out of ${total} records`;
+
+describe.skip("Laboratory Orders", () => {
     beforeEach(() => {
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
             fixture: "LaboratoryService/laboratoryOrders.json",
@@ -237,19 +240,6 @@ describe("Laboratory Orders", () => {
 
 describe("Laboratory Orders Refresh", () => {
     beforeEach(() => {
-        let isLoading = false;
-        cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", (req) => {
-            if (!isLoading) {
-                req.reply({
-                    fixture: "LaboratoryService/laboratoryOrdersRefresh.json",
-                });
-            } else {
-                req.reply({
-                    fixture: "LaboratoryService/laboratoryOrders.json",
-                });
-            }
-            isLoading = !isLoading;
-        });
         cy.configureSettings({
             datasets: [
                 {
@@ -273,28 +263,33 @@ describe("Laboratory Orders Refresh", () => {
         cy.get("[data-testid=laboratory-orders-queued-alert-message]").should(
             "not.exist"
         );
-
+        cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
+            fixture: "LaboratoryService/laboratoryOrdersRefresh.json",
+        });
         // Verify initial call
         cy.log(
             "Verify refresh in progress call from PHSA has returned 1 record."
         );
         cy.get("[data-testid=timeline-record-count]")
-            .should("be.visible")
-            .contains("Displaying 1 out of 1 records");
+            .contains("Displaying 1 out of 1 records")
+            .should("be.visible");
 
         // Verify subsequent call
         cy.log(
             "Verify refresh in progress call from PHSA has returned remaining records."
         );
+        cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
+            fixture: "LaboratoryService/laboratoryOrders.json",
+        });
         cy.get("[data-testid=loading-toast]").should("exist");
         cy.get("[data-testid=timeline-record-count]")
             .should("be.visible")
-            .contains("Displaying 9 out of 9 records");
+            .contains(recordDisplayMessage(1, 9, 9));
         cy.get("[data-testid=loading-toast]").should("not.exist");
     });
 });
 
-describe("Laboratory Orders Queued", () => {
+describe.skip("Laboratory Orders Queued", () => {
     beforeEach(() => {
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
             fixture: "LaboratoryService/laboratoryOrdersQueued.json",


### PR DESCRIPTION
# Fixes [AB#16008](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16008)

## Description
1. Refine record count display text generation on component.
2. Correct record count display text in tests.
3. Reduce lab order tests size for validating display to reduce observer errors thrown locally.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required
![image](https://github.com/bcgov/healthgateway/assets/19548348/8ba90a4b-a157-4839-a5c7-26423a817095)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
