### PR TITLE
Create AddressConfirmationDialog in Admin.Client AB#16064

### DIFF
--- a/Apps/Admin/Client/Components/AgentAudit/AuditReasonDialog.razor.cs
+++ b/Apps/Admin/Client/Components/AgentAudit/AuditReasonDialog.razor.cs
@@ -22,26 +22,27 @@ using Microsoft.AspNetCore.Components;
 using MudBlazor;
 
 /// <summary>
-/// Backing logic for the DelegationConfirmationDialog component.
-/// If the Save button is pressed, the dialog's Result will have the Data property populated with a bool value of true.
+/// Backing logic for the AuditReasonDialog component.
+/// If the Confirm button is pressed, the dialog's Result will have the Data property populated with a string representing
+/// the audit reason.
 /// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
 /// </summary>
-/// <typeparam name="TAction">An action to be performed when confirmation complete.</typeparam>
-/// <typeparam name="TErrorAction">An action to subscribe to when an error occurs dispatching TAction.</typeparam>
-/// <typeparam name="TSuccessAction">An action to subscribe to when TAction dispatch is successful.</typeparam>
+/// <typeparam name="TAction">An action to dispatch when the confirmation button is pressed.</typeparam>
+/// <typeparam name="TErrorAction">An action that indicates <typeparamref name="TAction"/> encountered an error.</typeparam>
+/// <typeparam name="TSuccessAction">An action that indicates <typeparamref name="TAction"/> completed successfully.</typeparam>
 public partial class AuditReasonDialog<TAction, TErrorAction, TSuccessAction> : FluxorComponent
     where TErrorAction : BaseFailAction
     where TAction : BaseAgentAuditAction
 {
     /// <summary>
-    /// Gets or sets the action to be performed when confirmation complete.
+    /// Gets or sets the action to dispatch when an audit reason has been confirmed.
     /// </summary>
     [Parameter]
     [EditorRequired]
     public TAction AuditableAction { get; set; } = default!;
 
     /// <summary>
-    /// Gets or sets the action to be performed when confirmation is cancelled.
+    /// Gets or sets the action to dispatch when the dialog is cancelled.
     /// </summary>
     [Parameter]
     public object? CancelAction { get; set; }

--- a/Apps/Admin/Client/Components/Common/HgAutocomplete.razor
+++ b/Apps/Admin/Client/Components/Common/HgAutocomplete.razor
@@ -1,0 +1,19 @@
+@typeparam T
+@inherits HgComponentBase
+
+<MudAutocomplete
+    @ref="MudComponent"
+    Class="@CombinedClass"
+    Style="@Style"
+    Tag="@Tag"
+    T="T"
+    SearchFunc="@SearchFunc"
+    ValueChanged="@ValueChanged"
+    Variant="@Variant.Filled"
+    Margin="@Margin.Dense"
+    ResetValueOnEmptyText="@true"
+    CoerceText="@true"
+    Clearable="@true"
+    @attributes="UnmatchedAttributes">
+    @ChildContent
+</MudAutocomplete>

--- a/Apps/Admin/Client/Components/Common/HgAutocomplete.razor
+++ b/Apps/Admin/Client/Components/Common/HgAutocomplete.razor
@@ -9,6 +9,7 @@
     T="T"
     SearchFunc="@SearchFunc"
     ValueChanged="@ValueChanged"
+    OnClearButtonClick="@OnClearButtonClick"
     Variant="@Variant.Filled"
     Margin="@Margin.Dense"
     ResetValueOnEmptyText="@true"

--- a/Apps/Admin/Client/Components/Common/HgAutocomplete.razor.cs
+++ b/Apps/Admin/Client/Components/Common/HgAutocomplete.razor.cs
@@ -56,7 +56,7 @@ namespace HealthGateway.Admin.Client.Components.Common
         /// Gets or sets the function used to narrow the results when text is typed.
         /// </summary>
         [Parameter]
-        public Func<string, Task<IEnumerable<T>>> SearchFunc { get; set; }
+        public Func<string, Task<IEnumerable<T>>> SearchFunc { get; set; } = default!;
 
         /// <summary>
         /// Gets the underlying MudBlazor component.

--- a/Apps/Admin/Client/Components/Common/HgAutocomplete.razor.cs
+++ b/Apps/Admin/Client/Components/Common/HgAutocomplete.razor.cs
@@ -1,0 +1,59 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components.Common
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Components;
+    using MudBlazor;
+
+    /// <summary>
+    /// Backing logic for the HgAutocomplete component.
+    /// </summary>
+    /// <typeparam name="T">The type of data to store in the field.</typeparam>
+    [SuppressMessage("Major Code Smell", "S2326:Unused type parameters should be removed", Justification = "Used in .razor file")]
+    public partial class HgAutocomplete<T> : HgComponentBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HgAutocomplete{T}"/> class.
+        /// </summary>
+        public HgAutocomplete()
+        {
+            this.HorizontalMarginSize = 3;
+            this.VerticalMarginSize = 3;
+            this.TopMargin = Breakpoint.Always;
+        }
+
+        /// <summary>
+        /// Gets or sets the event callback that will be triggered when the value changes.
+        /// </summary>
+        [Parameter]
+        public EventCallback<T> ValueChanged { get; set; }
+
+        /// <summary>
+        /// Gets or sets the function used to narrow the results when text is typed.
+        /// </summary>
+        [Parameter]
+        public Func<string, Task<IEnumerable<T>>> SearchFunc { get; set; }
+
+        /// <summary>
+        /// Gets the underlying MudBlazor component.
+        /// </summary>
+        public MudAutocomplete<T> MudComponent { get; private set; } = default!;
+    }
+}

--- a/Apps/Admin/Client/Components/Common/HgAutocomplete.razor.cs
+++ b/Apps/Admin/Client/Components/Common/HgAutocomplete.razor.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.Admin.Client.Components.Common
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.Components.Web;
     using MudBlazor;
 
     /// <summary>
@@ -44,6 +45,12 @@ namespace HealthGateway.Admin.Client.Components.Common
         /// </summary>
         [Parameter]
         public EventCallback<T> ValueChanged { get; set; }
+
+        /// <summary>
+        /// Gets or sets the event callback that will be triggered when the value is cleared.
+        /// </summary>
+        [Parameter]
+        public EventCallback<MouseEventArgs> OnClearButtonClick { get; set; }
 
         /// <summary>
         /// Gets or sets the function used to narrow the results when text is typed.

--- a/Apps/Admin/Client/Components/Support/AddressConfirmationDialog.razor
+++ b/Apps/Admin/Client/Components/Support/AddressConfirmationDialog.razor
@@ -24,16 +24,16 @@
                         Lines="@(2)"
                         data-testid="address-lines-input" />
                 </MudItem>
-                <MudItem xs="6">
+                <MudItem xs="12" sm="6">
                     <HgTextField
                         Label="City"
                         @bind-Value="@City"
                         T="@string"
                         Required="@true"
-                        RightMargin="@Breakpoint.Always"
+                        RightMargin="@Breakpoint.Sm"
                         data-testid="city-input" />
                 </MudItem>
