### PR TITLE
Update vite to refresh less often running locally AB#15803

### DIFF
--- a/Apps/WebClient/src/ClientApp/vite.config.ts
+++ b/Apps/WebClient/src/ClientApp/vite.config.ts
@@ -1,10 +1,8 @@
-// Plugins
-import vue from "@vitejs/plugin-vue";
-import vuetify, { transformAssetUrls } from "vite-plugin-vuetify";
-
-// Utilities
-import { defineConfig } from "vite";
 import { fileURLToPath, URL } from "node:url";
+
+import vue from "@vitejs/plugin-vue";
+import { defineConfig } from "vite";
+import vuetify, { transformAssetUrls } from "vite-plugin-vuetify";
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -17,6 +15,9 @@ export default defineConfig({
             autoImport: true,
         }),
     ],
+    optimizeDeps: {
+        exclude: ["vuetify"],
+    },
     define: { "process.env": {} },
     resolve: {
         alias: {


### PR DESCRIPTION
# Fixes [AB#15803](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15803)

## Description

Resolves a dev annoyance where encountering uncached vuetify components would trigger a refresh of the site.

Should have no effect outside of local development as "dependency pre-bundling only applies in development mode" ([ref](https://vitejs.dev/guide/dep-pre-bundling.html)).

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
