### PR TITLE
Only show paper clip icon when file id exists for AB#16019

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/private/timeline/entry/DiagnosticImagingTimelineComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/timeline/entry/DiagnosticImagingTimelineComponent.vue
@@ -83,7 +83,7 @@ function downloadFile(): void {
         :entry="entry"
         :is-mobile-details="isMobileDetails"
         :allow-comment="commentsAreEnabled"
-        :has-attachment="entry.fileId !== undefined"
+        :has-attachment="Boolean(entry.fileId)"
     >
         <v-row class="mb-3">
             <v-col :cols="cols">


### PR DESCRIPTION
# Fixes [AB#16019](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16019)

## Description

Paper clip icon is only shown when file id exists.


<img width="2493" alt="Screenshot 2023-08-22 at 2 22 28 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/aa8a78cd-24da-4b97-9a8d-d688c7ac14cf">




## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
