### PR TITLE
Resolve class coupling warning for unit tests AB#15653

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -800,3 +800,8 @@ resharper_web_config_wrong_module_highlighting = warning
 dotnet_diagnostic.SA1629.severity = none
 # IDE0058: Remove unnecessary expression value
 dotnet_diagnostic.IDE0058.severity = none
+
+[**/test/unit/**/*Tests.cs]
+
+# CA1506: Avoid excessive class coupling
+dotnet_diagnostic.ca1506.severity = none


### PR DESCRIPTION
# Fixes [AB#15653](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15653)

## Description

Disables class coupling warning for unit tests only.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
