### PR TITLE
Remove sidebar covid19 link - AB#15895

### DIFF
--- a/Apps/WebClient/src/NewClientApp/src/components/site/SidebarComponent.vue
+++ b/Apps/WebClient/src/NewClientApp/src/components/site/SidebarComponent.vue
@@ -104,17 +104,6 @@ watch(isSidebarOpen, (value: boolean) => {
                 </template>
             </v-list-item>
             <v-list-item
-                title="COVID-19"
-                to="/covid19"
-                data-testid="menu-btn-covid19-link"
-            >
-                <template #prepend>
-                    <div class="nav-list-item-icon mr-8 d-flex justify-center">
-                        <v-icon icon="fas fa-circle-check" />
-                    </div>
-                </template>
-            </v-list-item>
-            <v-list-item
                 v-show="isDependentEnabled && userStore.userIsActive"
                 title="Dependents"
                 to="/dependents"


### PR DESCRIPTION
# Implements [AB#15895](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15895)

## Description
1. Remove sidebar link for /covid19 route.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required
Could find no tests that required a click on the sidebar link. 

## UI Changes
<img width="679" alt="image" src="https://github.com/bcgov/healthgateway/assets/19548348/9a29d7a8-6c85-46c2-8edc-ec4485c2e8df">

## Notes


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
