### PR TITLE
Fix functional tests after change to support search behaviour AB#16109

### DIFF
--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -10,7 +10,7 @@
 
 <PageTitle>Health Gateway Admin Patient Details</PageTitle>
 
-<MudLink Href="/support?details">
+<MudLink Href="/support?details" data-testid="patient-details-back-button">
     <MudText Typo="Typo.h5"><MudIcon Icon="fas fa-arrow-left" /> Back</MudText>
 </MudLink>
 

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details.cy.js
@@ -28,11 +28,6 @@ describe("Patient details page as admin", () => {
     it("Verify message verification", () => {
         performSearch("HDID", hdid);
 
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
-
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
         cy.get("[data-testid=patient-phn]").should("be.visible");
@@ -53,10 +48,6 @@ describe("Patient details page as admin", () => {
 
     it("Verify block access initial", () => {
         performSearch("HDID", hdid);
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get("[data-testid=block-access-switches]").should("be.visible");
         cy.get(`[data-testid*="block-access-switch"]`).should(
@@ -69,10 +60,6 @@ describe("Patient details page as admin", () => {
 
     it("Verify block access change can be cancelled", () => {
         performSearch("HDID", hdid);
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get("[data-testid=block-access-loader]").should("not.be.visible");
 
@@ -96,10 +83,6 @@ describe("Patient details page as admin", () => {
 
     it("Verify block access can be blocked with audit reason.", () => {
         performSearch("HDID", hdid);
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get("[data-testid=block-access-loader]").should("not.be.visible");
 
@@ -143,10 +126,6 @@ describe("Patient details page as admin", () => {
 
     it("Verify block access can be unblocked with audit reason.", () => {
         performSearch("HDID", hdid);
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get("[data-testid=block-access-loader]").should("not.be.visible");
 
@@ -205,10 +184,6 @@ describe("Patient details page as reviewer", () => {
     // verify that the reviewer cannot use the block access controls
     it("Verify block access readonly", () => {
         performSearch("HDID", hdid);
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get(`[data-testid*="block-access-switch-"]`).each(($el) => {
             // follow the mud tag structure to find the mud-readonly class

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
@@ -1,5 +1,6 @@
 import {
     performSearch,
+    verifySingleSupportResult,
     verifySupportTableResults,
 } from "../../utilities/supportUtilities";
 import { getTableRows } from "../../utilities/sharedUtilities";
@@ -26,16 +27,16 @@ describe("Support", () => {
 
     it("Verify support query.", () => {
         performSearch("PHN", phn);
-        verifySupportTableResults(hdid, phn);
+        verifySingleSupportResult(hdid, phn);
 
         performSearch("HDID", hdid);
-        verifySupportTableResults(hdid, phn);
+        verifySingleSupportResult(hdid, phn);
 
         performSearch("SMS", sms);
         verifySupportTableResults(hdid, phn, 2);
 
         performSearch("Email", email);
-        verifySupportTableResults(emailHdid, emailPhn);
+        verifySingleSupportResult(emailHdid, emailPhn);
     });
 
     it("Verify no results hdid query.", () => {
@@ -55,6 +56,6 @@ describe("Support", () => {
 
     it("Verify dependents query returns results.", () => {
         performSearch("Dependent", dependentPhn);
-        getTableRows("[data-testid=user-table]").should("have.length", 1);
+        cy.get("[data-testid=patient-name]").should("be.visible");
     });
 });

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
@@ -62,11 +62,6 @@ describe("Patient details", () => {
     it("Verify patient details", () => {
         performSearch("HDID", hdid);
 
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
-
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
         cy.get("[data-testid=patient-phn]").should("be.visible");
@@ -87,11 +82,6 @@ describe("Patient details", () => {
 
     it("Verify patient not found", () => {
         performSearch("HDID", hdidPatientNotFound);
-
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
@@ -117,11 +107,6 @@ describe("Patient details", () => {
     it("Verify patient deceased", () => {
         performSearch("HDID", hdidPatientDeceased);
 
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
-
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
         cy.get("[data-testid=patient-phn]").should("be.visible");
@@ -145,11 +130,6 @@ describe("Patient details", () => {
 
     it("Verify patient not a user", () => {
         performSearch("HDID", hdidPatientNotUser);
-
-        cy.get("[data-testid=user-table]")
-            .find("tbody tr.mud-table-row")
-            .first()
-            .click();
 
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
@@ -1,5 +1,6 @@
 import {
     performSearch,
+    verifySingleSupportResult,
     verifySupportTableResults,
 } from "../../utilities/supportUtilities";
 
@@ -90,16 +91,16 @@ describe("Support", () => {
 
     it("Verify support queries", () => {
         performSearch("PHN", phn);
-        verifySupportTableResults(hdid, phn);
+        verifySingleSupportResult(hdid, phn);
 
         performSearch("HDID", hdid);
-        verifySupportTableResults(hdid, phn);
+        verifySingleSupportResult(hdid, phn);
 
         performSearch("SMS", sms);
         verifySupportTableResults(hdid, phn, 2);
 
         performSearch("Email", email);
-        verifySupportTableResults(emailHdid, emailPhn);
+        verifySingleSupportResult(emailHdid, emailPhn);
     });
 
     it("Verify support query warnings", () => {
@@ -107,7 +108,7 @@ describe("Support", () => {
         cy.get("[data-testid=user-banner-feedback-warning-message]").should(
             "be.visible"
         );
-        verifySupportTableResults(hdid, phnDuplicate);
+        verifySingleSupportResult(hdid, phnDuplicate);
         cy.get("[data-testid=user-banner-feedback-warning-message]").within(
             () => {
                 cy.get("button").parent(".mud-alert-close").click();
@@ -143,10 +144,10 @@ describe("Support", () => {
     });
 
     it("Verify clear button", () => {
-        performSearch("HDID", hdid);
-        verifySupportTableResults(hdid, phn);
+        performSearch("SMS", sms);
+        verifySupportTableResults(hdid, phn, 2);
         cy.get("[data-testid=clear-btn]").click();
-        cy.get("[data-testid=query-type-select]").should("have.value", "Hdid");
+        cy.get("[data-testid=query-type-select]").should("have.value", "Sms");
         cy.get("[data-testid=query-input]").should("be.empty");
         cy.get("[data-testid=user-table]").should("not.exist");
     });

--- a/Apps/Admin/Tests/Functional/cypress/utilities/supportUtilities.js
+++ b/Apps/Admin/Tests/Functional/cypress/utilities/supportUtilities.js
@@ -15,10 +15,23 @@ export function performSearch(queryType, queryString) {
     cy.get("[data-testid=search-btn]").click();
 }
 
+export function verifySingleSupportResult(expectedHdid, expectedPhn) {
+    cy.get("[data-testid=user-table]").should("not.exist");
+    cy.get("[data-testid=patient-hdid]")
+        .should("be.visible")
+        .contains(expectedHdid);
+    cy.get("[data-testid=patient-phn]")
+        .should("be.visible")
+        .contains(expectedPhn);
+    cy.get("[data-testid=patient-details-back-button]")
+        .should("be.visible")
+        .click();
+}
+
 export function verifySupportTableResults(
     expectedHdid,
     expectedPhn,
-    expectedRowCount = 1
+    expectedRowCount
 ) {
     getTableRows("[data-testid=user-table]")
         .should("have.length", expectedRowCount)


### PR DESCRIPTION
# Implements [AB#16109](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16109)

## Description

Updates a number of functional tests on the support and patient details pages to account for the automatic navigation to the patient details page when there is only one result.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
