### PR TITLE
Swap address properties from string to Address model AB#16108

### DIFF
--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -3,6 +3,7 @@
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer},{Roles.Support}")]
 @using HealthGateway.Admin.Client.Store.PatientDetails
 @using HealthGateway.Admin.Client.Store.PatientSupport
+@using HealthGateway.Common.Data.Utils
 @using HealthGateway.Admin.Common.Constants
 @using HealthGateway.Admin.Client.Components.Support
 @using HealthGateway.Admin.Client.Components.AgentAudit
@@ -70,10 +71,10 @@
             <HgField Label="HDID" Value="@Patient.Hdid" data-testid="patient-hdid" />
         </MudItem>
         <MudItem xs="12" lg="6">
-            <HgField Label="Physical Address" Value="@Patient.PhysicalAddress" data-testid="patient-physical-address" />
+            <HgField Label="Physical Address" Value="@AddressUtility.GetAddressAsSingleLine(Patient.PhysicalAddress)" data-testid="patient-physical-address" />
         </MudItem>
         <MudItem xs="12" lg="6">
-            <HgField Label="Mailing Address" Value="@Patient.PostalAddress" data-testid="patient-mailing-address" />
+            <HgField Label="Mailing Address" Value="@AddressUtility.GetAddressAsSingleLine(Patient.PostalAddress)" data-testid="patient-mailing-address" />
         </MudItem>
     </MudGrid>
     @if (Patient.Status == PatientStatus.Default)

--- a/Apps/Admin/Common/Models/PatientSupportResult.cs
+++ b/Apps/Admin/Common/Models/PatientSupportResult.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Common.Models
 {
     using System;
     using HealthGateway.Admin.Common.Constants;
+    using HealthGateway.Common.Data.Models;
 
     /// <summary>
     /// Represents details associated with a patient retrieved by a support query.
@@ -66,12 +67,12 @@ namespace HealthGateway.Admin.Common.Models
         /// <summary>
         /// Gets or sets the physical address for the patient.
         /// </summary>
-        public string PhysicalAddress { get; set; } = string.Empty;
+        public Address? PhysicalAddress { get; set; }
 
         /// <summary>
         /// Gets or sets the postal address for the patient.
         /// </summary>
-        public string PostalAddress { get; set; } = string.Empty;
+        public Address? PostalAddress { get; set; }
 
         /// <summary>
         /// Gets or sets the user's created datetime.

--- a/Apps/Admin/Server/MapProfiles/AddressProfile.cs
+++ b/Apps/Admin/Server/MapProfiles/AddressProfile.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Admin.Server.MapProfiles
 {
     using AutoMapper;
-    using HealthGateway.Common.Data.Utils;
 
     /// <summary>
     /// An AutoMapper profile class which defines a mapping between a data access model and common model.
@@ -30,14 +29,6 @@ namespace HealthGateway.Admin.Server.MapProfiles
         {
             this.CreateMap<AccountDataAccess.Patient.Address?, HealthGateway.Common.Data.Models.Address?>()
                 .ReverseMap();
-
-            this.CreateMap<HealthGateway.Common.Data.Models.Address?, string>()
-                .ConvertUsing(address => AddressUtility.GetAddressAsSingleLine(address, false));
-
-            this.CreateMap<AccountDataAccess.Patient.Address?, string>()
-                .ConvertUsing(
-                    (src, _, context) => context.Mapper.Map<HealthGateway.Common.Data.Models.Address?, string>(
-                        context.Mapper.Map<AccountDataAccess.Patient.Address?, HealthGateway.Common.Data.Models.Address?>(src)));
         }
     }
 }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-email.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-email.json
@@ -17,8 +17,14 @@
             "surname": "ORPHANING"
         },
         "birthdate": "1964-06-04",
-        "physicalAddress": "2854 POYLE STREET, AXBRIDGE, BC, V0C6J8",
-        "postalAddress": "",
+        "physicalAddress": {
+            "streetLines": ["2854 POYLE STREET"],
+            "city": "AXBRIDGE",
+            "state": "BC",
+            "postalCode": "V0C6J8",
+            "country": ""
+        },
+        "postalAddress": null,
         "profileCreatedDateTime": "2023-01-01T16:47:24.674743Z",
         "profileLastLoginDateTime": "2023-05-01T16:47:24.674743Z"
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid-deceased.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid-deceased.json
@@ -17,8 +17,14 @@
             "surname": "Deceased"
         },
         "birthdate": "1942-08-09",
-        "physicalAddress": "818 FORT ST, Victoria, BC, V8W 1H8",
-        "postalAddress": "",
+        "physicalAddress": {
+            "streetLines": ["818 FORT ST"],
+            "city": "Victoria",
+            "state": "BC",
+            "postalCode": "V8W 1H8",
+            "country": ""
+        },
+        "postalAddress": null,
         "profileCreatedDateTime": null,
         "profileLastLoginDateTime": null
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid-not-found.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid-not-found.json
@@ -8,8 +8,8 @@
         "legalName": null,
         "preferredName": null,
         "birthdate": null,
