### PR TITLE
Fix broken tests and landing page bug - AB#16023

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/public/landing/LandingView.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/public/landing/LandingView.vue
@@ -108,7 +108,7 @@ function selectPreviewDevice(previewDevice: PreviewDevice): void {
             {{ offlineMessage }}
         </p>
     </div>
-    <v-container>
+    <v-container v-else>
         <v-row justify="start" align="start">
             <v-col lg="5">
                 <h1 class="mb-6 text-primary text-h4 font-weight-bold">

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/dependent.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/dependent.js
@@ -124,7 +124,7 @@ function disabledDependentDatasetShouldNotBePresent(
     assertDatasetPresence(dataset, false);
 }
 
-describe.skip("Dependent Timeline", () => {
+describe("Dependent Timeline", () => {
     beforeEach(() => {
         cy.configureSettings({
             timeline: {

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -22,41 +22,41 @@ function deleteDependent(cardSelector, confirmDelete) {
     }
 }
 
+const validDependent = {
+    firstName: "Sam ", // Aooend space to ensure field is trimmed
+    lastName: "Testfive ", // Aooend space to ensure field is trimmed
+    wrongLastName: "Testfive2",
+    invalidDoB: "2007-Aug-05",
+    doB: "2014-Mar-15",
+    phn: "9874307168",
+    hdid: "645645767756756767",
+};
+
+const protectedDependentWithAllowedDelegation = {
+    firstName: "Leroy Desmond",
+    lastName: "Tobias",
+    doB: "2015-Dec-02",
+    phn: "9872868128",
+    hdid: "35224807075386200",
+};
+
+const protectedDependentWithoutAllowedDelegation = {
+    firstName: "Lenny Francesco",
+    lastName: "Dansereau",
+    doB: "2019-May-14",
+    phn: "9872868103",
+};
+
+const noHdidDependent = {
+    firstName: "Baby Girl",
+    lastName: "Reid",
+    doB: "2018-Feb-04",
+    phn: "9879187222",
+};
+
+const validDependentHdid = "162346565465464564565463257";
+
 describe("dependents", () => {
-    const validDependent = {
-        firstName: "Sam ", // Aooend space to ensure field is trimmed
-        lastName: "Testfive ", // Aooend space to ensure field is trimmed
-        wrongLastName: "Testfive2",
-        invalidDoB: "2007-Aug-05",
-        doB: "2014-Mar-15",
-        phn: "9874307168",
-        hdid: "645645767756756767",
-    };
-
-    const protectedDependentWithAllowedDelegation = {
-        firstName: "Leroy Desmond",
-        lastName: "Tobias",
-        doB: "2015-Dec-02",
-        phn: "9872868128",
-        hdid: "35224807075386200",
-    };
-
-    const protectedDependentWithoutAllowedDelegation = {
-        firstName: "Lenny Francesco",
-        lastName: "Dansereau",
-        doB: "2019-May-14",
-        phn: "9872868103",
-    };
-
-    const noHdidDependent = {
-        firstName: "Baby Girl",
-        lastName: "Reid",
-        doB: "2018-Feb-04",
-        phn: "9879187222",
-    };
-
-    const validDependentHdid = "162346565465464564565463257";
-
     beforeEach(() => {
         cy.configureSettings({
             dependents: {
@@ -531,6 +531,40 @@ describe("dependents", () => {
             timeout: 60000,
             interval: 5000,
         });
+    });
+});
+
+describe("CRUD Operations", () => {
+    beforeEach(() => {
+        cy.configureSettings({
+            dependents: {
+                enabled: true,
+            },
+            datasets: [
+                {
+                    name: "immunization",
+                    enabled: true,
+                },
+                {
+                    name: "covid19TestResult",
+                    enabled: true,
+                },
+                {
+                    name: "clinicalDocument",
+                    enabled: true,
+                },
+                {
+                    name: "labResult",
+                    enabled: true,
+                },
+            ],
+        });
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/dependents"
+        );
     });
 
     it("Validate Adding, Viewing, and Removing Dependents", () => {

--- a/Testing/functional/tests/cypress/integration/ui/pages/LandingPage.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/LandingPage.js
@@ -23,13 +23,16 @@ describe("Landing Page", () => {
         cy.visit("/");
         cy.log("Laptop preview should be displayed by default");
         cy.get("[data-testid=preview-device-button-laptop]").should(
-            "be.disabled"
+            "have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-tablet]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-smartphone]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-image-laptop]")
             .scrollIntoView()
@@ -44,13 +47,16 @@ describe("Landing Page", () => {
         );
         cy.get("[data-testid=preview-device-button-tablet]").click();
         cy.get("[data-testid=preview-device-button-laptop]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-tablet]").should(
-            "be.disabled"
+            "have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-smartphone]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-image-laptop]").should("not.be.visible");
         cy.get("[data-testid=preview-image-tablet]").should("be.visible");
@@ -63,13 +69,16 @@ describe("Landing Page", () => {
         );
         cy.get("[data-testid=preview-device-button-smartphone]").click();
         cy.get("[data-testid=preview-device-button-laptop]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-tablet]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-smartphone]").should(
-            "be.disabled"
+            "have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-image-laptop]").should("not.be.visible");
         cy.get("[data-testid=preview-image-tablet]").should("not.be.visible");
@@ -80,13 +89,16 @@ describe("Landing Page", () => {
         );
         cy.get("[data-testid=preview-device-button-laptop]").click();
         cy.get("[data-testid=preview-device-button-laptop]").should(
-            "be.disabled"
+            "have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-tablet]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-device-button-smartphone]").should(
-            "not.be.disabled"
+            "not.have.class",
+            "bg-grey-lighten-3"
         );
         cy.get("[data-testid=preview-image-laptop]").should("be.visible");
         cy.get("[data-testid=preview-image-tablet]").should("not.be.visible");

--- a/Testing/functional/tests/cypress/integration/ui/pages/vaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/vaccineCard.js
@@ -2,21 +2,21 @@ const homeUrl = "/";
 const vaccineCardUrl = "/vaccinecard";
 
 describe("Vaccine Card Page", () => {
-    it.skip("Landing Page - Vaccine Card Button does not exist - Vaccine Status module disabled", () => {
+    it("Landing Page - Vaccine Card Button does not exist - Vaccine Status module disabled", () => {
         cy.configureSettings({});
         cy.logout();
         cy.visit(homeUrl);
         cy.get("[data-testid=btnVaccineCard]").should("not.exist");
     });
 
-    it.skip("Landing Page - Log In - Vaccine Status module disabled and vaccine card URL entered directly", () => {
+    it("Landing Page - Log In - Vaccine Status module disabled and vaccine card URL entered directly", () => {
         cy.configureSettings({});
         cy.logout();
         cy.visit(vaccineCardUrl);
         cy.get("[data-testid=vaccineCardFormTitle]").should("not.exist");
     });
 
-    it.skip("Landing Page - Vaccine Card Button Exists - Vaccine Status module enabled", () => {
+    it("Landing Page - Vaccine Card Button Exists - Vaccine Status module enabled", () => {
         cy.logout();
         cy.visit(homeUrl);
     });

--- a/Testing/functional/tests/cypress/integration/ui/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/dependents.js
@@ -77,8 +77,7 @@ describe("COVID-19", () => {
             .contains("td", "2020-Oct-06")
             .siblings("[data-testid=dependentCovidTestLabResult]")
             .contains("Negative")
-            .next()
-            .find("[data-testid=dependent-covid-test-info-button]")
+            .siblings("[data-testid=dependent-covid-test-info-button]")
             .click();
         cy.get("[data-testid=dependent-covid-test-info-popover]").should(
             "be.visible"

--- a/Testing/functional/tests/cypress/integration/ui/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/profile.js
@@ -82,9 +82,14 @@ describe("User Profile", () => {
             .contains("New email must be different from the previous one")
             .should("be.visible");
         cy.get("[data-testid=editEmailCancelBtn]").click();
-        cy.get("[data-testid=email-input] input")
-            .should("be.disabled")
-            .should("have.value", Cypress.env("emailAddress"));
+        cy.get("[data-testid=email-input] input").should(
+            "have.attr",
+            "readonly"
+        );
+        cy.get("[data-testid=email-input] input").should(
+            "have.value",
+            Cypress.env("emailAddress")
+        );
 
         cy.log("Clear/OptOut email address");
         cy.get("[data-testid=editEmailBtn]").click();


### PR DESCRIPTION
# Fixes or Implements [AB#16023](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16023)

## Description
1. Reintroduce the v-else of the v-container.
2. Remove disabled checks on preview toggle buttons.
3. Check for readonly on profile inputs.
4. Removed skip, that was accidentally left in during the conversions.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

<img width="603" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/5e78dc9e-266e-4803-a628-0ce56a72b0e0">

<img width="618" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/0902778f-797c-49b2-80f6-61574f5cb9b7">

<img width="622" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/a3c71008-85ab-4fca-a09a-918217c4c436">

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
