### PR TITLE
Add retrieve vaccine record to controller, service and unit tests AB#16106

### DIFF
--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Admin.Server.Controllers
     using HealthGateway.Admin.Server.Models.CovidSupport;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Models;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -137,6 +138,25 @@ namespace HealthGateway.Admin.Server.Controllers
         public async Task MailVaccineCard([FromBody] MailDocumentRequest request)
         {
             await this.covidSupportService.MailVaccineCardAsync(request).ConfigureAwait(true);
+        }
+
+        /// <summary>
+        /// Gets the COVID-19 Vaccine Record document that includes the Vaccine Card and Vaccination History.
+        /// </summary>
+        /// <returns>The encoded immunization document.</returns>
+        /// <param name="phn">The personal health number that matches the document to retrieve.</param>
+        /// <response code="200">The request to retrieve the encoded immunization document was successful.</response>
+        /// <response code="400">The request could not be submitted successfully.</response>
+        /// <response code="401">the client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        [Route("Patient/Document")]
+        public async Task<ReportModel> RetrieveVaccineRecord([FromHeader] string phn)
+        {
+            return await this.covidSupportService.RetrieveVaccineRecordAsync(phn).ConfigureAwait(true);
         }
 
         /// <summary>

--- a/Apps/Admin/Server/Services/CovidSupportService.cs
+++ b/Apps/Admin/Server/Services/CovidSupportService.cs
@@ -44,6 +44,7 @@ namespace HealthGateway.Admin.Server.Services
     /// </summary>
     public class CovidSupportService : ICovidSupportService
     {
+        private readonly BcMailPlusConfig bcmpConfig;
         private readonly VaccineCardConfig vaccineCardConfig;
         private readonly ILogger<CovidSupportService> logger;
         private readonly IAuthenticationDelegate authenticationDelegate;
@@ -78,28 +79,30 @@ namespace HealthGateway.Admin.Server.Services
             this.immunizationAdminApi = immunizationAdminApi;
             this.patientRepository = patientRepository;
 
+            this.bcmpConfig = new();
+            configuration.Bind(BcMailPlusConfig.ConfigSectionKey, this.bcmpConfig);
+
             this.vaccineCardConfig = new();
-            configuration.Bind(VaccineCardConfig.VaccineCardConfigSectionKey, this.vaccineCardConfig);
+            configuration.Bind(VaccineCardConfig.ConfigSectionKey, this.vaccineCardConfig);
         }
 
         /// <inheritdoc/>
         public async Task MailVaccineCardAsync(MailDocumentRequest request, CancellationToken ct = default)
         {
-            string accessToken = this.GetAccessToken();
+            PatientModel patient = await this.GetPatientAsync(request.PersonalHealthNumber, ct).ConfigureAwait(true);
+            VaccineStatusResult vaccineStatusResult = await this.GetVaccineStatusResult(request.PersonalHealthNumber, patient.Birthdate, this.GetAccessToken()).ConfigureAwait(true);
+            VaccinationStatus vaccinationStatus = this.GetVaccinationStatus(vaccineStatusResult);
+            await this.SendVaccineProofRequest(vaccinationStatus, vaccineStatusResult.QrCode.Data, request.MailAddress).ConfigureAwait(true);
+        }
 
-            PatientDetailsQuery query = new(request.PersonalHealthNumber, Source: PatientDetailSource.Empi, UseCache: true);
-            PatientModel? patient = (await this.patientRepository.Query(query, ct).ConfigureAwait(true)).Items.SingleOrDefault();
-            if (patient == null)
-            {
-                throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.ClientRegistryRecordsNotFound, HttpStatusCode.NotFound, nameof(SupportService)));
-            }
-
-            PhsaResult<VaccineStatusResult> vaccineStatusResult =
-                await this.vaccineStatusDelegate.GetVaccineStatusWithRetries(request.PersonalHealthNumber, patient.Birthdate, accessToken).ConfigureAwait(true);
-
-            VaccinationStatus status = this.GetVaccinationStatus(vaccineStatusResult.Result);
-
-            await this.SendVaccineProofRequest(status, vaccineStatusResult.Result.QrCode.Data, request.MailAddress).ConfigureAwait(true);
+        /// <inheritdoc/>
+        public async Task<ReportModel> RetrieveVaccineRecordAsync(string phn, CancellationToken ct = default)
+        {
+            PatientModel patient = await this.GetPatientAsync(phn, ct).ConfigureAwait(true);
+            VaccineStatusResult vaccineStatusResult = await this.GetVaccineStatusResult(phn, patient.Birthdate, this.GetAccessToken()).ConfigureAwait(true);
+            VaccinationStatus vaccinationStatus = this.GetVaccinationStatus(vaccineStatusResult);
+            VaccineProofResponse vaccineProofResponse = await this.GetVaccineProof(vaccinationStatus, vaccineStatusResult.QrCode.Data).ConfigureAwait(true);
+            return await this.GetVaccineProofReport(vaccineProofResponse.AssetUri).ConfigureAwait(true);
         }
 
         /// <inheritdoc/>
