### PR TITLE
Fix filter BC Cancer test - AB#16082

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -18,7 +18,7 @@ describe("Diagnostic Imaging", () => {
         cy.checkTimelineHasLoaded();
     });
 
-    it("Validate Card Details", () => {
+    it("Validate card details with a file", () => {
         cy.get("[data-testid=timelineCard")
             .filter(":has([data-testid=attachmentIcon])")
             .first()
@@ -35,6 +35,26 @@ describe("Diagnostic Imaging", () => {
                 cy.get(
                     "[data-testid=diagnostic-imaging-download-button]"
                 ).should("be.visible");
+            });
+    });
+
+    it("Validate card details without a file", () => {
+        cy.get("[data-testid=timelineCard")
+            .not(":has([data-testid=attachmentIcon])")
+            .first()
+            .within(() => {
+                cy.get("[data-testid=diagnosticimagingTitle]")
+                    .should("be.visible")
+                    .click({ force: true });
+                cy.get(
+                    "[data-testid=diagnostic-imaging-procedure-description]"
+                ).should("be.visible");
+                cy.get(
+                    "[data-testid=diagnostic-imaging-health-authority]"
+                ).should("be.visible");
+                cy.get(
+                    "[data-testid=diagnostic-imaging-download-button]"
+                ).should("not.exist");
             });
     });
 

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -20,6 +20,7 @@ describe("Diagnostic Imaging", () => {
 
     it("Validate Card Details", () => {
         cy.get("[data-testid=timelineCard")
+            .filter(":has([data-testid=attachmentIcon])")
             .first()
             .within(() => {
                 cy.get("[data-testid=diagnosticimagingTitle]")
@@ -39,6 +40,7 @@ describe("Diagnostic Imaging", () => {
 
     it("Validate file download", () => {
         cy.get("[data-testid=timelineCard")
+            .filter(":has([data-testid=attachmentIcon])")
             .first()
             .within(() => {
                 cy.get("[data-testid=diagnosticimagingTitle]")

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
@@ -340,7 +340,7 @@ describe("Filters", () => {
         testDatasetTimelineFiltering(
             "[data-testid=BcCancerScreening-filter]",
             "[data-testid=bccancerscreeningTitle]",
-            ["BC Cancer Results"]
+            ["BC Cancer Screening"]
         );
     });
 


### PR DESCRIPTION
# Fixes [AB#16082](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16082)

## Description
1. Correct filter label content test.
2. For diagnostic image test with a file, search for attachment icon before looking for file button and other card content.
3. For diagnostic image test without a file, search lack of an attachment icon before testing card content.
4. No fix required for the failing reportFiltering.js test as that fix was released after the test run mentioned in this task's description.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

### Diagnostic Test
![image](https://github.com/bcgov/healthgateway/assets/19548348/0ebcceef-fd68-431c-a666-52403df41e74)

### Filter tests
KNOWN: Medications and MSP Visits are breaking.
![image](https://github.com/bcgov/healthgateway/assets/19548348/adcf7a66-b4ef-4d6a-b805-d05c21c329a5)



## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
