### PR TITLE
Show date in local timezone on Admin Feedback Review page for AB#16057.

### DIFF
--- a/Apps/Admin/Client/Pages/FeedbackPage.razor
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor
@@ -112,7 +112,7 @@ else
             </HeaderContent>
             <RowTemplate>
                 <MudTd DataLabel="Date" data-testid="feedback-date">
-                    @DateFormatter.ToShortDateAndTime(context.DateTime)
+                    @DateFormatter.ToShortDateAndTime(ConvertDateTime(context.DateTime))
                 </MudTd>
                 <MudTd DataLabel="Email" data-testid="feedback-email">
                     @if (context.Hdid.Length > 0)

--- a/Apps/Admin/Client/Pages/FeedbackPage.razor.cs
+++ b/Apps/Admin/Client/Pages/FeedbackPage.razor.cs
@@ -27,7 +27,9 @@ using HealthGateway.Admin.Client.Store.Tag;
 using HealthGateway.Admin.Client.Store.UserFeedback;
 using HealthGateway.Admin.Common.Models;
 using HealthGateway.Common.Data.Constants;
+using HealthGateway.Common.Data.Utils;
 using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Configuration;
 using MudBlazor;
 
 /// <summary>
@@ -35,6 +37,9 @@ using MudBlazor;
 /// </summary>
 public partial class FeedbackPage : FluxorComponent
 {
+    [Inject]
+    private IConfiguration Configuration { get; set; } = default!;
+
     [Inject]
     private IDispatcher Dispatcher { get; set; } = default!;
 
@@ -206,6 +211,11 @@ public partial class FeedbackPage : FluxorComponent
             updatedFeedback.IsReviewed = !updatedFeedback.IsReviewed;
             this.Dispatcher.Dispatch(new UserFeedbackActions.UpdateAction(updatedFeedback));
         }
+    }
+
+    private DateTime ConvertDateTime(DateTime utcDateTime)
+    {
+        return TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, DateFormatter.GetLocalTimeZone(this.Configuration));
     }
 
     private sealed class AddTagFormModel


### PR DESCRIPTION
# Fixes [AB#16057](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16057)

## Description

Fix 'Date' on Admin Feedback Review to display in local timezone i.e., Pacific.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

<img width="2560" alt="Screenshot 2023-08-28 at 10 16 11 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/2312bf42-37ea-4ddd-98f1-cdbf75501bc7">


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