@@ -121,6 +124,30 @@ namespace HealthGateway.Admin.Server.Services
             return accessToken;
         }
 
+        private async Task<PatientModel> GetPatientAsync(string phn, CancellationToken ct = default)
+        {
+            PatientDetailsQuery query = new(phn, Source: PatientDetailSource.Empi, UseCache: true);
+            PatientModel? patient = (await this.patientRepository.Query(query, ct).ConfigureAwait(true)).Items.SingleOrDefault();
+            if (patient == null)
+            {
+                throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.ClientRegistryRecordsNotFound, HttpStatusCode.NotFound, nameof(SupportService)));
+            }
+
+            return patient;
+        }
+
+        private async Task<VaccineStatusResult> GetVaccineStatusResult(string phn, DateTime birthdate, string accessToken)
+        {
+            PhsaResult<VaccineStatusResult> phsaResult = await this.vaccineStatusDelegate.GetVaccineStatusWithRetries(phn, birthdate, accessToken).ConfigureAwait(true);
+
+            if (phsaResult.Result == null)
+            {
+                throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.CannotGetVaccineStatus, HttpStatusCode.BadRequest, nameof(CovidSupportService)));
+            }
+
+            return phsaResult.Result;
+        }
+
         private VaccinationStatus GetVaccinationStatus(VaccineStatusResult result)
         {
             this.logger.LogDebug("Vaccination Status Indicator: {Indicator}", result.StatusIndicator);
@@ -137,14 +164,60 @@ namespace HealthGateway.Admin.Server.Services
                 VaccineState.Exempt => VaccinationStatus.Exempt,
                 _ => VaccinationStatus.Unknown,
             };
+            this.logger.LogDebug("Vaccination Status: {Status}", status);
 
-            this.logger.LogDebug("Vaccination Status: {RequestState}", status);
             if (status == VaccinationStatus.Unknown)
             {
                 throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.VaccinationStatusUnknown, HttpStatusCode.BadRequest, nameof(CovidSupportService)));
             }
 
             return status;
+        }
+
+        private async Task<VaccineProofResponse> GetVaccineProof(VaccinationStatus vaccinationStatus, string qrCode)
+        {
+            VaccineProofRequest request = new()
+            {
+                Status = vaccinationStatus,
+                SmartHealthCardQr = qrCode,
+            };
+
+            RequestResult<VaccineProofResponse> vaccineProof = await this.vaccineProofDelegate.GenerateAsync(this.vaccineCardConfig.PrintTemplate, request).ConfigureAwait(true);
+            if (vaccineProof.ResultStatus != ResultType.Success || vaccineProof.ResourcePayload == null)
+            {
+                throw new ProblemDetailsException(
+                    ExceptionUtility.CreateProblemDetails(vaccineProof.ResultError?.ResultMessage ?? ErrorMessages.CannotGetVaccineProof, HttpStatusCode.BadRequest, nameof(CovidSupportService)));
+            }
+
+            return vaccineProof.ResourcePayload;
+        }
+
+        private async Task<ReportModel> GetVaccineProofReport(Uri assetUri)
+        {
+            bool processing = true;
+            int retryCount = 0;
+            RequestResult<ReportModel> result = new();
+
+            while (processing && retryCount++ <= this.bcmpConfig.MaxRetries)
+            {
+                this.logger.LogInformation("Waiting to fetch Vaccine Proof Asset...");
+                await Task.Delay(this.bcmpConfig.BackOffMilliseconds).ConfigureAwait(true);
+
+                result = await this.vaccineProofDelegate.GetAssetAsync(assetUri).ConfigureAwait(true);
+                processing = result.ResultStatus == ResultType.ActionRequired;
+            }
+
+            if (result.ResultStatus != ResultType.Success || result.ResourcePayload == null)
+            {
+                if (result.ResultError != null)
+                {
+                    throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(result.ResultError.ResultMessage, HttpStatusCode.BadRequest, nameof(CovidSupportService)));
+                }
+
+                throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.CannotGetVaccineProofPdf, HttpStatusCode.BadRequest, nameof(CovidSupportService)));
+            }
+
+            return result.ResourcePayload;
         }
 
         private async Task SendVaccineProofRequest(VaccinationStatus status, string smartHealthCardQr, Address address)