-                <MudItem xs="6">
+                <MudItem xs="12" sm="6">
                     @switch (SelectedCountryCode)
                     {
                         case CountryCode.CA:

--- a/Apps/Admin/Client/Components/Support/AddressConfirmationDialog.razor
+++ b/Apps/Admin/Client/Components/Support/AddressConfirmationDialog.razor
@@ -1,0 +1,121 @@
+@typeparam TAction
+@typeparam TErrorAction
+@typeparam TSuccessAction
+@using HealthGateway.Common.Data.Constants
+@using HealthGateway.Common.Data.Utils
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudDialog>
+    <DialogContent>
+        <HgBannerFeedback
+            Severity="@Severity.Error"
+            IsEnabled="@HasError"
+            TResetAction="@TAction">
+            @ErrorMessage
+        </HgBannerFeedback>
+        <MudForm @ref="Form" data-testid="address-confirmation-form">
+            <MudGrid Spacing="0">
+                <MudItem xs="12">
+                    <HgTextField
+                        Label="Address"
+                        @bind-Value="@AddressLines"
+                        T="@string"
+                        Required="@true"
+                        Lines="@(2)"
+                        data-testid="address-lines-input" />
+                </MudItem>
+                <MudItem xs="6">
+                    <HgTextField
+                        Label="City"
+                        @bind-Value="@City"
+                        T="@string"
+                        Required="@true"
+                        RightMargin="@Breakpoint.Always"
+                        data-testid="city-input" />
+                </MudItem>
+                <MudItem xs="6">
+                    @switch (SelectedCountryCode)
+                    {
+                        case CountryCode.CA:
+                            <HgSelect
+                                Label="Province/State"
+                                @bind-Value="@CanadianProvince"
+                                T="@string"
+                                Required="@true"
+                                data-testid="province-input">
+                                <MudSelectItem T="@string" Value="string.Empty" data-testid="province" />
+                                @foreach (string province in AddressUtility.Provinces)
+                                {
+                                    <MudSelectItem T="string" Value="@province" data-testid="province" />
+                                }
+                            </HgSelect>
+                            break;
+                        case CountryCode.US:
+                            <HgSelect
+                                Label="Province/State"
+                                @bind-Value="@AmericanState"
+                                T="@string"
+                                Required="@true"
+                                data-testid="state-input">
+                                <MudSelectItem T="@string" Value="string.Empty" data-testid="state" />
+                                @foreach (string state in AddressUtility.States)
+                                {
+                                    <MudSelectItem T="string" Value="@state" data-testid="state" />
+                                }
+                            </HgSelect>
+                            break;
+                        default:
+                            <HgTextField
+                                Label="Province/State"
+                                @bind-Value="@OtherState"
+                                T="@string"
+                                Required="@true"
+                                data-testid="province-state-input" />
+                            break;
+                    }
+                </MudItem>
+                <MudItem xs="12">
+                    <HgTextField
+                        Label="Postal Code"
+                        @bind-Value="@PostalCode"
+                        T="@string"
+                        Validation="@ValidatePostalCode"
+                        Required="@true"
+                        Mask="@PostalCodeMask"
+                        data-testid="postal-code-input" />
+                </MudItem>
+                <MudItem xs="12">
+                    <HgAutocomplete
+                        Label="Country"
+                        Value="@Country"
+                        ValueChanged="HandleCountryChanged"
+                        OnClearButtonClick="@(() => HandleCountryChanged(string.Empty))"
+                        SearchFunc="@SearchCountriesAsync"
+                        T="@string"
+                        data-testid="country-input" />
+                </MudItem>
+            </MudGrid>
+        </MudForm>
+    </DialogContent>
+    <DialogActions>
+        <HgButton
+            RightMargin="Breakpoint.Always"
+            HorizontalMarginSize="@(HgButton.DefaultHorizontalMarginSize - 2)"
+            BottomMargin="Breakpoint.Always"
+            Color="@Color.Primary"
+            Variant="@Variant.Text"
+            OnClick="@HandleClickCancel"
+            data-testid="address-cancel-button">
+            Cancel
+        </HgButton>
+        <HgButton
+            RightMargin="Breakpoint.Always"
+            BottomMargin="Breakpoint.Always"
+            Color="@Color.Primary"
+            Loading="@IsLoading"
+            OnClick="@HandleClickConfirm"
+            data-testid="address-confirmation-button">
+            @ConfirmButtonLabel
+        </HgButton>
+    </DialogActions>
+</MudDialog>

--- a/Apps/Admin/Client/Components/Support/AddressConfirmationDialog.razor.cs
+++ b/Apps/Admin/Client/Components/Support/AddressConfirmationDialog.razor.cs
@@ -1,0 +1,259 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components.Support;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Fluxor;
+using Fluxor.Blazor.Web.Components;
+using HealthGateway.Admin.Client.Store;
+using HealthGateway.Common.Data.Constants;
+using HealthGateway.Common.Data.Models;
+using HealthGateway.Common.Data.Utils;
+using HealthGateway.Common.Ui.Constants;
+using Microsoft.AspNetCore.Components;
+using MudBlazor;
+
+/// <summary>
+/// Backing logic for the AddressConfirmationDialog component.
+/// If the Confirmation button is pressed, the dialog's Result will have the Data property populated with an Address.
+/// If the Cancel button is pressed, the dialog's Result will have the Cancelled property set to true.
+/// </summary>
+/// <typeparam name="TAction">An action to dispatch when the confirmation button is pressed.</typeparam>
+/// <typeparam name="TErrorAction">An action that indicates <typeparamref name="TAction"/> encountered an error.</typeparam>
+/// <typeparam name="TSuccessAction">An action that indicates <typeparamref name="TAction"/> completed successfully.</typeparam>
+public partial class AddressConfirmationDialog<TAction, TErrorAction, TSuccessAction> : FluxorComponent
+    where TErrorAction : BaseFailAction
+    where TAction : IAddressAction
+{
+    private string country = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the default address to populate the dialog with.
+    /// </summary>
+    [Parameter]
+    [EditorRequired]
+    public Address DefaultAddress { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the action to dispatch when an address has been confirmed.
+    /// </summary>
+    [Parameter]
+    [EditorRequired]
+    public TAction ActionOnConfirm { get; set; } = default!;
+
+    /// <summary>
+    /// Gets or sets the action to dispatch when the dialog is cancelled.
+    /// </summary>
+    [Parameter]
+    public object? ActionOnCancel { get; set; }
+
+    /// <summary>
+    /// Gets or sets the text to display on the dialog's confirmation button.
+    /// </summary>
+    [Parameter]
+    public string ConfirmButtonLabel { get; set; } = "Confirm";
+
+    [CascadingParameter]
+    private MudDialogInstance MudDialog { get; set; } = default!;
+
+    [Inject]
+    private IActionSubscriber ActionSubscriber { get; set; } = default!;
+
+    [Inject]
+    private IDispatcher Dispatcher { get; set; } = default!;
+
+    private bool IsLoading { get; set; }
+
+    private RequestError? Error { get; set; }
+
+    private MudForm Form { get; set; } = default!;
+
+    private string AddressLines { get; set; } = string.Empty;
+
+    private string City { get; set; } = string.Empty;
+
+    private string CanadianProvince { get; set; } = string.Empty;
+
+    private ProvinceAbbreviation CanadianProvinceAbbreviation => EnumUtility.ToEnumOrDefault<ProvinceAbbreviation>(this.CanadianProvince, true);
+
+    private string AmericanState { get; set; } = string.Empty;
+
+    private StateAbbreviation AmericanStateAbbreviation => EnumUtility.ToEnumOrDefault<StateAbbreviation>(this.AmericanState, true);
+
+    private string OtherState { get; set; } = string.Empty;
+
+    private string PostalCode { get; set; } = string.Empty;
+
+    private IMask? PostalCodeMask { get; set; }
+
+    private string Country
+    {
+        get => this.country;
+
+        set
+        {
+            this.country = value;
+            this.PostalCodeMask = this.SelectedCountryCode switch
+            {
+                CountryCode.CA => Mask.PostalCodeMask,
+                CountryCode.US => Mask.ZipCodeMask,
+                _ => null,
+            };
+        }
+    }
+
+    private CountryCode SelectedCountryCode
+    {
+        get
+        {
+            CountryCode countryCode = AddressUtility.GetCountryCode(this.Country);
+            return countryCode == CountryCode.Unknown ? CountryCode.CA : countryCode;
+        }
+    }
+
+    private string? ErrorMessage => this.Error?.Message;
+
+    private bool HasError => this.Error is not null;
+
+    /// <inheritdoc/>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+        this.ActionSubscriber.SubscribeToAction<TErrorAction>(this, this.HandleActionFailed);
+        this.ActionSubscriber.SubscribeToAction<TSuccessAction>(this, this.HandleActionSuccess);
+        this.PopulateInputs(this.DefaultAddress);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        this.ActionSubscriber.UnsubscribeFromAllActions(this);
+        base.Dispose(disposing);
+    }
+
+    private static Task<IEnumerable<string>> SearchCountriesAsync(string value)
+    {
+        return Task.FromResult(
+            string.IsNullOrWhiteSpace(value)
+                ? AddressUtility.CountriesWithAliases
+                : AddressUtility.CountriesWithAliases.Where(c => c.ToUpperInvariant().StartsWith(value.ToUpperInvariant(), StringComparison.InvariantCulture)));
+    }
+
+    private void PopulateInputs(Address address)
+    {
+        this.AddressLines = string.Join(Environment.NewLine, address.StreetLines);
+
+        this.City = address.City;
+
+        ProvinceAbbreviation provinceAbbreviation = EnumUtility.ToEnumOrDefault<ProvinceAbbreviation>(address.State);
+        this.CanadianProvince = provinceAbbreviation == ProvinceAbbreviation.Unknown ? string.Empty : EnumUtility.ToEnumString(provinceAbbreviation, true);
+
+        StateAbbreviation stateAbbreviation = EnumUtility.ToEnumOrDefault<StateAbbreviation>(address.State);
+        this.AmericanState = stateAbbreviation == StateAbbreviation.Unknown ? string.Empty : EnumUtility.ToEnumString(stateAbbreviation, true);
+
+        this.OtherState = this.CanadianProvince.Length > 0 || this.AmericanState.Length > 0 ? string.Empty : address.State;
+
+        this.Country = AddressUtility.GetCountryCode(address.Country) == CountryCode.Unknown ? string.Empty : address.Country;
+
+        this.PostalCode = this.SelectedCountryCode == CountryCode.CA && address.PostalCode.Length == 6
+            ? $"{address.PostalCode[..3]} {address.PostalCode[^3..]}"
+            : address.PostalCode;
+    }
+
+    private Address GetAddressModel()
+    {
+        return new()
+        {
+            StreetLines = this.AddressLines.Split(Environment.NewLine),
+            City = this.City,
+            State = this.SelectedCountryCode switch
+            {
+                CountryCode.CA => this.CanadianProvinceAbbreviation.ToString(),
+                CountryCode.US => this.AmericanStateAbbreviation.ToString(),
+                _ => this.OtherState,
+            },
+            PostalCode = this.PostalCode,
+            Country = this.SelectedCountryCode == CountryCode.CA
+                ? string.Empty
+                : AddressUtility.GetCountryName(this.SelectedCountryCode),
+        };
+    }
+
+    private void HandleCountryChanged(string value)
+    {
+        this.Country = value;
+        this.PostalCode = string.Empty;
+        this.CanadianProvince = string.Empty;
+        this.AmericanState = string.Empty;
+        this.OtherState = string.Empty;
+    }
+
+    private string? ValidatePostalCode(string postalCode)
+    {
+        if (string.IsNullOrWhiteSpace(postalCode))
+        {
+            return "Required";
+        }
+
+        switch (this.SelectedCountryCode)
+        {
+            case CountryCode.CA:
+                return !AddressUtility.PostalCodeRegex().IsMatch(postalCode) ? "Incomplete postal code" : null;
+            case CountryCode.US:
+                return !AddressUtility.ZipCodeRegex().IsMatch(postalCode) ? "Incomplete zip code" : null;
+            default:
+                return null;
+        }
+    }
+
+    private void HandleActionSuccess(TSuccessAction successAction)
+    {
+        this.IsLoading = false;
+        this.MudDialog.Close(DialogResult.Ok(this.GetAddressModel()));
+    }
+
+    private void HandleActionFailed(BaseFailAction failAction)
+    {
+        this.IsLoading = false;
+        this.Error = failAction.Error;
+    }
+
+    private void HandleClickCancel()
+    {
+        if (this.ActionOnCancel is not null)
+        {
+            this.Dispatcher.Dispatch(this.ActionOnCancel);
+        }
+
+        this.MudDialog.Cancel();
+    }
+
+    private async Task HandleClickConfirm()
+    {
+        await this.Form.Validate().ConfigureAwait(true);
+        if (!this.Form.IsValid)
+        {
+            return;
+        }
+
+        this.IsLoading = true;
+        this.ActionOnConfirm.Address = this.GetAddressModel();
+        this.Dispatcher.Dispatch(this.ActionOnConfirm);
+    }
+}

--- a/Apps/Admin/Client/Pages/DelegationPage.razor
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor
@@ -19,7 +19,7 @@
             Label="PHN"
             Required="@true"
             Validation="@ValidateQueryParameter"
-            Mask="@(new PatternMask(Mask.PhnMaskTemplate))"
+            Mask="@Mask.PhnMask"
             TopMargin="Breakpoint.None"
             Class="flex-grow-1"
             @bind-Value="QueryParameter"

--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -45,7 +45,7 @@
                         Label="@FormatQueryType(PatientQueryType.Phn)"
                         Required="@true"
                         Validation="@ValidateQueryParameter"
-                        Mask="@(new PatternMask(Mask.PhnMaskTemplate))"
+                        Mask="@Mask.PhnMask"
                         @bind-Value="QueryParameter"
                         TopMargin="Breakpoint.None"
                         LeftMargin="Breakpoint.Sm"

--- a/Apps/Admin/Client/Store/IAddressAction.cs
+++ b/Apps/Admin/Client/Store/IAddressAction.cs
@@ -1,0 +1,30 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Store
+{
+    using HealthGateway.Common.Data.Models;
+
+    /// <summary>
+    /// An interface for an action that requires an address.
+    /// </summary>
+    public interface IAddressAction
+    {
+        /// <summary>
+        /// Gets or sets the address associated with the action performed.
+        /// </summary>
+        public Address Address { get; set; }
+    }
+}

--- a/Apps/CommonData/src/Constants/CountryCode.cs
+++ b/Apps/CommonData/src/Constants/CountryCode.cs
@@ -1,0 +1,780 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1602 // Enumeration items should be documented
+
+namespace HealthGateway.Common.Data.Constants
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Country codes.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Country codes should remain in all caps")]
+    [SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "Country names don't require spellchecking")]
+    public enum CountryCode
+    {
+        Unknown,
+
+        [EnumMember(Value = "Canada")]
+        CA,
+
+        [EnumMember(Value = "United States of America")]
+        US,
+
+        [EnumMember(Value = "Afghanistan")]
+        AF,
+
+        [EnumMember(Value = "Aland Islands")]
+        AX,
+
+        [EnumMember(Value = "Albania")]
+        AL,
+
+        [EnumMember(Value = "Algeria")]
+        DZ,
+
+        [EnumMember(Value = "American Samoa")]
+        AS,
+
+        [EnumMember(Value = "Andorra")]
+        AD,
+
+        [EnumMember(Value = "Angola")]
+        AO,
+
+        [EnumMember(Value = "Anguilla")]
+        AI,
+
+        [EnumMember(Value = "Antarctica")]
+        AQ,
+
+        [EnumMember(Value = "Antigua and Barbuda")]
+        AG,
+
+        [EnumMember(Value = "Argentina")]
+        AR,
+
+        [EnumMember(Value = "Armenia")]
+        AM,
+
+        [EnumMember(Value = "Aruba")]
+        AW,
+
+        [EnumMember(Value = "Australia")]
+        AU,
+
+        [EnumMember(Value = "Austria")]
+        AT,
+
+        [EnumMember(Value = "Azerbaijan")]
+        AZ,
+
+        [EnumMember(Value = "Bahamas")]
+        BS,
+
+        [EnumMember(Value = "Bahrain")]
+        BH,
+
+        [EnumMember(Value = "Bangladesh")]
+        BD,
+
+        [EnumMember(Value = "Barbados")]
+        BB,
+
+        [EnumMember(Value = "Belarus")]
+        BY,
+
+        [EnumMember(Value = "Belgium")]
+        BE,
+
+        [EnumMember(Value = "Belize")]
+        BZ,
+
+        [EnumMember(Value = "Benin")]
+        BJ,
+
+        [EnumMember(Value = "Bermuda")]
+        BM,
+
+        [EnumMember(Value = "Bhutan")]
+        BT,
+
+        [EnumMember(Value = "Bolivia")]
+        BO,
+
+        [EnumMember(Value = "Bosnia-Herzegovina")]
+        BA,
+
+        [EnumMember(Value = "Botswana")]
+        BW,
+
+        [EnumMember(Value = "Bouvet Island")]
+        BV,
+
+        [EnumMember(Value = "Brazil")]
+        BR,
+
+        [EnumMember(Value = "British Virgin Islands")]
+        VG,
+
+        [EnumMember(Value = "Brunei Darussalam")]
+        BN,
+
+        [EnumMember(Value = "Bulgaria")]
+        BG,
+
+        [EnumMember(Value = "Burkina Faso")]
+        BF,
+
+        [EnumMember(Value = "Burundi")]
+        BI,
+
+        [EnumMember(Value = "Cambodia")]
+        KH,
+
+        [EnumMember(Value = "Cameroon")]
+        CM,
+
+        [EnumMember(Value = "Cape Verde")]
+        CV,
+
+        [EnumMember(Value = "Cayman Islands")]
+        KY,
+
+        [EnumMember(Value = "Central African Republic")]
+        CF,
+
+        [EnumMember(Value = "Chad")]
+        TD,
+
+        [EnumMember(Value = "Chile")]
+        CL,
+
+        [EnumMember(Value = "China")]
+        CN,
+
+        [EnumMember(Value = "Christmas Island")]
+        CX,
+
+        [EnumMember(Value = "Cocos (Keeling) Island")]
+        CC,
+
+        [EnumMember(Value = "Colombia")]
+        CO,
+
+        [EnumMember(Value = "Comoros")]
+        KM,
+
+        [EnumMember(Value = "Congo (Republic)")]
+        CG,
+
+        [EnumMember(Value = "Congo, Democratic Republic Of")]
+        CD,
+
+        [EnumMember(Value = "Cook Islands")]
+        CK,
+
+        [EnumMember(Value = "Costa Rica")]
+        CR,
+
+        [EnumMember(Value = "Côte d'Ivoire")]
+        CI,
+
+        [EnumMember(Value = "Croatia")]
+        HR,
+
+        [EnumMember(Value = "Cuba")]
+        CU,
+
+        [EnumMember(Value = "Curacao")]
+        CW,
+
+        [EnumMember(Value = "Cyprus")]
+        CY,
+
+        [EnumMember(Value = "Czech Republic")]
+        CZ,
+
+        [EnumMember(Value = "Denmark ")]
+        DK,
+
+        [EnumMember(Value = "Djibouti")]
+        DJ,
+
+        [EnumMember(Value = "Dominica")]
+        DM,
+
+        [EnumMember(Value = "Dominican Republic")]
+        DO,
+
+        [EnumMember(Value = "Dutch Caribbean (formerly Netherlands Antilles)")]
+        BQ,
+
+        [EnumMember(Value = "Ecuador")]
+        EC,
+
+        [EnumMember(Value = "Egypt")]
+        EG,
+
+        [EnumMember(Value = "El Salvador")]
+        SV,
+
+        [EnumMember(Value = "Equatorial Guinea")]
+        GQ,
+
+        [EnumMember(Value = "Eritrea")]
+        ER,
+
+        [EnumMember(Value = "Estonia")]
+        EE,
+
+        [EnumMember(Value = "Eswatini (formerly known as Swaziland)")]
+        SZ,
+
+        [EnumMember(Value = "Ethiopia")]
+        ET,
+
+        [EnumMember(Value = "Falkland Islands")]
+        FK,
+
+        [EnumMember(Value = "Faroe Islands")]
+        FO,
+
+        [EnumMember(Value = "Fiji")]
+        FJ,
+
+        [EnumMember(Value = "Finland")]
+        FI,
+
+        [EnumMember(Value = "France")]
+        FR,
+
+        [EnumMember(Value = "French Guinea")]
+        GF,
+
+        [EnumMember(Value = "French Polynesia")]
+        PF,
+
+        [EnumMember(Value = "French Southern Territories")]
+        TF,
+
+        [EnumMember(Value = "Gabon")]
+        GA,
+
+        [EnumMember(Value = "Gambia")]
+        GM,
+
+        [EnumMember(Value = "Georgia")]
+        GE,
+
+        [EnumMember(Value = "Germany")]
+        DE,
+
+        [EnumMember(Value = "Ghana")]
+        GH,
+
+        [EnumMember(Value = "Gibraltar")]
+        GI,
+
+        [EnumMember(Value = "Greece")]
+        GR,
+
+        [EnumMember(Value = "Greenland")]
+        GL,
+
+        [EnumMember(Value = "Grenada")]
+        GD,
+
+        [EnumMember(Value = "Guadeloupe")]
+        GP,
+
+        [EnumMember(Value = "Guam")]
+        GU,
+
+        [EnumMember(Value = "Guatemala")]
+        GT,
+
+        [EnumMember(Value = "Guernsey")]
+        GG,
+
+        [EnumMember(Value = "Guinea")]
+        GN,
+
+        [EnumMember(Value = "Guinea-Bissau")]
+        GW,
+
+        [EnumMember(Value = "Guyana")]
+        GY,
+
+        [EnumMember(Value = "Haiti")]
+        HT,
+
+        [EnumMember(Value = "Heard & McDonald Islands")]
+        HM,
+
+        [EnumMember(Value = "Holy See (Vatican)")]
+        VA,
+
+        [EnumMember(Value = "Honduras")]
+        HN,
+
+        [EnumMember(Value = "Hong Kong")]
+        HK,
+
+        [EnumMember(Value = "Hungary")]
+        HU,
+
+        [EnumMember(Value = "Iceland")]
+        IS,
+
+        [EnumMember(Value = "India")]
+        IN,
+
+        [EnumMember(Value = "Indonesia")]
+        ID,
+
+        [EnumMember(Value = "Iran")]
+        IR,
+
+        [EnumMember(Value = "Iraq")]
+        IQ,
+
+        [EnumMember(Value = "Ireland")]
+        IE,
+
+        [EnumMember(Value = "Isle of Man")]
+        IM,
+
+        [EnumMember(Value = "Israel")]
+        IL,
+
+        [EnumMember(Value = "Italy")]
+        IT,
+
+        [EnumMember(Value = "Jamaica")]
+        JM,
+
+        [EnumMember(Value = "Japan")]
+        JP,
+
+        [EnumMember(Value = "Jersey")]
+        JE,
+
+        [EnumMember(Value = "Jordan")]
+        JO,
+
+        [EnumMember(Value = "Kazakhstan")]
+        KZ,
+
+        [EnumMember(Value = "Kenya")]
+        KE,
+
+        [EnumMember(Value = "Kiribati")]
+        KI,
+
+        [EnumMember(Value = "Korea (Democratic People's Republic)")]
+        KP,
+
+        [EnumMember(Value = "Korea (South)")]
+        KR,
+
+        [EnumMember(Value = "Kosovo")]
+        XZ,
+
+        [EnumMember(Value = "Kuwait")]
+        KW,
+
+        [EnumMember(Value = "Kyrgyzstan")]
+        KG,
+
+        [EnumMember(Value = "Lao (People's Democratic Republic)")]
+        LA,
+
+        [EnumMember(Value = "Latvia")]
+        LV,
+
+        [EnumMember(Value = "Lebanon")]
+        LB,
+
+        [EnumMember(Value = "Lesotho")]
+        LS,
+
+        [EnumMember(Value = "Liberia")]
+        LR,
+
+        [EnumMember(Value = "Libya")]
+        LY,
+
+        [EnumMember(Value = "Liechtenstein")]
+        LI,
+
+        [EnumMember(Value = "Lithuania")]
+        LT,
+
+        [EnumMember(Value = "Luxembourg")]
+        LU,
+
+        [EnumMember(Value = "Macau")]
+        MO,
+
+        [EnumMember(Value = "Macedonia")]
+        MK,
+
+        [EnumMember(Value = "Madagascar")]
+        MG,
+
+        [EnumMember(Value = "Malawi")]
+        MW,
+
+        [EnumMember(Value = "Malaysia")]
+        MY,
+
+        [EnumMember(Value = "Maldives")]
+        MV,
+
+        [EnumMember(Value = "Mali")]
+        ML,
+
+        [EnumMember(Value = "Malta")]
+        MT,
+
+        [EnumMember(Value = "Marshall Islands")]
+        MH,
+
+        [EnumMember(Value = "Martinique")]
+        MQ,
+
+        [EnumMember(Value = "Mauritania")]
+        MR,
+
+        [EnumMember(Value = "Mauritius")]
+        MU,
+
+        [EnumMember(Value = "Mayotte")]
+        YT,
+
+        [EnumMember(Value = "Mexico")]
+        MX,
+
+        [EnumMember(Value = "Micronesia, Federal States Of")]
+        FM,
+
+        [EnumMember(Value = "Moldova")]
+        MD,
+
+        [EnumMember(Value = "Monaco")]
+        MC,
+
+        [EnumMember(Value = "Mongolia")]
+        MN,
+
+        [EnumMember(Value = "Montenegro")]
+        ME,
+
+        [EnumMember(Value = "Montserrat")]
+        MS,
+
+        [EnumMember(Value = "Morocco")]
+        MA,
+
+        [EnumMember(Value = "Mozambique")]
+        MZ,
+
+        [EnumMember(Value = "Myanmar")]
+        MM,
+
+        [EnumMember(Value = "Namibia")]
+        NA,
+
+        [EnumMember(Value = "Nauru")]
+        NR,
+
+        [EnumMember(Value = "Nepal")]
+        NP,
+
+        [EnumMember(Value = "Netherlands")]
+        NL,
+
+        [EnumMember(Value = "New Caledonia")]
+        NC,
+
+        [EnumMember(Value = "New Zealand")]
+        NZ,
+
+        [EnumMember(Value = "Nicaragua")]
+        NI,
+
+        [EnumMember(Value = "Niger")]
+        NE,
+
+        [EnumMember(Value = "Nigeria")]
+        NG,
+
+        [EnumMember(Value = "Niue")]
+        NU,
+
+        [EnumMember(Value = "Norfolk Islands")]
+        NF,
+
+        [EnumMember(Value = "Northern Mariana Islands")]
+        MP,
+
+        [EnumMember(Value = "Norway")]
+        NO,
+
+        [EnumMember(Value = "Oman")]
+        OM,
+
+        [EnumMember(Value = "Pakistan")]
+        PK,
+
+        [EnumMember(Value = "Palau")]
+        PW,
+
+        [EnumMember(Value = "Panama")]
+        PA,
+
+        [EnumMember(Value = "Papua New Guinea")]
+        PG,
+
+        [EnumMember(Value = "Paraguay")]
+        PY,
+
+        [EnumMember(Value = "Peru")]
+        PE,
+
+        [EnumMember(Value = "Philippines")]
+        PH,
+
+        [EnumMember(Value = "Pitcairn")]
+        PN,
+
+        [EnumMember(Value = "Poland")]
+        PL,
+
+        [EnumMember(Value = "Portugal")]
+        PT,
+
+        [EnumMember(Value = "Puerto Rico")]
+        PR,
+
+        [EnumMember(Value = "Qatar")]
+        QA,
+
+        [EnumMember(Value = "Réunion")]
+        RE,
+
+        [EnumMember(Value = "Romania")]
+        RO,
+
+        [EnumMember(Value = "Russian Federation")]
+        RU,
+
+        [EnumMember(Value = "Rwanda")]
+        RW,
+
+        [EnumMember(Value = "Saint Barthélémy")]
+        BL,
+
+        [EnumMember(Value = "Saint Helena")]
+        SH,
+
+        [EnumMember(Value = "Saint Kitts and Nevis")]
+        KN,
+
+        [EnumMember(Value = "Saint Lucia")]
+        LC,
+
+        [EnumMember(Value = "Saint Martin (French Part)")]
+        MF,
+
+        [EnumMember(Value = "Saint Pierre and Miquelon")]
+        PM,
+
+        [EnumMember(Value = "Samoa")]
+        WS,
+
+        [EnumMember(Value = "San Marino")]
+        SM,
+
+        [EnumMember(Value = "Sao Tome and Principe")]
+        ST,
+
+        [EnumMember(Value = "Saudi Arabia")]
+        SA,
+
+        [EnumMember(Value = "Senegal")]
+        SN,
+
+        [EnumMember(Value = "Serbia")]
+        RS,
+
+        [EnumMember(Value = "Seychelles")]
+        SC,
+
+        [EnumMember(Value = "Sierra Leone")]
+        SL,
+
+        [EnumMember(Value = "Singapore")]
+        SG,
+
+        [EnumMember(Value = "Sint Maarten (Dutch Part)")]
+        SX,
+
+        [EnumMember(Value = "Slovakia")]
+        SK,
+
+        [EnumMember(Value = "Slovenia")]
+        SI,
+
+        [EnumMember(Value = "Solomon Islands")]
+        SB,
+
+        [EnumMember(Value = "Somalia")]
+        SO,
+
+        [EnumMember(Value = "South Africa")]
+        ZA,
+
+        [EnumMember(Value = "South Sudan")]
+        SS,
+
+        [EnumMember(Value = "Spain")]
+        ES,
+
+        [EnumMember(Value = "Sri Lanka")]
+        LK,
+
+        [EnumMember(Value = "St Vincent and the Grenadines")]
+        VC,
+
+        [EnumMember(Value = "Sudan")]
+        SD,
+
+        [EnumMember(Value = "Suriname")]
+        SR,
+
+        [EnumMember(Value = "Svalbard & Jan Mayen")]
+        SJ,
+
+        [EnumMember(Value = "Sweden")]
+        SE,
+
+        [EnumMember(Value = "Switzerland")]
+        CH,
+
+        [EnumMember(Value = "Syria")]
+        SY,
+
+        [EnumMember(Value = "Taiwan")]
+        TW,
+
+        [EnumMember(Value = "Tajikistan")]
+        TJ,
+
+        [EnumMember(Value = "Tanzania")]
+        TZ,
+
+        [EnumMember(Value = "Thailand")]
+        TH,
+
+        [EnumMember(Value = "Timor-Leste")]
+        TL,
+
+        [EnumMember(Value = "Togo")]
+        TG,
+
+        [EnumMember(Value = "Tokelau")]
+        TK,
+
+        [EnumMember(Value = "Tonga")]
+        TO,
+
+        [EnumMember(Value = "Trinidad and Tobago")]
+        TT,
+
+        [EnumMember(Value = "Tristan da Cunha")]
+        TA,
+
+        [EnumMember(Value = "Tunisia")]
+        TN,
+
+        [EnumMember(Value = "Turkey")]
+        TR,
+
+        [EnumMember(Value = "Turkmenistan")]
+        TM,
+
+        [EnumMember(Value = "Turks and Caicos Islands")]
+        TC,
+
+        [EnumMember(Value = "Tuvalu")]
+        TV,
+
+        [EnumMember(Value = "U.S. Minor Outlying Islands")]
+        UM,
+
+        [EnumMember(Value = "U.S. Virgin Islands")]
+        VI,
+
+        [EnumMember(Value = "Uganda")]
+        UG,
+
+        [EnumMember(Value = "Ukraine")]
+        UA,
+
+        [EnumMember(Value = "United Arab Emirates")]
+        AE,
+
+        [EnumMember(Value = "United Kingdom (Great Britain)")]
+        GB,
+
+        [EnumMember(Value = "Uruguay")]
+        UY,
+
+        [EnumMember(Value = "Uzbekistan")]
+        UZ,
+
+        [EnumMember(Value = "Vanuatu")]
+        VU,
+
+        [EnumMember(Value = "Venezuela")]
+        VE,
+
+        [EnumMember(Value = "Vietnam")]
+        VN,
+
+        [EnumMember(Value = "Wallis and Futuna")]
+        WF,
+
+        [EnumMember(Value = "West Bank and Gaza Strip")]
+        PS,
+
+        [EnumMember(Value = "Western Sahara")]
+        EH,
+
+        [EnumMember(Value = "Yemen")]
+        YE,
+
+        [EnumMember(Value = "Zambia")]
+        ZM,
+
+        [EnumMember(Value = "Zimbabwe")]
+        ZW,
+    }
+}

