### PR TITLE
Log out of site if access token expires AB#16014

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/authentication/LogoutView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/authentication/LogoutView.vue
@@ -3,18 +3,11 @@ import { onMounted } from "vue";
 
 import LoadingComponent from "@/components/common/LoadingComponent.vue";
 import { useAuthStore } from "@/stores/auth";
-import { useWaitlistStore } from "@/stores/waitlist";
 
 const authStore = useAuthStore();
-const waitlistStore = useWaitlistStore();
-
-function signOut(): void {
-    authStore.signOut();
-    waitlistStore.releaseTicket();
-}
 
 onMounted(() => {
-    signOut();
+    authStore.signOut();
 });
 </script>
 

--- a/Apps/WebClient/src/NewClientApp/src/stores/auth.ts
+++ b/Apps/WebClient/src/NewClientApp/src/stores/auth.ts
@@ -10,6 +10,7 @@ import {
     ILogger,
 } from "@/services/interfaces";
 import { useUserStore } from "@/stores/user";
+import { useWaitlistStore } from "@/stores/waitlist";
 
 export const useAuthStore = defineStore("auth", () => {
     const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
@@ -20,6 +21,7 @@ export const useAuthStore = defineStore("auth", () => {
         DELEGATE_IDENTIFIER.HttpDelegate
     );
     const userStore = useUserStore();
+    const waitlistStore = useWaitlistStore();
 
     const tokenDetails = ref<OidcTokenDetails>();
     const error = ref<unknown>();
@@ -93,6 +95,7 @@ export const useAuthStore = defineStore("auth", () => {
         authService.signOut().then(() => {
             logger.verbose("Successfully signed out");
         });
+        waitlistStore.releaseTicket();
     }
 
     function clearStorage() {
@@ -139,7 +142,7 @@ export const useAuthStore = defineStore("auth", () => {
             }
         } catch (err) {
             logger.warn("Access token expired unexpectedly");
-            clearStorage();
+            signOut();
         }
     }
 


### PR DESCRIPTION
# Fixes [AB#16014](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16014)

## Description

Logs the user out and takes them to the landing page instead of just clearing authenticated data when access token unexpectedly expires.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