--- a/Apps/Admin/Server/Services/ICovidSupportService.cs
+++ b/Apps/Admin/Server/Services/ICovidSupportService.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Admin.Server.Services
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Server.Models.CovidSupport;
+    using HealthGateway.Common.Models;
 
     /// <summary>
     /// Service that provides COVID-19 Support functionality.
@@ -31,6 +32,14 @@ namespace HealthGateway.Admin.Server.Services
         /// <param name="ct">A cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task MailVaccineCardAsync(MailDocumentRequest request, CancellationToken ct = default);
+
+        /// <summary>
+        /// Gets a document that represents a patient's vaccine card and vaccine history.
+        /// </summary>
+        /// <param name="phn">The personal health number that matches the person to retrieve.</param>
+        /// <param name="ct">A cancellation token.</param>
+        /// <returns>The encoded document.</returns>
+        Task<ReportModel> RetrieveVaccineRecordAsync(string phn, CancellationToken ct = default);
 
         /// <summary>
         /// Submits a covid therapy assessment request.

--- a/Apps/Common/src/Constants/ErrorMessages.cs
+++ b/Apps/Common/src/Constants/ErrorMessages.cs
@@ -114,5 +114,20 @@ namespace HealthGateway.Common.Constants
         /// Error message to return when vaccination status is unknown.
         /// </summary>
         public const string VaccinationStatusUnknown = "Vaccination status is unknown.";
+
+        /// <summary>
+        /// Error message to return when unable to get vaccine proof.
+        /// </summary>
+        public const string CannotGetVaccineProof = "Unable to obtain Vaccine Proof.";
+
+        /// <summary>
+        /// Error message to return when unable to get vaccine proof pdf.
+        /// </summary>
+        public const string CannotGetVaccineProofPdf = "Unable to obtain Vaccine Proof PDF.";
+
+        /// <summary>
+        /// Error message to return when unable to get vaccine status.
+        /// </summary>
+        public const string CannotGetVaccineStatus = "Error retrieving vaccine status information.";
     }
 }

--- a/Apps/Common/src/Models/BcMailPlusConfig.cs
+++ b/Apps/Common/src/Models/BcMailPlusConfig.cs
@@ -24,6 +24,11 @@ namespace HealthGateway.Common.Models
     public class BcMailPlusConfig
     {
         /// <summary>
+        /// Gets or sets the value for bc mail plus config section key.
+        /// </summary>
+        public const string ConfigSectionKey = "BCMailPlus";
+
+        /// <summary>
         /// Gets or sets the endpoint for the BCMailPlus integration.
         /// </summary>
         public string Endpoint { get; set; } = null!;

--- a/Apps/Common/src/Models/VaccineCardConfig.cs
+++ b/Apps/Common/src/Models/VaccineCardConfig.cs
@@ -26,7 +26,7 @@ namespace HealthGateway.Common.Models
         /// <summary>
         /// Gets or sets the value for vaccine card config section key.
         /// </summary>
-        public const string VaccineCardConfigSectionKey = "VaccineCard";
+        public const string ConfigSectionKey = "VaccineCard";
 
         /// <summary>
         /// Gets or sets the name of the print template.


### PR DESCRIPTION
# Implements [AB#16106](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16106)

## Description

- Add 'Retrieve Vaccine Record' from Admin Web Client to Admin Blazor to SupportController and CovidSupportService
- Add unit tests for 'Retrieve Vaccine Record'
- Updated existing unit tests for documentation and test names. Also re-order tests to match output in Rider.

**Swagger for Retrieve:**

<img width="1888" alt="Screenshot 2023-09-08 at 6 46 00 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/f948ad2d-6b21-49a0-99ba-9474599b9ee5">


**Swagger for Mail:**

<img width="2175" alt="Screenshot 2023-09-08 at 6 47 27 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/04e05729-8214-4149-916a-0cfd1b99c7c4">


**Admin CovidSupportService unit tests:**

<img width="1262" alt="Screenshot 2023-09-08 at 6 44 12 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/9b008afd-dad9-42dd-8205-995a5c111d66">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