--- a/Apps/CommonData/src/Constants/ProvinceAbbreviation.cs
+++ b/Apps/CommonData/src/Constants/ProvinceAbbreviation.cs
@@ -1,0 +1,71 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1602 // Enumeration items should be documented
+
+namespace HealthGateway.Common.Data.Constants
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Abbreviations for Canadian provinces and territories.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Province abbreviations should remain in all caps")]
+    public enum ProvinceAbbreviation
+    {
+        Unknown,
+
+        [EnumMember(Value = "Alberta")]
+        AB,
+
+        [EnumMember(Value = "British Columbia")]
+        BC,
+
+        [EnumMember(Value = "Manitoba")]
+        MB,
+
+        [EnumMember(Value = "New Brunswick")]
+        NB,
+
+        [EnumMember(Value = "Newfoundland and Labrador")]
+        NL,
+
+        [EnumMember(Value = "Northwest Territories")]
+        NT,
+
+        [EnumMember(Value = "Nova Scotia")]
+        NS,
+
+        [EnumMember(Value = "Nunavut")]
+        NU,
+
+        [EnumMember(Value = "Ontario")]
+        ON,
+
+        [EnumMember(Value = "Prince Edward Island")]
+        PE,
+
+        [EnumMember(Value = "Quebec")]
+        QC,
+
+        [EnumMember(Value = "Saskatchewan")]
+        SK,
+
+        [EnumMember(Value = "Yukon Territory")]
+        YT,
+    }
+}

