### PR TITLE
Fix "CA" country in address confirmation dialog AB#16134

### DIFF
--- a/Apps/Admin/Client/Components/Support/Covid19ImmunizationSection.razor.cs
+++ b/Apps/Admin/Client/Components/Support/Covid19ImmunizationSection.razor.cs
@@ -30,8 +30,8 @@ namespace HealthGateway.Admin.Client.Components.Support
     using Microsoft.JSInterop;
     using MudBlazor;
     using MailVaccineCardAddressConfirmationDialog = AddressConfirmationDialog<
-        Store.VaccineCard.VaccineCardActions.MailVaccineCardFailureAction,
-        Store.VaccineCard.VaccineCardActions.MailVaccineCardSuccessAction>;
+        HealthGateway.Admin.Client.Store.VaccineCard.VaccineCardActions.MailVaccineCardFailureAction,
+        HealthGateway.Admin.Client.Store.VaccineCard.VaccineCardActions.MailVaccineCardSuccessAction>;
 
     /// <summary>
     /// Backing logic for the COVID-19 immunization section.
@@ -123,6 +123,7 @@ namespace HealthGateway.Admin.Client.Components.Support
                 [nameof(MailVaccineCardAddressConfirmationDialog.ActionOnConfirm)] = (Action<Address>)this.MailVaccineCard,
                 [nameof(MailVaccineCardAddressConfirmationDialog.DefaultAddress)] = this.MailAddress,
                 [nameof(MailVaccineCardAddressConfirmationDialog.ConfirmButtonLabel)] = "Send",
+                [nameof(MailVaccineCardAddressConfirmationDialog.OutputCanadaAsEmptyString)] = true,
             };
             DialogOptions options = new()
             {

--- a/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor.cs
+++ b/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor.cs
@@ -182,6 +182,7 @@ namespace HealthGateway.Admin.Client.Pages
                 [nameof(AssessmentAddressConfirmationDialog.ActionOnConfirm)] = (Action<Address>)this.SubmitAssessment,
                 [nameof(AssessmentAddressConfirmationDialog.DefaultAddress)] = address,
                 [nameof(AssessmentAddressConfirmationDialog.ConfirmButtonLabel)] = "Send",
+                [nameof(AssessmentAddressConfirmationDialog.OutputCountryCodeFormat)] = true,
             };
             DialogOptions options = new()
             {


### PR DESCRIPTION
# Fixes [AB#16134](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16134)

## Description

- updates the address confirmation dialog so it can accept countries provided as country code or country name in the input Address
- adds parameters for configuring the country output
- updates the country output for the treatment assessment
  - outputs country code instead of country name
  - no longer outputs the empty string when selecting Canada

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
