### PR TITLE
Add cancer recall to set for AB#16084

### DIFF
--- a/Apps/Patient/src/Models/BcCancerScreeningType.cs
+++ b/Apps/Patient/src/Models/BcCancerScreeningType.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Patient.Models
+{
+    /// <summary>
+    /// BC Cancer screening types.
+    /// </summary>
+    public enum BcCancerScreeningType
+    {
+        /// <summary>
+        /// Cancer screening recall.
+        /// </summary>
+        Recall,
+
+        /// <summary>
+        /// Cancer screening result.
+        /// </summary>
+        Result,
+    }
+}

--- a/Apps/Patient/src/Models/BcCancerScreeningType.cs
+++ b/Apps/Patient/src/Models/BcCancerScreeningType.cs
@@ -15,11 +15,20 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Patient.Models
 {
+    using System.Text.Json.Serialization;
+
     /// <summary>
     /// BC Cancer screening types.
     /// </summary>
+    [JsonStringEnumMemberConverterOptions(deserializationFailureFallbackValue: Unknown)]
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum BcCancerScreeningType
     {
+        /// <summary>
+        /// Unknown result from PHSA
+        /// </summary>
+        Unknown,
+
         /// <summary>
         /// Cancer screening recall.
         /// </summary>

--- a/Apps/Patient/src/Models/BcCancerScreeningType.cs
+++ b/Apps/Patient/src/Models/BcCancerScreeningType.cs
@@ -25,7 +25,7 @@ namespace HealthGateway.Patient.Models
     public enum BcCancerScreeningType
     {
         /// <summary>
-        /// Unknown result from PHSA
+        /// Unknown result from PHSA.
         /// </summary>
         Unknown,
 

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -66,6 +66,7 @@ namespace HealthGateway.Patient.Services
     [JsonConverter(typeof(PatientDataJsonConverter))]
     [KnownType(typeof(OrganDonorRegistration))]
     [KnownType(typeof(DiagnosticImagingExam))]
+    [KnownType(typeof(BcCancerScreening))]
     public abstract record PatientData
     {
         /// <summary>
@@ -167,6 +168,11 @@ namespace HealthGateway.Patient.Services
     /// </summary>
     public record BcCancerScreening : PatientData
     {
+        /// <summary>
+        /// Gets or sets the type.
+        /// </summary>
+        public BcCancerScreeningType EventType { get; set; }
+
         /// <summary>
         /// Gets or sets the program name.
         /// </summary>

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -55,7 +55,7 @@ namespace HealthGateway.Patient.Services
             HealthQuery healthQuery = new(pid, unblockedPatientDataTypes.Select(t => this.mapper.Map<HealthCategory>(t)));
             PatientDataQueryResult result = await this.patientDataRepository.Query(healthQuery, ct)
                 .ConfigureAwait(true);
-            return new PatientDataResponse(result.Items.Where(Filter).Select(i => this.mapper.Map<PatientData>(i)));
+            return new PatientDataResponse(result.Items.Select(i => this.mapper.Map<PatientData>(i)));
         }
 
         public async Task<PatientFileResponse?> Query(PatientFileQuery query, CancellationToken ct)
@@ -67,16 +67,6 @@ namespace HealthGateway.Patient.Services
             return file != null
                 ? new PatientFileResponse(file.Content, file.ContentType)
                 : null;
-        }
-
-        private static bool Filter(HealthData healthData)
-        {
-            if (healthData is PatientDataAccess.BcCancerScreening cse)
-            {
-                return cse.EventType == BcCancerScreeningType.Result;
-            }
-
-            return true;
         }
 
         private async Task<IList<PatientDataType>> GetUnblockedPatientDataTypesAsync(string hdid, IEnumerable<PatientDataType> patientDataTypes)

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -160,31 +160,6 @@ namespace HealthGateway.PatientTests.Services
             }
         }
 
-        [Fact]
-        public async Task CannotGetCancerScreeningData()
-        {
-            BcCancerScreening expected = new()
-            {
-                EventType = BcCancerScreeningType.Recall,
-            };
-
-            Mock<IPatientDataRepository> patientDataRepository = new();
-            patientDataRepository.AttachMockQuery<HealthQuery>(
-                q => q.Pid == this.pid && q.Categories.Any(c => c == HealthCategory.BcCancerScreening),
-                expected);
-            Mock<IPersonalAccountsService> personalAccountService = this.GetMockPersonalAccountService();
-
-            Mock<IPatientRepository> patientRepository = new();
-            patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
-
-            PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
-
-            PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.BcCancerScreening }), CancellationToken.None)
-                .ConfigureAwait(true);
-
-            result.Items.ShouldBeEmpty();
-        }
-
         [Theory]
         [InlineData(true)]
         [InlineData(false)]

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
@@ -93,7 +93,7 @@ function downloadFile(): void {
         :has-attachment="Boolean(entry.fileId)"
     >
         <p class="text-body-1 mb-3">
-            <span v-if="isResult">
+            <span v-if="isResult" data-testid="bc-cancer-result-body">
                 For information about your results, you can contact
                 <a
                     href="http://www.bccancer.bc.ca/contact"
@@ -103,7 +103,7 @@ function downloadFile(): void {
                     >BC Cancer</a
                 >.
             </span>
-            <span v-else>
+            <span v-else data-testid="bc-cancer-screening-body">
                 <a
                     href="http://www.bccancer.bc.ca/screening/cervix/get-screened/what-is-cervical-screening"
                     target="_blank"

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
@@ -8,10 +8,7 @@ import TimelineEntryComponent from "@/components/private/timeline/TimelineEntryC
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
-import {
-    BcCancerScreeningType,
-    PatientDataFile,
-} from "@/models/patientDataResponse";
+import { PatientDataFile } from "@/models/patientDataResponse";
 import BcCancerScreeningTimelineEntry from "@/models/timeline/bcCancerScreeningTimelineEntry";
 import { ILogger } from "@/services/interfaces";
 import { usePatientDataStore } from "@/stores/patientData";
@@ -45,9 +42,6 @@ const isLoadingFile = computed(
 const hasFile = computed(
     () => props.entry.fileId !== undefined && props.entry.fileId !== ""
 );
-const isResult = computed(
-    () => props.entry.screeningType === BcCancerScreeningType.Result
-);
 
 function showConfirmationModal(): void {
     messageModal.value?.showModal();
@@ -55,15 +49,9 @@ function showConfirmationModal(): void {
 
 function downloadFile(): void {
     if (props.entry.fileId) {
-        const eventText = isResult.value
-            ? "BC Cancer Result PDF"
-            : "BC Cancer Screening PDF";
-        const fileName = isResult.value
-            ? "bc_cancer_result"
-            : "bc_cancer_screening";
         SnowPlow.trackEvent({
             action: "download_report",
-            text: eventText,
+            text: props.entry.eventText,
         });
         const dateString = props.entry.date.format("yyyy_MM_dd-HH_mm");
         patientDataStore
@@ -74,7 +62,9 @@ function downloadFile(): void {
                         type: patientFile.contentType,
                     })
             )
-            .then((blob) => saveAs(blob, `${fileName}_${dateString}.pdf`))
+            .then((blob) =>
+                saveAs(blob, `${props.entry.fileName}_${dateString}.pdf`)
+            )
             .catch((err) => logger.error(err));
     }
 }
@@ -93,7 +83,10 @@ function downloadFile(): void {
         :has-attachment="Boolean(entry.fileId)"
     >
         <p class="text-body-1 mb-3">
-            <span v-if="isResult" data-testid="bc-cancer-result-body">
+            <span
+                v-if="props.entry.isResult"
+                data-testid="bc-cancer-result-body"
+            >
                 For information about your results, you can contact
                 <a
                     href="http://www.bccancer.bc.ca/contact"

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
@@ -8,7 +8,10 @@ import TimelineEntryComponent from "@/components/private/timeline/TimelineEntryC
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
-import { PatientDataFile } from "@/models/patientDataResponse";
+import {
+    BcCancerScreeningType,
+    PatientDataFile,
+} from "@/models/patientDataResponse";
 import BcCancerScreeningTimelineEntry from "@/models/timeline/bcCancerScreeningTimelineEntry";
 import { ILogger } from "@/services/interfaces";
 import { usePatientDataStore } from "@/stores/patientData";
@@ -42,6 +45,9 @@ const isLoadingFile = computed(
 const hasFile = computed(
     () => props.entry.fileId !== undefined && props.entry.fileId !== ""
 );
+const isResult = computed(
+    () => props.entry.screeningType === BcCancerScreeningType.Result
+);
 
 function showConfirmationModal(): void {
     messageModal.value?.showModal();
@@ -49,9 +55,15 @@ function showConfirmationModal(): void {
 
 function downloadFile(): void {
     if (props.entry.fileId) {
+        const eventText = isResult.value
+            ? "BC Cancer Result PDF"
+            : "BC Cancer Screening PDF";
+        const fileName = isResult.value
+            ? "bc_cancer_result"
+            : "bc_cancer_screening";
         SnowPlow.trackEvent({
             action: "download_report",
-            text: "BC Cancer Result PDF",
+            text: eventText,
         });
         const dateString = props.entry.date.format("yyyy_MM_dd-HH_mm");
         patientDataStore
@@ -62,9 +74,7 @@ function downloadFile(): void {
                         type: patientFile.contentType,
                     })
             )
-            .then((blob) =>
-                saveAs(blob, `bc_cancer_screening_${dateString}.pdf`)
-            )
+            .then((blob) => saveAs(blob, `${fileName}_${dateString}.pdf`))
             .catch((err) => logger.error(err));
     }
 }
@@ -76,28 +86,50 @@ function downloadFile(): void {
         :entry-icon="entryIcon"
         icon-class="bg-primary"
         :title="entry.title"
-        :subtitle="`Program: ${entry.programName}`"
+        :subtitle="entry.subtitle"
         :entry="entry"
         :is-mobile-details="isMobileDetails"
         :allow-comment="commentsAreEnabled"
         :has-attachment="Boolean(entry.fileId)"
     >
         <p class="text-body-1 mb-3">
-            For information about your results, you can contact
-            <a
-                href="http://www.bccancer.bc.ca/contact"
-                target="_blank"
-                rel="noopener"
-                class="text-link"
-                >BC Cancer</a
-            >.
+            <span v-if="isResult">
+                For information about your results, you can contact
+                <a
+                    href="http://www.bccancer.bc.ca/contact"
+                    target="_blank"
+                    rel="noopener"
+                    class="text-link"
+                    >BC Cancer</a
+                >.
+            </span>
+            <span v-else>
+                <a
+                    href="http://www.bccancer.bc.ca/screening/cervix/get-screened/what-is-cervical-screening"
+                    target="_blank"
+                    rel="noopener"
+                    class="text-link"
+                    >Cervix screening</a
+                >
+                (Pap test) can stop at age 69 if your results have always been
+                normal. Ask your health care provider if you should still be
+                tested. To book your next Pap test, contact your health care
+                provider or a
+                <a
+                    href="http://www.bccancer.bc.ca/screening/cervix/clinic-locator"
+                    target="_blank"
+                    rel="noopener"
+                    class="text-link"
+                    >medical clinic</a
+                >.
+            </span>
         </p>
         <HgButtonComponent
             v-if="hasFile"
             data-testid="bc-cancer-screening-download-button"
             class="mb-6"
             variant="secondary"
-            text="View PDF"
+            :text="entry.callToActionText"
             prepend-icon="eye"
             :loading="isLoadingFile"
             @click="showConfirmationModal()"

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -165,7 +165,7 @@ entryTypeMap.set(EntryType.BcCancerScreening, {
     commentType: CommentEntryType.BcCancerScreening,
     name: "BC Cancer Screening",
     description:
-        "View and download your results as soon as they are available.",
+        "View and download your notices and results as soon as they are available.",
     icon: "ribbon",
     component: "BcCancerScreeningTimelineComponent",
     eventName: "bc_cancer_screening",

--- a/Apps/WebClient/src/ClientApp/src/models/patientDataResponse.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/patientDataResponse.ts
@@ -59,6 +59,7 @@ export class DiagnosticImagingExam extends PatientData {
 }
 
 export class BcCancerScreening extends PatientData {
+    public eventType!: BcCancerScreeningType;
     public programName!: string;
     public fileId!: string;
     public eventDateTime!: string;
@@ -68,4 +69,9 @@ export class BcCancerScreening extends PatientData {
 export class PatientDataFile {
     public content!: number[];
     public contentType!: string;
+}
+
+export enum BcCancerScreeningType {
+    Recall,
+    Result,
 }

--- a/Apps/WebClient/src/ClientApp/src/models/patientDataResponse.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/patientDataResponse.ts
@@ -72,6 +72,7 @@ export class PatientDataFile {
 }
 
 export enum BcCancerScreeningType {
-    Recall,
-    Result,
+    Unknown = "Unknown",
+    Recall = "Recall",
+    Result = "Result",
 }

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
@@ -24,38 +24,37 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
         model: BcCancerScreening,
         getComments: (entryId: string) => UserComment[] | null
     ) {
+        const isResult = model.eventType === BcCancerScreeningType.Result;
+        const date = isResult ? model.resultDateTime : model.eventDateTime;
         super(
-            model.id ?? `cancerScreening-${model.resultDateTime}`,
+            model.id ?? `cancerScreening-${date}`,
             EntryType.BcCancerScreening,
-            new DateWrapper(model.resultDateTime, { isUtc: true })
+            new DateWrapper(date, { isUtc: true })
         );
-
+        this.isResult = isResult;
+        this.entryDate = date;
         this.subtitle = `Programe: ${model.programName}`;
         this.fileId = model.fileId;
         this.screeningType = model.eventType;
-        this.setEntryProperties(model);
-        this.getComments = getComments;
-
-        this.isResult = model.eventType === BcCancerScreeningType.Result;
         this.fileName = this.isResult
             ? "bc_cancer_result"
             : "bc_cancer_screening";
         this.eventText = this.isResult
             ? "BC Cancer Result PDF"
             : "BC Cancer Screening PDF";
+        this.setEntryProperties();
+        this.getComments = getComments;
     }
 
-    private setEntryProperties(model: BcCancerScreening): void {
+    private setEntryProperties(): void {
         if (this.screeningType === BcCancerScreeningType.Result) {
             this.title = "BC Cancer Result";
-            this.entryDate = model.resultDateTime;
             this.callToActionText = "View PDF";
             this.documentType = "Screening results";
         } else {
             this.title = "BC Cancer Screening";
             this.callToActionText = "View Letter";
             this.documentType = "Screening letter";
-            this.entryDate = model.eventDateTime;
         }
     }
 

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
@@ -14,6 +14,9 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
     public subtitle: string;
     public callToActionText!: string;
     public screeningType: BcCancerScreeningType;
+    public isResult!: boolean;
+    public fileName!: string;
+    public eventText!: string;
 
     private getComments: (entryId: string) => UserComment[] | null;
 
@@ -32,6 +35,14 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
         this.screeningType = model.eventType;
         this.setEntryProperties(model);
         this.getComments = getComments;
+
+        this.isResult = model.eventType === BcCancerScreeningType.Result;
+        this.fileName = this.isResult
+            ? "bc_cancer_result"
+            : "bc_cancer_screening";
+        this.eventText = this.isResult
+            ? "BC Cancer Result PDF"
+            : "BC Cancer Screening PDF";
     }
 
     private setEntryProperties(model: BcCancerScreening): void {

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
@@ -1,5 +1,5 @@
 import { EntryType } from "@/constants/entryType";
-import { DateWrapper, StringISODate } from "@/models/dateWrapper";
+import { DateWrapper } from "@/models/dateWrapper";
 import {
     BcCancerScreening,
     BcCancerScreeningType,
@@ -10,7 +10,6 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
     public title!: string;
     public documentType!: string;
     public fileId: string;
-    public entryDate!: StringISODate;
     public subtitle: string;
     public callToActionText!: string;
     public screeningType: BcCancerScreeningType;
@@ -32,16 +31,9 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
             new DateWrapper(date, { isUtc: true })
         );
         this.isResult = isResult;
-        this.entryDate = date;
         this.subtitle = `Programe: ${model.programName}`;
         this.fileId = model.fileId;
         this.screeningType = model.eventType;
-        this.fileName = this.isResult
-            ? "bc_cancer_result"
-            : "bc_cancer_screening";
-        this.eventText = this.isResult
-            ? "BC Cancer Result PDF"
-            : "BC Cancer Screening PDF";
         this.setEntryProperties();
         this.getComments = getComments;
     }
@@ -51,10 +43,14 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
             this.title = "BC Cancer Result";
             this.callToActionText = "View PDF";
             this.documentType = "Screening results";
+            this.fileName = "bc_cancer_result";
+            this.eventText = "BC Cancer Result PDF";
         } else {
             this.title = "BC Cancer Screening";
             this.callToActionText = "View Letter";
             this.documentType = "Screening letter";
+            this.fileName = "bc_cancer_screening";
+            this.eventText = "BC Cancer Screening PDF";
         }
     }
 

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
@@ -1,14 +1,19 @@
 import { EntryType } from "@/constants/entryType";
 import { DateWrapper, StringISODate } from "@/models/dateWrapper";
-import { BcCancerScreening } from "@/models/patientDataResponse";
+import {
+    BcCancerScreening,
+    BcCancerScreeningType,
+} from "@/models/patientDataResponse";
 import TimelineEntry from "@/models/timeline/timelineEntry";
 import { UserComment } from "@/models/userComment";
 export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
-    public title: string;
-    public documentType: string;
+    public title!: string;
+    public documentType!: string;
     public fileId: string;
-    public resultDate: StringISODate;
-    public programName: string;
+    public entryDate!: StringISODate;
+    public subtitle: string;
+    public callToActionText!: string;
+    public screeningType: BcCancerScreeningType;
 
     private getComments: (entryId: string) => UserComment[] | null;
 
@@ -22,12 +27,25 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
             new DateWrapper(model.resultDateTime, { isUtc: true })
         );
 
-        this.title = "BC Cancer Result";
-        this.documentType = "Screening results";
-        this.programName = model.programName;
+        this.subtitle = `Programe: ${model.programName}`;
         this.fileId = model.fileId;
-        this.resultDate = model.resultDateTime;
+        this.screeningType = model.eventType;
+        this.setEntryProperties(model);
         this.getComments = getComments;
+    }
+
+    private setEntryProperties(model: BcCancerScreening): void {
+        if (this.screeningType === BcCancerScreeningType.Result) {
+            this.title = "BC Cancer Result";
+            this.entryDate = model.resultDateTime;
+            this.callToActionText = "View PDF";
+            this.documentType = "Screening results";
+        } else {
+            this.title = "BC Cancer Screening";
+            this.callToActionText = "View Letter";
+            this.documentType = "Screening letter";
+            this.entryDate = model.eventDateTime;
+        }
     }
 
     public get comments(): UserComment[] | null {

--- a/Testing/functional/tests/cypress/fixtures/PatientData/bcCancerTypes.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientData/bcCancerTypes.json
@@ -1,0 +1,24 @@
+{
+    "items": [
+        {
+            "eventType": 1,
+            "programName": "Cervical Cancer",
+            "fileId": "bccancerscreening_vpp_12345678931",
+            "eventDateTime": "2022-11-13T18:02:58.8640659Z",
+            "resultDateTime": "2022-10-22T06:34:07.7614979Z",
+            "type": "BcCancerScreening",
+            "id": "bccancerscreening_vpp_12345678931",
+            "$type": "BcCancerScreening"
+        },
+        {
+            "eventType": 0,
+            "programName": "Cervical Cancer",
+            "fileId": "bccancerscreening_vpp_12345678932",
+            "eventDateTime": "2023-03-01T10:59:45.5481227Z",
+            "resultDateTime": "2023-05-28T08:20:15.242515Z",
+            "type": "BcCancerScreening",
+            "id": "bccancerscreening_vpp_12345678932",
+            "$type": "BcCancerScreening"
+        }
+    ]
+}

--- a/Testing/functional/tests/cypress/fixtures/PatientData/bcCancerTypes.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientData/bcCancerTypes.json
@@ -1,7 +1,7 @@
 {
     "items": [
         {
-            "eventType": 1,
+            "eventType": "Result",
             "programName": "Cervical Cancer",
             "fileId": "bccancerscreening_vpp_12345678931",
             "eventDateTime": "2022-11-13T18:02:58.8640659Z",
@@ -11,7 +11,7 @@
             "$type": "BcCancerScreening"
         },
         {
-            "eventType": 0,
+            "eventType": "Recall",
             "programName": "Cervical Cancer",
             "fileId": "bccancerscreening_vpp_12345678932",
             "eventDateTime": "2023-03-01T10:59:45.5481227Z",

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/bcCancerScreening.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/bcCancerScreening.js
@@ -1,6 +1,41 @@
 const { AuthMethod } = require("../../../support/constants");
 
 describe("Diagnostic Imaging", () => {
+    function downloadFileTests(fileNamePrefix) {
+        // Expand the card (require force as the title isn't a natural click target)
+        cy.get("[data-testid=bccancerscreeningTitle]")
+            .should("be.visible")
+            .click({ force: true });
+        // Test for generic message modal regarding sensitive data
+        cy.get("[data-testid=bc-cancer-screening-download-button]")
+            .should("be.visible")
+            .click();
+        cy.document()
+            .find("[data-testid=generic-message-modal]")
+            .should("be.visible");
+        // Submit the generic message modal, which should close the modal
+        cy.document().find("[data-testid=generic-message-submit-btn]").click();
+        cy.document()
+            .find("[data-testid=generic-message-modal]")
+            .should("not.exist");
+
+        // Test for file download with the entry date suffix.
+        cy.get("[data-testid=entryCardDate]")
+            .first()
+            .invoke("text")
+            .then((text) => {
+                var date = new Date(text);
+                var dateSuffix = date
+                    .toISOString()
+                    .slice(0, 10)
+                    .replace(/-/g, "_");
+
+                cy.verifyDownload(`${fileNamePrefix}_${dateSuffix}`, {
+                    contains: true,
+                });
+            });
+    }
+
     beforeEach(() => {
         cy.configureSettings({
             datasets: [
@@ -31,46 +66,17 @@ describe("Diagnostic Imaging", () => {
             });
     });
 
-    it("Validate file download", () => {
+    it("Validate result file download", () => {
         cy.get("[data-testid=timelineCard")
+            .filter(`:contains(BC Cancer Result)`)
             .first()
-            .within(() => {
-                cy.get("[data-testid=bccancerscreeningTitle]")
-                    .should("be.visible")
-                    .click({ force: true });
-                cy.get(
-                    "[data-testid=bc-cancer-screening-download-button]"
-                ).should("be.visible");
-                // Test for generic message modal regarding sensitive data
-                cy.get(
-                    "[data-testid=bc-cancer-screening-download-button]"
-                ).click();
-                cy.document()
-                    .find("[data-testid=generic-message-modal]")
-                    .should("be.visible");
-                // Submit the generic message modal, which should close the modal
-                cy.document()
-                    .find("[data-testid=generic-message-submit-btn]")
-                    .click();
-                cy.document()
-                    .find("[data-testid=generic-message-modal]")
-                    .should("not.exist");
+            .within(() => downloadFileTests("bc_cancer_result"));
+    });
 
-                // Test for file download with the entry date suffix.
-                cy.get("[data-testid=entryCardDate]")
-                    .first()
-                    .invoke("text")
-                    .then((text) => {
-                        var date = new Date(text);
-                        var dateSuffix = date
-                            .toISOString()
-                            .slice(0, 10)
-                            .replace(/-/g, "_");
-
-                        cy.verifyDownload(`bc_cancer_screening_${dateSuffix}`, {
-                            contains: true,
-                        });
-                    });
-            });
+    it("Validate recall file download", () => {
+        cy.get("[data-testid=timelineCard]")
+            .filter(`:contains(BC Cancer Screening)`)
+            .first()
+            .within(() => downloadFileTests("bc_cancer_screening"));
     });
 });

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/bcCancerScreening.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/bcCancerScreening.js
@@ -68,14 +68,14 @@ describe("Diagnostic Imaging", () => {
 
     it("Validate result file download", () => {
         cy.get("[data-testid=timelineCard")
-            .filter(`:contains(BC Cancer Result)`)
+            .filter(`:contains("BC Cancer Result")`)
             .first()
             .within(() => downloadFileTests("bc_cancer_result"));
     });
 
     it("Validate recall file download", () => {
         cy.get("[data-testid=timelineCard]")
-            .filter(`:contains(BC Cancer Screening)`)
+            .filter(`:contains("BC Cancer Screening")`)
             .first()
             .within(() => downloadFileTests("bc_cancer_screening"));
     });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
@@ -34,6 +34,7 @@ describe("BC Cancer Screening cards", () => {
         );
         cy.checkTimelineHasLoaded();
     });
+    
     it("Should display different cards for different types", () => {
         testCard("BC Cancer Screening", "View Letter");
         testCard("BC Cancer Result", "View PDF");

--- a/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
@@ -1,0 +1,41 @@
+const { AuthMethod } = require("../../../support/constants");
+
+describe("BC Cancer Screening cards", () => {
+    function testCard(cardTitle, cardButtonText) {
+        cy.get("[data-testid=timelineCard")
+            .filter(`:contains(${cardTitle})`)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=bccancerscreeningTitle]").click({
+                    force: true,
+                });
+                cy.get("[data-testid=bc-cancer-screening-download-button]")
+                    .contains(cardButtonText, { matchCase: false })
+                    .should("exist");
+            });
+    }
+
+    before(() => {
+        cy.intercept("GET", "**/PatientData/*?patientDataTypes=*", {
+            fixture: "PatientData/bcCancerTypes.json",
+        });
+        cy.configureSettings({
+            datasets: [
+                {
+                    name: "bcCancerScreening",
+                    enabled: true,
+                },
+            ],
+        });
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak
+        );
+        cy.checkTimelineHasLoaded();
+    });
+    it("Should display different cards for different types", () => {
+        testCard("BC Cancer Screening", "View Letter");
+        testCard("BC Cancer Result", "View PDF");
+    });
+});

--- a/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
@@ -3,7 +3,7 @@ const { AuthMethod } = require("../../../support/constants");
 describe("BC Cancer Screening cards", () => {
     function testCard(cardTitle, cardButtonText) {
         cy.get("[data-testid=timelineCard")
-            .filter(`:contains(${cardTitle})`)
+            .filter(`:contains("${cardTitle}")`)
             .first()
             .within(() => {
                 cy.get("[data-testid=bccancerscreeningTitle]").click({


### PR DESCRIPTION
# Implements [AB#16084](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16084)

## Description
1. Remove recall filtering on returned data from PHSA patient.
2. Removed obsolete test related to filtering out recall results.
3. Added a UI test to test for the differences between screening types.
4. Update data set description for QuickLink and Landing page

## Testing

- [X] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

![image](https://github.com/bcgov/healthgateway/assets/19548348/1fcf7610-c5c2-4c21-8be1-e99a0b54b888)

![image](https://github.com/bcgov/healthgateway/assets/19548348/14f7af36-0b6a-4e2d-8789-8a8e25ea96c7)

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/659e0b21-6cc3-4621-a07d-ce0fc4868645)

![image](https://github.com/bcgov/healthgateway/assets/19548348/cfe9feb2-0c9a-49aa-9046-9d9e73ac0576)


## Notes
Data now extended to include recall data, with eventType to diferentiate:

![image](https://github.com/bcgov/healthgateway/assets/19548348/2896df10-f125-45c4-a1bf-1137d157f279)



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