--- a/Apps/CommonData/src/Constants/StateAbbreviation.cs
+++ b/Apps/CommonData/src/Constants/StateAbbreviation.cs
@@ -1,0 +1,185 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1602 // Enumeration items should be documented
+
+namespace HealthGateway.Common.Data.Constants
+{
+    using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Abbreviations for American states.
+    /// </summary>
+    [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "State abbreviations should remain in all caps")]
+    public enum StateAbbreviation
+    {
+        Unknown,
+
+        [EnumMember(Value = "Alabama")]
+        AL,
+
+        [EnumMember(Value = "Alaska")]
+        AK,
+
+        [EnumMember(Value = "Arizona")]
+        AZ,
+
+        [EnumMember(Value = "Arkansas")]
+        AR,
+
+        [EnumMember(Value = "California")]
+        CA,
+
+        [EnumMember(Value = "Colorado")]
+        CO,
+
+        [EnumMember(Value = "Connecticut")]
+        CT,
+
+        [EnumMember(Value = "Delaware")]
+        DE,
+
+        [EnumMember(Value = "District of Columbia")]
+        DC,
+
+        [EnumMember(Value = "Florida")]
+        FL,
+
+        [EnumMember(Value = "Georgia")]
+        GA,
+
+        [EnumMember(Value = "Hawaii")]
+        HI,
+
+        [EnumMember(Value = "Idaho")]
+        ID,
+
+        [EnumMember(Value = "Illinois")]
+        IL,
+
+        [EnumMember(Value = "Indiana")]
+        IN,
+
+        [EnumMember(Value = "Iowa")]
+        IA,
+
+        [EnumMember(Value = "Kansas")]
+        KS,
+
+        [EnumMember(Value = "Kentucky")]
+        KY,
+
+        [EnumMember(Value = "Louisiana")]
+        LA,
+
+        [EnumMember(Value = "Maine")]
+        ME,
+
+        [EnumMember(Value = "Maryland")]
+        MD,
+
+        [EnumMember(Value = "Massachusetts")]
+        MA,
+
+        [EnumMember(Value = "Michigan")]
+        MI,
+
+        [EnumMember(Value = "Minnesota")]
+        MN,
+
+        [EnumMember(Value = "Mississippi")]
+        MS,
+
+        [EnumMember(Value = "Missouri")]
+        MO,
+
+        [EnumMember(Value = "Montana")]
+        MT,
+
+        [EnumMember(Value = "Nebraska")]
+        NE,
+
+        [EnumMember(Value = "Nevada")]
+        NV,
+
+        [EnumMember(Value = "New Hampshire")]
+        NH,
+
+        [EnumMember(Value = "New Jersey")]
+        NJ,
+
+        [EnumMember(Value = "New Mexico")]
+        NM,
+
+        [EnumMember(Value = "New York")]
+        NY,
+
+        [EnumMember(Value = "North Carolina")]
+        NC,
+
+        [EnumMember(Value = "North Dakota")]
+        ND,
+
+        [EnumMember(Value = "Ohio")]
+        OH,
+
+        [EnumMember(Value = "Oklahoma")]
+        OK,
+
+        [EnumMember(Value = "Oregon")]
+        OR,
+
+        [EnumMember(Value = "Pennsylvania")]
+        PA,
+
+        [EnumMember(Value = "Rhode Island")]
+        RI,
+
+        [EnumMember(Value = "South Carolina")]
+        SC,
+
+        [EnumMember(Value = "South Dakota")]
+        SD,
+
+        [EnumMember(Value = "Tennessee")]
+        TN,
+
+        [EnumMember(Value = "Texas")]
+        TX,
+
+        [EnumMember(Value = "Utah")]
+        UT,
+
+        [EnumMember(Value = "Vermont")]
+        VT,
+
+        [EnumMember(Value = "Virginia")]
+        VA,
+
+        [EnumMember(Value = "Washington")]
+        WA,
+
+        [EnumMember(Value = "West Virginia")]
+        WV,
+
+        [EnumMember(Value = "Wisconsin")]
+        WI,
+
+        [EnumMember(Value = "Wyoming")]
+        WY,
+    }
+}

