### PR TITLE
Add disabled to active link in Breadcrumb - AB#16012

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/site/BreadcrumbComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/BreadcrumbComponent.vue
@@ -45,6 +45,7 @@ const displayBreadcrumbs = computed(
                 :to="item.to"
                 :active="item.active"
                 :data-testid="item.dataTestId"
+                :disabled="item.active"
             >
                 {{ item.text }}
             </v-breadcrumbs-item>


### PR DESCRIPTION
# Fixes [AB#16012](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16012)

## Description
1. Active link is set to be disabled


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required
![image](https://github.com/bcgov/healthgateway/assets/19548348/bc1f46d5-9643-49af-88ce-4f91908492c8)


## UI Changes

![MicrosoftTeams-image (3)](https://github.com/bcgov/healthgateway/assets/19548348/f7dfc8a1-9b3f-4bfa-a39f-16a0fb54f8ec)

## Notes


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
