### PR TITLE
Update input variant to "solo" AB#15990

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/private/dependent/DependentCardComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/dependent/DependentCardComponent.vue
@@ -105,7 +105,7 @@ function removeDependent(): void {
             </v-card-title>
             <v-card-text class="pa-4">
                 <v-window v-model="selectedTabIndex">
-                    <v-window-item data-testid="dashboard-tab">
+                    <v-window-item data-testid="dashboard-tab" class="pa-1">
                         <div
                             v-if="isExpired"
                             class="text-center"
@@ -146,13 +146,13 @@ function removeDependent(): void {
                             :dependent="dependent"
                         />
                     </v-window-item>
-                    <v-window-item data-testid="report-tab">
+                    <v-window-item data-testid="report-tab" class="pa-1">
                         <ReportsComponent
                             :hdid="dependent.dependentInformation.hdid"
                             :is-dependent="true"
                         />
                     </v-window-item>
-                    <v-window-item data-testid="profile-tab">
+                    <v-window-item data-testid="profile-tab" class="pa-1">
                         <DependentProfileTabComponent :dependent="dependent" />
                     </v-window-item>
                 </v-window>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/dependent/legacy/LegacyDependentCardComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/dependent/legacy/LegacyDependentCardComponent.vue
@@ -963,7 +963,7 @@ watch(vaccineRecordState, () => {
             </v-card-title>
             <v-card-text class="pa-4">
                 <v-window v-model="selectedTabIndex">
-                    <v-window-item data-testid="dependentTab">
+                    <v-window-item data-testid="dependentTab" class="pa-1">
                         <div v-if="isExpired">
                             <v-row>
                                 <v-col class="d-flex justify-content-center">
@@ -1025,7 +1025,7 @@ watch(vaccineRecordState, () => {
                             </v-row>
                         </div>
                     </v-window-item>
-                    <v-window-item data-testid="covid19Tab">
+                    <v-window-item data-testid="covid19Tab" class="pa-1">
                         <div class="d-flex justify-center">
                             <HgButtonComponent
                                 :id="`download-proof-of-vaccination-btn-id-${dependent.ownerId}`"
@@ -1196,6 +1196,7 @@ watch(vaccineRecordState, () => {
                     </v-window-item>
                     <v-window-item
                         :data-testid="`immunization-tab-${dependent.ownerId}`"
+                        class="pa-1"
                     >
                         <v-alert
                             v-if="immunizationItems.length != 0"
@@ -1239,7 +1240,7 @@ watch(vaccineRecordState, () => {
                                 v-model="immunizationTabIndex"
                                 class="pa-4"
                             >
-                                <v-window-item>
+                                <v-window-item class="pa-1">
                                     <p
                                         v-if="immunizationItems.length === 0"
                                         class="text-body-1"
@@ -1395,7 +1396,7 @@ watch(vaccineRecordState, () => {
                                         </v-table>
                                     </div>
                                 </v-window-item>
-                                <v-window-item>
+                                <v-window-item class="pa-1">
                                     <v-row justify="end" no-gutters>
                                         <v-col cols="12" :md="true">
                                             <p class="mb-md-0 text-body-1">
@@ -1528,6 +1529,7 @@ watch(vaccineRecordState, () => {
                     </v-window-item>
                     <v-window-item
                         :data-testid="`lab-results-tab-${dependent.ownerId}`"
+                        class="pa-1"
                     >
                         <v-progress-circular
                             v-if="isLoading"
@@ -1615,6 +1617,7 @@ watch(vaccineRecordState, () => {
                     </v-window-item>
                     <v-window-item
                         :data-testid="`clinical-document-tab-${dependent.ownerId}`"
+                        class="pa-1"
                     >
                         <v-progress-circular
                             v-if="isLoading"

--- a/Apps/WebClient/src/NewClientApp/src/components/private/dependent/tabs/DependentDashboardTabComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/dependent/tabs/DependentDashboardTabComponent.vue
@@ -106,7 +106,7 @@ watch(vaccineRecordState, () => {
         <v-col :cols="getGridCols" class="d-flex">
             <HgCardComponent
                 title="Health Records"
-                class="flex-grow-1 ma-1"
+                class="flex-grow-1"
                 :data-testid="`dependent-health-records-button-${dependent.ownerId}`"
                 @click="handleClickHealthRecordsButton"
             >

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -141,7 +141,7 @@ watch(email, (value) => (inputValue.value = value));
             label="Email Address"
             :placeholder="isEmailEditable ? 'Your email address' : 'Empty'"
             persistent-placeholder
-            :disabled="!isEmailEditable"
+            :readonly="!isEmailEditable"
             :error-messages="inputErrorMessages"
             @blur="v$.inputValue.$touch()"
         />

--- a/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileSmsComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/profile/UserProfileSmsComponent.vue
@@ -186,7 +186,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
             label="Cell Number"
             :placeholder="isSmsEditable ? 'Your phone number' : 'Empty'"
             persistent-placeholder
-            :disabled="!isSmsEditable"
+            :readonly="!isSmsEditable"
             :error-messages="inputErrorMessages"
         >
             <template #append-inner>

--- a/Apps/WebClient/src/NewClientApp/src/components/private/timeline/comment/AddCommentComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/private/timeline/comment/AddCommentComponent.vue
@@ -79,11 +79,11 @@ function addComment(): void {
         maxlength="1000"
         auto-grow
         rows="1"
-        variant="outlined"
         :loading="isSaving"
         placeholder="Write a comment"
         style="overflow-y: auto"
         hide-details
+        class="pa-1"
     >
         <template #prepend>
             <v-tooltip

--- a/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
+++ b/Apps/WebClient/src/NewClientApp/src/plugins/vuetify.ts
@@ -18,6 +18,15 @@ export default createVuetify({
         VIcon: {
             style: "width: auto",
         },
+        VSelect: {
+            variant: "solo",
+        },
+        VTextarea: {
+            variant: "solo",
+        },
+        VTextField: {
+            variant: "solo",
+        },
         VTooltip: {
             location: "bottom",
             contentClass: "bg-grey-darken-3",


### PR DESCRIPTION
# Fixes [AB#15990](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15990)

## Description

- changes the default variant to "solo" for text-input, textarea, and select components
- adds margins where needed to prevent input shadows from being cut off
- changes Email and SMS fields on profile page to readonly instead of disabled when not in edit mode

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/18f3371d-fc85-4e4c-87c3-b12dd60875f5)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