--- a/Apps/CommonData/src/Utils/AddressUtility.cs
+++ b/Apps/CommonData/src/Utils/AddressUtility.cs
@@ -29,18 +29,6 @@ namespace HealthGateway.Common.Data.Utils
     public static partial class AddressUtility
     {
         /// <summary>
-        /// Regular expression for Canadian postal codes.
-        /// </summary>
-        [GeneratedRegex(@"^[A-Z]\d[A-Z] \d[A-Z]\d$")]
-        public static partial Regex PostalCodeRegex();
-
-        /// <summary>
-        /// Regular expression for American ZIP codes and ZIP+4 codes.
-        /// </summary>
-        [GeneratedRegex(@"^\d{5}(-\d{4})?$")]
-        public static partial Regex ZipCodeRegex();
-
-        /// <summary>
         /// Canadian province and territory abbreviations ordered alphabetically by province name.
         /// </summary>
         public static readonly IEnumerable<ProvinceAbbreviation> ProvinceAbbreviations = new List<ProvinceAbbreviation>
@@ -299,5 +287,17 @@ namespace HealthGateway.Common.Data.Utils
 
             return StringManipulator.JoinWithoutBlanks(addressElements, ", ");
         }
+
+        /// <summary>
+        /// Regular expression for Canadian postal codes.
+        /// </summary>
+        [GeneratedRegex(@"^[A-Z]\d[A-Z] \d[A-Z]\d$")]
+        public static partial Regex PostalCodeRegex();
+
+        /// <summary>
+        /// Regular expression for American ZIP codes and ZIP+4 codes.
+        /// </summary>
+        [GeneratedRegex(@"^\d{5}(-\d{4})?$")]
+        public static partial Regex ZipCodeRegex();
     }
 }

--- a/Apps/CommonData/src/Utils/AddressUtility.cs
+++ b/Apps/CommonData/src/Utils/AddressUtility.cs
@@ -31,55 +31,17 @@ namespace HealthGateway.Common.Data.Utils
         /// <summary>
         /// Canadian province and territory abbreviations ordered alphabetically by province name.
         /// </summary>
-        public static readonly IEnumerable<ProvinceAbbreviation> ProvinceAbbreviations = new List<ProvinceAbbreviation>
-        {
-            ProvinceAbbreviation.AB, ProvinceAbbreviation.BC, ProvinceAbbreviation.MB, ProvinceAbbreviation.NB, ProvinceAbbreviation.NL, ProvinceAbbreviation.NT, ProvinceAbbreviation.NS,
-            ProvinceAbbreviation.NU, ProvinceAbbreviation.ON, ProvinceAbbreviation.PE, ProvinceAbbreviation.QC, ProvinceAbbreviation.SK, ProvinceAbbreviation.YT,
-        };
+        public static readonly IEnumerable<ProvinceAbbreviation> ProvinceAbbreviations = Enum.GetValues<ProvinceAbbreviation>()[1..];
 
         /// <summary>
         /// American state abbreviations ordered alphabetically by state name.
         /// </summary>
-        public static readonly IEnumerable<StateAbbreviation> StateAbbreviations = new List<StateAbbreviation>
-        {
-            StateAbbreviation.AL, StateAbbreviation.AK, StateAbbreviation.AZ, StateAbbreviation.AR, StateAbbreviation.CA, StateAbbreviation.CO, StateAbbreviation.CT, StateAbbreviation.DE,
-            StateAbbreviation.DC, StateAbbreviation.FL, StateAbbreviation.GA, StateAbbreviation.HI, StateAbbreviation.ID, StateAbbreviation.IL, StateAbbreviation.IN, StateAbbreviation.IA,
-            StateAbbreviation.KS, StateAbbreviation.KY, StateAbbreviation.LA, StateAbbreviation.ME, StateAbbreviation.MD, StateAbbreviation.MA, StateAbbreviation.MI, StateAbbreviation.MN,
-            StateAbbreviation.MS, StateAbbreviation.MO, StateAbbreviation.MT, StateAbbreviation.NE, StateAbbreviation.NV, StateAbbreviation.NH, StateAbbreviation.NJ, StateAbbreviation.NM,
-            StateAbbreviation.NY, StateAbbreviation.NC, StateAbbreviation.ND, StateAbbreviation.OH, StateAbbreviation.OK, StateAbbreviation.OR, StateAbbreviation.PA, StateAbbreviation.RI,
-            StateAbbreviation.SC, StateAbbreviation.SD, StateAbbreviation.TN, StateAbbreviation.TX, StateAbbreviation.UT, StateAbbreviation.VT, StateAbbreviation.VA, StateAbbreviation.WA,
-            StateAbbreviation.WV, StateAbbreviation.WI, StateAbbreviation.WY,
-        };
+        public static readonly IEnumerable<StateAbbreviation> StateAbbreviations = Enum.GetValues<StateAbbreviation>()[1..];
 
         /// <summary>
         /// Country codes with Canada first, followed by USA, then the remaining countries ordered alphabetically by country name.
         /// </summary>
