### PR TITLE
Add unit tests for getting cancer screening exams for AB#15999.

### DIFF
--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.PatientTests.Services
 {
     using System;
+    using System.Globalization;
     using System.Linq;
     using System.Security.Cryptography;
     using System.Text.Json;
@@ -33,6 +34,7 @@ namespace HealthGateway.PatientTests.Services
     using Moq;
     using Shouldly;
     using Xunit;
+    using CancerScreeningExam = HealthGateway.PatientDataAccess.CancerScreeningExam;
     using DiagnosticImagingExam = HealthGateway.Patient.Services.DiagnosticImagingExam;
     using DiagnosticImagingStatus = HealthGateway.Patient.Models.DiagnosticImagingStatus;
     using OrganDonorRegistration = HealthGateway.Patient.Services.OrganDonorRegistration;
@@ -151,6 +153,75 @@ namespace HealthGateway.PatientTests.Services
                 actual.Status.ShouldBe(OrganDonorRegistrationStatus.Registered);
                 actual.StatusMessage.ShouldBe(expected.StatusMessage);
                 actual.RegistrationFileId.ShouldBe(expected.RegistrationFileId);
+            }
+            else
+            {
+                result.Items.ShouldBeEmpty();
+            }
+        }
+
+        [Fact]
+        public async Task CannotGetCancerScreeningData()
+        {
+            CancerScreeningExam expected = new()
+            {
+                EventType = CancerScreeningType.Recall,
+            };
+
+            Mock<IPatientDataRepository> patientDataRepository = new();
+            patientDataRepository.AttachMockQuery<HealthQuery>(
+                q => q.Pid == this.pid && q.Categories.Any(c => c == HealthCategory.BcCancerScreening),
+                expected);
+            Mock<IPersonalAccountsService> personalAccountService = this.GetMockPersonalAccountService();
+
+            Mock<IPatientRepository> patientRepository = new();
+            patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
+
+            PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.CancerScreening }), CancellationToken.None)
+                .ConfigureAwait(true);
+
+            result.Items.ShouldBeEmpty();
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanGetCancerScreeningData(bool canAccessDataSource)
+        {
+            CancerScreeningExam expected = new()
+            {
+                Id = "12345678931",
+                FileId = "12345678931",
+                ProgramName = "Cervical Cancer",
+                EventType = CancerScreeningType.Result,
+                EventTimestampUtc = Convert.ToDateTime("2022-10-18T08:49:37.3051315Z", CultureInfo.InvariantCulture),
+                ResultTimestamp = Convert.ToDateTime("2023-05-03T08:29:41.2820921+00:00", CultureInfo.InvariantCulture),
+            };
+
+            Mock<IPatientDataRepository> patientDataRepository = new();
+            patientDataRepository.AttachMockQuery<HealthQuery>(
+                q => q.Pid == this.pid && q.Categories.Any(c => c == HealthCategory.BcCancerScreening),
+                expected);
+            Mock<IPersonalAccountsService> personalAccountService = this.GetMockPersonalAccountService();
+
+            Mock<IPatientRepository> patientRepository = new();
+            patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(canAccessDataSource);
+
+            PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
+
+            PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.CancerScreening }), CancellationToken.None)
+                .ConfigureAwait(true);
+
+            if (canAccessDataSource)
+            {
+                Patient.Services.CancerScreeningExam actual = result.Items.ShouldHaveSingleItem().ShouldBeOfType<Patient.Services.CancerScreeningExam>();
+                actual.Id.ShouldBe(expected.Id);
+                actual.FileId.ShouldBe(expected.FileId);
+                actual.ProgramName.ShouldBe(expected.ProgramName);
+                actual.EventTimestampUtc.ShouldBe(expected.EventTimestampUtc);
+                actual.ResultTimestamp.ShouldBe(expected.ResultTimestamp);
             }
             else
             {

--- a/Apps/Patient/test/unit/Utils/MapperUtil.cs
+++ b/Apps/Patient/test/unit/Utils/MapperUtil.cs
@@ -34,6 +34,7 @@ namespace HealthGateway.PatientTests.Utils
                 cfg =>
                 {
                     cfg.AddProfile(new OrganDonorRegistrationProfile());
+                    cfg.AddProfile(new CancerScreeningProfile());
                     cfg.AddProfile(new DiagnosticImagingExamProfile());
                     cfg.AddProfile(new PatientDataAccessMappings());
                     cfg.AddProfile(new AccountDataAccessMappings());

--- a/Apps/PatientDataAccess/test/unit/HealthDataJsonConverterTests.cs
+++ b/Apps/PatientDataAccess/test/unit/HealthDataJsonConverterTests.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace PatientDataAccessTests
 {
+    using System.Text;
     using System.Text.Json;
     using HealthGateway.PatientDataAccess.Api;
 
@@ -33,10 +34,11 @@ namespace PatientDataAccessTests
         [InlineData("{\"healthDataType\":\"COVID19Laboratory\"}", typeof(LaboratoryOrder))]
         [InlineData("{\"healthDataType\":\"ClinicalDocument\"}", typeof(ClinicalDocument))]
         [InlineData("{\"healthDataType\":\"DiagnosticImaging\"}", typeof(DiagnosticImagingExam))]
+        [InlineData("{\"healthDataType\":\"BcCancerScreening\"}", typeof(CancerScreeningExam))]
         public void TestValidHealthDataJsonConversions(string json, Type expectedType)
         {
             // Create Utf8JsonReader from json string.
-            Utf8JsonReader reader = new(System.Text.Encoding.UTF8.GetBytes(json));
+            Utf8JsonReader reader = new(Encoding.UTF8.GetBytes(json));
             HealthDataEntry result = new HealthDataJsonConverter().Read(ref reader, expectedType, JsonSerializerOptions.Default);
             Assert.IsType(expectedType, result);
         }

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -15,12 +15,15 @@
 // -------------------------------------------------------------------------
 namespace PatientDataAccessTests
 {
+    using System.Globalization;
     using System.Net;
     using AutoMapper;
     using HealthGateway.PatientDataAccess;
     using HealthGateway.PatientDataAccess.Api;
     using Moq;
     using Refit;
+    using CancerScreeningExam = HealthGateway.PatientDataAccess.Api.CancerScreeningExam;
+    using CancerScreeningType = HealthGateway.PatientDataAccess.Api.CancerScreeningType;
     using DiagnosticImagingExam = HealthGateway.PatientDataAccess.Api.DiagnosticImagingExam;
     using DiagnosticImagingStatus = HealthGateway.PatientDataAccess.Api.DiagnosticImagingStatus;
     using OrganDonorRegistration = HealthGateway.PatientDataAccess.Api.OrganDonorRegistration;
@@ -61,6 +64,45 @@ namespace PatientDataAccessTests
         }
 
         [Fact]
+        public async Task CanGetCancerScreeningData()
+        {
+            Mock<IPatientApi> patientApi = new();
+
+            CancerScreeningExam cancerScreeningExam = new()
+            {
+                HealthDataId = "12345678931",
+                HealthDataFileId = "12345678931",
+                ProgramName = "Cervical Cancer",
+                EventType = CancerScreeningType.Result,
+                EventTimestampUtc = Convert.ToDateTime("2022-10-18T08:49:37.3051315Z", CultureInfo.InvariantCulture),
+                ResultTimestamp = Convert.ToDateTime("2023-05-03T08:29:41.2820921+00:00", CultureInfo.InvariantCulture),
+            };
+
+            patientApi
+                .Setup(api => api.GetHealthDataAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new HealthDataResult(
+                        new HealthDataMetadata(),
+                        new[]
+                        {
+                            cancerScreeningExam,
+                        }));
+
+            IPatientDataRepository sut = CreateSut(patientApi.Object);
+
+            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.BcCancerScreening }), CancellationToken.None).ConfigureAwait(true);
+
+            result.ShouldNotBeNull();
+            HealthGateway.PatientDataAccess.CancerScreeningExam exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.CancerScreeningExam>();
+            exam.Id.ShouldBe(cancerScreeningExam.HealthDataId);
+            exam.FileId.ShouldBe(cancerScreeningExam.HealthDataFileId);
+            exam.ProgramName.ShouldBe(cancerScreeningExam.ProgramName);
+            exam.EventType.ShouldBe(HealthGateway.PatientDataAccess.CancerScreeningType.Result);
+            exam.EventTimestampUtc.ShouldBe(cancerScreeningExam.EventTimestampUtc);
+            exam.ResultTimestamp.ShouldBe(cancerScreeningExam.ResultTimestamp);
+        }
+
+        [Fact]
         public async Task CanGetDiagnosticImagingData()
         {
             Mock<IPatientApi> patientApi = new();
@@ -78,7 +120,13 @@ namespace PatientDataAccessTests
 
             patientApi
                 .Setup(api => api.GetHealthDataAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new HealthDataResult(new HealthDataMetadata(), new[] { phsaDiagnosticImageExam }));
+                .ReturnsAsync(
+                    new HealthDataResult(
+                        new HealthDataMetadata(),
+                        new[]
+                        {
+                            phsaDiagnosticImageExam,
+                        }));
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
@@ -94,6 +142,38 @@ namespace PatientDataAccessTests
             exam.Modality.ShouldBe(phsaDiagnosticImageExam.Modality);
             exam.Organization.ShouldBe(phsaDiagnosticImageExam.Organization);
             exam.ProcedureDescription.ShouldBe(phsaDiagnosticImageExam.ProcedureDescription);
+        }
+
+        [Fact]
+        public async Task CanGetCancerScreeningAndDiagnosticImagingData()
+        {
+            Mock<IPatientApi> patientApi = new();
+
+            CancerScreeningExam cancerScreeningExam = new()
+            {
+                HealthDataId = "bccancerscreening_vpp_12345678931",
+            };
+
+            DiagnosticImagingExam phsaDiagnosticImageExam = new()
+            {
+                HealthDataId = "diexam_vpp_12345678935",
+            };
+
+            patientApi
+                .Setup(api => api.GetHealthDataAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new HealthDataResult(new HealthDataMetadata(), new HealthDataEntry[] { phsaDiagnosticImageExam, cancerScreeningExam }));
+
+            IPatientDataRepository sut = CreateSut(patientApi.Object);
+
+            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening }), CancellationToken.None)
+                .ConfigureAwait(true);
+
+            result.ShouldNotBeNull();
+            HealthGateway.PatientDataAccess.DiagnosticImagingExam diExam = result.Items.First().ShouldBeOfType<HealthGateway.PatientDataAccess.DiagnosticImagingExam>();
+            diExam.Id.ShouldBe(phsaDiagnosticImageExam.HealthDataId);
+
+            HealthGateway.PatientDataAccess.CancerScreeningExam csExam = result.Items.Last().ShouldBeOfType<HealthGateway.PatientDataAccess.CancerScreeningExam>();
+            csExam.Id.ShouldBe(cancerScreeningExam.HealthDataId);
         }
 
         [Fact]


### PR DESCRIPTION
# Implements [AB#15999](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15999)

## Description

Add unit tests for:

- health data json converter - validate BcCancerScreening
- patient repository - get patient data for cancer screening
- patient repository - get patient data for cancer screening and diagnostic imaging
- patient data service - get patient data for cancer screening for event type Result
- patient data service - get patient data for cancer screening for event type Recall

<img width="1250" alt="Screenshot 2023-08-25 at 12 35 53 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/37e08198-144a-4448-8ba9-ec239d2487dc">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

NO

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
