### PR TITLE
move EF Migration history into gateway schema

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
@@ -44,7 +44,9 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
             services.AddDbContextPool<GatewayDbContext>(
                 options =>
                 {
-                    options.UseNpgsql(configuration.GetConnectionString("GatewayConnection"));
+                    options.UseNpgsql(
+                        configuration.GetConnectionString("GatewayConnection"),
+                        x => x.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
                     if (isSensitiveDataLoggingEnabled)
                     {
                         options.EnableSensitiveDataLogging();

--- a/Apps/DBMaintainer/Program.cs
+++ b/Apps/DBMaintainer/Program.cs
@@ -90,7 +90,9 @@ namespace HealthGateway.DBMaintainer
                     (hostContext, services) =>
                     {
                         Console.WriteLine("Configuring Services...");
-                        services.AddDbContextPool<GatewayDbContext>(options => options.UseNpgsql(hostContext.Configuration.GetConnectionString("GatewayConnection")));
+                        services.AddDbContextPool<GatewayDbContext>(options => options.UseNpgsql(
+                            hostContext.Configuration.GetConnectionString("GatewayConnection"),
+                            x => x.MigrationsHistoryTable("__EFMigrationsHistory", "gateway")));
 
                         // Add HTTP Client
                         services.AddHttpClient();

--- a/Apps/Database/src/Migrations/20230508204917_CreateBlockedAccessTable.cs
+++ b/Apps/Database/src/Migrations/20230508204917_CreateBlockedAccessTable.cs
@@ -34,9 +34,10 @@ namespace HealthGateway.Database.Migrations
             // Store DependentAudit data into a temporary table to be used later to populate AgentAddit
             string dependentAuditTempTable = "TempDependentAudit";
             string dependentAuditTempTableSql = @$"
-                SELECT ""DependentAuditId"", ""HdId"", ""AgentUsername"", ""ProtectedReason"", ""OperationCode""||'Dependent',
-                'Dependent' AS ""GroupCode"", ""TransactionDateTime"", ""CreatedBy"", ""CreatedDateTime"", ""UpdatedBy"", ""UpdatedDateTime""
-                INTO TEMPORARY {dependentAuditTempTable} FROM gateway.""DependentAudit"";
+                CREATE TEMP TABLE {dependentAuditTempTable} AS
+                SELECT ""DependentAuditId"", ""HdId"", ""AgentUsername"", ""ProtectedReason"", ""OperationCode""||'Dependent' AS ""OperationCode"",
+                    'Dependent' AS ""GroupCode"", ""TransactionDateTime"", ""CreatedBy"", ""CreatedDateTime"", ""UpdatedBy"", ""UpdatedDateTime""
+                FROM gateway.""DependentAudit"";
                 ";
             migrationBuilder.Sql(dependentAuditTempTableSql);
 

--- a/Tools/Dev/Postgres/MoveMigrationHistory.sql
+++ b/Tools/Dev/Postgres/MoveMigrationHistory.sql
@@ -1,0 +1,19 @@
+DO
+$$
+BEGIN
+    IF EXISTS (
+        SELECT 1 
+        FROM   information_schema.tables 
+        WHERE  table_schema = 'public'
+        AND    table_name = '__EFMigrationsHistory'
+    ) THEN
+		CREATE TABLE IF NOT EXISTS gateway."__EFMigrationsHistory" (
+			"MigrationId" character varying(150) NOT NULL,
+			"ProductVersion" character varying(32) NOT NULL,
+		CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId"));
+        -- Copy data
+        INSERT INTO gateway."__EFMigrationsHistory"
+        	SELECT * FROM public."__EFMigrationsHistory";
+    END IF;
+END
+$$;

--- a/Tools/Dev/Postgres/init/01_init-to-AddDiagnosticImagingCommentEntryTypeCode.sql
+++ b/Tools/Dev/Postgres/init/01_init-to-AddDiagnosticImagingCommentEntryTypeCode.sql
@@ -1,7 +1,10 @@
-﻿\c hglocal
-SET ROLE hglocal;
-
-CREATE TABLE IF NOT EXISTS "__EFMigrationsHistory" (
+﻿DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'gateway') THEN
+        CREATE SCHEMA gateway;
+    END IF;
+END $EF$;
+CREATE TABLE IF NOT EXISTS gateway."__EFMigrationsHistory" (
     "MigrationId" character varying(150) NOT NULL,
     "ProductVersion" character varying(32) NOT NULL,
     CONSTRAINT "PK___EFMigrationsHistory" PRIMARY KEY ("MigrationId")
@@ -12,7 +15,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
         IF NOT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'gateway') THEN
             CREATE SCHEMA gateway;
         END IF;
@@ -21,14 +24,14 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE SEQUENCE gateway.trace_seq START WITH 1 INCREMENT BY 1 MINVALUE 1 MAXVALUE 999999 CYCLE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."AuditTransactionResultCode" (
         "ResultCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -43,7 +46,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."EmailFormatCode" (
         "FormatCode" character varying(4) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -57,7 +60,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."EmailStatusCode" (
         "StatusCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -72,7 +75,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."ProgramTypeCode" (
         "ProgramCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -87,7 +90,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Schedule" (
         "ScheduleId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -104,7 +107,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."UserFeedback" (
         "UserFeedbackId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -120,7 +123,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."UserProfile" (
         "UserProfileId" character varying(52) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -136,7 +139,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."EmailTemplate" (
         "EmailTemplateId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -159,7 +162,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Email" (
         "EmailId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -186,7 +189,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."AuditEvent" (
         "AuditEventId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -211,7 +214,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."FileDownload" (
         "FileDownloadId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -229,7 +232,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."EmailInvite" (
         "EmailInviteId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -248,7 +251,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."DrugProduct" (
         "DrugProductId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -278,7 +281,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."PharmaCareDrug" (
         "PharmaCareDrugId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -318,7 +321,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."ActiveIngredient" (
         "ActiveIngredientId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -348,7 +351,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Company" (
         "CompanyId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -381,7 +384,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Form" (
         "FormId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -400,7 +403,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Packaging" (
         "PackagingId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -423,7 +426,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."PharmaceuticalStd" (
         "PharmaceuticalStdId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -440,7 +443,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Route" (
         "RouteId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -459,7 +462,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."Status" (
         "StatusId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -481,7 +484,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."TherapeuticClass" (
         "TherapeuticClassId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -503,7 +506,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE TABLE gateway."VeterinarySpecies" (
         "VeterinarySpeciesId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -522,7 +525,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."AuditTransactionResultCode" ("ResultCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Ok', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Success', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -530,7 +533,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."AuditTransactionResultCode" ("ResultCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Fail', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Failure', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -538,7 +541,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."AuditTransactionResultCode" ("ResultCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('NotAuth', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Unauthorized', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -546,7 +549,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."AuditTransactionResultCode" ("ResultCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Err', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'System Error', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -554,7 +557,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailFormatCode" ("FormatCode", "CreatedBy", "CreatedDateTime", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Text', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -562,7 +565,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailFormatCode" ("FormatCode", "CreatedBy", "CreatedDateTime", "UpdatedBy", "UpdatedDateTime")
     VALUES ('HTML', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -570,7 +573,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Processed', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'An email that has been sent', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -578,7 +581,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Error', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'An Email that will not be sent', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -586,7 +589,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('New', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'A newly created email', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -594,7 +597,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Pending', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'An email pending batch pickup', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -602,7 +605,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('PAT', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Patient Service', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -610,7 +613,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('FED-DRUG-A', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Federal Approved Drug Load', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -618,7 +621,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('FED-DRUG-M', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Federal Marketed Drug Load', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -626,7 +629,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('FED-DRUG-C', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Federal Cancelled Drug Load', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -634,7 +637,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('FED-DRUG-D', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Federal Dormant Drug Load', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -642,7 +645,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('PROV-DRUG', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Provincial Pharmacare Drug Load', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -650,7 +653,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('CFG', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Configuration Service', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -658,7 +661,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('WEB', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Web Client', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -666,7 +669,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('IMM', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Immunization Service', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -674,7 +677,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('MED', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Medication Service', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -682,7 +685,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     INSERT INTO gateway."EmailTemplate" ("EmailTemplateId", "Body", "CreatedBy", "CreatedDateTime", "EffectiveDate", "ExpiryDate", "FormatCode", "From", "Name", "Priority", "Subject", "UpdatedBy", "UpdatedDateTime")
     VALUES ('040c2ec3-d6c0-4199-9e4b-ebe6da48d52a', '<!doctype html>
     <html lang="en">
@@ -719,142 +722,142 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_ActiveIngredient_DrugProductId" ON gateway."ActiveIngredient" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_AuditEvent_ApplicationType" ON gateway."AuditEvent" ("ApplicationType");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_AuditEvent_TransactionResultCode" ON gateway."AuditEvent" ("TransactionResultCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_Company_DrugProductId" ON gateway."Company" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_DrugProduct_FileDownloadId" ON gateway."DrugProduct" ("FileDownloadId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_Email_EmailStatusCode" ON gateway."Email" ("EmailStatusCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_Email_FormatCode" ON gateway."Email" ("FormatCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_EmailInvite_EmailId" ON gateway."EmailInvite" ("EmailId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_EmailTemplate_FormatCode" ON gateway."EmailTemplate" ("FormatCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_FileDownload_Hash" ON gateway."FileDownload" ("Hash");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_FileDownload_ProgramCode" ON gateway."FileDownload" ("ProgramCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_Form_DrugProductId" ON gateway."Form" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_Packaging_DrugProductId" ON gateway."Packaging" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_PharmaCareDrug_FileDownloadId" ON gateway."PharmaCareDrug" ("FileDownloadId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_PharmaceuticalStd_DrugProductId" ON gateway."PharmaceuticalStd" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_Route_DrugProductId" ON gateway."Route" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE INDEX "IX_Status_DrugProductId" ON gateway."Status" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_TherapeuticClass_DrugProductId" ON gateway."TherapeuticClass" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
     CREATE UNIQUE INDEX "IX_VeterinarySpecies_DrugProductId" ON gateway."VeterinarySpecies" ("DrugProductId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20191119083157_InitialCreate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191119083157_InitialCreate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20191119083157_InitialCreate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -864,7 +867,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191120010543_UpdateRegistrationEmail') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191120010543_UpdateRegistrationEmail') THEN
     UPDATE gateway."EmailTemplate" SET "From" = 'HG_Donotreply@gov.bc.ca'
     WHERE "EmailTemplateId" = '040c2ec3-d6c0-4199-9e4b-ebe6da48d52a';
     END IF;
@@ -872,9 +875,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191120010543_UpdateRegistrationEmail') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20191120010543_UpdateRegistrationEmail', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191120010543_UpdateRegistrationEmail') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20191120010543_UpdateRegistrationEmail', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -884,16 +887,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191128232437_ChangeEmailInviteToNullableHdid') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191128232437_ChangeEmailInviteToNullableHdid') THEN
     ALTER TABLE gateway."EmailInvite" ALTER COLUMN "HdId" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191128232437_ChangeEmailInviteToNullableHdid') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20191128232437_ChangeEmailInviteToNullableHdid', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191128232437_ChangeEmailInviteToNullableHdid') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20191128232437_ChangeEmailInviteToNullableHdid', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -903,7 +906,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191203232803_AddUpdateEmailTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191203232803_AddUpdateEmailTemplate') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head></head>
@@ -940,7 +943,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191203232803_AddUpdateEmailTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191203232803_AddUpdateEmailTemplate') THEN
     INSERT INTO gateway."EmailTemplate" ("EmailTemplateId", "Body", "CreatedBy", "CreatedDateTime", "EffectiveDate", "ExpiryDate", "FormatCode", "From", "Name", "Priority", "Subject", "UpdatedBy", "UpdatedDateTime")
     VALUES ('896f8f2e-3bed-400b-acaf-51dd6082b4bd', '<!doctype html>
         <html lang="en">
@@ -978,9 +981,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191203232803_AddUpdateEmailTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20191203232803_AddUpdateEmailTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191203232803_AddUpdateEmailTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20191203232803_AddUpdateEmailTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -990,7 +993,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191204191457_UpdateEmailVerificationTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191204191457_UpdateEmailVerificationTemplate') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head></head>
@@ -1027,9 +1030,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191204191457_UpdateEmailVerificationTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20191204191457_UpdateEmailVerificationTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191204191457_UpdateEmailVerificationTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20191204191457_UpdateEmailVerificationTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1039,7 +1042,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191204211020_UpdateEmailTemplateLogo') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191204211020_UpdateEmailTemplateLogo') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head></head>
@@ -1076,7 +1079,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191204211020_UpdateEmailTemplateLogo') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191204211020_UpdateEmailTemplateLogo') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
         <html lang="en">
         <head></head>
@@ -1114,9 +1117,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20191204211020_UpdateEmailTemplateLogo') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20191204211020_UpdateEmailTemplateLogo', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20191204211020_UpdateEmailTemplateLogo') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20191204211020_UpdateEmailTemplateLogo', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1126,30 +1129,30 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
     ALTER TABLE gateway."PharmaCareDrug" ALTER COLUMN "BrandName" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
     ALTER TABLE gateway."DrugProduct" ALTER COLUMN "DrugIdentificationNumber" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
     ALTER TABLE gateway."DrugProduct" ALTER COLUMN "BrandName" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200107171825_NullableReferenceTypes', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200107171825_NullableReferenceTypes') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200107171825_NullableReferenceTypes', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1159,7 +1162,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200115203341_AddBetaRequest') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200115203341_AddBetaRequest') THEN
     CREATE TABLE gateway."BetaRequest" (
         "BetaRequestId" character varying(52) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -1174,9 +1177,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200115203341_AddBetaRequest') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200115203341_AddBetaRequest', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200115203341_AddBetaRequest') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200115203341_AddBetaRequest', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1186,16 +1189,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200117220253_UpdateEmailInviteExpire') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200117220253_UpdateEmailInviteExpire') THEN
     ALTER TABLE gateway."EmailInvite" ADD "ExpireDate" timestamp without time zone NOT NULL DEFAULT TIMESTAMP 'infinity';
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200117220253_UpdateEmailInviteExpire') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200117220253_UpdateEmailInviteExpire', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200117220253_UpdateEmailInviteExpire') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200117220253_UpdateEmailInviteExpire', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1205,7 +1208,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200123030013_UpdateBetaConfirmationTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200123030013_UpdateBetaConfirmationTemplate') THEN
     INSERT INTO gateway."EmailTemplate" ("EmailTemplateId", "Body", "CreatedBy", "CreatedDateTime", "EffectiveDate", "ExpiryDate", "FormatCode", "From", "Name", "Priority", "Subject", "UpdatedBy", "UpdatedDateTime")
     VALUES ('2ab5d4aa-c4c9-4324-a753-cde4e21e7612', '<!doctype html>
         <html lang="en">
@@ -1241,9 +1244,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200123030013_UpdateBetaConfirmationTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200123030013_UpdateBetaConfirmationTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200123030013_UpdateBetaConfirmationTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200123030013_UpdateBetaConfirmationTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1253,7 +1256,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200129233249_UpdateProgramTypes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200129233249_UpdateProgramTypes') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('ADMIN', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Admin Client', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -1261,9 +1264,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200129233249_UpdateProgramTypes') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200129233249_UpdateProgramTypes', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200129233249_UpdateProgramTypes') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200129233249_UpdateProgramTypes', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1273,16 +1276,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200218200745_UpdateUserFeedbackReviewed') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200218200745_UpdateUserFeedbackReviewed') THEN
     ALTER TABLE gateway."UserFeedback" ADD "IsReviewed" boolean NOT NULL DEFAULT FALSE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200218200745_UpdateUserFeedbackReviewed') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200218200745_UpdateUserFeedbackReviewed', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200218200745_UpdateUserFeedbackReviewed') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200218200745_UpdateUserFeedbackReviewed', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1292,7 +1295,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
     CREATE TABLE gateway."LegalAgreementTypeCode" (
         "LegalAgreementCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -1307,7 +1310,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
     CREATE TABLE gateway."LegalAgreement" (
         "LegalAgreementsId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -1325,7 +1328,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
     INSERT INTO gateway."LegalAgreementTypeCode" ("LegalAgreementCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('ToS', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Terms of Service', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -1333,7 +1336,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('f5acf1de-2f5f-431e-955d-a837d5854182', 'System', TIMESTAMP '2019-05-01 00:00:00', TIMESTAMP '2019-12-06 00:00:00', 'ToS', '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
@@ -1388,16 +1391,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
     CREATE INDEX "IX_LegalAgreement_LegalAgreementCode" ON gateway."LegalAgreement" ("LegalAgreementCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200221211918_LegalAgreements', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200221211918_LegalAgreements') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200221211918_LegalAgreements', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1407,7 +1410,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
     CREATE TABLE gateway."ApplicationSetting" (
         "ApplicationSettingsId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -1426,7 +1429,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
     UPDATE gateway."LegalAgreement" SET "EffectiveDate" = TIMESTAMP '2019-05-01 00:00:00'
     WHERE "LegalAgreementsId" = 'f5acf1de-2f5f-431e-955d-a837d5854182';
     END IF;
@@ -1434,7 +1437,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('JOBS', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Job Scheduler', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -1442,7 +1445,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
     INSERT INTO gateway."ApplicationSetting" ("ApplicationSettingsId", "Application", "Component", "CreatedBy", "CreatedDateTime", "Key", "UpdatedBy", "UpdatedDateTime", "Value")
     VALUES ('5f279ba2-8e7b-4b1d-8c69-467d94dcb7fb', 'JOBS', 'NotifyUpdatedLegalAgreementsJob', 'System', TIMESTAMP '2019-05-01 00:00:00', 'ToS-Last-Checked', 'System', TIMESTAMP '2019-05-01 00:00:00', '05/01/2019');
     END IF;
@@ -1450,16 +1453,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
     CREATE INDEX "IX_ApplicationSetting_Application" ON gateway."ApplicationSetting" ("Application");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200224231036_ApplicationSettings', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200224231036_ApplicationSettings') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200224231036_ApplicationSettings', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1469,28 +1472,28 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
     ALTER TABLE gateway."UserProfile" ADD "ClosedDateTime" timestamp without time zone NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
     ALTER TABLE gateway."UserProfile" ADD "IdentityManagementId" uuid NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
     ALTER TABLE gateway."UserProfile" ADD "LastLoginDateTime" timestamp without time zone NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
     CREATE TABLE gateway."UserProfileHistory" (
         "UserProfileHistoryId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -1512,7 +1515,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
 
     CREATE FUNCTION gateway."UserProfileHistoryFunction"()
         RETURNS trigger
@@ -1535,7 +1538,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
 
     CREATE TRIGGER "UserProfileHistoryTrigger"
         AFTER DELETE
@@ -1547,9 +1550,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200226012259_UserProfileHistory', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226012259_UserProfileHistory') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200226012259_UserProfileHistory', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1559,21 +1562,21 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
     DROP INDEX gateway."IX_ApplicationSetting_Application";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
     ALTER TABLE gateway."ApplicationSetting" ALTER COLUMN "Key" TYPE character varying(250);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
     INSERT INTO gateway."EmailTemplate" ("EmailTemplateId", "Body", "CreatedBy", "CreatedDateTime", "EffectiveDate", "ExpiryDate", "FormatCode", "From", "Name", "Priority", "Subject", "UpdatedBy", "UpdatedDateTime")
     VALUES ('eb695050-e2fb-4933-8815-3d4656e4541d', '<!doctype html>
     <html lang="en">
@@ -1615,16 +1618,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
     CREATE UNIQUE INDEX "IX_ApplicationSetting_Application_Component_Key" ON gateway."ApplicationSetting" ("Application", "Component", "Key");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200226200434_ToSTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226200434_ToSTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200226200434_ToSTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1634,7 +1637,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226230220_AccountClosureTemplates') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226230220_AccountClosureTemplates') THEN
     INSERT INTO gateway."EmailTemplate" ("EmailTemplateId", "Body", "CreatedBy", "CreatedDateTime", "EffectiveDate", "ExpiryDate", "FormatCode", "From", "Name", "Priority", "Subject", "UpdatedBy", "UpdatedDateTime")
     VALUES ('79503a38-c14a-4992-b2fe-5586629f552e', '<!doctype html>
                     <html lang="en">
@@ -1742,9 +1745,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200226230220_AccountClosureTemplates') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200226230220_AccountClosureTemplates', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200226230220_AccountClosureTemplates') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200226230220_AccountClosureTemplates', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1754,7 +1757,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
     UPDATE gateway."EmailTemplate" SET "Priority" = 1
     WHERE "EmailTemplateId" = '2fe8c825-d4de-4884-be6a-01a97b466425';
     END IF;
@@ -1762,7 +1765,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
     UPDATE gateway."EmailTemplate" SET "Priority" = 1
     WHERE "EmailTemplateId" = '79503a38-c14a-4992-b2fe-5586629f552e';
     END IF;
@@ -1770,7 +1773,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
     UPDATE gateway."EmailTemplate" SET "Priority" = 1
     WHERE "EmailTemplateId" = 'd9898318-4e53-4074-9979-5d24bd370055';
     END IF;
@@ -1778,9 +1781,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200227234222_ChangeEmailTemplatePriority', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200227234222_ChangeEmailTemplatePriority') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200227234222_ChangeEmailTemplatePriority', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1790,7 +1793,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200228193314_ToSTemplateUpdate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200228193314_ToSTemplateUpdate') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -1832,9 +1835,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200228193314_ToSTemplateUpdate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200228193314_ToSTemplateUpdate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200228193314_ToSTemplateUpdate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200228193314_ToSTemplateUpdate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1844,7 +1847,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200304212452_Notes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200304212452_Notes') THEN
     CREATE TABLE gateway."Note" (
         "NoteId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -1863,16 +1866,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200304212452_Notes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200304212452_Notes') THEN
     CREATE INDEX "IX_Note_UserProfileId" ON gateway."Note" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200304212452_Notes') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200304212452_Notes', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200304212452_Notes') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200304212452_Notes', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1882,7 +1885,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200304214641_UpdateVerifyEmailTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200304214641_UpdateVerifyEmailTemplate') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head></head>
@@ -1919,9 +1922,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200304214641_UpdateVerifyEmailTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200304214641_UpdateVerifyEmailTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200304214641_UpdateVerifyEmailTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200304214641_UpdateVerifyEmailTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1931,23 +1934,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200312180332_CompositeNoteKeys') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200312180332_CompositeNoteKeys') THEN
     ALTER TABLE gateway."Note" DROP CONSTRAINT "PK_Note";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200312180332_CompositeNoteKeys') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200312180332_CompositeNoteKeys') THEN
     ALTER TABLE gateway."Note" ADD CONSTRAINT "PK_Note" PRIMARY KEY ("NoteId", "UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200312180332_CompositeNoteKeys') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200312180332_CompositeNoteKeys', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200312180332_CompositeNoteKeys') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200312180332_CompositeNoteKeys', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -1957,7 +1960,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200317223800_ToSUpdate4Notes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200317223800_ToSUpdate4Notes') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('ec438d12-f8e2-4719-8444-28e35d34674c', 'System', TIMESTAMP '2020-03-18 00:00:00', TIMESTAMP '2020-03-18 00:00:00', 'ToS', '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
@@ -2060,9 +2063,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200317223800_ToSUpdate4Notes') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200317223800_ToSUpdate4Notes', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200317223800_ToSUpdate4Notes') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200317223800_ToSUpdate4Notes', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2072,7 +2075,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200330230502_GenericCache') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200330230502_GenericCache') THEN
     CREATE TABLE gateway."GenericCache" (
         "GenericCacheId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2091,9 +2094,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200330230502_GenericCache') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200330230502_GenericCache', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200330230502_GenericCache') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200330230502_GenericCache', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2103,30 +2106,30 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
     ALTER TABLE gateway."UserFeedback" ADD "UserProfileId" character varying(52) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
     CREATE INDEX "IX_UserFeedback_UserProfileId" ON gateway."UserFeedback" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
     ALTER TABLE gateway."UserFeedback" ADD CONSTRAINT "FK_UserFeedback_UserProfile_UserProfileId" FOREIGN KEY ("UserProfileId") REFERENCES gateway."UserProfile" ("UserProfileId") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200413234129_AddHDID2Feedback', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200413234129_AddHDID2Feedback') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200413234129_AddHDID2Feedback', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2136,7 +2139,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200421223141_Comment') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200421223141_Comment') THEN
     CREATE TABLE gateway."Comment" (
         "CommentId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2155,16 +2158,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200421223141_Comment') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200421223141_Comment') THEN
     CREATE INDEX "IX_Comment_UserProfileId" ON gateway."Comment" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200421223141_Comment') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200421223141_Comment', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200421223141_Comment') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200421223141_Comment', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2174,42 +2177,42 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
     ALTER TABLE gateway."UserProfileHistory" ADD "EncryptionKey" character varying(44) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
     ALTER TABLE gateway."UserProfile" ADD "EncryptionKey" character varying(44) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
     ALTER TABLE gateway."Note" ALTER COLUMN "Title" TYPE character varying(152);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
     ALTER TABLE gateway."Note" ALTER COLUMN "Text" TYPE character varying(1344);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
     ALTER TABLE gateway."Comment" ALTER COLUMN "Text" TYPE character varying(1344);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
 
     CREATE or REPLACE FUNCTION gateway."UserProfileHistoryFunction"()
         RETURNS trigger
@@ -2232,9 +2235,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200422234729_SupportEncryption', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200422234729_SupportEncryption') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200422234729_SupportEncryption', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2244,7 +2247,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200423173644_Communication') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200423173644_Communication') THEN
     CREATE TABLE gateway."Communication" (
         "CommunicationId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2262,9 +2265,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200423173644_Communication') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200423173644_Communication', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200423173644_Communication') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200423173644_Communication', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2274,7 +2277,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200512223446_AddLaboratoryApplication') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200512223446_AddLaboratoryApplication') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('LAB', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Laboratory Service', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -2282,9 +2285,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200512223446_AddLaboratoryApplication') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200512223446_AddLaboratoryApplication', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200512223446_AddLaboratoryApplication') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200512223446_AddLaboratoryApplication', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2294,16 +2297,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200514220748_UpdateCommentModel') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200514220748_UpdateCommentModel') THEN
     ALTER TABLE gateway."Comment" ALTER COLUMN "ParentEntryId" TYPE character varying(36);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200514220748_UpdateCommentModel') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200514220748_UpdateCommentModel', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200514220748_UpdateCommentModel') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200514220748_UpdateCommentModel', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2313,16 +2316,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200515154544_UpdateProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200515154544_UpdateProfile') THEN
     ALTER TABLE gateway."UserProfile" ADD "PhoneNumber" character varying(20) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200515154544_UpdateProfile') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200515154544_UpdateProfile', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200515154544_UpdateProfile') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200515154544_UpdateProfile', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2332,51 +2335,51 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
     ALTER TABLE gateway."EmailInvite" DROP CONSTRAINT "FK_EmailInvite_Email_EmailId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
     ALTER TABLE gateway."EmailInvite" DROP CONSTRAINT "PK_EmailInvite";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
     ALTER TABLE gateway."EmailInvite" RENAME TO "MessagingVerification";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
     ALTER INDEX gateway."IX_EmailInvite_EmailId" RENAME TO "IX_MessagingVerification_EmailId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
     ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "PK_MessagingVerification" PRIMARY KEY ("EmailInviteId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
     ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "FK_MessagingVerification_Email_EmailId" FOREIGN KEY ("EmailId") REFERENCES gateway."Email" ("EmailId") ON DELETE CASCADE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200521185337_RenameEmailInviteDB', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185337_RenameEmailInviteDB') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200521185337_RenameEmailInviteDB', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2386,16 +2389,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185607_RenameEmailInviteModel') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185607_RenameEmailInviteModel') THEN
     ALTER TABLE gateway."MessagingVerification" RENAME COLUMN "EmailInviteId" TO "MessagingVerificationId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200521185607_RenameEmailInviteModel') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200521185607_RenameEmailInviteModel', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200521185607_RenameEmailInviteModel') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200521185607_RenameEmailInviteModel', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2405,28 +2408,28 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ADD "SMSNumber" text NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ADD "SMSValidationCode" character varying(6) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ADD "VerificationType" character varying(10) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     CREATE TABLE gateway."MessagingVerificationTypeCode" (
         "MessagingVerificationCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2441,7 +2444,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     INSERT INTO gateway."MessagingVerificationTypeCode" ("MessagingVerificationCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Email', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Email Verification Type Code', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."MessagingVerificationTypeCode" ("MessagingVerificationCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -2451,21 +2454,21 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     CREATE INDEX "IX_MessagingVerification_VerificationType" ON gateway."MessagingVerification" ("VerificationType");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "FK_MessagingVerification_MessagingVerificationTypeCode_Verific~" FOREIGN KEY ("VerificationType") REFERENCES gateway."MessagingVerificationTypeCode" ("MessagingVerificationCode") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
 
     UPDATE  gateway."MessagingVerification" 
         SET "VerificationType"='Email', "UpdatedBy"='SMSVerificationMigration', "UpdatedDateTime"=now();
@@ -2475,16 +2478,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "VerificationType" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200526063610_SMSVerification', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526063610_SMSVerification') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200526063610_SMSVerification', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2494,16 +2497,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526203427_MissingMigrationNullable') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526203427_MissingMigrationNullable') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "VerificationType" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200526203427_MissingMigrationNullable') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200526203427_MissingMigrationNullable', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200526203427_MissingMigrationNullable') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200526203427_MissingMigrationNullable', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2513,28 +2516,28 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
     ALTER TABLE gateway."UserProfile" RENAME COLUMN "PhoneNumber" TO "SMSNumber";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "SMSNumber" TYPE character varying(10);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
     ALTER TABLE gateway."UserProfileHistory" ADD "SMSNumber" character varying(10) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
 
     CREATE or REPLACE FUNCTION gateway."UserProfileHistoryFunction"()
         RETURNS trigger
@@ -2557,9 +2560,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200529202233_PhoneBugfix', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200529202233_PhoneBugfix') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200529202233_PhoneBugfix', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2569,30 +2572,30 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
     ALTER TABLE gateway."MessagingVerification" DROP CONSTRAINT "FK_MessagingVerification_Email_EmailId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "EmailId" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "FK_MessagingVerification_Email_EmailId" FOREIGN KEY ("EmailId") REFERENCES gateway."Email" ("EmailId") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200601194243_UpdateMessagingVerification', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200601194243_UpdateMessagingVerification') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200601194243_UpdateMessagingVerification', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2602,23 +2605,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200609144240_UpdateMessagingVerificationAttempts') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200609144240_UpdateMessagingVerificationAttempts') THEN
     ALTER TABLE gateway."MessagingVerification" ADD "Deleted" boolean NOT NULL DEFAULT FALSE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200609144240_UpdateMessagingVerificationAttempts') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200609144240_UpdateMessagingVerificationAttempts') THEN
     ALTER TABLE gateway."MessagingVerification" ADD "VerificationAttempts" integer NOT NULL DEFAULT 0;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200609144240_UpdateMessagingVerificationAttempts') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200609144240_UpdateMessagingVerificationAttempts', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200609144240_UpdateMessagingVerificationAttempts') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200609144240_UpdateMessagingVerificationAttempts', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2628,7 +2631,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200619221413_CommunicationDateConstraint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200619221413_CommunicationDateConstraint') THEN
 
                     ALTER TABLE gateway."Communication" ADD CONSTRAINT unique_date_range EXCLUDE USING gist (tsrange("EffectiveDateTime", "ExpiryDateTime") WITH &&);
     END IF;
@@ -2636,9 +2639,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200619221413_CommunicationDateConstraint') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200619221413_CommunicationDateConstraint', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200619221413_CommunicationDateConstraint') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200619221413_CommunicationDateConstraint', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2648,7 +2651,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200622183501_ToSUpdateCovid') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200622183501_ToSUpdateCovid') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('1d94c170-5118-4aa6-ba31-e3e07274ccbd', 'System', TIMESTAMP '2020-06-22 00:00:00', TIMESTAMP '2020-06-22 00:00:00', 'ToS', '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
@@ -2767,9 +2770,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200622183501_ToSUpdateCovid') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200622183501_ToSUpdateCovid', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200622183501_ToSUpdateCovid') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200622183501_ToSUpdateCovid', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2779,7 +2782,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200630213031_MvToSEffDt') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200630213031_MvToSEffDt') THEN
     UPDATE gateway."LegalAgreement" SET "EffectiveDate" = TIMESTAMP '2020-07-31 00:00:00'
     WHERE "LegalAgreementsId" = '1d94c170-5118-4aa6-ba31-e3e07274ccbd';
     END IF;
@@ -2787,9 +2790,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200630213031_MvToSEffDt') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200630213031_MvToSEffDt', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200630213031_MvToSEffDt') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200630213031_MvToSEffDt', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2799,7 +2802,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200710203326_AddUserPreference') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200710203326_AddUserPreference') THEN
     CREATE TABLE gateway."UserPreference" (
         "UserProfileId" character varying(52) NOT NULL,
         "Preference" text NOT NULL,
@@ -2815,9 +2818,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200710203326_AddUserPreference') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200710203326_AddUserPreference', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200710203326_AddUserPreference') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200710203326_AddUserPreference', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2827,42 +2830,42 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "Text" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "Subject" SET NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ADD "CommunicationStatusCode" character varying(10) NOT NULL DEFAULT '';
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ADD "CommunicationTypeCode" character varying(10) NOT NULL DEFAULT '';
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ADD "Priority" integer NOT NULL DEFAULT 0;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE TABLE gateway."CommunicationEmail" (
         "CommunicationEmailId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2882,7 +2885,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE TABLE gateway."CommunicationStatusCode" (
         "StatusCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2897,7 +2900,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE TABLE gateway."CommunicationTypeCode" (
         "StatusCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -2912,7 +2915,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     INSERT INTO gateway."CommunicationStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('New', 'System', TIMESTAMP '2019-05-01 00:00:00', 'A newly created Communication', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."CommunicationStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -2928,7 +2931,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     INSERT INTO gateway."CommunicationTypeCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Banner', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Banner communication type', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."CommunicationTypeCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -2938,58 +2941,58 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE INDEX "IX_Communication_CommunicationStatusCode" ON gateway."Communication" ("CommunicationStatusCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE INDEX "IX_Communication_CommunicationTypeCode" ON gateway."Communication" ("CommunicationTypeCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE INDEX "IX_CommunicationEmail_CommunicationId" ON gateway."CommunicationEmail" ("CommunicationId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE INDEX "IX_CommunicationEmail_EmailId" ON gateway."CommunicationEmail" ("EmailId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     CREATE INDEX "IX_CommunicationEmail_UserProfileHdId" ON gateway."CommunicationEmail" ("UserProfileHdId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ADD CONSTRAINT "FK_Communication_CommunicationStatusCode_CommunicationStatusCo~" FOREIGN KEY ("CommunicationStatusCode") REFERENCES gateway."CommunicationStatusCode" ("StatusCode") ON DELETE CASCADE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
     ALTER TABLE gateway."Communication" ADD CONSTRAINT "FK_Communication_CommunicationTypeCode_CommunicationTypeCode" FOREIGN KEY ("CommunicationTypeCode") REFERENCES gateway."CommunicationTypeCode" ("StatusCode") ON DELETE CASCADE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200724222252_NewComms', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724222252_NewComms') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200724222252_NewComms', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -2999,16 +3002,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724230921_UpdateCommunicationAddScheduledDate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724230921_UpdateCommunicationAddScheduledDate') THEN
     ALTER TABLE gateway."Communication" ADD "ScheduledDateTime" timestamp without time zone NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200724230921_UpdateCommunicationAddScheduledDate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200724230921_UpdateCommunicationAddScheduledDate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200724230921_UpdateCommunicationAddScheduledDate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200724230921_UpdateCommunicationAddScheduledDate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3018,7 +3021,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200803222317_PushBannerChange') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200803222317_PushBannerChange') THEN
 
     CREATE OR REPLACE FUNCTION gateway."PushBannerChange"()
         RETURNS trigger
@@ -3055,7 +3058,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200803222317_PushBannerChange') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200803222317_PushBannerChange') THEN
 
     DROP TRIGGER IF EXISTS "PushBannerChange" ON gateway."Communication";
     CREATE TRIGGER "PushBannerChange"
@@ -3068,9 +3071,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200803222317_PushBannerChange') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200803222317_PushBannerChange', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200803222317_PushBannerChange') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200803222317_PushBannerChange', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3080,7 +3083,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200817213421_AddRatingsTable') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200817213421_AddRatingsTable') THEN
     CREATE TABLE gateway."Rating" (
         "RatingId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -3096,9 +3099,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200817213421_AddRatingsTable') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200817213421_AddRatingsTable', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200817213421_AddRatingsTable') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200817213421_AddRatingsTable', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3108,7 +3111,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200901174715_UpdateProgramTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200901174715_UpdateProgramTypeCode') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('ENC', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Encounter Service', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -3116,9 +3119,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200901174715_UpdateProgramTypeCode') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200901174715_UpdateProgramTypeCode', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200901174715_UpdateProgramTypeCode') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200901174715_UpdateProgramTypeCode', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3128,7 +3131,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200922192259_AddCommunicationStatusCodeDraft') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200922192259_AddCommunicationStatusCodeDraft') THEN
     INSERT INTO gateway."CommunicationStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Draft', 'System', TIMESTAMP '2019-05-01 00:00:00', 'A draft Communication which has not been published', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -3136,9 +3139,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200922192259_AddCommunicationStatusCodeDraft') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200922192259_AddCommunicationStatusCodeDraft', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200922192259_AddCommunicationStatusCodeDraft') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200922192259_AddCommunicationStatusCodeDraft', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3148,7 +3151,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200926222603_ModifyUniqueDateRangeConstraint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200926222603_ModifyUniqueDateRangeConstraint') THEN
 
                     ALTER TABLE gateway."Communication" DROP CONSTRAINT unique_date_range;
     END IF;
@@ -3156,7 +3159,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200926222603_ModifyUniqueDateRangeConstraint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200926222603_ModifyUniqueDateRangeConstraint') THEN
 
                     ALTER TABLE gateway."Communication" ADD CONSTRAINT unique_date_range EXCLUDE USING gist (tsrange("EffectiveDateTime", "ExpiryDateTime") WITH &&) WHERE ("CommunicationTypeCode" = 'Banner');
     END IF;
@@ -3164,9 +3167,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20200926222603_ModifyUniqueDateRangeConstraint') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20200926222603_ModifyUniqueDateRangeConstraint', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20200926222603_ModifyUniqueDateRangeConstraint') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20200926222603_ModifyUniqueDateRangeConstraint', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3176,7 +3179,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201008222443_UserDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201008222443_UserDelegate') THEN
     CREATE TABLE gateway."UserDelegate" (
         "OwnerId" character varying(52) NOT NULL,
         "DelegateId" character varying(52) NOT NULL,
@@ -3191,9 +3194,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201008222443_UserDelegate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201008222443_UserDelegate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201008222443_UserDelegate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201008222443_UserDelegate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3203,23 +3206,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201017085954_GenericCacheIndexes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201017085954_GenericCacheIndexes') THEN
     CREATE INDEX "IX_GenericCache_HdId_Domain" ON gateway."GenericCache" ("HdId", "Domain");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201017085954_GenericCacheIndexes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201017085954_GenericCacheIndexes') THEN
     CREATE INDEX "IX_GenericCache_JSON_GIN" on gateway."GenericCache" USING gin("JSON");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201017085954_GenericCacheIndexes') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201017085954_GenericCacheIndexes', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201017085954_GenericCacheIndexes') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201017085954_GenericCacheIndexes', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3229,30 +3232,30 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
     TRUNCATE gateway."GenericCache";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
     DROP INDEX gateway."IX_GenericCache_HdId_Domain";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
     CREATE UNIQUE INDEX "IX_GenericCache_HdId_Domain" ON gateway."GenericCache" ("HdId", "Domain");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201018001236_GenericCacheUnique', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201018001236_GenericCacheUnique') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201018001236_GenericCacheUnique', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3262,7 +3265,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
     CREATE TABLE gateway."UserDelegateHistory" (
         "UserDelegateHistoryId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -3280,7 +3283,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
 
     CREATE FUNCTION gateway."UserDelegateHistoryFunction"()
         RETURNS trigger
@@ -3303,7 +3306,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
 
     CREATE TRIGGER "UserDelegateHistoryTrigger"
         AFTER DELETE
@@ -3315,9 +3318,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201021193628_AddUserDelegateHistory', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201021193628_AddUserDelegateHistory') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201021193628_AddUserDelegateHistory', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3327,35 +3330,35 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     DROP TRIGGER IF EXISTS "UserDelegateHistoryTrigger" ON gateway."UserDelegate";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     DROP FUNCTION IF EXISTS gateway."UserDelegateHistoryFunction"();
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     DROP TABLE IF EXISTS gateway."UserDelegate";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     DROP TABLE IF EXISTS gateway."UserDelegateHistory";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     CREATE TABLE gateway."ResourceDelegateHistory" (
         "ResourceDelegateHistoryId" uuid NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -3376,7 +3379,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     CREATE TABLE gateway."ResourceDelegateReasonCode" (
         "ReasonTypeCode" character varying(10) NOT NULL,
         "CreatedBy" character varying(60) NOT NULL,
@@ -3391,7 +3394,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     CREATE TABLE gateway."ResourceDelegate" (
         "ResourceOwnerHdid" character varying(52) NOT NULL,
         "ProfileHdid" character varying(52) NOT NULL,
@@ -3411,7 +3414,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     INSERT INTO gateway."ResourceDelegateReasonCode" ("ReasonTypeCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('COVIDLab', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Resource Delegation for Covid Laboratory', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -3419,21 +3422,21 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     CREATE INDEX "IX_ResourceDelegate_ProfileHdid" ON gateway."ResourceDelegate" ("ProfileHdid");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
     CREATE INDEX "IX_ResourceDelegate_ReasonCode" ON gateway."ResourceDelegate" ("ReasonCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
 
     CREATE FUNCTION gateway."ResourceDelegateHistoryFunction"()
         RETURNS trigger
@@ -3456,7 +3459,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
 
     CREATE TRIGGER "ResourceDelegateHistoryTrigger"
         AFTER DELETE
@@ -3468,9 +3471,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201118002050_AddResourceDelegate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201118002050_AddResourceDelegate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201118002050_AddResourceDelegate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3480,16 +3483,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201208231819_RemoveBetaRequest') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201208231819_RemoveBetaRequest') THEN
     DROP TABLE gateway."BetaRequest";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201208231819_RemoveBetaRequest') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201208231819_RemoveBetaRequest', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201208231819_RemoveBetaRequest') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201208231819_RemoveBetaRequest', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3499,7 +3502,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201224092706_UpdatedTermsOfService') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201224092706_UpdatedTermsOfService') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('2947456b-2b67-42b9-b239-13c4ed86060b', 'System', TIMESTAMP '2020-12-24 00:00:00', TIMESTAMP '2020-12-24 00:00:00', 'ToS', '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
@@ -3708,9 +3711,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201224092706_UpdatedTermsOfService') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201224092706_UpdatedTermsOfService', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201224092706_UpdatedTermsOfService') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201224092706_UpdatedTermsOfService', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3720,7 +3723,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201224191731_FixTermsOfService') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201224191731_FixTermsOfService') THEN
     DELETE FROM gateway."LegalAgreement"
     WHERE "LegalAgreementsId" = '2947456b-2b67-42b9-b239-13c4ed86060b';
     END IF;
@@ -3728,7 +3731,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201224191731_FixTermsOfService') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201224191731_FixTermsOfService') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('c99fd839-b4a2-40f9-b103-529efccd0dcd', 'System', TIMESTAMP '2020-12-24 00:00:00', TIMESTAMP '2020-12-24 00:00:00', 'ToS', '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
@@ -3948,9 +3951,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20201224191731_FixTermsOfService') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20201224191731_FixTermsOfService', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20201224191731_FixTermsOfService') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20201224191731_FixTermsOfService', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3960,7 +3963,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210105213714_UpdateToSDate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210105213714_UpdateToSDate') THEN
     UPDATE gateway."LegalAgreement" SET "EffectiveDate" = TIMESTAMP '2020-01-06 00:00:00', "UpdatedDateTime" = TIMESTAMP '2020-01-05 00:00:00'
     WHERE "LegalAgreementsId" = 'c99fd839-b4a2-40f9-b103-529efccd0dcd';
     END IF;
@@ -3968,9 +3971,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210105213714_UpdateToSDate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210105213714_UpdateToSDate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210105213714_UpdateToSDate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210105213714_UpdateToSDate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -3980,23 +3983,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210105220604_UpdateFeedbackFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210105220604_UpdateFeedbackFK') THEN
     ALTER TABLE gateway."UserFeedback" DROP CONSTRAINT "FK_UserFeedback_UserProfile_UserProfileId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210105220604_UpdateFeedbackFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210105220604_UpdateFeedbackFK') THEN
     DROP INDEX gateway."IX_UserFeedback_UserProfileId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210105220604_UpdateFeedbackFK') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210105220604_UpdateFeedbackFK', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210105220604_UpdateFeedbackFK') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210105220604_UpdateFeedbackFK', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4006,7 +4009,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210106170417_UpdateToSDate2') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210106170417_UpdateToSDate2') THEN
     UPDATE gateway."LegalAgreement" SET "EffectiveDate" = TIMESTAMP '2021-01-07 00:00:00', "UpdatedDateTime" = TIMESTAMP '2021-01-06 00:00:00'
     WHERE "LegalAgreementsId" = 'c99fd839-b4a2-40f9-b103-529efccd0dcd';
     END IF;
@@ -4014,9 +4017,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210106170417_UpdateToSDate2') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210106170417_UpdateToSDate2', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210106170417_UpdateToSDate2') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210106170417_UpdateToSDate2', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4026,7 +4029,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
 
                     UPDATE gateway."UserProfile" AS up1
                     SET "LastLoginDateTime" = up2."CreatedDateTime", "UpdatedBy" = 'UserProfileHistoryLoginMigration', "UpdatedDateTime"=now()
@@ -4038,7 +4041,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
     UPDATE gateway."UserProfile" SET "LastLoginDateTime" = TIMESTAMP '-infinity' WHERE "LastLoginDateTime" IS NULL;
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "LastLoginDateTime" SET NOT NULL;
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "LastLoginDateTime" SET DEFAULT TIMESTAMP '-infinity';
@@ -4047,7 +4050,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
 
     CREATE or REPLACE FUNCTION gateway."UserProfileHistoryFunction"()
         RETURNS trigger
@@ -4078,7 +4081,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
 
         CREATE TRIGGER "UserProfileHistoryLoginTrigger"
         AFTER UPDATE OF "LastLoginDateTime"
@@ -4090,9 +4093,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210107205552_UserProfileHistoryLogin', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107205552_UserProfileHistoryLogin') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210107205552_UserProfileHistoryLogin', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4102,7 +4105,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107212709_UpdateToSEmail') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107212709_UpdateToSEmail') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -4144,9 +4147,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210107212709_UpdateToSEmail') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210107212709_UpdateToSEmail', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210107212709_UpdateToSEmail') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210107212709_UpdateToSEmail', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4156,7 +4159,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210111203912_UserProfileHistoryNullValue') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210111203912_UserProfileHistoryNullValue') THEN
     UPDATE gateway."UserProfileHistory" SET "LastLoginDateTime" = TIMESTAMP '-infinity' WHERE "LastLoginDateTime" IS NULL;
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "LastLoginDateTime" SET NOT NULL;
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "LastLoginDateTime" SET DEFAULT TIMESTAMP '-infinity';
@@ -4165,9 +4168,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210111203912_UserProfileHistoryNullValue') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210111203912_UserProfileHistoryNullValue', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210111203912_UserProfileHistoryNullValue') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210111203912_UserProfileHistoryNullValue', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4177,7 +4180,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210119080944_EventLog') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210119080944_EventLog') THEN
     CREATE TABLE gateway."EventLog" (
         "EventLogId" uuid NOT NULL,
         "EventName" character varying(200) NOT NULL,
@@ -4194,9 +4197,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210119080944_EventLog') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210119080944_EventLog', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210119080944_EventLog') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210119080944_EventLog', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4206,7 +4209,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
      
                     UPDATE gateway."Comment" 
                     SET "EntryTypeCode" = 'NA', "UpdatedBy" = 'AddCommentEntryTypeCodeMigration', "UpdatedDateTime"=now()
@@ -4216,7 +4219,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
     CREATE TABLE gateway."CommentEntryTypeCode" (
         "CommentEntryCode" character varying(3) NOT NULL,
         "Description" character varying(50) NOT NULL,
@@ -4231,7 +4234,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
     INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('NA', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Comment for an Unknown type Entry', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -4247,23 +4250,23 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
     CREATE INDEX "IX_Comment_EntryTypeCode" ON gateway."Comment" ("EntryTypeCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
     ALTER TABLE gateway."Comment" ADD CONSTRAINT "FK_Comment_CommentEntryTypeCode_EntryTypeCode" FOREIGN KEY ("EntryTypeCode") REFERENCES gateway."CommentEntryTypeCode" ("CommentEntryCode") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210122215516_AddCommentEntryTypeCode', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210122215516_AddCommentEntryTypeCode') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210122215516_AddCommentEntryTypeCode', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4273,7 +4276,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210211202508_UpdateEmailValidationTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210211202508_UpdateEmailValidationTemplate') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head></head>
@@ -4311,9 +4314,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210211202508_UpdateEmailValidationTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210211202508_UpdateEmailValidationTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210211202508_UpdateEmailValidationTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210211202508_UpdateEmailValidationTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4323,7 +4326,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
 
     UPDATE gateway."MessagingVerification"
     SET "SMSNumber" = regexp_replace("SMSNumber", '[^0-9]', '', 'g')
@@ -4333,7 +4336,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
 
     UPDATE gateway."MessagingVerification"
     SET "ExpireDate" = "CreatedDateTime" + interval '5' hour
@@ -4343,16 +4346,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "SMSNumber" TYPE character varying(10);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210316172822_FixMessagingVerification', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210316172822_FixMessagingVerification') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210316172822_FixMessagingVerification', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4362,7 +4365,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210317235519_AddSpecialAuthorityCommentEntryTypeCode') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210317235519_AddSpecialAuthorityCommentEntryTypeCode') THEN
     INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "Description", "CreatedBy", "CreatedDateTime", "UpdatedBy", "UpdatedDateTime")
     VALUES ('SAR', 'Comment for a Special Authority Request Entry', 'System', TIMESTAMP '2019-05-01 00:00:00', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -4370,9 +4373,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210317235519_AddSpecialAuthorityCommentEntryTypeCode') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210317235519_AddSpecialAuthorityCommentEntryTypeCode', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210317235519_AddSpecialAuthorityCommentEntryTypeCode') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210317235519_AddSpecialAuthorityCommentEntryTypeCode', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -4382,7 +4385,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     DELETE FROM gateway."EmailTemplate"
     WHERE "EmailTemplateId" = '2ab5d4aa-c4c9-4324-a753-cde4e21e7612';
     END IF;
@@ -4390,7 +4393,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     DELETE FROM gateway."EmailTemplate"
     WHERE "EmailTemplateId" = '896f8f2e-3bed-400b-acaf-51dd6082b4bd';
     END IF;
@@ -4398,7 +4401,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -4438,7 +4441,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -4479,7 +4482,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -4520,7 +4523,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -4561,7 +4564,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!doctype html>
     <html lang="en">
     <head>
@@ -4604,7 +4607,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of the Health Gateway service (the <strong>"Service"</strong>) is governed by the following terms and
@@ -4723,7 +4726,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of the Health Gateway service (the <strong>"Service"</strong>) is
@@ -4947,7 +4950,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of the Health Gateway service (the “Service”) is governed by the following terms and conditions. Please read
@@ -5050,7 +5053,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of this service is governed by the following terms and conditions. Please read these terms and conditions
@@ -5105,9 +5108,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210330184059_UpdatedAssets', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210330184059_UpdatedAssets') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210330184059_UpdatedAssets', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -5117,7 +5120,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!DOCTYPE html>
     <html lang="en">
         <head>
@@ -5188,7 +5191,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!DOCTYPE html>
     <html lang="en">
         <head>
@@ -5245,7 +5248,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!DOCTYPE html>
     <html lang="en">
         <head>
@@ -5306,7 +5309,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!DOCTYPE html>
     <html lang="en">
         <head>
@@ -5364,7 +5367,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!DOCTYPE html>
     <html lang="en">
         <head>
@@ -5433,7 +5436,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of the Health Gateway service (the <strong>"Service"</strong>) is
@@ -5569,7 +5572,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of the Health Gateway service (the <strong>"Service"</strong>) is
@@ -5792,7 +5795,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of the Health Gateway service (the “Service”) is governed by the
@@ -5925,7 +5928,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
         Use of this service is governed by the following terms and conditions.
@@ -5991,9 +5994,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210420220008_UpdateAssets', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210420220008_UpdateAssets') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210420220008_UpdateAssets', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6003,7 +6006,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
     CREATE TABLE gateway."AdminTag" (
         "AdminTagId" uuid NOT NULL,
         "Name" character varying(20) NOT NULL,
@@ -6018,7 +6021,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
     CREATE TABLE gateway."UserFeedbackTag" (
         "UserFeedbackTagId" uuid NOT NULL,
         "AdminTagId" uuid NOT NULL,
@@ -6036,30 +6039,30 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
     CREATE UNIQUE INDEX "IX_AdminTag_Name" ON gateway."AdminTag" ("Name");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
     CREATE UNIQUE INDEX "IX_UserFeedbackTag_AdminTagId_UserFeedbackId" ON gateway."UserFeedbackTag" ("AdminTagId", "UserFeedbackId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
     CREATE INDEX "IX_UserFeedbackTag_UserFeedbackId" ON gateway."UserFeedbackTag" ("UserFeedbackId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210510213821_CreateAdminTag', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210510213821_CreateAdminTag') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210510213821_CreateAdminTag', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6069,7 +6072,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE TABLE gateway."WalletConnectionStatusCode" (
         "StatusCode" character varying(15) NOT NULL,
         "Description" character varying(50) NOT NULL,
@@ -6084,7 +6087,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE TABLE gateway."WalletCredentialStatusCode" (
         "StatusCode" character varying(10) NOT NULL,
         "Description" character varying(50) NOT NULL,
@@ -6099,7 +6102,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE TABLE gateway."WalletConnection" (
         "WalletConnectionId" uuid NOT NULL,
         "UserProfileId" character varying(54) NOT NULL,
@@ -6121,7 +6124,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE TABLE gateway."WalletCredential" (
         "WalletCredentialId" uuid NOT NULL,
         "WalletConnectionId" uuid NOT NULL,
@@ -6146,7 +6149,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     INSERT INTO gateway."WalletConnectionStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Pending', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Wallet Connection is Pending', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."WalletConnectionStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -6158,7 +6161,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     INSERT INTO gateway."WalletCredentialStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Created', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Wallet Credential has been created', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."WalletCredentialStatusCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -6170,37 +6173,37 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE INDEX "IX_WalletConnection_Status" ON gateway."WalletConnection" ("Status");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE INDEX "IX_WalletConnection_UserProfileId" ON gateway."WalletConnection" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE INDEX "IX_WalletCredential_Status" ON gateway."WalletCredential" ("Status");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
     CREATE INDEX "IX_WalletCredential_WalletConnectionId" ON gateway."WalletCredential" ("WalletConnectionId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210601235231_SetupWallet', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210601235231_SetupWallet') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210601235231_SetupWallet', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6210,7 +6213,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210604003608_AddRequiredCredentialsAttributes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210604003608_AddRequiredCredentialsAttributes') THEN
     UPDATE gateway."WalletCredential" SET "RevocationRegistryId" = '' WHERE "RevocationRegistryId" IS NULL;
     ALTER TABLE gateway."WalletCredential" ALTER COLUMN "RevocationRegistryId" SET NOT NULL;
     ALTER TABLE gateway."WalletCredential" ALTER COLUMN "RevocationRegistryId" SET DEFAULT '';
@@ -6219,7 +6222,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210604003608_AddRequiredCredentialsAttributes') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210604003608_AddRequiredCredentialsAttributes') THEN
     UPDATE gateway."WalletCredential" SET "RevocationId" = '' WHERE "RevocationId" IS NULL;
     ALTER TABLE gateway."WalletCredential" ALTER COLUMN "RevocationId" SET NOT NULL;
     ALTER TABLE gateway."WalletCredential" ALTER COLUMN "RevocationId" SET DEFAULT '';
@@ -6228,9 +6231,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210604003608_AddRequiredCredentialsAttributes') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210604003608_AddRequiredCredentialsAttributes', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210604003608_AddRequiredCredentialsAttributes') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210604003608_AddRequiredCredentialsAttributes', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6240,23 +6243,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210607193749_UpdateCredFieldsRegd') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210607193749_UpdateCredFieldsRegd') THEN
     ALTER TABLE gateway."WalletCredential" ALTER COLUMN "RevocationRegistryId" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210607193749_UpdateCredFieldsRegd') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210607193749_UpdateCredFieldsRegd') THEN
     ALTER TABLE gateway."WalletCredential" ALTER COLUMN "RevocationId" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210607193749_UpdateCredFieldsRegd') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210607193749_UpdateCredFieldsRegd', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210607193749_UpdateCredFieldsRegd') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210607193749_UpdateCredFieldsRegd', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6266,7 +6269,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210618155609_AdminFeedbackEmail') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210618155609_AdminFeedbackEmail') THEN
     INSERT INTO gateway."EmailTemplate" ("EmailTemplateId", "Body", "CreatedBy", "CreatedDateTime", "EffectiveDate", "ExpiryDate", "FormatCode", "From", "Name", "Priority", "Subject", "UpdatedBy", "UpdatedDateTime")
     VALUES ('75c79b3e-1a61-403b-82ee-fddcda7144af', '<!DOCTYPE html>
     <html lang="en">
@@ -6284,9 +6287,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210618155609_AdminFeedbackEmail') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210618155609_AdminFeedbackEmail', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210618155609_AdminFeedbackEmail') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210618155609_AdminFeedbackEmail', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6296,7 +6299,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
     INSERT INTO gateway."CommunicationTypeCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('InApp', 'System', TIMESTAMP '2019-05-01 00:00:00', 'In-App communication type', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -6304,7 +6307,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
 
     CREATE OR REPLACE FUNCTION gateway."PushBannerChange"()
         RETURNS trigger
@@ -6343,7 +6346,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
 
     DROP TRIGGER IF EXISTS "PushBannerChange" ON gateway."Communication";
     CREATE TRIGGER "PushBannerChange"
@@ -6356,9 +6359,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210618185129_AddInAppCommsType', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210618185129_AddInAppCommsType') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210618185129_AddInAppCommsType', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6368,7 +6371,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210621184624_UpdateAdminFeedbackTemplate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210621184624_UpdateAdminFeedbackTemplate') THEN
     UPDATE gateway."EmailTemplate" SET "Body" = '<!DOCTYPE html>
     <html lang="en">
         <head>
@@ -6387,9 +6390,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210621184624_UpdateAdminFeedbackTemplate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210621184624_UpdateAdminFeedbackTemplate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210621184624_UpdateAdminFeedbackTemplate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210621184624_UpdateAdminFeedbackTemplate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6399,23 +6402,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210621225608_UserProfileVerifications') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210621225608_UserProfileVerifications') THEN
     CREATE INDEX "IX_MessagingVerification_HdId" ON gateway."MessagingVerification" ("HdId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210621225608_UserProfileVerifications') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210621225608_UserProfileVerifications') THEN
     ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "FK_MessagingVerification_UserProfile_HdId" FOREIGN KEY ("HdId") REFERENCES gateway."UserProfile" ("UserProfileId") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210621225608_UserProfileVerifications') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210621225608_UserProfileVerifications', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210621225608_UserProfileVerifications') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210621225608_UserProfileVerifications', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6425,14 +6428,14 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
     ALTER TABLE gateway."MessagingVerification" DROP CONSTRAINT "FK_MessagingVerification_UserProfile_HdId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
     UPDATE gateway."MessagingVerification" SET "HdId" = '' WHERE "HdId" IS NULL;
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "HdId" SET NOT NULL;
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "HdId" SET DEFAULT '';
@@ -6441,16 +6444,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
     ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "FK_MessagingVerification_UserProfile_HdId" FOREIGN KEY ("HdId") REFERENCES gateway."UserProfile" ("UserProfileId") ON DELETE CASCADE;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20210726205526_FixMVConstraint', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20210726205526_FixMVConstraint') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20210726205526_FixMVConstraint', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6460,7 +6463,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
     CREATE TABLE gateway."VaccineProofTemplateCode" (
         "TemplateCode" character varying(15) NOT NULL,
         "Description" character varying(75) NOT NULL,
@@ -6475,7 +6478,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
     CREATE TABLE gateway."VaccineProofRequestCache" (
         "VaccineProofRequestCacheId" uuid NOT NULL,
         "PersonIdentifier" character varying(54) NOT NULL,
@@ -6496,7 +6499,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
     INSERT INTO gateway."VaccineProofTemplateCode" ("TemplateCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('BCProvincial', 'System', TIMESTAMP '2019-05-01 00:00:00', 'The Provincial template (single page)', 'System', TIMESTAMP '2019-05-01 00:00:00');
     INSERT INTO gateway."VaccineProofTemplateCode" ("TemplateCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -6510,16 +6513,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
     CREATE INDEX "IX_VaccineProofRequestCache_ProofTemplate" ON gateway."VaccineProofRequestCache" ("ProofTemplate");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20211027211258_VaccineProofRequestCache', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211027211258_VaccineProofRequestCache') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20211027211258_VaccineProofRequestCache', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6529,16 +6532,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211028175602_VPAddAssetEndpoint') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211028175602_VPAddAssetEndpoint') THEN
     ALTER TABLE gateway."VaccineProofRequestCache" ADD "AssetEndpoint" text NOT NULL DEFAULT '';
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211028175602_VPAddAssetEndpoint') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20211028175602_VPAddAssetEndpoint', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211028175602_VPAddAssetEndpoint') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20211028175602_VPAddAssetEndpoint', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6548,51 +6551,51 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
     DROP TABLE gateway."VaccineProofRequestCache";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
     DROP TABLE gateway."WalletCredential";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
     DROP TABLE gateway."VaccineProofTemplateCode";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
     DROP TABLE gateway."WalletConnection";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
     DROP TABLE gateway."WalletCredentialStatusCode";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
     DROP TABLE gateway."WalletConnectionStatusCode";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20211103205732_CleanupVCVP', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211103205732_CleanupVCVP') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20211103205732_CleanupVCVP', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6602,7 +6605,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211109195934_AdminAllowOverlapMultipleStatus') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211109195934_AdminAllowOverlapMultipleStatus') THEN
 
                     ALTER TABLE IF EXISTS gateway."Communication" DROP CONSTRAINT IF EXISTS unique_date_range;
     END IF;
@@ -6610,7 +6613,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211109195934_AdminAllowOverlapMultipleStatus') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211109195934_AdminAllowOverlapMultipleStatus') THEN
 
                     ALTER TABLE gateway."Communication" ADD CONSTRAINT unique_date_range EXCLUDE USING gist (tsrange("EffectiveDateTime", "ExpiryDateTime") WITH &&) WHERE ("CommunicationTypeCode" = 'Banner'  AND "CommunicationStatusCode"  IN ('New' ,'Pending','Processed','Processing'));
     END IF;
@@ -6618,9 +6621,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211109195934_AdminAllowOverlapMultipleStatus') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20211109195934_AdminAllowOverlapMultipleStatus', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211109195934_AdminAllowOverlapMultipleStatus') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20211109195934_AdminAllowOverlapMultipleStatus', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6630,16 +6633,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211206215849_AddIndexToUserProfileHistory') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211206215849_AddIndexToUserProfileHistory') THEN
     CREATE INDEX "IX_UserProfileHistory_UserProfileId" ON gateway."UserProfileHistory" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211206215849_AddIndexToUserProfileHistory') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20211206215849_AddIndexToUserProfileHistory', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211206215849_AddIndexToUserProfileHistory') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20211206215849_AddIndexToUserProfileHistory', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6649,7 +6652,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211221220853_CreateAdminUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211221220853_CreateAdminUserProfile') THEN
     CREATE TABLE gateway."AdminUserProfile" (
         "AdminUserProfileId" uuid NOT NULL,
         "Username" character varying(255) NOT NULL,
@@ -6666,16 +6669,16 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211221220853_CreateAdminUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211221220853_CreateAdminUserProfile') THEN
     CREATE UNIQUE INDEX "IX_AdminUserProfile_Username" ON gateway."AdminUserProfile" ("Username");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20211221220853_CreateAdminUserProfile') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20211221220853_CreateAdminUserProfile', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20211221220853_CreateAdminUserProfile') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20211221220853_CreateAdminUserProfile', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6685,16 +6688,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220112050257_DropEmailFromAdminUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220112050257_DropEmailFromAdminUserProfile') THEN
     ALTER TABLE gateway."AdminUserProfile" DROP COLUMN "Email";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220112050257_DropEmailFromAdminUserProfile') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220112050257_DropEmailFromAdminUserProfile', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220112050257_DropEmailFromAdminUserProfile') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220112050257_DropEmailFromAdminUserProfile', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6704,7 +6707,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220127215846_AddAllLaboratoryOrdersCommentEntryType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220127215846_AddAllLaboratoryOrdersCommentEntryType') THEN
     UPDATE gateway."CommentEntryTypeCode" SET "Description" = 'Comment for a Covid 19 Laboratory Entry'
     WHERE "CommentEntryCode" = 'Lab';
     END IF;
@@ -6712,7 +6715,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220127215846_AddAllLaboratoryOrdersCommentEntryType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220127215846_AddAllLaboratoryOrdersCommentEntryType') THEN
     INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('ALO', 'System', TIMESTAMP '2019-05-01 00:00:00', 'Comment for a Laboratory Entry', 'System', TIMESTAMP '2019-05-01 00:00:00');
     END IF;
@@ -6720,9 +6723,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220127215846_AddAllLaboratoryOrdersCommentEntryType') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220127215846_AddAllLaboratoryOrdersCommentEntryType', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220127215846_AddAllLaboratoryOrdersCommentEntryType') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220127215846_AddAllLaboratoryOrdersCommentEntryType', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -6732,805 +6735,805 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     DROP TRIGGER IF EXISTS "UserProfileHistoryLoginTrigger" ON gateway."UserProfile";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Communication" DROP CONSTRAINT unique_date_range;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."VeterinarySpecies" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."VeterinarySpecies" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "OperationDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "LastLoginDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "ClosedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "LastLoginDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserProfile" ALTER COLUMN "ClosedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserPreference" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserPreference" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserFeedbackTag" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserFeedbackTag" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserFeedback" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."UserFeedback" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."TherapeuticClass" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."TherapeuticClass" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Status" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Status" ALTER COLUMN "HistoryDate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Status" ALTER COLUMN "ExpirationDate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Status" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Schedule" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Schedule" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Route" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Route" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegateReasonCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegateReasonCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegateHistory" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegateHistory" ALTER COLUMN "OperationDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegateHistory" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegate" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ResourceDelegate" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Rating" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Rating" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ProgramTypeCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ProgramTypeCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."PharmaceuticalStd" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."PharmaceuticalStd" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."PharmaCareDrug" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."PharmaCareDrug" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Packaging" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Packaging" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Note" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Note" ALTER COLUMN "JournalDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Note" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."MessagingVerificationTypeCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."MessagingVerificationTypeCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "ExpireDate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."LegalAgreementTypeCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."LegalAgreementTypeCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."LegalAgreement" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."LegalAgreement" ALTER COLUMN "EffectiveDate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."LegalAgreement" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."GenericCache" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."GenericCache" ALTER COLUMN "ExpiryDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."GenericCache" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Form" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Form" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."FileDownload" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."FileDownload" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EventLog" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EventLog" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailTemplate" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailTemplate" ALTER COLUMN "ExpiryDate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailTemplate" ALTER COLUMN "EffectiveDate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailTemplate" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailStatusCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailStatusCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailFormatCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."EmailFormatCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Email" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Email" ALTER COLUMN "SentDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Email" ALTER COLUMN "LastRetryDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Email" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."DrugProduct" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."DrugProduct" ALTER COLUMN "LastUpdate" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."DrugProduct" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Company" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Company" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommunicationTypeCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommunicationTypeCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommunicationStatusCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommunicationStatusCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommunicationEmail" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommunicationEmail" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "ScheduledDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "ExpiryDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "EffectiveDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Communication" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommentEntryTypeCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."CommentEntryTypeCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Comment" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."Comment" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AuditTransactionResultCode" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AuditTransactionResultCode" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AuditEvent" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AuditEvent" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AuditEvent" ALTER COLUMN "AuditEventDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ApplicationSetting" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ApplicationSetting" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AdminUserProfile" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AdminUserProfile" ALTER COLUMN "LastLoginDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AdminUserProfile" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AdminTag" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."AdminTag" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ActiveIngredient" ALTER COLUMN "UpdatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
     ALTER TABLE gateway."ActiveIngredient" ALTER COLUMN "CreatedDateTime" TYPE timestamp with time zone;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
 
          CREATE TRIGGER "UserProfileHistoryLoginTrigger"
          AFTER UPDATE OF "LastLoginDateTime"
@@ -7542,7 +7545,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
 
          ALTER TABLE gateway."Communication"
              ADD CONSTRAINT unique_date_range EXCLUDE USING gist (
@@ -7554,9 +7557,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220419231412_EF6Upgrade', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220419231412_EF6Upgrade') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220419231412_EF6Upgrade', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7566,16 +7569,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220420211930_NoteJournalType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220420211930_NoteJournalType') THEN
     ALTER TABLE gateway."Note" ALTER COLUMN "JournalDateTime" TYPE date;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220420211930_NoteJournalType') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220420211930_NoteJournalType', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220420211930_NoteJournalType') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220420211930_NoteJournalType', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7585,16 +7588,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220420212201_RenameNoteJournal') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220420212201_RenameNoteJournal') THEN
     ALTER TABLE gateway."Note" RENAME COLUMN "JournalDateTime" TO "JournalDate";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220420212201_RenameNoteJournal') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220420212201_RenameNoteJournal', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220420212201_RenameNoteJournal') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220420212201_RenameNoteJournal', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7604,7 +7607,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220503003723_AddDateTruncate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220503003723_AddDateTruncate') THEN
 
     CREATE OR REPLACE FUNCTION gateway.date_trunc(
     	text,
@@ -7620,9 +7623,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220503003723_AddDateTruncate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220503003723_AddDateTruncate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220503003723_AddDateTruncate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220503003723_AddDateTruncate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7632,16 +7635,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220510181145_UpdateParentEntryIdPrecision') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220510181145_UpdateParentEntryIdPrecision') THEN
     ALTER TABLE gateway."Comment" ALTER COLUMN "ParentEntryId" TYPE character varying(100);
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220510181145_UpdateParentEntryIdPrecision') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220510181145_UpdateParentEntryIdPrecision', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220510181145_UpdateParentEntryIdPrecision') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220510181145_UpdateParentEntryIdPrecision', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7651,44 +7654,44 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
     DROP TRIGGER IF EXISTS "UserProfileHistoryLoginTrigger" ON gateway."UserProfile";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
     ALTER TABLE gateway."UserProfileHistory" ADD "TermsOfServiceId" uuid NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
     ALTER TABLE gateway."UserProfile" ADD "TermsOfServiceId" uuid NOT NULL DEFAULT 'c99fd839-b4a2-40f9-b103-529efccd0dcd';
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
     CREATE INDEX "IX_UserProfile_TermsOfServiceId" ON gateway."UserProfile" ("TermsOfServiceId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
     ALTER TABLE gateway."UserProfile" ADD CONSTRAINT "FK_UserProfile_LegalAgreement_TermsOfServiceId" FOREIGN KEY ("TermsOfServiceId") REFERENCES gateway."LegalAgreement" ("LegalAgreementsId") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220518183026_UserProfileToSFK', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518183026_UserProfileToSFK') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220518183026_UserProfileToSFK', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7698,21 +7701,21 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
     ALTER TABLE gateway."UserProfile" DROP COLUMN "AcceptedTermsOfService";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
     ALTER TABLE gateway."UserProfileHistory" ALTER COLUMN "AcceptedTermsOfService" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
 
          CREATE TRIGGER "UserProfileHistoryLoginTrigger"
          AFTER UPDATE OF "LastLoginDateTime"
@@ -7724,7 +7727,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
 
     CREATE or REPLACE FUNCTION gateway."UserProfileHistoryFunction"()
         RETURNS trigger
@@ -7755,9 +7758,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220518211625_UserRemoveAcceptedToS', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220518211625_UserRemoveAcceptedToS') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220518211625_UserRemoveAcceptedToS', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7767,7 +7770,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220519190920_ToSJobCleanup') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220519190920_ToSJobCleanup') THEN
     DELETE FROM gateway."ApplicationSetting"
     WHERE "ApplicationSettingsId" = '5f279ba2-8e7b-4b1d-8c69-467d94dcb7fb';
     END IF;
@@ -7775,7 +7778,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220519190920_ToSJobCleanup') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220519190920_ToSJobCleanup') THEN
     DELETE FROM gateway."EmailTemplate"
     WHERE "EmailTemplateId" = 'eb695050-e2fb-4933-8815-3d4656e4541d';
     END IF;
@@ -7783,9 +7786,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220519190920_ToSJobCleanup') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220519190920_ToSJobCleanup', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220519190920_ToSJobCleanup') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220519190920_ToSJobCleanup', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -7795,7 +7798,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220519201544_ToSUpdate051922') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220519201544_ToSUpdate051922') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('eafeee76-8a64-49ee-81ba-ddfe2c01deb8', 'System', TIMESTAMPTZ '2022-05-19 00:00:00Z', TIMESTAMPTZ '2022-05-19 00:00:00Z', 'ToS', '<p><strong>HealthGateway Terms of Service</strong></p>
     <p>
@@ -8014,9 +8017,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220519201544_ToSUpdate051922') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220519201544_ToSUpdate051922', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220519201544_ToSUpdate051922') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220519201544_ToSUpdate051922', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8026,7 +8029,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220606211634_RevampTermsOfService') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220606211634_RevampTermsOfService') THEN
     INSERT INTO gateway."LegalAgreement" ("LegalAgreementsId", "CreatedBy", "CreatedDateTime", "EffectiveDate", "LegalAgreementCode", "LegalText", "UpdatedBy", "UpdatedDateTime")
     VALUES ('2fab66e7-37c9-4b03-ba25-e8fad604dc7f', 'System', TIMESTAMPTZ '2022-06-07 00:00:00Z', TIMESTAMPTZ '2022-06-07 00:00:00Z', 'ToS', '<p><strong>Health Gateway Terms of Service</strong></p>
     <p><strong>Last updated: June 7, 2022</strong></p>
@@ -8274,9 +8277,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220606211634_RevampTermsOfService') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220606211634_RevampTermsOfService', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220606211634_RevampTermsOfService') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220606211634_RevampTermsOfService', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8286,14 +8289,14 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220607220711_RemoveCommunicationEmail') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220607220711_RemoveCommunicationEmail') THEN
     DROP TABLE gateway."CommunicationEmail";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220607220711_RemoveCommunicationEmail') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220607220711_RemoveCommunicationEmail') THEN
     DELETE FROM gateway."CommunicationTypeCode"
     WHERE "StatusCode" = 'Email';
     END IF;
@@ -8301,9 +8304,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220607220711_RemoveCommunicationEmail') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220607220711_RemoveCommunicationEmail', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220607220711_RemoveCommunicationEmail') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220607220711_RemoveCommunicationEmail', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8313,35 +8316,35 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
     ALTER TABLE gateway."ResourceDelegateHistory" ALTER COLUMN "ReasonObjectType" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
     ALTER TABLE gateway."ResourceDelegateHistory" ALTER COLUMN "ReasonObject" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
     ALTER TABLE gateway."ResourceDelegate" ALTER COLUMN "ReasonObjectType" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
     ALTER TABLE gateway."ResourceDelegate" ALTER COLUMN "ReasonObject" DROP NOT NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
     INSERT INTO gateway."ResourceDelegateReasonCode" ("ReasonTypeCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Guardian', 'System', TIMESTAMPTZ '2022-08-01 00:00:00Z', 'Resource Delegation for attested guardian', 'System', TIMESTAMPTZ '2022-08-01 00:00:00Z');
     END IF;
@@ -8349,9 +8352,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220819210700_UpdateResourceDelegate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220819210700_UpdateResourceDelegate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220819210700_UpdateResourceDelegate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8361,7 +8364,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220822182613_ToSUpdate') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220822182613_ToSUpdate') THEN
     UPDATE gateway."LegalAgreement" SET "LegalText" = '<p><strong>Health Gateway Terms of Service</strong></p>
     <p><strong>Last updated: June 7, 2022</strong></p>
     <p>
@@ -8608,9 +8611,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220822182613_ToSUpdate') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220822182613_ToSUpdate', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220822182613_ToSUpdate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220822182613_ToSUpdate', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8620,16 +8623,16 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220823003707_RemoveGenericCache') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220823003707_RemoveGenericCache') THEN
     DROP TABLE gateway."GenericCache";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220823003707_RemoveGenericCache') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220823003707_RemoveGenericCache', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220823003707_RemoveGenericCache') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220823003707_RemoveGenericCache', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8639,7 +8642,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220825002518_ClinicalDocCommentEntry') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220825002518_ClinicalDocCommentEntry') THEN
     INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('CDO', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Comment for Clinical Documents Entry', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
     END IF;
@@ -8647,9 +8650,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220825002518_ClinicalDocCommentEntry') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220825002518_ClinicalDocCommentEntry', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220825002518_ClinicalDocCommentEntry') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220825002518_ClinicalDocCommentEntry', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8659,7 +8662,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220830055608_NewCDOAppType') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220830055608_NewCDOAppType') THEN
     INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('CDO', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Clinical Document Service', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
     END IF;
@@ -8667,9 +8670,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220830055608_NewCDOAppType') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220830055608_NewCDOAppType', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220830055608_NewCDOAppType') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220830055608_NewCDOAppType', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8679,7 +8682,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
     INSERT INTO gateway."CommunicationTypeCode" ("StatusCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Mobile', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Mobile communication type', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
     END IF;
@@ -8687,7 +8690,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
 
     CREATE OR REPLACE FUNCTION gateway."PushBannerChange"()
         RETURNS trigger
@@ -8730,7 +8733,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
 
     DROP TRIGGER IF EXISTS "PushBannerChange" ON gateway."Communication";
     CREATE TRIGGER "PushBannerChange"
@@ -8743,9 +8746,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20220903162916_AddMobileComms', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20220903162916_AddMobileComms') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20220903162916_AddMobileComms', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8755,21 +8758,21 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
     ALTER TABLE gateway."UserProfileHistory" ADD "YearOfBirth" character varying(4) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
     ALTER TABLE gateway."UserProfile" ADD "YearOfBirth" character varying(4) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
 
     CREATE or REPLACE FUNCTION gateway."UserProfileHistoryFunction"()
         RETURNS trigger
@@ -8800,9 +8803,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20221005233413_AddYearOfBirthToUserProfile', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221005233413_AddYearOfBirthToUserProfile') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20221005233413_AddYearOfBirthToUserProfile', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8812,7 +8815,7 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221019215540_HospitalVisitCommentEntry') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221019215540_HospitalVisitCommentEntry') THEN
     INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Hos', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Comment for Hospital Visits Entry', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     END IF;
@@ -8820,9 +8823,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221019215540_HospitalVisitCommentEntry') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20221019215540_HospitalVisitCommentEntry', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221019215540_HospitalVisitCommentEntry') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20221019215540_HospitalVisitCommentEntry', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8832,23 +8835,23 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221208194329_AddUserProfileToUserFeedback') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221208194329_AddUserProfileToUserFeedback') THEN
     CREATE INDEX "IX_UserFeedback_UserProfileId" ON gateway."UserFeedback" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221208194329_AddUserProfileToUserFeedback') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221208194329_AddUserProfileToUserFeedback') THEN
     ALTER TABLE gateway."UserFeedback" ADD CONSTRAINT "FK_UserFeedback_UserProfile_UserProfileId" FOREIGN KEY ("UserProfileId") REFERENCES gateway."UserProfile" ("UserProfileId");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221208194329_AddUserProfileToUserFeedback') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20221208194329_AddUserProfileToUserFeedback', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221208194329_AddUserProfileToUserFeedback') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20221208194329_AddUserProfileToUserFeedback', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8858,21 +8861,21 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     ALTER TABLE gateway."UserProfileHistory" ADD "LastLoginClientCode" character varying(10) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     ALTER TABLE gateway."UserProfile" ADD "LastLoginClientCode" character varying(10) NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     CREATE TABLE gateway."UserLoginClientTypeCode" (
         "UserLoginClientCode" character varying(10) NOT NULL,
         "Description" character varying(50) NOT NULL,
@@ -8887,7 +8890,7 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     INSERT INTO gateway."UserLoginClientTypeCode" ("UserLoginClientCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
     VALUES ('Mobile', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z', 'Code for a login from the hg mobile app', 'System', TIMESTAMPTZ '2019-05-01 00:00:00Z');
     INSERT INTO gateway."UserLoginClientTypeCode" ("UserLoginClientCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
@@ -8897,35 +8900,35 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     CREATE INDEX "IX_UserProfileHistory_LastLoginClientCode" ON gateway."UserProfileHistory" ("LastLoginClientCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     CREATE INDEX "IX_UserProfile_LastLoginClientCode" ON gateway."UserProfile" ("LastLoginClientCode");
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     ALTER TABLE gateway."UserProfile" ADD CONSTRAINT "FK_UserProfile_UserLoginClientTypeCode_LastLoginClientCode" FOREIGN KEY ("LastLoginClientCode") REFERENCES gateway."UserLoginClientTypeCode" ("UserLoginClientCode") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
     ALTER TABLE gateway."UserProfileHistory" ADD CONSTRAINT "FK_UserProfileHistory_UserLoginClientTypeCode_LastLoginClientC~" FOREIGN KEY ("LastLoginClientCode") REFERENCES gateway."UserLoginClientTypeCode" ("UserLoginClientCode") ON DELETE RESTRICT;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
 
                 CREATE or REPLACE FUNCTION gateway."UserProfileHistoryFunction"()
                     RETURNS trigger
@@ -8956,9 +8959,9 @@ END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20221209222859_AddLastLoginClientCodeToUserProfile', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20221209222859_AddLastLoginClientCodeToUserProfile') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20221209222859_AddLastLoginClientCodeToUserProfile', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;
@@ -8968,23 +8971,556 @@ START TRANSACTION;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20230104233040_OnDeleteSetNullUserFeedbackUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230104233040_OnDeleteSetNullUserFeedbackUserProfile') THEN
     ALTER TABLE gateway."UserFeedback" DROP CONSTRAINT "FK_UserFeedback_UserProfile_UserProfileId";
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20230104233040_OnDeleteSetNullUserFeedbackUserProfile') THEN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230104233040_OnDeleteSetNullUserFeedbackUserProfile') THEN
     ALTER TABLE gateway."UserFeedback" ADD CONSTRAINT "FK_UserFeedback_UserProfile_UserProfileId" FOREIGN KEY ("UserProfileId") REFERENCES gateway."UserProfile" ("UserProfileId") ON DELETE SET NULL;
     END IF;
 END $EF$;
 
 DO $EF$
 BEGIN
-    IF NOT EXISTS(SELECT 1 FROM "__EFMigrationsHistory" WHERE "MigrationId" = '20230104233040_OnDeleteSetNullUserFeedbackUserProfile') THEN
-    INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-    VALUES ('20230104233040_OnDeleteSetNullUserFeedbackUserProfile', '7.0.2');
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230104233040_OnDeleteSetNullUserFeedbackUserProfile') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230104233040_OnDeleteSetNullUserFeedbackUserProfile', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230313212610_ResolveMigrationIssueForCommentEntryType') THEN
+    UPDATE gateway."CommentEntryTypeCode" SET "Description" = 'Comment for a Clinical Document Entry'
+    WHERE "CommentEntryCode" = 'CDO';
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230313212610_ResolveMigrationIssueForCommentEntryType') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230313212610_ResolveMigrationIssueForCommentEntryType', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230314220815_CreateDependentDelegationTables') THEN
+    CREATE TABLE gateway."Dependent" (
+        "HdId" character varying(52) NOT NULL,
+        "Protected" boolean NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_Dependent" PRIMARY KEY ("HdId")
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230314220815_CreateDependentDelegationTables') THEN
+    CREATE TABLE gateway."AllowedDelegation" (
+        "DependentHdId" character varying(52) NOT NULL,
+        "DelegateHdId" character varying(52) NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_AllowedDelegation" PRIMARY KEY ("DependentHdId", "DelegateHdId"),
+        CONSTRAINT "FK_AllowedDelegation_Dependent_DependentHdId" FOREIGN KEY ("DependentHdId") REFERENCES gateway."Dependent" ("HdId") ON DELETE CASCADE
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230314220815_CreateDependentDelegationTables') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230314220815_CreateDependentDelegationTables', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230323175128_AddExpiryDateToResourceDelegate') THEN
+    ALTER TABLE gateway."ResourceDelegate" ADD "ExpiryDate" date NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230323175128_AddExpiryDateToResourceDelegate') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230323175128_AddExpiryDateToResourceDelegate', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230412022509_CreateDependentAuditTables') THEN
+    CREATE TABLE gateway."DependentAuditOperationCode" (
+        "Code" character varying(10) NOT NULL,
+        "Description" character varying(50) NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_DependentAuditOperationCode" PRIMARY KEY ("Code")
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230412022509_CreateDependentAuditTables') THEN
+    CREATE TABLE gateway."DependentAudit" (
+        "DependentAuditId" uuid NOT NULL,
+        "HdId" character varying(52) NOT NULL,
+        "AgentUsername" character varying(255) NOT NULL,
+        "ProtectedReason" character varying(500) NOT NULL,
+        "OperationCode" character varying(10) NOT NULL,
+        "TransactionDateTime" timestamp with time zone NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_DependentAudit" PRIMARY KEY ("DependentAuditId"),
+        CONSTRAINT "FK_DependentAudit_DependentAuditOperationCode_OperationCode" FOREIGN KEY ("OperationCode") REFERENCES gateway."DependentAuditOperationCode" ("Code") ON DELETE RESTRICT
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230412022509_CreateDependentAuditTables') THEN
+    INSERT INTO gateway."DependentAuditOperationCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('Protect', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Protect Dependent Operation Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    INSERT INTO gateway."DependentAuditOperationCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('Unprotect', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Unprotect Dependent Operation Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230412022509_CreateDependentAuditTables') THEN
+    CREATE INDEX "IX_DependentAudit_OperationCode" ON gateway."DependentAudit" ("OperationCode");
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230412022509_CreateDependentAuditTables') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230412022509_CreateDependentAuditTables', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230421214103_TourChangeInitial') THEN
+    INSERT INTO gateway."ApplicationSetting" ("ApplicationSettingsId", "Application", "Component", "CreatedBy", "CreatedDateTime", "Key", "UpdatedBy", "UpdatedDateTime", "Value")
+    VALUES ('bfcb45f6-27f9-4c0c-b494-80b147bcba8e', 'WEB', 'Tour', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'latestChangeDateTime', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', '2023-05-03T22:00:00.0000000Z');
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230421214103_TourChangeInitial') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230421214103_TourChangeInitial', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."MessagingVerification" DROP CONSTRAINT "FK_MessagingVerification_Email_EmailId";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."MessagingVerification" ADD "EmailAddress" character varying(254) NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."Email" ALTER COLUMN "Subject" DROP NOT NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."Email" ALTER COLUMN "Body" DROP NOT NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."Email" ADD "NotificationId" uuid NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."Email" ADD "Personalization" jsonb NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."Email" ADD "Template" character varying(60) NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    ALTER TABLE gateway."MessagingVerification" ADD CONSTRAINT "FK_MessagingVerification_Email_EmailId" FOREIGN KEY ("EmailId") REFERENCES gateway."Email" ("EmailId") ON DELETE SET NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230428053159_ReworkMessageVerfications') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230428053159_ReworkMessageVerfications', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230501202904_RemoveRequiredInviteKey') THEN
+    ALTER TABLE gateway."MessagingVerification" ALTER COLUMN "InviteKey" DROP NOT NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230501202904_RemoveRequiredInviteKey') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230501202904_RemoveRequiredInviteKey', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230504184240_CreateMessagingOutbox') THEN
+    CREATE TABLE gateway."Outbox" (
+        "Id" uuid NOT NULL,
+        "CreatedOn" timestamp with time zone NOT NULL,
+        "Content" jsonb NOT NULL,
+        "Metadata" jsonb NOT NULL,
+        "Status" integer NOT NULL,
+        CONSTRAINT "PK_Outbox" PRIMARY KEY ("Id")
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230504184240_CreateMessagingOutbox') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230504184240_CreateMessagingOutbox', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+
+                    CREATE TEMP TABLE TempDependentAudit AS
+                    SELECT "DependentAuditId", "HdId", "AgentUsername", "ProtectedReason", "OperationCode"||'Dependent' AS "OperationCode",
+                        'Dependent' AS "GroupCode", "TransactionDateTime", "CreatedBy", "CreatedDateTime", "UpdatedBy", "UpdatedDateTime"
+                    FROM gateway."DependentAudit";
+                    
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    DROP TABLE gateway."DependentAudit";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    DROP TABLE gateway."DependentAuditOperationCode";
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    CREATE TABLE gateway."AuditGroupCode" (
+        "Code" character varying(50) NOT NULL,
+        "Description" character varying(50) NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_AuditGroupCode" PRIMARY KEY ("Code")
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    CREATE TABLE gateway."AuditOperationCode" (
+        "Code" character varying(50) NOT NULL,
+        "Description" character varying(50) NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_AuditOperationCode" PRIMARY KEY ("Code")
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    CREATE TABLE gateway."BlockedAccess" (
+        "Hdid" character varying(52) NOT NULL,
+        "DataSources" jsonb NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_BlockedAccess" PRIMARY KEY ("Hdid")
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    CREATE TABLE gateway."AgentAudit" (
+        "AgentAuditId" uuid NOT NULL,
+        "Hdid" character varying(52) NOT NULL,
+        "AgentUsername" character varying(255) NOT NULL,
+        "Reason" character varying(500) NOT NULL,
+        "OperationCode" character varying(50) NOT NULL,
+        "GroupCode" character varying(50) NOT NULL,
+        "TransactionDateTime" timestamp with time zone NOT NULL,
+        "CreatedBy" character varying(60) NOT NULL,
+        "CreatedDateTime" timestamp with time zone NOT NULL,
+        "UpdatedBy" character varying(60) NOT NULL,
+        "UpdatedDateTime" timestamp with time zone NOT NULL,
+        CONSTRAINT "PK_AgentAudit" PRIMARY KEY ("AgentAuditId"),
+        CONSTRAINT "FK_AgentAudit_AuditGroupCode_GroupCode" FOREIGN KEY ("GroupCode") REFERENCES gateway."AuditGroupCode" ("Code") ON DELETE RESTRICT,
+        CONSTRAINT "FK_AgentAudit_AuditOperationCode_OperationCode" FOREIGN KEY ("OperationCode") REFERENCES gateway."AuditOperationCode" ("Code") ON DELETE RESTRICT
+    );
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    INSERT INTO gateway."AuditGroupCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('BlockedAccess', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Audit Blocked Access Group Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    INSERT INTO gateway."AuditGroupCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('Dependent', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Audit Dependent Group Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    INSERT INTO gateway."AuditOperationCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('ChangeDataSourceAccess', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Change Data Source Access Operation Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    INSERT INTO gateway."AuditOperationCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('ProtectDependent', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Protect Dependent Operation Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    INSERT INTO gateway."AuditOperationCode" ("Code", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('UnprotectDependent', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Unprotect Dependent Operation Code', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    CREATE INDEX "IX_AgentAudit_GroupCode" ON gateway."AgentAudit" ("GroupCode");
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    CREATE INDEX "IX_AgentAudit_OperationCode" ON gateway."AgentAudit" ("OperationCode");
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+
+                    INSERT INTO gateway."AgentAudit" ("AgentAuditId", "Hdid", "AgentUsername", "Reason",
+                                                        "OperationCode", "GroupCode", "TransactionDateTime",
+                                                        "CreatedBy", "CreatedDateTime", "UpdatedBy", "UpdatedDateTime")
+                    SELECT * FROM TempDependentAudit;
+                    
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    DROP TABLE TempDependentAudit;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230508204917_CreateBlockedAccessTable') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230508204917_CreateBlockedAccessTable', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230524201808_AddColumnsPharmaCareDrug') THEN
+    ALTER TABLE gateway."PharmaCareDrug" ADD "PharmacyAssessmentTitle" character varying(250) NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230524201808_AddColumnsPharmaCareDrug') THEN
+    ALTER TABLE gateway."PharmaCareDrug" ADD "PrescriptionProvided" boolean NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230524201808_AddColumnsPharmaCareDrug') THEN
+    ALTER TABLE gateway."PharmaCareDrug" ADD "RedirectedToHealthCareProvider" boolean NULL;
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230524201808_AddColumnsPharmaCareDrug') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230524201808_AddColumnsPharmaCareDrug', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230526034844_AddNewProgramTypeCode') THEN
+    INSERT INTO gateway."ProgramTypeCode" ("ProgramCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('PHAR-ASSMT', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Pharmacy Assessment', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230526034844_AddNewProgramTypeCode') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230526034844_AddNewProgramTypeCode', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230530175319_UpdateExpiryDateToRequired') THEN
+    UPDATE gateway."ResourceDelegate" SET "ExpiryDate" = DATE '-infinity' WHERE "ExpiryDate" IS NULL;
+    ALTER TABLE gateway."ResourceDelegate" ALTER COLUMN "ExpiryDate" SET NOT NULL;
+    ALTER TABLE gateway."ResourceDelegate" ALTER COLUMN "ExpiryDate" SET DEFAULT DATE '-infinity';
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230530175319_UpdateExpiryDateToRequired') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230530175319_UpdateExpiryDateToRequired', '7.0.10');
+    END IF;
+END $EF$;
+COMMIT;
+
+START TRANSACTION;
+
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230811223424_AddDiagnosticImagingCommentEntryTypeCode') THEN
+    INSERT INTO gateway."CommentEntryTypeCode" ("CommentEntryCode", "CreatedBy", "CreatedDateTime", "Description", "UpdatedBy", "UpdatedDateTime")
+    VALUES ('DIA', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z', 'Comment for a Diagnostic Imaging Entry', 'System', TIMESTAMPTZ '2019-05-01 07:00:00Z');
+    END IF;
+END $EF$;
+
+DO $EF$
+BEGIN
+    IF NOT EXISTS(SELECT 1 FROM gateway."__EFMigrationsHistory" WHERE "MigrationId" = '20230811223424_AddDiagnosticImagingCommentEntryTypeCode') THEN
+    INSERT INTO gateway."__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+    VALUES ('20230811223424_AddDiagnosticImagingCommentEntryTypeCode', '7.0.10');
     END IF;
 END $EF$;
 COMMIT;

--- a/Tools/Dev/Postgres/init/01_init-to-AddDiagnosticImagingCommentEntryTypeCode.sql
+++ b/Tools/Dev/Postgres/init/01_init-to-AddDiagnosticImagingCommentEntryTypeCode.sql
@@ -1,4 +1,7 @@
-﻿DO $EF$
+﻿\c hglocal
+SET ROLE hglocal;
+
+DO $EF$
 BEGIN
     IF NOT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname = 'gateway') THEN
         CREATE SCHEMA gateway;


### PR DESCRIPTION
# Fixes or Implements [AB#16017](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16017)

## Description
Code updates to move the migration history into the Gateway schema
Created a script to be run manually to migrate the data
Fixes the CreatedBlockedAccessTable migration to resolve a problem where it would work when executed by the db context but not in a larger stand-alone script block created by ` dotnet ef migrations script --output output.sql --idempotent`
Updated the dev init script to have the latest migrations


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

N/A

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
