### PR TITLE
Fixed NotificationCentre swiping, unauth presence - AB#16010

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/App.vue
+++ b/Apps/WebClient/src/NewClientApp/src/App.vue
@@ -12,12 +12,14 @@ import NotificationCentreComponent from "@/components/site/NotificationCentreCom
 import ResourceCentreComponent from "@/components/site/ResourceCentreComponent.vue";
 import SidebarComponent from "@/components/site/SidebarComponent.vue";
 import { Path } from "@/constants/path";
+import { useAuthStore } from "@/stores/auth";
 import { EventName, useEventStore } from "@/stores/event";
 import { useWaitlistStore } from "@/stores/waitlist";
 
 const route = useRoute();
 const eventStore = useEventStore();
 const waitlistStore = useWaitlistStore();
+const authStore = useAuthStore();
 
 const hideErrorAlerts = computed(() =>
     currentPathMatches(Path.Root, Path.Queue, Path.Busy)
@@ -64,7 +66,7 @@ eventStore.emit(EventName.RegisterOnBeforeUnloadWaitlistListener);
         <DevBannerComponent />
         <HeaderComponent v-if="isHeaderVisible" />
         <SidebarComponent />
-        <NotificationCentreComponent />
+        <NotificationCentreComponent v-if="authStore.oidcIsAuthenticated" />
         <v-main class="position-relative">
             <CommunicationComponent v-if="isCommunicationVisible" />
             <router-view v-if="currentPathMatches(Path.VaccineCard)" />

--- a/Apps/WebClient/src/NewClientApp/src/components/site/NotificationCentreComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/NotificationCentreComponent.vue
@@ -127,6 +127,7 @@ function isNew(notification: Notification): boolean {
         temporary
         location="right"
         width="500"
+        touchless
     >
         <v-container class="h-100">
             <v-row align="center" no-gutters>


### PR DESCRIPTION
# Fixes [AB#16010](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16010)

## Description
1. Remove swipe functionality on notification centre drawer.
2. Remove notification component when not authenticated (this can't really be triggered without the swipe but its a more completed solution).


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
Swiper no swiping
![image](https://github.com/bcgov/healthgateway/assets/19548348/135029f6-7f41-4e22-8b65-e8026f8ec30c)


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