-        "physicalAddress": "",
-        "postalAddress": "",
+        "physicalAddress": null,
+        "postalAddress": null,
         "profileCreatedDateTime": "2023-05-08T21:18:08.312207Z",
         "profileLastLoginDateTime": "2023-05-08T21:18:08.312207Z"
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid-not-user.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid-not-user.json
@@ -17,8 +17,14 @@
             "surname": "ONE"
         },
         "birthdate": "2015-07-06",
-        "physicalAddress": "6860 BRIARWOOD ROW, TRAIL, BC, V1R 4J6",
-        "postalAddress": "",
+        "physicalAddress": {
+            "streetLines": ["6860 BRIARWOOD ROW"],
+            "city": "TRAIL",
+            "state": "BC",
+            "postalCode": "V1R 4J6",
+            "country": ""
+        },
+        "postalAddress": null,
         "profileCreatedDateTime": null,
         "profileLastLoginDateTime": null
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-hdid.json
@@ -17,8 +17,20 @@
             "surname": "PROTERVITY"
         },
         "birthdate": "1967-06-02",
-        "physicalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
-        "postalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
+        "physicalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
+        "postalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
         "profileCreatedDateTime": "2023-04-29T16:47:23.554687Z",
         "profileLastLoginDateTime": "2023-05-01T16:47:23.554687Z"
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-phn-duplicate.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-phn-duplicate.json
@@ -17,8 +17,20 @@
             "surname": "PROTERVITY"
         },
         "birthdate": "1967-06-02",
-        "physicalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
-        "postalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
+        "physicalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
+        "postalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
         "profileCreatedDateTime": "2023-04-29T16:47:23.554687Z",
         "profileLastLoginDateTime": "2023-05-01T16:47:23.554687Z"
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-phn.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-phn.json
@@ -17,8 +17,20 @@
             "surname": "PROTERVITY"
         },
         "birthdate": "1967-06-02",
-        "physicalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
-        "postalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
+        "physicalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
+        "postalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
         "profileCreatedDateTime": "2023-04-29T16:47:23.554687Z",
         "profileLastLoginDateTime": "2023-05-01T16:47:23.554687Z"
     }

--- a/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-sms.json
+++ b/Apps/Admin/Tests/Functional/cypress/fixtures/SupportService/users-sms.json
@@ -17,8 +17,20 @@
             "surname": "PROTERVITY"
         },
         "birthdate": "1967-06-02",
-        "physicalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
-        "postalAddress": "3815 HILLSPOINT STREET, CHATHAM, BC, V0G8B8",
+        "physicalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
+        "postalAddress": {
+            "streetLines": ["3815 HILLSPOINT STREET"],
+            "city": "CHATHAM",
+            "state": "BC",
+            "postalCode": "V0G8B8",
+            "country": ""
+        },
         "profileCreatedDateTime": "2023-04-29T16:47:23.554687Z",
         "profileLastLoginDateTime": "2023-05-01T16:47:23.554687Z"
     },
@@ -40,8 +52,20 @@
             "surname": "E'PISTEMICS"
         },
         "birthdate": "1994-06-09",
-        "physicalAddress": "1234 LEE AVENUE, VICTORIA, BC, V9C6P1",
-        "postalAddress": "8128 WILD CREEK DR, HOLBORN, BC, V3A3P1",
+        "physicalAddress": {
+            "streetLines": ["1234 LEE AVENUE"],
+            "city": "VICTORIA",
+            "state": "BC",
+            "postalCode": "V9C6P1",
+            "country": ""
+        },
+        "postalAddress": {
+            "streetLines": ["8128 WILD CREEK DR"],
+            "city": "HOLBORN",
+            "state": "BC",
+            "postalCode": "V3A3P1",
+            "country": ""
+        },
         "profileCreatedDateTime": "2023-05-01T16:47:24.388611Z",
         "profileLastLoginDateTime": "2023-05-01T16:47:24.388611Z"
     }

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -40,7 +40,6 @@ namespace HealthGateway.Admin.Tests.Services
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Data.Utils;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
@@ -647,8 +646,8 @@ namespace HealthGateway.Admin.Tests.Services
                 CommonName = Map(patient?.CommonName),
                 LegalName = Map(patient?.LegalName),
                 Birthdate = patient == null ? null : DateOnly.FromDateTime(patient.Birthdate),
-                PhysicalAddress = AddressUtility.GetAddressAsSingleLine(AutoMapper.Map<HealthGateway.Common.Data.Models.Address?>(patient?.PhysicalAddress)),
-                PostalAddress = AddressUtility.GetAddressAsSingleLine(AutoMapper.Map<HealthGateway.Common.Data.Models.Address?>(patient?.PostalAddress)),
+                PhysicalAddress = AutoMapper.Map<HealthGateway.Common.Data.Models.Address?>(patient?.PhysicalAddress),
+                PostalAddress = AutoMapper.Map<HealthGateway.Common.Data.Models.Address?>(patient?.PostalAddress),
                 ProfileCreatedDateTime = profile?.CreatedDateTime,
                 ProfileLastLoginDateTime = profile?.LastLoginDateTime,
             };


### PR DESCRIPTION
# Implements AB#16108

## Description

- changes properties for `PhysicalAddress` and `PostalAddress` in PatientSupportResult from string type to Address type
- calls `AddressUtility.GetAddressAsSingleLine()` in front-end instead of back-end
- updates unit tests and functional tests

## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