-        public static readonly IEnumerable<CountryCode> CountryCodes = new List<CountryCode>
-        {
-            CountryCode.CA, CountryCode.US, CountryCode.AF, CountryCode.AX, CountryCode.AL, CountryCode.DZ, CountryCode.AS, CountryCode.AD, CountryCode.AO, CountryCode.AI, CountryCode.AQ,
-            CountryCode.AG, CountryCode.AR, CountryCode.AM, CountryCode.AW, CountryCode.AU, CountryCode.AT, CountryCode.AZ, CountryCode.BS, CountryCode.BH, CountryCode.BD, CountryCode.BB,
-            CountryCode.BY, CountryCode.BE, CountryCode.BZ, CountryCode.BJ, CountryCode.BM, CountryCode.BT, CountryCode.BO, CountryCode.BA, CountryCode.BW, CountryCode.BV, CountryCode.BR,
-            CountryCode.VG, CountryCode.BN, CountryCode.BG, CountryCode.BF, CountryCode.BI, CountryCode.KH, CountryCode.CM, CountryCode.CV, CountryCode.KY, CountryCode.CF, CountryCode.TD,
-            CountryCode.CL, CountryCode.CN, CountryCode.CX, CountryCode.CC, CountryCode.CO, CountryCode.KM, CountryCode.CG, CountryCode.CD, CountryCode.CK, CountryCode.CR, CountryCode.CI,
-            CountryCode.HR, CountryCode.CU, CountryCode.CW, CountryCode.CY, CountryCode.CZ, CountryCode.DK, CountryCode.DJ, CountryCode.DM, CountryCode.DO, CountryCode.BQ, CountryCode.EC,
-            CountryCode.EG, CountryCode.SV, CountryCode.GQ, CountryCode.ER, CountryCode.EE, CountryCode.SZ, CountryCode.ET, CountryCode.FK, CountryCode.FO, CountryCode.FJ, CountryCode.FI,
-            CountryCode.FR, CountryCode.GF, CountryCode.PF, CountryCode.TF, CountryCode.GA, CountryCode.GM, CountryCode.GE, CountryCode.DE, CountryCode.GH, CountryCode.GI, CountryCode.GR,
-            CountryCode.GL, CountryCode.GD, CountryCode.GP, CountryCode.GU, CountryCode.GT, CountryCode.GG, CountryCode.GN, CountryCode.GW, CountryCode.GY, CountryCode.HT, CountryCode.HM,
-            CountryCode.VA, CountryCode.HN, CountryCode.HK, CountryCode.HU, CountryCode.IS, CountryCode.IN, CountryCode.ID, CountryCode.IR, CountryCode.IQ, CountryCode.IE, CountryCode.IM,
-            CountryCode.IL, CountryCode.IT, CountryCode.JM, CountryCode.JP, CountryCode.JE, CountryCode.JO, CountryCode.KZ, CountryCode.KE, CountryCode.KI, CountryCode.KP, CountryCode.KR,
-            CountryCode.XZ, CountryCode.KW, CountryCode.KG, CountryCode.LA, CountryCode.LV, CountryCode.LB, CountryCode.LS, CountryCode.LR, CountryCode.LY, CountryCode.LI, CountryCode.LT,
-            CountryCode.LU, CountryCode.MO, CountryCode.MK, CountryCode.MG, CountryCode.MW, CountryCode.MY, CountryCode.MV, CountryCode.ML, CountryCode.MT, CountryCode.MH, CountryCode.MQ,
-            CountryCode.MR, CountryCode.MU, CountryCode.YT, CountryCode.MX, CountryCode.FM, CountryCode.MD, CountryCode.MC, CountryCode.MN, CountryCode.ME, CountryCode.MS, CountryCode.MA,
-            CountryCode.MZ, CountryCode.MM, CountryCode.NA, CountryCode.NR, CountryCode.NP, CountryCode.NL, CountryCode.NC, CountryCode.NZ, CountryCode.NI, CountryCode.NE, CountryCode.NG,
-            CountryCode.NU, CountryCode.NF, CountryCode.MP, CountryCode.NO, CountryCode.OM, CountryCode.PK, CountryCode.PW, CountryCode.PA, CountryCode.PG, CountryCode.PY, CountryCode.PE,
-            CountryCode.PH, CountryCode.PN, CountryCode.PL, CountryCode.PT, CountryCode.PR, CountryCode.QA, CountryCode.RE, CountryCode.RO, CountryCode.RU, CountryCode.RW, CountryCode.BL,
-            CountryCode.SH, CountryCode.KN, CountryCode.LC, CountryCode.MF, CountryCode.PM, CountryCode.WS, CountryCode.SM, CountryCode.ST, CountryCode.SA, CountryCode.SN, CountryCode.RS,
-            CountryCode.SC, CountryCode.SL, CountryCode.SG, CountryCode.SX, CountryCode.SK, CountryCode.SI, CountryCode.SB, CountryCode.SO, CountryCode.ZA, CountryCode.SS, CountryCode.ES,
-            CountryCode.LK, CountryCode.VC, CountryCode.SD, CountryCode.SR, CountryCode.SJ, CountryCode.SE, CountryCode.CH, CountryCode.SY, CountryCode.TW, CountryCode.TJ, CountryCode.TZ,
-            CountryCode.TH, CountryCode.TL, CountryCode.TG, CountryCode.TK, CountryCode.TO, CountryCode.TT, CountryCode.TA, CountryCode.TN, CountryCode.TR, CountryCode.TM, CountryCode.TC,
-            CountryCode.TV, CountryCode.UM, CountryCode.VI, CountryCode.UG, CountryCode.UA, CountryCode.AE, CountryCode.GB, CountryCode.UY, CountryCode.UZ, CountryCode.VU, CountryCode.VE,
-            CountryCode.VN, CountryCode.WF, CountryCode.PS, CountryCode.EH, CountryCode.YE, CountryCode.ZM, CountryCode.ZW,
-        };
+        public static readonly IEnumerable<CountryCode> CountryCodes = Enum.GetValues<CountryCode>()[1..];
 
         [SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "Country names don't require spellchecking")]
         private static readonly IDictionary<string, CountryCode> CountryAliases = new Dictionary<string, CountryCode>

--- a/Apps/CommonData/src/Utils/AddressUtility.cs
+++ b/Apps/CommonData/src/Utils/AddressUtility.cs
@@ -15,15 +15,267 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Data.Utils
 {
+    using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Text.RegularExpressions;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
 
     /// <summary>
-    /// Utilities for extracting and constructing values to and from a client registry address.
+    /// Utilities for interacting with addresses.
     /// </summary>
-    public static class AddressUtility
+    public static partial class AddressUtility
     {
+        /// <summary>
+        /// Regular expression for Canadian postal codes.
+        /// </summary>
+        [GeneratedRegex(@"^[A-Z]\d[A-Z] \d[A-Z]\d$")]
+        public static partial Regex PostalCodeRegex();
+
+        /// <summary>
+        /// Regular expression for American ZIP codes and ZIP+4 codes.
+        /// </summary>
+        [GeneratedRegex(@"^\d{5}(-\d{4})?$")]
+        public static partial Regex ZipCodeRegex();
+
+        /// <summary>
+        /// Canadian province and territory abbreviations ordered alphabetically by province name.
+        /// </summary>
+        public static readonly IEnumerable<ProvinceAbbreviation> ProvinceAbbreviations = new List<ProvinceAbbreviation>
+        {
+            ProvinceAbbreviation.AB, ProvinceAbbreviation.BC, ProvinceAbbreviation.MB, ProvinceAbbreviation.NB, ProvinceAbbreviation.NL, ProvinceAbbreviation.NT, ProvinceAbbreviation.NS,
+            ProvinceAbbreviation.NU, ProvinceAbbreviation.ON, ProvinceAbbreviation.PE, ProvinceAbbreviation.QC, ProvinceAbbreviation.SK, ProvinceAbbreviation.YT,
+        };
+
+        /// <summary>
+        /// American state abbreviations ordered alphabetically by state name.
+        /// </summary>
+        public static readonly IEnumerable<StateAbbreviation> StateAbbreviations = new List<StateAbbreviation>
+        {
+            StateAbbreviation.AL, StateAbbreviation.AK, StateAbbreviation.AZ, StateAbbreviation.AR, StateAbbreviation.CA, StateAbbreviation.CO, StateAbbreviation.CT, StateAbbreviation.DE,
+            StateAbbreviation.DC, StateAbbreviation.FL, StateAbbreviation.GA, StateAbbreviation.HI, StateAbbreviation.ID, StateAbbreviation.IL, StateAbbreviation.IN, StateAbbreviation.IA,
+            StateAbbreviation.KS, StateAbbreviation.KY, StateAbbreviation.LA, StateAbbreviation.ME, StateAbbreviation.MD, StateAbbreviation.MA, StateAbbreviation.MI, StateAbbreviation.MN,
+            StateAbbreviation.MS, StateAbbreviation.MO, StateAbbreviation.MT, StateAbbreviation.NE, StateAbbreviation.NV, StateAbbreviation.NH, StateAbbreviation.NJ, StateAbbreviation.NM,
+            StateAbbreviation.NY, StateAbbreviation.NC, StateAbbreviation.ND, StateAbbreviation.OH, StateAbbreviation.OK, StateAbbreviation.OR, StateAbbreviation.PA, StateAbbreviation.RI,
+            StateAbbreviation.SC, StateAbbreviation.SD, StateAbbreviation.TN, StateAbbreviation.TX, StateAbbreviation.UT, StateAbbreviation.VT, StateAbbreviation.VA, StateAbbreviation.WA,
+            StateAbbreviation.WV, StateAbbreviation.WI, StateAbbreviation.WY,
+        };
+
+        /// <summary>
+        /// Country codes with Canada first, followed by USA, then the remaining countries ordered alphabetically by country name.
+        /// </summary>
+        public static readonly IEnumerable<CountryCode> CountryCodes = new List<CountryCode>
+        {
+            CountryCode.CA, CountryCode.US, CountryCode.AF, CountryCode.AX, CountryCode.AL, CountryCode.DZ, CountryCode.AS, CountryCode.AD, CountryCode.AO, CountryCode.AI, CountryCode.AQ,
+            CountryCode.AG, CountryCode.AR, CountryCode.AM, CountryCode.AW, CountryCode.AU, CountryCode.AT, CountryCode.AZ, CountryCode.BS, CountryCode.BH, CountryCode.BD, CountryCode.BB,
+            CountryCode.BY, CountryCode.BE, CountryCode.BZ, CountryCode.BJ, CountryCode.BM, CountryCode.BT, CountryCode.BO, CountryCode.BA, CountryCode.BW, CountryCode.BV, CountryCode.BR,
+            CountryCode.VG, CountryCode.BN, CountryCode.BG, CountryCode.BF, CountryCode.BI, CountryCode.KH, CountryCode.CM, CountryCode.CV, CountryCode.KY, CountryCode.CF, CountryCode.TD,
+            CountryCode.CL, CountryCode.CN, CountryCode.CX, CountryCode.CC, CountryCode.CO, CountryCode.KM, CountryCode.CG, CountryCode.CD, CountryCode.CK, CountryCode.CR, CountryCode.CI,
+            CountryCode.HR, CountryCode.CU, CountryCode.CW, CountryCode.CY, CountryCode.CZ, CountryCode.DK, CountryCode.DJ, CountryCode.DM, CountryCode.DO, CountryCode.BQ, CountryCode.EC,
+            CountryCode.EG, CountryCode.SV, CountryCode.GQ, CountryCode.ER, CountryCode.EE, CountryCode.SZ, CountryCode.ET, CountryCode.FK, CountryCode.FO, CountryCode.FJ, CountryCode.FI,
+            CountryCode.FR, CountryCode.GF, CountryCode.PF, CountryCode.TF, CountryCode.GA, CountryCode.GM, CountryCode.GE, CountryCode.DE, CountryCode.GH, CountryCode.GI, CountryCode.GR,
+            CountryCode.GL, CountryCode.GD, CountryCode.GP, CountryCode.GU, CountryCode.GT, CountryCode.GG, CountryCode.GN, CountryCode.GW, CountryCode.GY, CountryCode.HT, CountryCode.HM,
+            CountryCode.VA, CountryCode.HN, CountryCode.HK, CountryCode.HU, CountryCode.IS, CountryCode.IN, CountryCode.ID, CountryCode.IR, CountryCode.IQ, CountryCode.IE, CountryCode.IM,
+            CountryCode.IL, CountryCode.IT, CountryCode.JM, CountryCode.JP, CountryCode.JE, CountryCode.JO, CountryCode.KZ, CountryCode.KE, CountryCode.KI, CountryCode.KP, CountryCode.KR,
+            CountryCode.XZ, CountryCode.KW, CountryCode.KG, CountryCode.LA, CountryCode.LV, CountryCode.LB, CountryCode.LS, CountryCode.LR, CountryCode.LY, CountryCode.LI, CountryCode.LT,
+            CountryCode.LU, CountryCode.MO, CountryCode.MK, CountryCode.MG, CountryCode.MW, CountryCode.MY, CountryCode.MV, CountryCode.ML, CountryCode.MT, CountryCode.MH, CountryCode.MQ,
+            CountryCode.MR, CountryCode.MU, CountryCode.YT, CountryCode.MX, CountryCode.FM, CountryCode.MD, CountryCode.MC, CountryCode.MN, CountryCode.ME, CountryCode.MS, CountryCode.MA,
+            CountryCode.MZ, CountryCode.MM, CountryCode.NA, CountryCode.NR, CountryCode.NP, CountryCode.NL, CountryCode.NC, CountryCode.NZ, CountryCode.NI, CountryCode.NE, CountryCode.NG,
+            CountryCode.NU, CountryCode.NF, CountryCode.MP, CountryCode.NO, CountryCode.OM, CountryCode.PK, CountryCode.PW, CountryCode.PA, CountryCode.PG, CountryCode.PY, CountryCode.PE,
+            CountryCode.PH, CountryCode.PN, CountryCode.PL, CountryCode.PT, CountryCode.PR, CountryCode.QA, CountryCode.RE, CountryCode.RO, CountryCode.RU, CountryCode.RW, CountryCode.BL,
+            CountryCode.SH, CountryCode.KN, CountryCode.LC, CountryCode.MF, CountryCode.PM, CountryCode.WS, CountryCode.SM, CountryCode.ST, CountryCode.SA, CountryCode.SN, CountryCode.RS,
+            CountryCode.SC, CountryCode.SL, CountryCode.SG, CountryCode.SX, CountryCode.SK, CountryCode.SI, CountryCode.SB, CountryCode.SO, CountryCode.ZA, CountryCode.SS, CountryCode.ES,
+            CountryCode.LK, CountryCode.VC, CountryCode.SD, CountryCode.SR, CountryCode.SJ, CountryCode.SE, CountryCode.CH, CountryCode.SY, CountryCode.TW, CountryCode.TJ, CountryCode.TZ,
+            CountryCode.TH, CountryCode.TL, CountryCode.TG, CountryCode.TK, CountryCode.TO, CountryCode.TT, CountryCode.TA, CountryCode.TN, CountryCode.TR, CountryCode.TM, CountryCode.TC,
+            CountryCode.TV, CountryCode.UM, CountryCode.VI, CountryCode.UG, CountryCode.UA, CountryCode.AE, CountryCode.GB, CountryCode.UY, CountryCode.UZ, CountryCode.VU, CountryCode.VE,
+            CountryCode.VN, CountryCode.WF, CountryCode.PS, CountryCode.EH, CountryCode.YE, CountryCode.ZM, CountryCode.ZW,
+        };
+
+        [SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "Country names don't require spellchecking")]
+        private static readonly IDictionary<string, CountryCode> CountryAliases = new Dictionary<string, CountryCode>
+        {
+            ["Admiralty Islands (included in Papua New Guinea)"] = CountryCode.PG,
+            ["Aegean Islands (included in Greece)"] = CountryCode.GR,
+            ["Alofi Islands (included in Wallis and Futana)"] = CountryCode.WF,
+            ["Andaman Islands (included in India)"] = CountryCode.IN,
+            ["Ascension (included in Saint Helena)"] = CountryCode.SH,
+            ["Aunu'u and Manua Islands (included in American Samoa)"] = CountryCode.AS,
+            ["Azores (included in Portugal)"] = CountryCode.PT,
+            ["Baker Island (included in U.S. Minor Outlying Islands)"] = CountryCode.UM,
+            ["Balearic Islands (included in Spain)"] = CountryCode.ES,
+            ["Bikini Island (included in Marshall Islands)"] = CountryCode.MH,
+            ["Billiton Island (included in Indonesia)"] = CountryCode.ID,
+            ["Bonaire (included in Dutch Caribbean (formerly Netherlands Antilles))"] = CountryCode.BQ,
+            ["British Antarctic Territory (included in Falkland Islands)"] = CountryCode.FK,
+            ["British Indian Ocean Territory (included in Seychelles)"] = CountryCode.SC,
+            ["Burma (included in Myanmar)"] = CountryCode.MM,
+            ["Campbell Island (included in New Zealand)"] = CountryCode.NZ,
+            ["Canary Islands (included in Spain)"] = CountryCode.ES,
+            ["Caroline Islands (included in Micronesia, Federal States of)"] = CountryCode.FM,
+            ["Channel Islands (included in United Kingdom (Great Britain))"] = CountryCode.GB,
+            ["Chatham Island (included in New Zealand)"] = CountryCode.NZ,
+            ["Corfu (included in Greece)"] = CountryCode.GR,
+            ["Corsica (included in France)"] = CountryCode.FR,
+            ["Crete (included in Greece)"] = CountryCode.GR,
+            ["Cyrenaica (included in Libya)"] = CountryCode.LY,
+            ["Desroches (included in Seychelles)"] = CountryCode.SC,
+            ["Dodecanese Island (included in Greece)"] = CountryCode.GR,
+            ["Ducie Island (included in Pitcairn)"] = CountryCode.PN,
+            ["East Timor (included in Timor-Leste)"] = CountryCode.TL,
+            ["Easter Island (included in Chile)"] = CountryCode.CL,
+            ["Ellice Island (included in Tuvalu)"] = CountryCode.TV,
+            ["England (included in United Kingdom (Great Britain))"] = CountryCode.GB,
+            ["Enwetok and Kwajelein Islands (included in Marshall Islands)"] = CountryCode.MH,
+            ["Fanning Island (included in Kiribati)"] = CountryCode.KI,
+            ["Farquhar Island (included in Seychelles)"] = CountryCode.SC,
+            ["Friendly Islands (included in Tonga)"] = CountryCode.TO,
+            ["Futuna Island (included in Wallis and Futuna)"] = CountryCode.WF,
+            ["Gambier Islands (included in French Polynesia)"] = CountryCode.PF,
+            ["Gilbert Islands (included in Kiribati)"] = CountryCode.KI,
+            ["Great Britain (included in United Kingdom (Great Britain))"] = CountryCode.GB,
+            ["Hawaii (included in United States of America)"] = CountryCode.US,
+            ["Henderson Island (included in Pitcairn)"] = CountryCode.PN,
+            ["Hervey Islands (included in New Zealand)"] = CountryCode.NZ,
+            ["Holland (included in Netherlands)"] = CountryCode.NL,
+            ["Howland Island (included in U.S. Minor Outlying Islands)"] = CountryCode.UM,
+            ["Huon Islands (included in New Caledonia)"] = CountryCode.NC,
+            ["Ifni Territory (included in Morocco)"] = CountryCode.MA,
+            ["Inner Mongolia (included in China)"] = CountryCode.CN,
+            ["Isle of Pines (included in New Caledonia)"] = CountryCode.NC,
+            ["Ivory Coast (included in Côte d'Ivoire)"] = CountryCode.CI,
+            ["Jarvis Island (included in U.S. Minor Outlying Island)"] = CountryCode.UM,
+            ["Johnston Island (included in U.S. Minor Outlying Islands)"] = CountryCode.UM,
+            ["Kamaran Islands (included in Yemen)"] = CountryCode.YE,
+            ["Kermadec Islands (included in New Zealand)"] = CountryCode.NZ,
+            ["Kosova (included in Kosovo)"] = CountryCode.XZ,
+            ["Leeward Islands (included in British Virgin Islands)"] = CountryCode.VG,
+            ["Line Island (included in Kiribati)"] = CountryCode.KI,
+            ["Lord Howe Island (included in Australia)"] = CountryCode.AU,
+            ["Loyalty Islands (included in New Caledonia)"] = CountryCode.NC,
+            ["Madeira (included in Portugal)"] = CountryCode.PT,
+            ["Malvinas (included in Falkland Islands)"] = CountryCode.FK,
+            ["Manchuria (included in China)"] = CountryCode.CN,
+            ["Manus Island (included in Papua New Guinea)"] = CountryCode.PG,
+            ["Mariana Islands (included in Northern Mariana Islands)"] = CountryCode.MP,
+            ["Marquesas Islands (included in French Polynesia)"] = CountryCode.PF,
+            ["Midway Island (included in U.S. Minor Outlying Island)"] = CountryCode.UM,
+            ["Moluccas Islands (included in Indonesia)"] = CountryCode.ID,
+            ["Navassa Island (included in United States of America)"] = CountryCode.US,
+            ["Netherlands Antilles (now known as Dutch Caribbean)"] = CountryCode.BQ,
+            ["Nevis (included in Saint Kitts and Nevis)"] = CountryCode.KN,
+            ["New Britain (included in Papua New Guinea)"] = CountryCode.PG,
+            ["New Ireland (included in Papua New Guinea)"] = CountryCode.PG,
+            ["Nicobar Island (included in India)"] = CountryCode.IN,
+            ["Northern Ireland (included in United Kingdom (Great Britain))"] = CountryCode.GB,
+            ["Ocean Island (included in Kiribati)"] = CountryCode.KI,
+            ["Oeno Island (included in Pitcairn)"] = CountryCode.PN,
+            ["Phoenix Island (included in Kiribati)"] = CountryCode.KI,
+            ["Portuguese Timor (included in Timor-Leste)"] = CountryCode.TL,
+            ["Principe (included in Sao Tome and Principe)"] = CountryCode.ST,
+            ["Rarotonga (included in Cook Islands)"] = CountryCode.CK,
+            ["Rodriguez Island (included in Mauritius)"] = CountryCode.MU,
+            ["Ross Dependency (included in New Zealand)"] = CountryCode.NZ,
+            ["Saba (included in Dutch Caribbean (formerly Netherlands Antilles))"] = CountryCode.BQ,
+            ["Sand Island (included in U.S. Minor Outlying Islands)"] = CountryCode.UM,
+            ["Santas Cruz Island (included in Solomon Islands)"] = CountryCode.SB,
+            ["Savage Island (included in U.S. Minor Outlying Islands)"] = CountryCode.UM,
+            ["Scotland (included in United Kingdom (Great Britain))"] = CountryCode.GB,
+            ["Shortland Island (included in Solomon Islands)"] = CountryCode.SB,
+            ["Sicily (included in Italy)"] = CountryCode.IT,
+            ["Sint Eustatius (included Dutch Caribbean (formerly Netherlands Antilles))"] = CountryCode.BQ,
+            ["Society Islands (included in French Polynesia)"] = CountryCode.PF,
+            ["South Georgia & South Sandwich Islands (included in Falkland Islands)"] = CountryCode.FK,
+            ["South Orkney Islands (included in Falkland Islands)"] = CountryCode.FK,
+            ["South Shetland Islands (included in Falkland Islands)"] = CountryCode.FK,
+            ["Spanish Territories of North Africa (included in Spain)"] = CountryCode.ES,
+            ["St Croix (included in U.S. Virgin Islands)"] = CountryCode.VI,
+            ["St John Island (included in U.S. Virgin Islands)"] = CountryCode.VI,
+            ["St Thomas Island (included in U.S. Virgin Islands)"] = CountryCode.VI,
+            ["Suwarrow Island (included in New Zealand)"] = CountryCode.NZ,
+            ["Swains Island (included in American Samoa)"] = CountryCode.AS,
+            ["Tahiti (included in French Polynesia)"] = CountryCode.PF,
+            ["Tarawa Island (included in Kiribati)"] = CountryCode.KI,
+            ["Tasmania (included in Australia)"] = CountryCode.AU,
+            ["Tibet (included in China)"] = CountryCode.CN,
+            ["Torres Island (included in Vanuatu)"] = CountryCode.VU,
+            ["Tortola Island (included in British Virgin Islands)"] = CountryCode.VG,
+            ["Touamotu Islands (included in French Polynesia)"] = CountryCode.PF,
+            ["Tripolitania (included in Libya)"] = CountryCode.LY,
+            ["Truk Island (included in Micronesia, Federal States Of)"] = CountryCode.FM,
+            ["Trust Territory of Pacific (included in United States of America)"] = CountryCode.US,
+            ["Tubuai Islands (included in French Polynesia)"] = CountryCode.PF,
+            ["Tutuila Island (included in American Samoa)"] = CountryCode.AS,
+            ["Union Group (included in Tokelau)"] = CountryCode.TK,
+            ["Vatican (included in Holy See (Vatican))"] = CountryCode.VA,
+            ["Vojvodina (included in Serbia)"] = CountryCode.RS,
+            ["Wake Island (including in U.S. Minor Outlying Islands)"] = CountryCode.UM,
+            ["Wales (included in United Kingdom (Great Britain))"] = CountryCode.GB,
+            ["Washington Island (included in Kiribati)"] = CountryCode.KI,
+            ["Yap Island (included in Micronesia, Federal States Of)"] = CountryCode.FM,
+            ["Yugoslavia (included in Serbia)"] = CountryCode.RS,
+            ["Zaire (included in Congo, Democratic Republic Of)"] = CountryCode.CD,
+        };
+
+        /// <summary>
+        /// Gets country names, with Canada first, followed by USA, then the remaining countries ordered alphabetically.
+        /// </summary>
+        public static IEnumerable<string> Countries => CountryCodes.Select(GetCountryName);
+
+        /// <summary>
+        /// Gets country names, with Canada first, followed by USA, then the remaining countries and aliases ordered
+        /// alphabetically.
+        /// </summary>
+        public static IEnumerable<string> CountriesWithAliases =>
+            CountryCodes.Take(2)
+                .Select(GetCountryName)
+                .Concat(
+                    CountryCodes.Skip(2)
+                        .Select(GetCountryName)
+                        .Concat(CountryAliases.Select(c => c.Key))
+                        .Order());
+
+        /// <summary>
+        /// Gets the names of Canadian provinces in alphabetical order.
+        /// </summary>
+        public static IEnumerable<string> Provinces => ProvinceAbbreviations.Select(p => EnumUtility.ToEnumString(p, true));
+
+        /// <summary>
+        /// Gets the names of American states in alphabetical order.
+        /// </summary>
+        public static IEnumerable<string> States => StateAbbreviations.Select(s => EnumUtility.ToEnumString(s, true));
+
+        /// <summary>
+        /// Returns the name of a country given its country code.
+        /// </summary>
+        /// <param name="code">The country code in question.</param>
+        /// <returns>A string containing the name of the country.</returns>
+        public static string GetCountryName(CountryCode code)
+        {
+            return EnumUtility.ToEnumString(code, true);
+        }
+
+        /// <summary>
+        /// Returns the country code corresponding to a country (or country alias).
+        /// </summary>
+        /// <param name="name">The name of the country in question, or one of its aliases.</param>
+        /// <returns>
+        /// The <see cref="CountryCode"/> corresponding to the country, or <see cref="CountryCode.Unknown"/> if there's no
+        /// matching value.
+        /// </returns>
+        public static CountryCode GetCountryCode(string name)
+        {
+            try
+            {
+                return CountryAliases.TryGetValue(name, out CountryCode code) ? code : EnumUtility.ToEnum<CountryCode>(name, true);
+            }
+            catch (ArgumentException)
+            {
+                return CountryCode.Unknown;
+            }
+        }
+
         /// <summary>
         /// Concatenates elements of the address into a single string, separated by commas and spaces.
         /// </summary>

--- a/Apps/CommonUi/src/Constants/Mask.cs
+++ b/Apps/CommonUi/src/Constants/Mask.cs
@@ -15,14 +15,30 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Ui.Constants
 {
+    using MudBlazor;
+
     /// <summary>
-    /// A class with constants representing the various format masks.
+    /// A class with fields representing the various format masks.
     /// </summary>
     public static class Mask
     {
         /// <summary>
-        /// Format mask template for PHN.
+        /// Format mask for Personal Health Number (PHN).
         /// </summary>
-        public const string PhnMaskTemplate = "0000 000 000";
+        public static readonly IMask PhnMask = new PatternMask("0000 000 000");
+
+        /// <summary>
+        /// Format mask for Canadian postal codes.
+        /// </summary>
+        public static readonly IMask PostalCodeMask = new PatternMask("a0a 0a0")
+        {
+            Transformation = char.ToUpperInvariant,
+        };
+
+        /// <summary>
+        /// Format mask for American zip codes (00000 or 00000-0000).
+        /// </summary>
+        // Using a RegexMask instead of a PatternMask ensures the hyphen won't appear after 5 digits are entered.
+        public static readonly IMask ZipCodeMask = new RegexMask(@"^\d{0,4}$|^\d{5}(-\d{0,4})?$");
     }
 }


### PR DESCRIPTION
# Implements [AB#16064](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16064)

## Description

Adds AddressConfirmationDialog and supporting items, including:

- HgAutocomplete component
- utility methods for retrieving countries, provinces, and states
- masks and regular expressions for postal codes and zip codes

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

![Screenshot 2023-09-06 173834](https://github.com/bcgov/healthgateway/assets/16570293/eaa00122-36fe-44af-aa45-5196704795dc)
![Screenshot 2023-09-06 173906](https://github.com/bcgov/healthgateway/assets/16570293/bff8cc0d-4029-4c6d-a2b6-a47171d6dcce)
![Screenshot 2023-09-06 174019](https://github.com/bcgov/healthgateway/assets/16570293/1351db49-8020-46fa-94bf-481e2e9e19ef)
![Screenshot 2023-09-06 174740](https://github.com/bcgov/healthgateway/assets/16570293/3356ae7c-54e3-494c-9e20-031fcd2a772d)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
