### PR TITLE
Upgrade XUnit and fix rider warnings AB#16142

### DIFF
--- a/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
+++ b/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
@@ -21,8 +21,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
@@ -54,7 +54,7 @@ namespace AccountDataAccessTest
             AuditRepository auditRepository = GetAuditRepository(agentAudits);
 
             // Act
-            IEnumerable<AgentAudit> actual = await auditRepository.Handle(query).ConfigureAwait(true);
+            IEnumerable<AgentAudit> actual = await auditRepository.Handle(query);
 
             // Verify
             IEnumerable<AgentAudit> collection = actual.ToList();

--- a/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
+++ b/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
@@ -238,7 +238,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId);
 
             // Verify
             Assert.Equal(expectedHdId, actual?.Hdid);
@@ -364,7 +364,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId);
 
             // Verify
             Assert.Equal(expectedHdId, actual?.Hdid);
@@ -512,7 +512,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Hdid, expectedHdId);
 
             // Verify
             Assert.Equal(expectedHdId, actual?.Hdid);
@@ -619,7 +619,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0019", actual?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -721,7 +721,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0021", actual?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -823,7 +823,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0022", actual?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -925,7 +925,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, expectedPhn);
 
             // Verify
             Assert.Contains("BCHCIM.GD.0.0023", actual?.ResponseCode, StringComparison.InvariantCultureIgnoreCase);
@@ -943,7 +943,7 @@ namespace AccountDataAccessTest
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, true);
 
             // Act
-            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn, true).ConfigureAwait(true);
+            PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn, true);
 
             // Verify
             Assert.NotNull(actual);
@@ -963,11 +963,11 @@ namespace AccountDataAccessTest
             // Act
             async Task Actual()
             {
-                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.ClientRegistryDoesNotReturnPerson, exception.ProblemDetails!.Detail);
         }
 
@@ -985,11 +985,11 @@ namespace AccountDataAccessTest
             // Act
             async Task Actual()
             {
-                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn).ConfigureAwait(true);
+                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.PhnInvalid, exception.ProblemDetails!.Detail);
         }
 

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -71,7 +71,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery);
 
             // Act
-            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None).ConfigureAwait(true);
+            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
@@ -96,7 +96,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery);
 
             // Act
-            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None).ConfigureAwait(true);
+            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
@@ -125,7 +125,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientResult, cachedPatient);
 
             // Act
-            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None).ConfigureAwait(true);
+            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
@@ -168,7 +168,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientIdentity, cachedPatient);
 
             // Act
-            PatientQueryResult actual = await patientRepository.Query(patientDetailsQuery, CancellationToken.None).ConfigureAwait(true);
+            PatientQueryResult actual = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             expectedPatient.ShouldDeepEqual(actual.Items.SingleOrDefault());
@@ -191,7 +191,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientIdentity, cachedPatient);
 
             // Act
-            PatientQueryResult actual = await patientRepository.Query(patientDetailsQuery, CancellationToken.None).ConfigureAwait(true);
+            PatientQueryResult actual = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Null(actual.Items.SingleOrDefault());
@@ -219,11 +219,11 @@ namespace AccountDataAccessTest
             // Act
             async Task Actual()
             {
-                await patientRepository.Query(patientQuery, CancellationToken.None).ConfigureAwait(true);
+                await patientRepository.Query(patientQuery, CancellationToken.None);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.PhnInvalid, exception.ProblemDetails!.Detail);
         }
 
@@ -300,7 +300,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(blockedAccess);
 
             // Act
-            bool actual = await patientRepository.CanAccessDataSourceAsync(hdid, dataSource).ConfigureAwait(true);
+            bool actual = await patientRepository.CanAccessDataSourceAsync(hdid, dataSource);
 
             // Verify
             Assert.Equal(canAccessDataSource, actual);
@@ -328,7 +328,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(blockedAccess);
 
             // Act
-            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecords(hdid).ConfigureAwait(true);
+            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecords(hdid);
 
             // Verify
             blockedAccess.ShouldDeepEqual(actual);
@@ -359,7 +359,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(blockedAccess);
 
             // Act
-            IEnumerable<DataSource> actual = await patientRepository.GetDataSources(hdid).ConfigureAwait(true);
+            IEnumerable<DataSource> actual = await patientRepository.GetDataSources(hdid);
 
             // Verify
             dataSources.ShouldDeepEqual(actual);

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace AccountDataAccessTest
 {
+    // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
     using System.Globalization;
     using System.Net;
     using System.ServiceModel;

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -69,7 +69,7 @@ namespace AccountDataAccessTest.Strategy
             PatientRequest request = new(Hdid, useCache);
 
             // Act
-            PatientModel? result = await hdidAllStrategy.GetPatientAsync(request).ConfigureAwait(true);
+            PatientModel? result = await hdidAllStrategy.GetPatientAsync(request);
 
             // Verify
             Assert.Equal(Hdid, result?.Hdid);
@@ -113,7 +113,7 @@ namespace AccountDataAccessTest.Strategy
             HdidAllStrategy hdidAllStrategy = GetHdidAllStrategy(patient, patientIdentity, cachedPatient);
 
             // Act
-            PatientModel? actual = await hdidAllStrategy.GetPatientAsync(request).ConfigureAwait(true);
+            PatientModel? actual = await hdidAllStrategy.GetPatientAsync(request);
 
             // Verify
             expectedPatient.ShouldDeepEqual(actual);
@@ -136,7 +136,7 @@ namespace AccountDataAccessTest.Strategy
             HdidAllStrategy hdidAllStrategy = GetHdidAllStrategy(patient, patientIdentity, cachedPatient);
 
             // Act
-            PatientModel? actual = await hdidAllStrategy.GetPatientAsync(request).ConfigureAwait(true);
+            PatientModel? actual = await hdidAllStrategy.GetPatientAsync(request);
 
             // Verify
             Assert.Null(actual);

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
@@ -57,7 +57,7 @@ namespace AccountDataAccessTest.Strategy
             PatientRequest request = new(Hdid, useCache);
 
             // Act
-            PatientModel? result = await hdidEmpiStrategy.GetPatientAsync(request).ConfigureAwait(true);
+            PatientModel? result = await hdidEmpiStrategy.GetPatientAsync(request);
 
             // Verify
             Assert.Equal(Hdid, result?.Hdid);

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -82,7 +82,7 @@ namespace AccountDataAccessTest.Strategy
             PatientRequest request = new(Hdid, useCache);
 
             // Act
-            PatientModel? actual = await hdidPhsaStrategy.GetPatientAsync(request).ConfigureAwait(true);
+            PatientModel? actual = await hdidPhsaStrategy.GetPatientAsync(request);
 
             // Verify
             expectedPatient.ShouldDeepEqual(actual);

--- a/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
@@ -59,7 +59,7 @@ namespace AccountDataAccessTest.Strategy
             PatientRequest request = new(Phn, useCache);
 
             // Act
-            PatientModel? result = await phnEmpiStrategy.GetPatientAsync(request).ConfigureAwait(true);
+            PatientModel? result = await phnEmpiStrategy.GetPatientAsync(request);
 
             // Verify
             Assert.Equal(Hdid, result?.Hdid);
@@ -83,11 +83,11 @@ namespace AccountDataAccessTest.Strategy
             // Act
             async Task Actual()
             {
-                await phnEmpiStrategy.GetPatientAsync(request).ConfigureAwait(true);
+                await phnEmpiStrategy.GetPatientAsync(request);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.PhnInvalid, exception.ProblemDetails!.Detail);
         }
 

--- a/Apps/Admin/Tests/Admin.Tests.csproj
+++ b/Apps/Admin/Tests/Admin.Tests.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/Admin/Tests/Delegates/RestImmunizationAdminDelegateTests.cs
+++ b/Apps/Admin/Tests/Delegates/RestImmunizationAdminDelegateTests.cs
@@ -80,11 +80,11 @@ namespace HealthGateway.Admin.Tests.Delegates
             // Act
             async Task Actual()
             {
-                await adminDelegate.GetVaccineDetailsWithRetries(patient, AccessToken).ConfigureAwait(true);
+                await adminDelegate.GetVaccineDetailsWithRetries(patient, AccessToken);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.MaximumRetryAttemptsReached, exception.ProblemDetails!.Detail);
         }
 
@@ -118,7 +118,7 @@ namespace HealthGateway.Admin.Tests.Delegates
             IImmunizationAdminDelegate adminDelegate = CreateImmunizationAdminDelegate(immunizationAdminApiMock);
 
             // Act
-            VaccineDetails actual = await adminDelegate.GetVaccineDetailsWithRetries(patient, AccessToken).ConfigureAwait(true);
+            VaccineDetails actual = await adminDelegate.GetVaccineDetailsWithRetries(patient, AccessToken);
 
             // Assert
             Assert.NotNull(actual.VaccineStatusResult);

--- a/Apps/Admin/Tests/Delegates/RestVaccineStatusDelegateTests.cs
+++ b/Apps/Admin/Tests/Delegates/RestVaccineStatusDelegateTests.cs
@@ -68,11 +68,11 @@ namespace HealthGateway.Admin.Tests.Delegates
             // Act
             async Task Actual()
             {
-                await vaccineStatusDelegate.GetVaccineStatusWithRetries(Phn, Birthdate, AccessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusWithRetries(Phn, Birthdate, AccessToken);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.MaximumRetryAttemptsReached, exception.ProblemDetails!.Detail);
         }
 
@@ -102,7 +102,7 @@ namespace HealthGateway.Admin.Tests.Delegates
             IVaccineStatusDelegate vaccineStatusDelegate = CreateVaccineStatusDelegate(immunizationAdminApiMock);
 
             // Act
-            PhsaResult<VaccineStatusResult> actual = await vaccineStatusDelegate.GetVaccineStatusWithRetries(Phn, Birthdate, AccessToken).ConfigureAwait(true);
+            PhsaResult<VaccineStatusResult> actual = await vaccineStatusDelegate.GetVaccineStatusWithRetries(Phn, Birthdate, AccessToken);
 
             // Assert
             Assert.NotNull(actual.Result);

--- a/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
@@ -73,11 +73,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.ProblemDetails!.Detail);
         }
 
@@ -122,11 +122,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.CannotGetVaccineProofPdf, exception.ProblemDetails!.Detail);
         }
 
@@ -175,11 +175,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(expected.ResultError.ResultMessage, exception.ProblemDetails!.Detail);
         }
 
@@ -215,11 +215,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.CannotGetVaccineProof, exception.ProblemDetails!.Detail);
         }
 
@@ -254,11 +254,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(expected.ResultError.ResultMessage, exception.ProblemDetails!.Detail);
         }
 
@@ -293,11 +293,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.VaccineStatusNotFound, exception.ProblemDetails!.Detail);
         }
 
@@ -328,11 +328,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.CannotGetVaccineStatus, exception.ProblemDetails!.Detail);
         }
 
@@ -355,11 +355,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+                await service.RetrieveVaccineRecordAsync(Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.MaximumRetryAttemptsReached, exception.ProblemDetails!.Detail);
         }
 
@@ -392,11 +392,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.MailVaccineCardAsync(request).ConfigureAwait(true);
+                await service.MailVaccineCardAsync(request);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.CannotGetVaccineStatus, exception.ProblemDetails!.Detail);
         }
 
@@ -420,11 +420,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.MailVaccineCardAsync(request).ConfigureAwait(true);
+                await service.MailVaccineCardAsync(request);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.ProblemDetails!.Detail);
         }
 
@@ -460,11 +460,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.MailVaccineCardAsync(request).ConfigureAwait(true);
+                await service.MailVaccineCardAsync(request);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(expected.ResultError.ResultMessage, exception.ProblemDetails!.Detail);
         }
 
@@ -501,11 +501,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.MailVaccineCardAsync(request).ConfigureAwait(true);
+                await service.MailVaccineCardAsync(request);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.VaccineStatusNotFound, exception.ProblemDetails!.Detail);
         }
 
@@ -530,11 +530,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await service.MailVaccineCardAsync(request).ConfigureAwait(true);
+                await service.MailVaccineCardAsync(request);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.MaximumRetryAttemptsReached, exception.ProblemDetails!.Detail);
         }
 
@@ -574,7 +574,7 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Action()
             {
-                await service.MailVaccineCardAsync(request).ConfigureAwait(true);
+                await service.MailVaccineCardAsync(request);
             }
 
             Exception? exception = await Record.ExceptionAsync(Action);
@@ -625,7 +625,7 @@ namespace HealthGateway.Admin.Tests.Services
                 GetImmunizationAdminApiMock(covidAssessmentResponse));
 
             // Act
-            ReportModel actual = await service.RetrieveVaccineRecordAsync(Phn).ConfigureAwait(true);
+            ReportModel actual = await service.RetrieveVaccineRecordAsync(Phn);
 
             // Verify
             Assert.Equal(expected.ResourcePayload, actual);
@@ -652,7 +652,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            CovidAssessmentResponse actual = await service.SubmitCovidAssessmentAsync(request).ConfigureAwait(true);
+            CovidAssessmentResponse actual = await service.SubmitCovidAssessmentAsync(request);
 
             // Verify
             Assert.Equal(expected, actual);

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -98,7 +98,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<PatientModel> patientResult2 = GetPatientResult(patient2);
 
             IDelegationService delegationService = this.GetDelegationService(dependentResult, delegateResult, protectedDependent, patientResult1, patientResult2, agentAudits);
-            DelegationInfo actualResult = await delegationService.GetDelegationInformationAsync(DependentPhn).ConfigureAwait(true);
+            DelegationInfo actualResult = await delegationService.GetDelegationInformationAsync(DependentPhn);
 
             Assert.NotNull(actualResult);
             expectedDelegationInfo.ShouldDeepEqual(actualResult);
@@ -127,7 +127,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<PatientModel> patientResult2 = GetPatientResult(patient2);
 
             IDelegationService delegationService = this.GetDelegationService(dependentResult, delegateResult, unprotectedDependent, patientResult1, patientResult2, agentAudits);
-            DelegationInfo actualResult = await delegationService.GetDelegationInformationAsync(DependentPhn).ConfigureAwait(true);
+            DelegationInfo actualResult = await delegationService.GetDelegationInformationAsync(DependentPhn);
 
             Assert.NotNull(actualResult);
             expectedDelegationInfo.ShouldDeepEqual(actualResult);
@@ -146,7 +146,7 @@ namespace HealthGateway.Admin.Tests.Services
             IDelegationService delegationService = this.GetDelegationService(patientResult);
 
             // Act
-            DelegateInfo actualResult = await delegationService.GetDelegateInformationAsync(DelegatePhn).ConfigureAwait(true);
+            DelegateInfo actualResult = await delegationService.GetDelegateInformationAsync(DelegatePhn);
 
             // Assert
             Assert.NotNull(actualResult);
@@ -168,7 +168,7 @@ namespace HealthGateway.Admin.Tests.Services
             IDelegationService delegationService = this.GetDelegationService(patientResult);
 
             // Act and Assert
-            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegateInformationAsync(DelegatePhn)).ConfigureAwait(true);
+            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegateInformationAsync(DelegatePhn));
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace HealthGateway.Admin.Tests.Services
             DelegationService delegationService = this.GetDelegationService(null, delegationDelegate, resourceDelegateQueryResult, NewDependentHdid, AuthenticatedUser, AuthenticatedPreferredUsername);
 
             // Act
-            await delegationService.ProtectDependentAsync(NewDependentHdid, delegateHdids, It.IsAny<string>()).ConfigureAwait(true);
+            await delegationService.ProtectDependentAsync(NewDependentHdid, delegateHdids, It.IsAny<string>());
 
             // Assert
             delegationDelegate.Verify(
@@ -259,7 +259,7 @@ namespace HealthGateway.Admin.Tests.Services
                 AuthenticatedPreferredUsername);
 
             // Act
-            await delegationService.UnprotectDependentAsync(DependentHdid, It.IsAny<string>()).ConfigureAwait(true);
+            await delegationService.UnprotectDependentAsync(DependentHdid, It.IsAny<string>());
 
             // Assert
             delegationDelegate.Verify(
@@ -322,7 +322,7 @@ namespace HealthGateway.Admin.Tests.Services
                 AuthenticatedPreferredUsername);
 
             // Act
-            await delegationService.ProtectDependentAsync(DependentHdid, delegateHdids, It.IsAny<string>()).ConfigureAwait(true);
+            await delegationService.ProtectDependentAsync(DependentHdid, delegateHdids, It.IsAny<string>());
 
             // Assert
             delegationDelegate.Verify(
@@ -354,7 +354,7 @@ namespace HealthGateway.Admin.Tests.Services
                 AuthenticatedPreferredUsername);
 
             // Act and Assert
-            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.UnprotectDependentAsync(invalidDependentHdid, It.IsAny<string>())).ConfigureAwait(true);
+            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.UnprotectDependentAsync(invalidDependentHdid, It.IsAny<string>()));
         }
 
         /// <summary>
@@ -374,7 +374,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<PatientModel> patientResult2 = GetPatientResult(patient2);
 
             IDelegationService delegationService = this.GetDelegationService(dependentResult, delegateResult, protectedDependent, patientResult1, patientResult2, new List<AgentAudit>());
-            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegationInformationAsync(DependentPhn)).ConfigureAwait(true);
+            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegationInformationAsync(DependentPhn));
         }
 
         /// <summary>
@@ -404,7 +404,7 @@ namespace HealthGateway.Admin.Tests.Services
                 new Mock<IAuditRepository>().Object,
                 this.autoMapper);
 
-            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegationInformationAsync(DependentPhn)).ConfigureAwait(true);
+            await Assert.ThrowsAsync<ProblemDetailsException>(() => delegationService.GetDelegationInformationAsync(DependentPhn));
         }
 
         /// <summary>

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Tests.Services
 {
+    // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
     using System;
     using System.Collections.Generic;
     using System.Linq;

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -126,7 +126,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             // Act
             PatientSupportDetails actualResult =
-                await supportService.GetPatientSupportDetailsAsync(Hdid, includeMessagingVerifications, includeBlockedDataSources, includeAgentActions).ConfigureAwait(true);
+                await supportService.GetPatientSupportDetailsAsync(Hdid, includeMessagingVerifications, includeBlockedDataSources, includeAgentActions);
 
             // Assert
             Assert.Equal(expectedMessagingVerifications, actualResult.MessagingVerifications?.Count().ToString(CultureInfo.InvariantCulture));
@@ -157,11 +157,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await supportService.GetPatientSupportDetailsAsync(Hdid, true, true, true).ConfigureAwait(true);
+                await supportService.GetPatientSupportDetailsAsync(Hdid, true, true, true);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.ProblemDetails!.Detail);
         }
 
@@ -190,11 +190,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await supportService.GetPatientSupportDetailsAsync(Hdid, true, true, true).ConfigureAwait(true);
+                await supportService.GetPatientSupportDetailsAsync(Hdid, true, true, true);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.PhnOrDateAndBirthInvalid, exception.ProblemDetails!.Detail);
         }
 
@@ -224,11 +224,11 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await supportService.GetPatientSupportDetailsAsync(Hdid, true, true, true).ConfigureAwait(true);
+                await supportService.GetPatientSupportDetailsAsync(Hdid, true, true, true);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.CannotFindAccessToken, exception.ProblemDetails!.Detail);
         }
 
@@ -259,7 +259,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Single(actualResult);
@@ -285,7 +285,7 @@ namespace HealthGateway.Admin.Tests.Services
             ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Single(actualResult);
@@ -316,7 +316,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Single(actualResult);
@@ -351,7 +351,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Single(actualResult);
@@ -386,7 +386,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Single(actualResult);
@@ -409,7 +409,7 @@ namespace HealthGateway.Admin.Tests.Services
             ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Empty(actualResult);
@@ -442,7 +442,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn);
 
             // Assert
             Assert.Single(actualResult);
@@ -465,7 +465,7 @@ namespace HealthGateway.Admin.Tests.Services
             ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn);
 
             // Assert
             Assert.Empty(actualResult);
@@ -482,8 +482,8 @@ namespace HealthGateway.Admin.Tests.Services
             ISupportService supportService = CreateSupportService();
 
             // Act
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(async () => await supportService.GetPatientsAsync((PatientQueryType)99, Hdid).ConfigureAwait(true))
-                .ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(async () => await supportService.GetPatientsAsync((PatientQueryType)99, Hdid))
+                ;
 
             // Assert
             Assert.Equal(HttpStatusCode.BadRequest, exception.ProblemDetails?.StatusCode);
@@ -530,7 +530,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Dependent, dependentPhn).ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Dependent, dependentPhn);
 
             // Assert
             Assert.Equal(resourceDelegates.Count, actualResult.Count());
@@ -572,7 +572,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Email, "email").ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Email, "email");
 
             // Assert
             Assert.Equal(profiles.Count, actualResult.Count());
@@ -614,7 +614,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             // Act
-            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Sms, "sms").ConfigureAwait(true);
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Sms, "sms");
 
             // Assert
             Assert.Equal(profiles.Count, actualResult.Count());

--- a/Apps/AdminWebClient/test/unit/AdminWebClientTests.csproj
+++ b/Apps/AdminWebClient/test/unit/AdminWebClientTests.csproj
@@ -25,8 +25,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/AdminWebClient/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
+++ b/Apps/AdminWebClient/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
@@ -78,7 +78,7 @@ namespace HealthGateway.AdminWebClientTests.Delegates.Test
                 this.configuration);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusWithRetries(this.phn, this.dob, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusWithRetries(this.phn, this.dob, this.accessToken);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -104,7 +104,7 @@ namespace HealthGateway.AdminWebClientTests.Delegates.Test
                 this.configuration);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusWithRetries(this.phn, this.dob, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusWithRetries(this.phn, this.dob, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -130,7 +130,7 @@ namespace HealthGateway.AdminWebClientTests.Delegates.Test
                 this.configuration);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusWithRetries(this.phn, this.dob, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusWithRetries(this.phn, this.dob, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);

--- a/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/CovidSupportServiceTests.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using HealthGateway.Admin.Api;
     using HealthGateway.Admin.Delegates;
     using HealthGateway.Admin.Models.CovidSupport;
@@ -49,60 +50,65 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
         /// <summary>
         /// Validates the processing when a bad PHN is used.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetCovidAssessmentDetailsBadPhn()
+        public async Task GetCovidAssessmentDetailsBadPhn()
         {
             CovidAssessmentDetailsResponse expectedResult = new();
-            RequestResult<CovidAssessmentDetailsResponse> actualResult = GetCovidSupportService(expectedResult, false).GetCovidAssessmentDetailsAsync("BADPHN").Result;
+            RequestResult<CovidAssessmentDetailsResponse> actualResult = await GetCovidSupportService(expectedResult, false).GetCovidAssessmentDetailsAsync("BADPHN");
             Assert.True(actualResult is { ResultStatus: ResultType.ActionRequired, ResultError: { } } && actualResult.ResultError.ActionCodeValue == ActionType.Validation.Value);
         }
 
         /// <summary>
         /// Confirms Exception handling.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetCovidAssessmentDetailsException()
+        public async Task GetCovidAssessmentDetailsException()
         {
             CovidAssessmentDetailsResponse expectedResult = new();
-            RequestResult<CovidAssessmentDetailsResponse> actualResult = GetCovidSupportService(expectedResult, true).GetCovidAssessmentDetailsAsync(Phn).Result;
+            RequestResult<CovidAssessmentDetailsResponse> actualResult = await GetCovidSupportService(expectedResult, true).GetCovidAssessmentDetailsAsync(Phn);
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
         /// <summary>
         /// Performs a valid covid assessment submission.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void SubmitCovidAssessment()
+        public async Task SubmitCovidAssessment()
         {
             CovidAssessmentResponse expectedResult = new();
             CovidAssessmentRequest request = new()
             {
                 Phn = Phn,
             };
-            RequestResult<CovidAssessmentResponse> actualResult = GetCovidSupportService(expectedResult, false).SubmitCovidAssessmentAsync(request).Result;
+            RequestResult<CovidAssessmentResponse> actualResult = await GetCovidSupportService(expectedResult, false).SubmitCovidAssessmentAsync(request);
             Assert.True(actualResult.ResultStatus == ResultType.Success);
         }
 
         /// <summary>
         /// Confirms Exception handling.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void SubmitCovidAssessmentException()
+        public async Task SubmitCovidAssessmentException()
         {
             CovidAssessmentResponse expectedResult = new();
             CovidAssessmentRequest request = new()
             {
                 Phn = Phn,
             };
-            RequestResult<CovidAssessmentResponse> actualResult = GetCovidSupportService(expectedResult, true).SubmitCovidAssessmentAsync(request).Result;
+            RequestResult<CovidAssessmentResponse> actualResult = await GetCovidSupportService(expectedResult, true).SubmitCovidAssessmentAsync(request);
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
         /// <summary>
         /// Confirms Error handling when bad data is returned.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ConfirmErrorHandling()
+        public async Task ConfirmErrorHandling()
         {
             using MockHttpMessageHandler mockHttp = new();
             string baseEndpoint = "https://localhost";
@@ -111,7 +117,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             HttpClient httpClient = mockHttp.ToHttpClient();
             httpClient.BaseAddress = new Uri(baseEndpoint);
 
-            RequestResult<CovidAssessmentDetailsResponse> actualResult = GetCovidSupportService(httpClient).GetCovidAssessmentDetailsAsync(Phn).Result;
+            RequestResult<CovidAssessmentDetailsResponse> actualResult = await GetCovidSupportService(httpClient).GetCovidAssessmentDetailsAsync(Phn);
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 

--- a/Apps/AdminWebClient/test/unit/Services.Test/SupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/SupportServiceTests.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.Success), GetUserProfile(DbStatusCode.Read));
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -87,7 +87,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.Success), GetUserProfile(DbStatusCode.Read));
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Phn, Phn);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -105,7 +105,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.Success), GetUserProfile(DbStatusCode.Read), GetUserProfiles());
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Email, Email).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Email, Email);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -123,7 +123,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.Success), GetUserProfile(DbStatusCode.Read), GetUserProfiles());
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Sms, SmsNumber).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Sms, SmsNumber);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -141,7 +141,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.Success), GetUserProfile(DbStatusCode.NotFound));
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -160,7 +160,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.ActionRequired), GetUserProfile(DbStatusCode.Read));
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
@@ -179,7 +179,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             ISupportService supportService = CreateSupportService(GetPatient(ResultType.Error));
 
             // Act
-            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -244,7 +244,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
 
             ISupportService supportService = CreateSupportService(patientServiceMock: patientServiceMock, resourceDelegateDelegateMock: resourceDelegateDelegateMock);
 
-            RequestResult<IEnumerable<PatientSupportDetails>> result = await supportService.GetPatientsAsync(PatientQueryType.Dependent, dependentPhn).ConfigureAwait(true);
+            RequestResult<IEnumerable<PatientSupportDetails>> result = await supportService.GetPatientsAsync(PatientQueryType.Dependent, dependentPhn);
 
             Assert.Equal(ResultType.Success, result.ResultStatus);
             Assert.NotNull(result.ResourcePayload);

--- a/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
+++ b/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
+++ b/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
@@ -49,10 +49,11 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         ///  Get clinical document records - happy path.
         /// </summary>
         /// <param name="canAccessDataSource">The value indicates whether the clinical document data source can be accessed or not.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ShouldGetClinicalDocumentRecords(bool canAccessDataSource)
+        public async Task ShouldGetClinicalDocumentRecords(bool canAccessDataSource)
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -61,8 +62,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
             IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, false, canAccessDataSource);
 
             // Act
-            RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>())).Result;
+            RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult = await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -81,8 +81,9 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         /// <summary>
         ///  Get clinical document records throws exception.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetClinicalDocumentRecordsThrowsException()
+        public async Task ShouldGetClinicalDocumentRecordsThrowsException()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -91,8 +92,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
             IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, true);
 
             // Act
-            RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>())).Result;
+            RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult = await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -102,8 +102,9 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         /// <summary>
         ///  Get clinical document file - happy path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetClinicalDocumentFile()
+        public async Task ShouldGetClinicalDocumentFile()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -112,8 +113,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
             IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, false);
 
             // Act
-            RequestResult<EncodedMedia> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>())).Result;
+            RequestResult<EncodedMedia> actualResult = await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -123,8 +123,9 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         /// <summary>
         ///  Get clinical document records throws exception.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetClinicalDocumentFileThrowsException()
+        public async Task ShouldGetClinicalDocumentFileThrowsException()
         {
             // Arrange
             Guid id = Guid.NewGuid();
@@ -133,8 +134,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
             IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, true);
 
             // Act
-            RequestResult<EncodedMedia> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>())).Result;
+            RequestResult<EncodedMedia> actualResult = await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
+++ b/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
@@ -62,7 +62,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
 
             // Act
             RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>()).ConfigureAwait(true)).Result;
+                Task.Run(async () => await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>())).Result;
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -92,7 +92,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
 
             // Act
             RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>()).ConfigureAwait(true)).Result;
+                Task.Run(async () => await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>())).Result;
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -113,7 +113,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
 
             // Act
             RequestResult<EncodedMedia> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()).ConfigureAwait(true)).Result;
+                Task.Run(async () => await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>())).Result;
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -134,7 +134,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
 
             // Act
             RequestResult<EncodedMedia> actualResult =
-                Task.Run(async () => await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>()).ConfigureAwait(true)).Result;
+                Task.Run(async () => await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>())).Result;
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Common/test/unit/CacheProviders/DistributedCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/DistributedCacheProviderTests.cs
@@ -130,9 +130,9 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(5000)).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(5000));
 
-            Assert.NotNull(await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true));
+            Assert.NotNull(await this.cacheProvider.GetItemAsync<string>(key));
         }
 
         /// <summary>
@@ -147,10 +147,10 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(100)).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(100));
             Thread.Sleep(101);
 
-            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true));
+            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key));
         }
 
         /// <summary>
@@ -165,8 +165,8 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value).ConfigureAwait(true);
-            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value);
+            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key);
 
             Assert.Equal(value, cacheItem);
         }
@@ -183,12 +183,12 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value).ConfigureAwait(true);
-            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value);
+            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key);
             Assert.NotNull(cacheItem);
 
-            await this.cacheProvider.RemoveItemAsync(key).ConfigureAwait(true);
-            cacheItem = await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true);
+            await this.cacheProvider.RemoveItemAsync(key);
+            cacheItem = await this.cacheProvider.GetItemAsync<string>(key);
             Assert.Null(cacheItem);
         }
 
@@ -204,9 +204,9 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true));
+            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key));
 
-            string? cacheItem = await this.cacheProvider.GetOrSetAsync(key, () => Task.FromResult(value)).ConfigureAwait(true);
+            string? cacheItem = await this.cacheProvider.GetOrSetAsync(key, () => Task.FromResult(value));
 
             Assert.Equal(value, cacheItem);
         }

--- a/Apps/Common/test/unit/CacheProviders/MemoryCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/MemoryCacheProviderTests.cs
@@ -130,9 +130,9 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(5000)).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(5000));
 
-            Assert.NotNull(await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true));
+            Assert.NotNull(await this.cacheProvider.GetItemAsync<string>(key));
         }
 
         /// <summary>
@@ -147,10 +147,10 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(100)).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(100));
             Thread.Sleep(101);
 
-            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true));
+            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key));
         }
 
         /// <summary>
@@ -165,8 +165,8 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value).ConfigureAwait(true);
-            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value);
+            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key);
 
             Assert.Equal(value, cacheItem);
         }
@@ -183,12 +183,12 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            await this.cacheProvider.AddItemAsync(key, value).ConfigureAwait(true);
-            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true);
+            await this.cacheProvider.AddItemAsync(key, value);
+            string? cacheItem = await this.cacheProvider.GetItemAsync<string>(key);
             Assert.NotNull(cacheItem);
 
-            await this.cacheProvider.RemoveItemAsync(key).ConfigureAwait(true);
-            cacheItem = await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true);
+            await this.cacheProvider.RemoveItemAsync(key);
+            cacheItem = await this.cacheProvider.GetItemAsync<string>(key);
             Assert.Null(cacheItem);
         }
 
@@ -204,9 +204,9 @@ namespace HealthGateway.CommonTests.CacheProviders
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
-            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key).ConfigureAwait(true));
+            Assert.Null(await this.cacheProvider.GetItemAsync<string>(key));
 
-            string? cacheItem = await this.cacheProvider.GetOrSetAsync(key, () => Task.FromResult(value)).ConfigureAwait(true);
+            string? cacheItem = await this.cacheProvider.GetOrSetAsync(key, () => Task.FromResult(value));
 
             Assert.Equal(value, cacheItem);
         }

--- a/Apps/Common/test/unit/CacheProviders/RedisCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/RedisCacheProviderTests.cs
@@ -215,8 +215,8 @@ namespace HealthGateway.CommonTests.CacheProviders
         /// <returns>A task representing nothing.</returns>
         public async Task InitializeAsync()
         {
-            await this.redisContainer.StartAsync().ConfigureAwait(true);
-            this.connectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(this.redisContainer.GetConnectionString()).ConfigureAwait(true);
+            await this.redisContainer.StartAsync();
+            this.connectionMultiplexer = await ConnectionMultiplexer.ConnectAsync(this.redisContainer.GetConnectionString());
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace HealthGateway.CommonTests.CacheProviders
         /// <returns>A task representing nothing.</returns>
         public async Task DisposeAsync()
         {
-            await this.redisContainer.DisposeAsync().ConfigureAwait(true);
+            await this.redisContainer.DisposeAsync();
         }
     }
 }

--- a/Apps/Common/test/unit/CommonTests.csproj
+++ b/Apps/Common/test/unit/CommonTests.csproj
@@ -20,8 +20,8 @@
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Testcontainers" Version="3.5.0" />
         <PackageReference Include="Testcontainers.Redis" Version="3.5.0" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.CommonTests.Delegates
             ICDogsDelegate cdogsDelegate = new CDogsDelegate(mockLogger.Object, mockCdogsApi.Object);
 
             CDogsRequestModel request = GetRequestModel();
-            RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request).ConfigureAwait(true);
+            RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -110,7 +110,7 @@ namespace HealthGateway.CommonTests.Delegates
             ICDogsDelegate cdogsDelegate = new CDogsDelegate(mockLogger.Object, mockCdogsApi.Object);
 
             CDogsRequestModel request = GetRequestModel();
-            RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request).ConfigureAwait(true);
+            RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -137,7 +137,7 @@ namespace HealthGateway.CommonTests.Delegates
             ICDogsDelegate cdogsDelegate = new CDogsDelegate(mockLogger.Object, mockCdogsApi.Object);
 
             CDogsRequestModel request = GetRequestModel();
-            RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request).ConfigureAwait(true);
+            RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request);
 
             Assert.NotNull(actualResult.ResultError);
             Assert.Equal(expectedResult.ResultError.ErrorCode, actualResult.ResultError?.ErrorCode);

--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -129,7 +129,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync("9875023209").ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync("9875023209");
 
             // Verify
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
@@ -347,7 +347,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(expectedHdId).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(expectedHdId);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -457,7 +457,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(hdid).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(hdid);
 
             // Verify
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
@@ -578,7 +578,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(expectedHdId).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(expectedHdId);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -728,7 +728,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(expectedHdId).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByHdidAsync(expectedHdId);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -837,7 +837,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -941,7 +941,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -1045,7 +1045,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -1149,7 +1149,7 @@ namespace HealthGateway.CommonTests.Delegates
                 HttpContextAccessorMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn).ConfigureAwait(true);
+            RequestResult<PatientModel> actual = await patientDelegate.GetDemographicsByPhnAsync(expectedPhn);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);

--- a/Apps/Common/test/unit/Delegates/NotificationSettingsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/NotificationSettingsDelegateTests.cs
@@ -62,7 +62,7 @@ namespace HealthGateway.CommonTests.Delegates
             RestNotificationSettingsDelegate notificationSettingsDelegate = new(mockLogger.Object, mockNotificationSettingsApi.Object);
 
             RequestResult<NotificationSettingsResponse> actualResult =
-                await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty).ConfigureAwait(true);
+                await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -93,7 +93,7 @@ namespace HealthGateway.CommonTests.Delegates
             RestNotificationSettingsDelegate notificationSettingsDelegate = new(mockLogger.Object, mockNotificationSettingsApi.Object);
 
             RequestResult<NotificationSettingsResponse> actualResult =
-                await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty).ConfigureAwait(true);
+                await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -121,7 +121,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             using HttpRequestMessage requestMessage = new();
             using HttpResponseMessage responseMessage = new(HttpStatusCode.NotFound);
-            ApiException apiException = await ApiException.Create(requestMessage, HttpMethod.Put, responseMessage, new()).ConfigureAwait(true);
+            ApiException apiException = await ApiException.Create(requestMessage, HttpMethod.Put, responseMessage, new());
 
             mockNotificationSettingsApi.Setup(s => s.SetNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<string>(), It.IsAny<string>()))
                 .ThrowsAsync(apiException);
@@ -129,7 +129,7 @@ namespace HealthGateway.CommonTests.Delegates
             RestNotificationSettingsDelegate notificationSettingsDelegate = new(mockLogger.Object, mockNotificationSettingsApi.Object);
 
             RequestResult<NotificationSettingsResponse> actualResult =
-                await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty).ConfigureAwait(true);
+                await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty);
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/Common/test/unit/Delegates/RestTokenSwapDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/RestTokenSwapDelegateTests.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.CommonTests.Delegates
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -39,8 +40,11 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// Swap token - Happy Path.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void SwapToken()
+        public async Task SwapToken()
         {
             // Arrange
             TokenSwapResponse expectedTokenSwapResponse = new()
@@ -54,7 +58,7 @@ namespace HealthGateway.CommonTests.Delegates
             ITokenSwapDelegate tokenSwapDelegate = GetTokenSwapDelegate(expectedTokenSwapResponse, false);
 
             // Act
-            RequestResult<TokenSwapResponse> actualResult = tokenSwapDelegate.SwapToken(It.IsAny<string>()).Result;
+            RequestResult<TokenSwapResponse> actualResult = await tokenSwapDelegate.SwapToken(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -65,8 +69,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// Swap token - HttpRequestException.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void SwapTokenThrowsException()
+        public async Task SwapTokenThrowsException()
         {
             // Arrange
             TokenSwapResponse expectedTokenSwapResponse = new()
@@ -80,7 +85,7 @@ namespace HealthGateway.CommonTests.Delegates
             ITokenSwapDelegate tokenSwapDelegate = GetTokenSwapDelegate(expectedTokenSwapResponse, true);
 
             // Act
-            RequestResult<TokenSwapResponse> actualResult = tokenSwapDelegate.SwapToken(It.IsAny<string>()).Result;
+            RequestResult<TokenSwapResponse> actualResult = await tokenSwapDelegate.SwapToken(It.IsAny<string>());
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(HttpExceptionMessage, actualResult.ResultError?.ResultMessage);

--- a/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
@@ -68,8 +68,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// MailAsync - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateMailAsyncSuccess()
+        public async Task ValidateMailAsyncSuccess()
         {
             VaccineProofRequest request = new()
             {
@@ -111,8 +112,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<VaccineProofResponse> actualResult = await vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
 
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -123,8 +123,11 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// MailAsync - Error Specified in Payload.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ValidateMailAsyncPayloadError()
+        public async Task ValidateMailAsyncPayloadError()
         {
             VaccineProofRequest request = new()
             {
@@ -147,8 +150,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<VaccineProofResponse> actualResult = await vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -158,8 +160,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// MailAsync - HTTP Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateMailAsyncHttpError()
+        public async Task ValidateMailAsyncHttpError()
         {
             VaccineProofRequest request = new()
             {
@@ -180,8 +183,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<VaccineProofResponse> actualResult = await vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -191,8 +193,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GenerateAsync - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGenerateAsyncSuccess()
+        public async Task ValidateGenerateAsyncSuccess()
         {
             VaccineProofRequest request = new()
             {
@@ -234,8 +237,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<VaccineProofResponse> actualResult = await vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
 
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -246,8 +248,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GenerateAsync - Error Specified in Payload.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGenerateAsyncPayloadError()
+        public async Task ValidateGenerateAsyncPayloadError()
         {
             VaccineProofRequest request = new()
             {
@@ -270,8 +273,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<VaccineProofResponse> actualResult = await vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -281,8 +283,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GenerateAsync - HTTP Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGenerateAsyncHttpError()
+        public async Task ValidateGenerateAsyncHttpError()
         {
             VaccineProofRequest request = new()
             {
@@ -303,8 +306,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<VaccineProofResponse> actualResult = await vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -314,8 +316,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GetAssetAsync - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGetAssetAsyncSuccess()
+        public async Task ValidateGetAssetAsyncSuccess()
         {
             Uri jobUri = new($"https://localhost/{JobId}");
             RequestResult<ReportModel> expectedRequestResult = new()
@@ -346,8 +349,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<ReportModel> actualResult = await vaccineProofDelegate.GetAssetAsync(jobUri);
 
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -358,8 +360,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GetAssetAsync - NotFound.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGetAssetAsyncNotFound()
+        public async Task ValidateGetAssetAsyncNotFound()
         {
             Uri jobUri = new($"https://localhost/{JobId}");
             using HttpResponseMessage httpResponseMessage = new()
@@ -375,8 +378,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<ReportModel> actualResult = await vaccineProofDelegate.GetAssetAsync(jobUri);
 
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -386,8 +388,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GetAssetAsync - Empty Payload.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGetAssetAsyncEmptyPayload()
+        public async Task ValidateGetAssetAsyncEmptyPayload()
         {
             Uri jobUri = new($"https://localhost/{JobId}");
             byte[] fileContents = Array.Empty<byte>();
@@ -405,8 +408,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<ReportModel> actualResult = await vaccineProofDelegate.GetAssetAsync(jobUri);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -416,8 +418,9 @@ namespace HealthGateway.CommonTests.Delegates
         /// <summary>
         /// GetAssetAsync - HTTP Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateGetAssetAsyncHttpError()
+        public async Task ValidateGetAssetAsyncHttpError()
         {
             Uri jobUri = new($"https://localhost/{JobId}");
             using HttpResponseMessage httpResponseMessage = new()
@@ -433,8 +436,7 @@ namespace HealthGateway.CommonTests.Delegates
                 GetHttpClientFactoryMock(httpResponseMessage).Object,
                 this.configuration);
 
-            Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
+            RequestResult<ReportModel> actualResult = await vaccineProofDelegate.GetAssetAsync(jobUri);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);

--- a/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
@@ -112,7 +112,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -148,7 +148,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -181,7 +181,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.MailAsync(VaccineProofTemplate.Provincial, request, this.address);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -235,7 +235,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -271,7 +271,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -304,7 +304,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<VaccineProofResponse>> task = vaccineProofDelegate.GenerateAsync(VaccineProofTemplate.Provincial, request);
-            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofResponse> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -347,7 +347,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(expectedRequestResult.ResultStatus, actualResult.ResultStatus);
             Assert.Equal(expectedRequestResult.ResultError, actualResult.ResultError);
@@ -376,7 +376,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -406,7 +406,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -434,7 +434,7 @@ namespace HealthGateway.CommonTests.Delegates
                 this.configuration);
 
             Task<RequestResult<ReportModel>> task = vaccineProofDelegate.GetAssetAsync(jobUri);
-            RequestResult<ReportModel> actualResult = Task.Run(async () => await task.ConfigureAwait(true)).Result;
+            RequestResult<ReportModel> actualResult = Task.Run(async () => await task).Result;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);

--- a/Apps/Common/test/unit/Services/AccessTokenServiceTests.cs
+++ b/Apps/Common/test/unit/Services/AccessTokenServiceTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.CommonTests.Services
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Data.Constants;
@@ -43,8 +44,11 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// Get PHSA access token.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void GetPhsaToken()
+        public async Task GetPhsaToken()
         {
             // Arrange
             TokenSwapResponse expectedTokenSwapResponse = new()
@@ -58,7 +62,7 @@ namespace HealthGateway.CommonTests.Services
             IAccessTokenService accessTokenService = GetAccessTokenService(expectedTokenSwapResponse, true, false);
 
             // Act
-            RequestResult<TokenSwapResponse> actualResult = accessTokenService.GetPhsaAccessToken().Result;
+            RequestResult<TokenSwapResponse> actualResult = await accessTokenService.GetPhsaAccessToken();
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -69,8 +73,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// Get PHSA access token - use cache.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetPhsaTokenFromCache()
+        public async Task GetPhsaTokenFromCache()
         {
             // Arrange
             TokenSwapResponse expectedTokenSwapResponse = new()
@@ -84,7 +89,7 @@ namespace HealthGateway.CommonTests.Services
             IAccessTokenService accessTokenService = GetAccessTokenService(expectedTokenSwapResponse, true, true);
 
             // Act
-            RequestResult<TokenSwapResponse> actualResult = accessTokenService.GetPhsaAccessToken().Result;
+            RequestResult<TokenSwapResponse> actualResult = await accessTokenService.GetPhsaAccessToken();
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -95,8 +100,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// Get PHSA access token - could not get access token from authentication delegate.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetPhsaTokenReturnsError()
+        public async Task GetPhsaTokenReturnsError()
         {
             // Arrange
             TokenSwapResponse expectedTokenSwapResponse = new()
@@ -110,7 +116,7 @@ namespace HealthGateway.CommonTests.Services
             IAccessTokenService accessTokenService = GetAccessTokenService(expectedTokenSwapResponse, false, true);
 
             // Act
-            RequestResult<TokenSwapResponse> actualResult = accessTokenService.GetPhsaAccessToken().Result;
+            RequestResult<TokenSwapResponse> actualResult = await accessTokenService.GetPhsaAccessToken();
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
+++ b/Apps/Common/test/unit/Services/BroadcastServiceTests.cs
@@ -44,8 +44,11 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// CreateBroadcastAsync.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldCreateBroadcast()
+        public async Task ShouldCreateBroadcast()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, false);
@@ -56,7 +59,7 @@ namespace HealthGateway.CommonTests.Services
             };
 
             // Act
-            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.CreateBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -68,8 +71,11 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// CreateBroadcastAsync fails effective expiry date validation.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void CreateBroadcastFailDateValidation()
+        public async Task CreateBroadcastFailDateValidation()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, false);
@@ -80,7 +86,7 @@ namespace HealthGateway.CommonTests.Services
             };
 
             // Act
-            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.CreateBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -91,8 +97,11 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// CreateBroadcastAsync - api throws exception.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void CreateBroadcastShouldThrowsException()
+        public async Task CreateBroadcastShouldThrowsException()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, true);
@@ -103,7 +112,7 @@ namespace HealthGateway.CommonTests.Services
             };
 
             // Act
-            RequestResult<Broadcast> actualResult = service.CreateBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.CreateBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -115,15 +124,16 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// GetBroadcastsAsync - api returns one row.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetBroadcasts()
+        public async Task ShouldGetBroadcasts()
         {
             // Arrange
             Guid expectedId = Guid.NewGuid();
             IBroadcastService service = GetBroadcastService(expectedId, false);
 
             // Act
-            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+            RequestResult<IEnumerable<Broadcast>> actualResult = await service.GetBroadcastsAsync();
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -136,14 +146,17 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// GetBroadcastsAsync - returns no rows.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetBroadcastsNoRowsReturned()
+        public async Task ShouldGetBroadcastsNoRowsReturned()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, false);
 
             // Act
-            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+            RequestResult<IEnumerable<Broadcast>> actualResult = await service.GetBroadcastsAsync();
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -155,14 +168,15 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// GetBroadcastsAsync - api throws exception.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetBroadcastsShouldThrowsException()
+        public async Task GetBroadcastsShouldThrowsException()
         {
             // Arrange
             IBroadcastService service = GetBroadcastService(null, true);
 
             // Act
-            RequestResult<IEnumerable<Broadcast>> actualResult = service.GetBroadcastsAsync().Result;
+            RequestResult<IEnumerable<Broadcast>> actualResult = await service.GetBroadcastsAsync();
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -174,8 +188,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// UpdateBroadcastAsync.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateBroadcast()
+        public async Task ShouldUpdateBroadcast()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -189,7 +204,7 @@ namespace HealthGateway.CommonTests.Services
             IBroadcastService service = GetBroadcastService(expectedId, false);
 
             // Act
-            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.UpdateBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -201,8 +216,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// UpdateBroadcastAsync fails effective expiry date validation.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void UpdateBroadcastFailsDateValidation()
+        public async Task UpdateBroadcastFailsDateValidation()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -216,7 +232,7 @@ namespace HealthGateway.CommonTests.Services
             IBroadcastService service = GetBroadcastService(expectedId, false);
 
             // Act
-            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.UpdateBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -227,8 +243,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// CreateBroadcastAsync - api throws exception.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void UpdateBroadcastShouldThrowsException()
+        public async Task UpdateBroadcastShouldThrowsException()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -242,7 +259,7 @@ namespace HealthGateway.CommonTests.Services
             IBroadcastService service = GetBroadcastService(null, true);
 
             // Act
-            RequestResult<Broadcast> actualResult = service.UpdateBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.UpdateBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -254,8 +271,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// DeleteBroadcastAsync.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteBroadcast()
+        public async Task ShouldDeleteBroadcast()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -267,7 +285,7 @@ namespace HealthGateway.CommonTests.Services
             IBroadcastService service = GetBroadcastService(expectedId, false);
 
             // Act
-            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.DeleteBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -279,8 +297,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// DeleteBroadcastAsync - api throws exception.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void DeleteBroadcastShouldThrowException()
+        public async Task DeleteBroadcastShouldThrowException()
         {
             Guid expectedId = Guid.NewGuid();
 
@@ -292,7 +311,7 @@ namespace HealthGateway.CommonTests.Services
             IBroadcastService service = GetBroadcastService(null, true);
 
             // Act
-            RequestResult<Broadcast> actualResult = service.DeleteBroadcastAsync(broadcast).Result;
+            RequestResult<Broadcast> actualResult = await service.DeleteBroadcastAsync(broadcast);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Common/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PatientServiceTests.cs
@@ -130,7 +130,7 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICacheProvider>().Object);
 
             // Act
-            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn)).Result;
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -169,7 +169,7 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICacheProvider>().Object);
 
             // Act
-            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient("abc123", PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient("abc123", PatientIdentifierType.Phn)).Result;
 
             // Verify
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
@@ -209,7 +209,7 @@ namespace HealthGateway.CommonTests.Services
                 patientDelegateMock.Object,
                 new Mock<ICacheProvider>().Object);
 
-            await Assert.ThrowsAsync<NotImplementedException>(() => service.GetPatient("abc123", (PatientIdentifierType)23)).ConfigureAwait(true);
+            await Assert.ThrowsAsync<NotImplementedException>(() => service.GetPatient("abc123", (PatientIdentifierType)23));
         }
 
         private static RequestResult<string> GetPatientPhn(Dictionary<string, string?> configDictionary, bool returnNullPatientResult)
@@ -244,7 +244,7 @@ namespace HealthGateway.CommonTests.Services
                 cacheProviderMock.Object);
 
             // Act
-            RequestResult<string> actual = Task.Run(async () => await service.GetPatientPhn(Hdid).ConfigureAwait(true)).Result;
+            RequestResult<string> actual = Task.Run(async () => await service.GetPatientPhn(Hdid)).Result;
             return actual;
         }
 
@@ -285,7 +285,7 @@ namespace HealthGateway.CommonTests.Services
                 cacheProviderMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(identifierType == PatientIdentifierType.Hdid ? Hdid : Phn, identifierType).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(identifierType == PatientIdentifierType.Hdid ? Hdid : Phn, identifierType)).Result;
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);

--- a/Apps/Common/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PatientServiceTests.cs
@@ -99,10 +99,13 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// GetPatient - Valid ID.
+        ///  GetPatient - Valid ID.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldSearchByValidIdentifier()
+        public async Task ShouldSearchByValidIdentifier()
         {
             RequestResult<PatientModel> requestResult = new()
             {
@@ -130,7 +133,7 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICacheProvider>().Object);
 
             // Act
-            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(Phn, PatientIdentifierType.Phn)).Result;
+            RequestResult<PatientModel> actual = await service.GetPatient(Phn, PatientIdentifierType.Phn);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -140,8 +143,9 @@ namespace HealthGateway.CommonTests.Services
         /// <summary>
         /// GetPatient - Valid ID.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldFailModCheck()
+        public async Task ShouldFailModCheck()
         {
             RequestResult<PatientModel> requestResult = new()
             {
@@ -169,7 +173,7 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICacheProvider>().Object);
 
             // Act
-            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient("abc123", PatientIdentifierType.Phn)).Result;
+            RequestResult<PatientModel> actual = await service.GetPatient("abc123", PatientIdentifierType.Phn);
 
             // Verify
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);

--- a/Apps/Common/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PatientServiceTests.cs
@@ -99,7 +99,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        ///  GetPatient - Valid ID.
+        /// GetPatient - Valid ID.
         /// </summary>
         /// <returns>
         /// A <see cref="Task"/> representing the asynchronous unit test.

--- a/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
@@ -52,7 +52,7 @@ namespace HealthGateway.CommonTests.Services
             IPersonalAccountsService personalAccountsServiceService = GetPersonalAccountsService(expectedPersonalAccount, false, false);
 
             // Act
-            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>()).ConfigureAwait(true);
+            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -74,7 +74,7 @@ namespace HealthGateway.CommonTests.Services
             IPersonalAccountsService personalAccountsServiceService = GetPersonalAccountsService(expectedPersonalAccount, true, false);
 
             // Act
-            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>()).ConfigureAwait(true);
+            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -96,7 +96,7 @@ namespace HealthGateway.CommonTests.Services
             IPersonalAccountsService personalAccountsServiceService = GetPersonalAccountsService(expectedPersonalAccount, false, true);
 
             // Act
-            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>()).ConfigureAwait(true);
+            RequestResult<PersonalAccount> actualResult = await personalAccountsServiceService.GetPatientAccountResultAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Common/test/unit/Swagger/SwaggerTests.cs
+++ b/Apps/Common/test/unit/Swagger/SwaggerTests.cs
@@ -55,7 +55,7 @@ namespace HealthGateway.CommonTests.Swagger
 
             filter.Apply(openApiOperation, filterContext);
 
-            Assert.Equal(1, openApiOperation.Security.Count);
+            Assert.Single(openApiOperation.Security);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace HealthGateway.CommonTests.Swagger
 
             filter.Apply(openApiOperation, filterContext);
 
-            Assert.Equal(0, openApiOperation.Security.Count);
+            Assert.Empty(openApiOperation.Security);
         }
     }
 }

--- a/Apps/CommonData/test/unit/CommonDataTests.csproj
+++ b/Apps/CommonData/test/unit/CommonDataTests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/CommonData/test/unit/Utils/StringManipulatorTests.cs
+++ b/Apps/CommonData/test/unit/Utils/StringManipulatorTests.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.Common.Data.Tests.Utils
         {
             string clean = " e m p t y  s t r i n g ";
             string expected = "emptystring";
-            string? actual = StringManipulator.StripWhitespace(clean);
+            string actual = StringManipulator.StripWhitespace(clean);
             Assert.Equal(expected, actual);
         }
 

--- a/Apps/CommonUi/test/unit/CommonUiTests.csproj
+++ b/Apps/CommonUi/test/unit/CommonUiTests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/CommonUi/test/unit/Utils/IJSRuntimeExtensionMethodsTests.cs
+++ b/Apps/CommonUi/test/unit/Utils/IJSRuntimeExtensionMethodsTests.cs
@@ -38,7 +38,7 @@ namespace HealthGateway.CommonUi.Tests.Utils
         {
             Mock<IJSRuntime> jsRuntime = new();
             using DotNetObjectReference<IjsRuntimeExtensionMethodsTests> objectReference = DotNetObjectReference.Create(this);
-            await jsRuntime.Object.InitializeInactivityTimer(objectReference).ConfigureAwait(true);
+            await jsRuntime.Object.InitializeInactivityTimer(objectReference);
 
             jsRuntime.Verify(
                 a => a.InvokeAsync<IJSVoidResult>(

--- a/Apps/Database/test/unit/DatabaseTests.csproj
+++ b/Apps/Database/test/unit/DatabaseTests.csproj
@@ -29,9 +29,9 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.11" />
-    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit" Version="2.5.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/Encounter/test/unit/Controllers/EncounterControllerTests.cs
+++ b/Apps/Encounter/test/unit/Controllers/EncounterControllerTests.cs
@@ -80,7 +80,7 @@ namespace HealthGateway.EncounterTests.Controllers
             EncounterController controller = new(new Mock<ILogger<EncounterController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<IEnumerable<EncounterModel>> actual = await controller.GetEncounters(Hdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<EncounterModel>> actual = await controller.GetEncounters(Hdid);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Success);
@@ -120,7 +120,7 @@ namespace HealthGateway.EncounterTests.Controllers
             EncounterController controller = new(new Mock<ILogger<EncounterController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<HospitalVisitResult> actual = await controller.GetHospitalVisits(Hdid).ConfigureAwait(true);
+            RequestResult<HospitalVisitResult> actual = await controller.GetHospitalVisits(Hdid);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Success);

--- a/Apps/Encounter/test/unit/Delegates/EncounterDelegateTests.cs
+++ b/Apps/Encounter/test/unit/Delegates/EncounterDelegateTests.cs
@@ -42,8 +42,11 @@ namespace HealthGateway.EncounterTests.Delegates
         /// <summary>
         /// GetMSPVisits - Happy Path.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetMspVisits()
+        public async Task ShouldGetMspVisits()
         {
             Guid expectedMspHistoryResponseId = Guid.NewGuid();
             int expectedClaimId = 1005;
@@ -102,7 +105,7 @@ namespace HealthGateway.EncounterTests.Delegates
                 mockMspVisitApi.Object);
 
             // Act
-            RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(async () => await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty)).Result;
+            RequestResult<MspVisitHistoryResponse> actualResult = await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty);
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -115,8 +118,11 @@ namespace HealthGateway.EncounterTests.Delegates
         /// <summary>
         /// GetMSPVisits - Handles api exception.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetMspVisitsHandleApiException()
+        public async Task ShouldGetMspVisitsHandleApiException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.Unauthorized}. Error while retrieving Msp Visits";
             OdrHistoryQuery query = new()
@@ -131,10 +137,8 @@ namespace HealthGateway.EncounterTests.Delegates
             IMspVisitDelegate mspVisitDelegate = new RestMspVisitDelegate(new Mock<ILogger<RestMspVisitDelegate>>().Object, mockMspVisitApi.Object);
 
             // Act
-            RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(
-                    async () =>
-                        await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty))
-                .Result;
+            RequestResult<MspVisitHistoryResponse> actualResult =
+                await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -144,8 +148,11 @@ namespace HealthGateway.EncounterTests.Delegates
         /// <summary>
         /// GetMSPVisits - Handles api exception.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetMspVisitsHandleHttpRequestException()
+        public async Task ShouldGetMspVisitsHandleHttpRequestException()
         {
             string expectedMessage = $"Status: {HttpStatusCode.InternalServerError}. Error while retrieving Msp Visits";
 
@@ -161,10 +168,8 @@ namespace HealthGateway.EncounterTests.Delegates
             IMspVisitDelegate mspVisitDelegate = new RestMspVisitDelegate(new Mock<ILogger<RestMspVisitDelegate>>().Object, mockMspVisitApi.Object);
 
             // Act
-            RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(
-                    async () =>
-                        await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty))
-                .Result;
+            RequestResult<MspVisitHistoryResponse> actualResult =
+                await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Encounter/test/unit/Delegates/EncounterDelegateTests.cs
+++ b/Apps/Encounter/test/unit/Delegates/EncounterDelegateTests.cs
@@ -102,7 +102,7 @@ namespace HealthGateway.EncounterTests.Delegates
                 mockMspVisitApi.Object);
 
             // Act
-            RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(async () => await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty).ConfigureAwait(true)).Result;
+            RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(async () => await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty)).Result;
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -133,7 +133,7 @@ namespace HealthGateway.EncounterTests.Delegates
             // Act
             RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(
                     async () =>
-                        await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty).ConfigureAwait(true))
+                        await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty))
                 .Result;
 
             // Verify
@@ -163,7 +163,7 @@ namespace HealthGateway.EncounterTests.Delegates
             // Act
             RequestResult<MspVisitHistoryResponse> actualResult = Task.Run(
                     async () =>
-                        await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty).ConfigureAwait(true))
+                        await mspVisitDelegate.GetMspVisitHistoryAsync(query, string.Empty, string.Empty))
                 .Result;
 
             // Verify

--- a/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
+++ b/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.EncounterTests.Delegates
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -46,8 +47,11 @@ namespace HealthGateway.EncounterTests.Delegates
         /// <summary>
         /// GetHospitalVisits - api returns one row.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetHospitalVisits()
+        public async Task ShouldGetHospitalVisits()
         {
             // Arrange
             PhsaResult<IEnumerable<HospitalVisit>> phsaResponse = new()
@@ -80,7 +84,7 @@ namespace HealthGateway.EncounterTests.Delegates
                 GetIConfigurationRoot());
 
             // Act
-            RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> actualResult = hospitalVisitDelegate.GetHospitalVisitsAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> actualResult = await hospitalVisitDelegate.GetHospitalVisitsAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -93,8 +97,11 @@ namespace HealthGateway.EncounterTests.Delegates
         /// <summary>
         /// GetHospitalVisits - api throws Http Request Exception.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void GetHospitalVisitShouldHandleApiException()
+        public async Task GetHospitalVisitShouldHandleApiException()
         {
             // Arrange
             ApiException mockException = MockRefitExceptionHelper.CreateApiException(HttpStatusCode.Unauthorized, HttpMethod.Post);
@@ -110,7 +117,7 @@ namespace HealthGateway.EncounterTests.Delegates
                 GetIConfigurationRoot());
 
             // Act
-            RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> actualResult = hospitalVisitDelegate.GetHospitalVisitsAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> actualResult = await hospitalVisitDelegate.GetHospitalVisitsAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -122,8 +129,11 @@ namespace HealthGateway.EncounterTests.Delegates
         /// <summary>
         /// GetHospitalVisits - api throws Http Request Exception.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void GetHospitalVisitShouldHandleHttpRequestException()
+        public async Task GetHospitalVisitShouldHandleHttpRequestException()
         {
             // Arrange
             HttpRequestException mockException = MockRefitExceptionHelper.CreateHttpRequestException("Internal Server Error", HttpStatusCode.InternalServerError);
@@ -139,7 +149,7 @@ namespace HealthGateway.EncounterTests.Delegates
                 GetIConfigurationRoot());
 
             // Act
-            RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> actualResult = hospitalVisitDelegate.GetHospitalVisitsAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> actualResult = await hospitalVisitDelegate.GetHospitalVisitsAsync(It.IsAny<string>());
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Encounter/test/unit/EncounterTests.csproj
+++ b/Apps/Encounter/test/unit/EncounterTests.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
@@ -93,10 +93,13 @@ namespace HealthGateway.EncounterTests.Services
         /// GetEncounters - Happy Path.
         /// </summary>
         /// <param name="canAccessDataSource">The value indicates whether the health visit data source can be accessed or not.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ValidateEncounters(bool canAccessDataSource)
+        public async Task ValidateEncounters(bool canAccessDataSource)
         {
             RequestResult<MspVisitHistoryResponse> delegateResult = new()
             {
@@ -137,7 +140,7 @@ namespace HealthGateway.EncounterTests.Services
                 GetIConfigurationRoot(),
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<IEnumerable<EncounterModel>> actualResult = service.GetEncounters(hdid).Result;
+            RequestResult<IEnumerable<EncounterModel>> actualResult = await service.GetEncounters(hdid);
 
             Assert.True(actualResult.ResultStatus == ResultType.Success);
 
@@ -154,8 +157,11 @@ namespace HealthGateway.EncounterTests.Services
         /// <summary>
         /// GetEncounters - Empty Claims.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void NoClaims()
+        public async Task NoClaims()
         {
             RequestResult<MspVisitHistoryResponse> delegateResult = new()
             {
@@ -192,7 +198,7 @@ namespace HealthGateway.EncounterTests.Services
                 GetIConfigurationRoot(),
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<IEnumerable<EncounterModel>> actualResult = service.GetEncounters(hdid).Result;
+            RequestResult<IEnumerable<EncounterModel>> actualResult = await service.GetEncounters(hdid);
 
             Assert.True(actualResult.ResultStatus == ResultType.Success);
             Assert.False(actualResult.ResourcePayload.Any());
@@ -201,8 +207,11 @@ namespace HealthGateway.EncounterTests.Services
         /// <summary>
         /// GetEncounters - Patient Error.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void PatientError()
+        public async Task PatientError()
         {
             RequestResult<MspVisitHistoryResponse> delegateResult = new();
 
@@ -241,7 +250,7 @@ namespace HealthGateway.EncounterTests.Services
                 GetIConfigurationRoot(),
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<IEnumerable<EncounterModel>> actualResult = service.GetEncounters(hdid).Result;
+            RequestResult<IEnumerable<EncounterModel>> actualResult = await service.GetEncounters(hdid);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             errorPatientResult.ResultError.ShouldDeepEqual(actualResult.ResultError);
@@ -251,10 +260,13 @@ namespace HealthGateway.EncounterTests.Services
         /// GetHospitalVisits - returns a single row.
         /// </summary>
         /// <param name="canAccessDataSource">The value indicates whether the hospital visit data source can be accessed or not.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ShouldGetHospitalVisits(bool canAccessDataSource)
+        public async Task ShouldGetHospitalVisits(bool canAccessDataSource)
         {
             // Arrange
             RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> hospitalVisitResults = new()
@@ -277,7 +289,7 @@ namespace HealthGateway.EncounterTests.Services
             IEncounterService service = GetEncounterService(hospitalVisitResults, canAccessDataSource);
 
             // Act
-            RequestResult<HospitalVisitResult> actualResult = service.GetHospitalVisits(Hdid).Result;
+            RequestResult<HospitalVisitResult> actualResult = await service.GetHospitalVisits(Hdid);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -297,8 +309,11 @@ namespace HealthGateway.EncounterTests.Services
         /// <summary>
         /// GetHospitalVisits - returns no rows.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void GetHospitalVisitsShouldReturnNoRows()
+        public async Task GetHospitalVisitsShouldReturnNoRows()
         {
             // Arrange
             RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> hospitalVisitResults = new()
@@ -313,7 +328,7 @@ namespace HealthGateway.EncounterTests.Services
             IEncounterService service = GetEncounterService(hospitalVisitResults);
 
             // Act
-            RequestResult<HospitalVisitResult> actualResult = service.GetHospitalVisits(Hdid).Result;
+            RequestResult<HospitalVisitResult> actualResult = await service.GetHospitalVisits(Hdid);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -327,8 +342,11 @@ namespace HealthGateway.EncounterTests.Services
         /// <summary>
         /// GetHospitalVisits - returns refresh in progress.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void GetHospitalVisitsShouldReturnRefreshInProgress()
+        public async Task GetHospitalVisitsShouldReturnRefreshInProgress()
         {
             // Arrange
             RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> hospitalVisitResults = new()
@@ -348,7 +366,7 @@ namespace HealthGateway.EncounterTests.Services
             IEncounterService service = GetEncounterService(hospitalVisitResults);
 
             // Act
-            RequestResult<HospitalVisitResult> actualResult = service.GetHospitalVisits(Hdid).Result;
+            RequestResult<HospitalVisitResult> actualResult = await service.GetHospitalVisits(Hdid);
 
             // Assert
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
@@ -363,8 +381,11 @@ namespace HealthGateway.EncounterTests.Services
         /// <summary>
         /// GetHospitalVisits - returns error caused by delegate.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void GetHospitalVisitsShouldReturnError()
+        public async Task GetHospitalVisitsShouldReturnError()
         {
             // Arrange
             RequestResult<PhsaResult<IEnumerable<HospitalVisit>>> hospitalVisitResults = new()
@@ -378,7 +399,7 @@ namespace HealthGateway.EncounterTests.Services
             IEncounterService service = GetEncounterService(hospitalVisitResults);
 
             // Act
-            RequestResult<HospitalVisitResult> actualResult = service.GetHospitalVisits(Hdid).Result;
+            RequestResult<HospitalVisitResult> actualResult = await service.GetHospitalVisits(Hdid);
 
             // Assert
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
@@ -56,7 +56,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             PhsaController phsaController = new(
                 dependentServiceMock.Object,
                 new Mock<IPatientDetailsService>().Object);
-            ActionResult<RequestResult<IEnumerable<DependentModel>>> actualResult = await phsaController.GetAll(this.hdid).ConfigureAwait(true);
+            ActionResult<RequestResult<IEnumerable<DependentModel>>> actualResult = await phsaController.GetAll(this.hdid);
 
             RequestResult<IEnumerable<DependentModel>>? actualRequestResult = actualResult.Value;
             expectedResult.ShouldDeepEqual(actualRequestResult);

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -53,7 +53,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         public async Task ShouldGetUserProfile()
         {
             RequestResult<UserProfileModel> expected = this.GetUserProfileExpectedRequestResultMock(ResultType.Success);
-            RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected, new Dictionary<string, UserPreferenceModel>()).ConfigureAwait(true);
+            RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected, new Dictionary<string, UserPreferenceModel>());
 
             expected.ShouldDeepEqual(actualResult);
         }
@@ -66,7 +66,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         public async Task ShouldGetUserProfileWithoutUserPreference()
         {
             RequestResult<UserProfileModel> expected = this.GetUserProfileExpectedRequestResultMock(ResultType.Success);
-            RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected, null).ConfigureAwait(true);
+            RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected, null);
 
             Assert.NotNull(actualResult);
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -112,7 +112,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest).ConfigureAwait(true);
+            ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest);
             expected.ShouldDeepEqual(actualResult.Value);
         }
 
@@ -154,7 +154,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest).ConfigureAwait(true);
+            ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest);
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
 
@@ -178,7 +178,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<IUserSmsService>().Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            RequestResult<bool> actualResult = await controller.Validate(this.hdid).ConfigureAwait(true);
+            RequestResult<bool> actualResult = await controller.Validate(this.hdid);
 
             Assert.Equal(expected, actualResult);
         }
@@ -370,7 +370,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<IUserSmsService>().Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<bool>> actualResult = await controller.ValidateEmail(this.hdid, Guid.NewGuid()).ConfigureAwait(true);
+            ActionResult<RequestResult<bool>> actualResult = await controller.ValidateEmail(this.hdid, Guid.NewGuid());
             Assert.Equal(ResultType.Success, actualResult.Value?.ResultStatus);
         }
 
@@ -398,7 +398,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<IUserSmsService>().Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<bool>> actualResult = await controller.ValidateEmail(this.hdid, Guid.NewGuid()).ConfigureAwait(true);
+            ActionResult<RequestResult<bool>> actualResult = await controller.ValidateEmail(this.hdid, Guid.NewGuid());
             Assert.Equal(ResultType.Error, actualResult.Value?.ResultStatus);
         }
 
@@ -446,7 +446,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSms(this.hdid, "205 123 4567").ConfigureAwait(true)).Result;
+            ActionResult<RequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSms(this.hdid, "205 123 4567")).Result;
 
             RequestResult<bool>? result = actualResult.Value;
             Assert.Equal(ResultType.Success, result?.ResultStatus);
@@ -476,7 +476,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSms(this.hdid, "205 123 4567").ConfigureAwait(true)).Result;
+            ActionResult<RequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSms(this.hdid, "205 123 4567")).Result;
 
             RequestResult<bool>? result = actualResult.Value;
             Assert.Equal(ResultType.Success, result?.ResultStatus);
@@ -588,7 +588,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 emailServiceMock.Object,
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
-            return await service.GetUserProfile(this.hdid).ConfigureAwait(true);
+            return await service.GetUserProfile(this.hdid);
         }
 
         private ActionResult<RequestResult<UserPreferenceModel>> UpdateUserPreference(UserPreferenceModel? userPref)

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -426,8 +426,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// ValidateSms - Happy Path.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldValidateSms()
+        public async Task ShouldValidateSms()
         {
             RequestResult<bool> requestResult = new()
             {
@@ -446,7 +449,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSms(this.hdid, "205 123 4567")).Result;
+            ActionResult<RequestResult<bool>> actualResult = await controller.ValidateSms(this.hdid, "205 123 4567");
 
             RequestResult<bool>? result = actualResult.Value;
             Assert.Equal(ResultType.Success, result?.ResultStatus);
@@ -456,8 +459,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// ValidateSms - Sms not found error.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldValidateSmsNotFoundResult()
+        public async Task ShouldValidateSmsNotFoundResult()
         {
             RequestResult<bool> requestResult = new()
             {
@@ -476,7 +482,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            ActionResult<RequestResult<bool>> actualResult = Task.Run(async () => await controller.ValidateSms(this.hdid, "205 123 4567")).Result;
+            ActionResult<RequestResult<bool>> actualResult = await controller.ValidateSms(this.hdid, "205 123 4567");
 
             RequestResult<bool>? result = actualResult.Value;
             Assert.Equal(ResultType.Success, result?.ResultStatus);

--- a/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
+++ b/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
@@ -24,8 +24,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -69,7 +69,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             IDependentService service = this.SetupMockForGetDependents();
 
-            RequestResult<IEnumerable<DependentModel>> actualResult = await service.GetDependentsAsync(this.mockParentHdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<DependentModel>> actualResult = await service.GetDependentsAsync(this.mockParentHdid);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Equal(10, actualResult.TotalResultCount);
@@ -115,7 +115,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<PatientModel> patientResult = new();
             IDependentService service = this.SetupMockForGetDependents(patientResult);
 
-            RequestResult<IEnumerable<DependentModel>> actualResult = await service.GetDependentsAsync(this.mockParentHdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<DependentModel>> actualResult = await service.GetDependentsAsync(this.mockParentHdid);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.True(actualResult.ResultError?.ErrorCode.EndsWith("-CE-PAT", StringComparison.InvariantCulture));
@@ -134,7 +134,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             AddDependentRequest addDependentRequest = this.SetupMockInput();
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Dictionary<string, int> delegateCounts = this.GenerateMockDelegateCounts(true);
@@ -153,7 +153,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             addDependentRequest.LastName = "O’Neil"; // Last name with smart apostrophe
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Dictionary<string, int> delegateCounts = this.GenerateMockDelegateCounts(true);
@@ -173,7 +173,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Test Scenario - Happy Path: Found HdId for the PHN, Found Patient.
             IDependentService service = this.SetupMockDependentService(addDependentRequest, null, patientResult);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.True(actualResult.ResultError?.ErrorCode.EndsWith("-CE-PAT", StringComparison.InvariantCulture));
@@ -214,7 +214,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             addDependentRequest.FirstName = "wrong";
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             RequestResultError userError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
@@ -233,7 +233,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             addDependentRequest.LastName = "wrong";
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             RequestResultError userError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
@@ -252,7 +252,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             addDependentRequest.DateOfBirth = DateTime.Now;
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             RequestResultError userError = ErrorTranslator.ActionRequired(ErrorMessages.DataMismatch, ActionType.DataMismatch);
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
@@ -283,7 +283,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             AddDependentRequest addDependentRequest = this.SetupMockInput();
             IDependentService service = this.SetupMockDependentService(addDependentRequest, patientResult: patientResult);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             RequestResultError userError = ErrorTranslator.ActionRequired(ErrorMessages.InvalidServicesCard, ActionType.NoHdId);
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
@@ -310,7 +310,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
             IDependentService service = this.SetupMockDependentService(addDependentRequest, dependent: dependent);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
         }
@@ -330,7 +330,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
             IDependentService service = this.SetupMockDependentService(addDependentRequest, dependent: dependent);
 
-            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest).ConfigureAwait(true);
+            RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
 
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.Equal(ActionType.Protected, actualResult.ResultError!.ActionCode);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -150,7 +150,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IUserProfileService service = mockService.UserProfileServiceMockInstance();
 
             // Act
-            RequestResult<UserProfileModel> actualResult = await service.GetUserProfile(this.hdid, newLoginDateTime).ConfigureAwait(true);
+            RequestResult<UserProfileModel> actualResult = await service.GetUserProfile(this.hdid, newLoginDateTime);
 
             // Assert
             if (dBStatus == DbStatusCode.Read)
@@ -289,7 +289,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     new CreateUserRequest { Profile = userProfile },
                     DateTime.Today,
                     It.IsAny<string>())
-                .ConfigureAwait(true);
+                ;
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -339,7 +339,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     new CreateUserRequest { Profile = userProfile },
                     DateTime.Today,
                     It.IsAny<string>())
-                .ConfigureAwait(true);
+                ;
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -371,7 +371,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<bool> expected = new() { ResultStatus = ResultType.Success, ResourcePayload = false };
 
             // Act
-            RequestResult<bool> actualResult = await service.ValidateMinimumAge(this.hdid).ConfigureAwait(true);
+            RequestResult<bool> actualResult = await service.ValidateMinimumAge(this.hdid);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);

--- a/Apps/GatewayApi/test/unit/Services.Test/WebAlertServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/WebAlertServiceTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IWebAlertService service = GetWebAlertService();
 
             // Act
-            IEnumerable<WebAlert> actual = await service.GetWebAlertsAsync(Hdid).ConfigureAwait(true);
+            IEnumerable<WebAlert> actual = await service.GetWebAlertsAsync(Hdid);
 
             // Assert
             expected.ShouldDeepEqual(actual);
@@ -76,7 +76,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IWebAlertService service = GetWebAlertService();
 
             // Act
-            Exception? exception = await Record.ExceptionAsync(() => service.DismissWebAlertsAsync(Hdid)).ConfigureAwait(true);
+            Exception? exception = await Record.ExceptionAsync(() => service.DismissWebAlertsAsync(Hdid));
 
             // Assert
             Assert.Null(exception);
@@ -93,7 +93,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IWebAlertService service = GetWebAlertService();
 
             // Act
-            Exception? exception = await Record.ExceptionAsync(() => service.DismissWebAlertAsync(Hdid, WebAlertId)).ConfigureAwait(true);
+            Exception? exception = await Record.ExceptionAsync(() => service.DismissWebAlertAsync(Hdid, WebAlertId));
 
             // Assert
             Assert.Null(exception);

--- a/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
@@ -91,7 +91,7 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
             ImmunizationController controller = new(new Mock<ILogger<ImmunizationController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<ImmunizationResult> actual = await controller.GetImmunizations(this.hdid).ConfigureAwait(true);
+            RequestResult<ImmunizationResult> actual = await controller.GetImmunizations(this.hdid);
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Success);
@@ -138,7 +138,7 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
             ImmunizationController controller = new(new Mock<ILogger<ImmunizationController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<ImmunizationEvent> actual = await controller.GetImmunization(this.hdid, immunizationId).ConfigureAwait(true);
+            RequestResult<ImmunizationEvent> actual = await controller.GetImmunization(this.hdid, immunizationId);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Success);

--- a/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
             PublicVaccineStatusController controller = new(new Mock<ILogger<PublicVaccineStatusController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<VaccineStatus> actual = await controller.GetVaccineStatus(this.phn, this.dob, this.dov).ConfigureAwait(true);
+            RequestResult<VaccineStatus> actual = await controller.GetVaccineStatus(this.phn, this.dob, this.dov);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -45,8 +46,9 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
         /// <summary>
         /// GetImmunizations - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetImmunization()
+        public async Task GetImmunization()
         {
             ImmunizationViewResponse expectedViewResponse = new()
             {
@@ -61,7 +63,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 Result = expectedViewResponse,
             };
 
-            RequestResult<PhsaResult<ImmunizationViewResponse>> actualResult = GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, false).GetImmunizationAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<ImmunizationViewResponse>> actualResult = await GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, false).GetImmunizationAsync(It.IsAny<string>());
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResourcePayload);
@@ -71,8 +73,9 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
         /// <summary>
         /// GetImmunizations - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetImmunizations()
+        public async Task GetImmunizations()
         {
             ImmunizationViewResponse expectedViewResponse = new()
             {
@@ -90,7 +93,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                     new List<ImmunizationRecommendationResponse>()),
             };
 
-            RequestResult<PhsaResult<ImmunizationResponse>> actualResult = GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, false).GetImmunizationsAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<ImmunizationResponse>> actualResult = await GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, false).GetImmunizationsAsync(It.IsAny<string>());
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResourcePayload);
@@ -100,8 +103,9 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
         /// <summary>
         /// GetImmunization - HttpRequestException.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetImmunizationThrowsException()
+        public async Task GetImmunizationThrowsException()
         {
             ImmunizationViewResponse expectedViewResponse = new()
             {
@@ -116,7 +120,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 Result = expectedViewResponse,
             };
 
-            RequestResult<PhsaResult<ImmunizationViewResponse>> actualResult = GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, true).GetImmunizationAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<ImmunizationViewResponse>> actualResult = await GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, true).GetImmunizationAsync(It.IsAny<string>());
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(HttpExceptionMessage, actualResult.ResultError?.ResultMessage);
@@ -125,8 +129,9 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
         /// <summary>
         /// GetImmunizations - HttpRequestException.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void GetImmunizationsThrowsException()
+        public async Task GetImmunizationsThrowsException()
         {
             ImmunizationViewResponse expectedViewResponse = new()
             {
@@ -144,7 +149,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                     new List<ImmunizationRecommendationResponse>()),
             };
 
-            RequestResult<PhsaResult<ImmunizationResponse>> actualResult = GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, true).GetImmunizationsAsync(It.IsAny<string>()).Result;
+            RequestResult<PhsaResult<ImmunizationResponse>> actualResult = await GetImmunizationDelegate(phsaResponse, HttpStatusCode.OK, true).GetImmunizationsAsync(It.IsAny<string>());
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(HttpExceptionMessage, actualResult.ResultError?.ResultMessage);

--- a/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -107,7 +107,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -140,7 +140,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -173,7 +173,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 mockImmunizationPublicApi.Object);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -200,7 +200,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 mockImmunizationPublicApi.Object);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -227,7 +227,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 mockImmunizationPublicApi.Object);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken).ConfigureAwait(true);
+                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);

--- a/Apps/Immunization/test/unit/ImmunizationTests.csproj
+++ b/Apps/Immunization/test/unit/ImmunizationTests.csproj
@@ -22,8 +22,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -56,10 +56,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// GetImmunizations - Happy Path.
         /// </summary>
         /// <param name="canAccessDataSource">The value indicates whether the immunization data source can be accessed or not.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ShouldGetImmunizations(bool canAccessDataSource)
+        public async Task ShouldGetImmunizations(bool canAccessDataSource)
         {
             Mock<IImmunizationDelegate> mockDelegate = new();
             RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = new()
@@ -105,24 +108,27 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            Task<RequestResult<ImmunizationResult>> actualResult = service.GetImmunizations(It.IsAny<string>());
+            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizations(It.IsAny<string>());
 
             if (canAccessDataSource)
             {
-                expectedResult.ShouldDeepEqual(actualResult.Result);
+                expectedResult.ShouldDeepEqual(actualResult);
             }
             else
             {
-                Assert.Equal(0, actualResult.Result.ResourcePayload?.Immunizations.Count);
-                Assert.Equal(0, actualResult.Result.ResourcePayload?.Recommendations.Count);
+                Assert.Equal(0, actualResult.ResourcePayload?.Immunizations.Count);
+                Assert.Equal(0, actualResult.ResourcePayload?.Recommendations.Count);
             }
         }
 
         /// <summary>
         /// GetImmunization - Happy Path.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetImmunization()
+        public async Task ShouldGetImmunization()
         {
             Mock<IImmunizationDelegate> mockDelegate = new();
             RequestResult<PhsaResult<ImmunizationViewResponse>> delegateResult = new()
@@ -161,17 +167,18 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            Task<RequestResult<ImmunizationEvent>> actualResult = service.GetImmunization("immz_id");
+            RequestResult<ImmunizationEvent> actualResult = await service.GetImmunization("immz_id");
 
-            expectedResult.ShouldDeepEqual(actualResult.Result);
+            expectedResult.ShouldDeepEqual(actualResult);
         }
 
         /// <summary>
         /// GetImmunizations - Happy Path (With Recommendations).
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
-        public void ShouldGetRecommendation()
+        public async Task ShouldGetRecommendation()
         {
             ImmunizationRecommendationResponse immzRecommendationResponse = this.GetImmzRecommendationResponse();
             Mock<IImmunizationDelegate> mockDelegate = new();
@@ -195,32 +202,33 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            Task<RequestResult<ImmunizationResult>> actualResult = service.GetImmunizations(It.IsAny<string>());
+            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizations(It.IsAny<string>());
 
-            expectedResult.ShouldDeepEqual(actualResult.Result);
-            Assert.Equal(1, expectedResult.ResourcePayload.Recommendations.Count);
-            ImmunizationRecommendation recomendationResult = expectedResult.ResourcePayload.Recommendations[0];
-            Assert.Equal(this.recomendationSetId, recomendationResult.RecommendationSetId);
-            Assert.Equal(this.vaccineName, recomendationResult.Immunization.Name);
+            expectedResult.ShouldDeepEqual(actualResult);
+            Assert.Single(expectedResult.ResourcePayload.Recommendations);
+            ImmunizationRecommendation recommendationResult = expectedResult.ResourcePayload.Recommendations[0];
+            Assert.Equal(this.recomendationSetId, recommendationResult.RecommendationSetId);
+            Assert.Equal(this.vaccineName, recommendationResult.Immunization.Name);
             Assert.Collection(
-                recomendationResult.Immunization.ImmunizationAgents,
+                recommendationResult.Immunization.ImmunizationAgents,
                 item => Assert.Equal(this.antigenName, item.Name));
-            Assert.Equal(this.antigenName, recomendationResult.Immunization.ImmunizationAgents.First().Name);
+            Assert.Equal(this.antigenName, recommendationResult.Immunization.ImmunizationAgents.First().Name);
             Assert.Collection(
-                recomendationResult.TargetDiseases,
+                recommendationResult.TargetDiseases,
                 item => Assert.Equal(immzRecommendationResponse.Recommendations.First().TargetDisease?.TargetDiseaseCodes.FirstOrDefault()?.Code, item.Code));
-            Assert.Equal(this.diseaseName, recomendationResult.TargetDiseases.First().Name);
-            Assert.Equal(DateTime.Parse(this.diseaseEligibleDateString, CultureInfo.CurrentCulture), recomendationResult.DiseaseEligibleDate);
-            Assert.Null(recomendationResult.DiseaseDueDate);
-            Assert.Null(recomendationResult.AgentDueDate);
-            Assert.Null(recomendationResult.AgentEligibleDate);
+            Assert.Equal(this.diseaseName, recommendationResult.TargetDiseases.First().Name);
+            Assert.Equal(DateTime.Parse(this.diseaseEligibleDateString, CultureInfo.CurrentCulture), recommendationResult.DiseaseEligibleDate);
+            Assert.Null(recommendationResult.DiseaseDueDate);
+            Assert.Null(recommendationResult.AgentDueDate);
+            Assert.Null(recommendationResult.AgentEligibleDate);
         }
 
         /// <summary>
         /// GetImmunizations - Request Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ValidateImmunizationError()
+        public async Task ValidateImmunizationError()
         {
             Mock<IImmunizationDelegate> mockDelegate = new();
             RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = new()
@@ -245,9 +253,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            Task<RequestResult<ImmunizationResult>> actualResult = service.GetImmunizations(It.IsAny<string>());
+            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizations(It.IsAny<string>());
 
-            expectedResult.ShouldDeepEqual(actualResult.Result);
+            expectedResult.ShouldDeepEqual(actualResult);
         }
 
         /*

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -320,7 +320,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 mockVaccineDelegate.Object,
                 mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             Assert.True(actualResult.ResultStatus == ResultType.Success);
             Assert.True(actualResult.ResourcePayload != null && actualResult.ResourcePayload.Document.Data == assetResult.ResourcePayload.Data);
@@ -373,7 +373,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 mockVaccineDelegate.Object,
                 mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             Assert.True(actualResult.ResultStatus == ResultType.ActionRequired && actualResult.ResultError != null);
         }
@@ -405,7 +405,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 mockVaccineDelegate.Object,
                 mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             vaccineStatusResult.ShouldDeepEqual(actualResult);
         }
@@ -446,7 +446,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 mockVaccineDelegate.Object,
                 mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
@@ -484,7 +484,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 mockVaccineDelegate.Object,
                 mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
@@ -542,7 +542,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 mockVaccineDelegate.Object,
                 mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
@@ -605,7 +605,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
               mockVaccineDelegate.Object,
               mockHttpContextAccessor.Object);
 
-            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial).ConfigureAwait(true)).Result;
+            RequestResult<VaccineProofDocument> actualResult = Task.Run(async () => await service.GetVaccineProof(hdid, VaccineProofTemplate.Provincial)).Result;
 
             Assert.True(actualResult.ResultStatus == ResultType.ActionRequired && actualResult.ResultError != null);
         }

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -56,6 +56,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// <param name="statusIndicator"> status indicator from delegate.</param>
         /// <param name="state">final state.</param>
         /// <param name="isPublicEndpoint">check to determine if the test is for public or authenticated page.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData("Exempt", VaccineState.Exempt, true)]
         [InlineData("PartialDosesReceived", VaccineState.PartialDosesReceived, true)]
@@ -63,7 +66,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         [InlineData("Exempt", VaccineState.Exempt, false)]
         [InlineData("PartialDosesReceived", VaccineState.PartialDosesReceived, false)]
         [InlineData("AllDosesReceived", VaccineState.AllDosesReceived, false)]
-        public void ShouldGetVaccineStatus(string statusIndicator, VaccineState state, bool isPublicEndpoint)
+        public async Task ShouldGetVaccineStatus(string statusIndicator, VaccineState state, bool isPublicEndpoint)
         {
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -123,13 +126,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             {
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
-                RequestResult<VaccineStatus> actualResultPublic = service.GetPublicVaccineStatus(this.phn, dobString, dovString).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
 
                 expectedResult.ShouldDeepEqual(actualResultPublic);
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = service.GetAuthenticatedVaccineStatus(this.hdid).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
 
                 expectedResult.ShouldDeepEqual(actualResultAuthenticated);
             }
@@ -140,10 +143,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// DataMismatch.
         /// </summary>
         /// <param name="isPublicEndpoint">check to determine if the test is for public or authenticated page.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ShouldGetErrorDataMismatchVaccineStatus(bool isPublicEndpoint)
+        public async Task ShouldGetErrorDataMismatchVaccineStatus(bool isPublicEndpoint)
         {
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -205,14 +211,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineStatus> actualResultPublic = service.GetPublicVaccineStatus(this.phn, dobString, dovString).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultPublic.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultPublic.ResultError?.ActionCode);
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = service.GetAuthenticatedVaccineStatus(this.hdid).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultAuthenticated.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultAuthenticated.ResultError?.ActionCode);
@@ -223,10 +229,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// GetPublicVaccineStatus and GetAuthenticatedVaccineStatus - get the error result when the refresh in progress is enable.
         /// </summary>
         /// <param name="isPublicEndpoint">check to determine if the test is for public or authenticated page.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void ShouldGetErrorRefreshInProgressVaccineStatus(bool isPublicEndpoint)
+        public async Task ShouldGetErrorRefreshInProgressVaccineStatus(bool isPublicEndpoint)
         {
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -293,7 +302,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineStatus> actualResultPublic = service.GetPublicVaccineStatus(this.phn, dobString, dovString).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultPublic.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultPublic.ResultError?.ActionCode);
@@ -301,7 +310,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = service.GetAuthenticatedVaccineStatus(this.hdid).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
                 Assert.Equal(ResultType.ActionRequired, actualResultAuthenticated.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultAuthenticated.ResultError?.ActionCode);
                 Assert.Equal(expectedResult.ResourcePayload.RetryIn, actualResultAuthenticated.ResourcePayload?.RetryIn);
@@ -312,10 +321,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// GetPublicVaccineStatus and GetAuthenticatedVaccineStatus - get the error result when the status indicator is NotFound.
         /// </summary>
         /// <param name="isPublicEndpoint">check to determine if the test is for public (true) or authenticated (false) page.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void ShouldGetErrorNotFoundVaccineStatus(bool isPublicEndpoint)
+        public async Task ShouldGetErrorNotFoundVaccineStatus(bool isPublicEndpoint)
         {
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -382,14 +394,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineStatus> actualResultPublic = service.GetPublicVaccineStatus(this.phn, dobString, dovString).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultPublic.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultPublic.ResultError?.ActionCode);
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = service.GetAuthenticatedVaccineStatus(this.hdid).GetAwaiter().GetResult();
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultAuthenticated.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultAuthenticated.ResultError?.ActionCode);
@@ -401,10 +413,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// path).
         /// </summary>
         /// <param name="isPublicEndpoint">check to determine if the test is for public (true) or authenticated (false) page.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public void ShouldGetVaccineProof(bool isPublicEndpoint)
+        public async Task ShouldGetVaccineProof(bool isPublicEndpoint)
         {
             RequestResult<PhsaResult<VaccineStatusResult>> delegateResult = new()
             {
@@ -475,7 +490,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineProofDocument> actualResultPublic = service.GetPublicVaccineProof(this.phn, dobString, dovString).GetAwaiter().GetResult();
+                RequestResult<VaccineProofDocument> actualResultPublic = await service.GetPublicVaccineProof(this.phn, dobString, dovString);
 
                 Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResultPublic.ResourcePayload?.Document.Data);
                 Assert.NotNull(actualResultPublic.ResourcePayload?.Document.Data);
@@ -483,7 +498,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             }
             else
             {
-                RequestResult<VaccineProofDocument> actualResultAuthenticated = service.GetAuthenticatedVaccineProof(this.hdid).GetAwaiter().GetResult();
+                RequestResult<VaccineProofDocument> actualResultAuthenticated = await service.GetAuthenticatedVaccineProof(this.hdid);
 
                 Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResultAuthenticated.ResourcePayload?.Document.Data);
                 Assert.NotNull(actualResultAuthenticated.ResourcePayload?.Document.Data);
@@ -494,8 +509,11 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// <summary>
         /// GetVaccineStatusAsync - Invalid PHN.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldErrorOnPHN()
+        public async Task ShouldErrorOnPHN()
         {
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -508,7 +526,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<VaccineStatus> actualResult = service.GetPublicVaccineStatus("123", dobString, dovString).GetAwaiter().GetResult();
+            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatus("123", dobString, dovString);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -516,8 +534,11 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// <summary>
         /// GetVaccineStatusAsync - Invalid DOB.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldErrorOnDOB()
+        public async Task ShouldErrorOnDOB()
         {
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -529,7 +550,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<VaccineStatus> actualResult = service.GetPublicVaccineStatus(this.phn, "yyyyMMddx", dovString).GetAwaiter().GetResult();
+            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatus(this.phn, "yyyyMMddx", dovString);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -537,8 +558,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
         /// <summary>
         /// GetVaccineStatusAsync - Invalid DOV.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldErrorOnDOV()
+        public async Task ShouldErrorOnDOV()
         {
             IVaccineStatusService service = new VaccineStatusService(
                 this.configuration,
@@ -550,7 +572,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<VaccineStatus> actualResult = service.GetPublicVaccineStatus(this.phn, dobString, "yyyyMMddx").GetAwaiter().GetResult();
+            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatus(this.phn, dobString, "yyyyMMddx");
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -89,7 +89,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -117,7 +117,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -146,7 +146,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -174,7 +174,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<List<PhsaCovid19Order>>> actualResult = await labDelegate.GetCovid19Orders(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -206,7 +206,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true);
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -233,7 +233,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -261,7 +261,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -289,7 +289,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, true);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -322,7 +322,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false);
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -350,7 +350,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -378,7 +378,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -406,7 +406,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false).ConfigureAwait(true);
+            RequestResult<LaboratoryReport> actualResult = await labDelegate.GetLabReport(ReportId, Hdid, AccessToken, false);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -441,7 +441,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -467,7 +467,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -496,7 +496,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
@@ -524,7 +524,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 this.configuration);
 
             // Act
-            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken).ConfigureAwait(true);
+            RequestResult<PhsaResult<PhsaLaboratorySummary>> actualResult = await labDelegate.GetLaboratorySummary(Hdid, AccessToken);
 
             // Verify
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);

--- a/Apps/Laboratory/test/unit/LaboratoryTests.csproj
+++ b/Apps/Laboratory/test/unit/LaboratoryTests.csproj
@@ -17,8 +17,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LabTestKitServiceTests.cs
@@ -49,7 +49,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<LabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync("hdid", new LabTestKit()).ConfigureAwait(false);
+            RequestResult<LabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync("hdid", new LabTestKit());
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
         }
 
@@ -64,7 +64,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.True(actualResult.ResultStatus == ResultType.Success);
         }
 
@@ -75,7 +75,7 @@ namespace HealthGateway.LaboratoryTests.Services
         [Fact]
         public async Task RegisterPublicLabTestHttpException()
         {
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitServiceException().RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitServiceException().RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -86,7 +86,7 @@ namespace HealthGateway.LaboratoryTests.Services
         [Fact]
         public async Task RegisterLabTestHttpException()
         {
-            RequestResult<LabTestKit> actualResult = await this.GetLabTestKitServiceException().RegisterLabTestKitAsync("hdid", new LabTestKit()).ConfigureAwait(false);
+            RequestResult<LabTestKit> actualResult = await this.GetLabTestKitServiceException().RegisterLabTestKitAsync("hdid", new LabTestKit());
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -101,7 +101,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse, true).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse, true).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -116,7 +116,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.Conflict,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
             Assert.Equal(ActionType.Processed.Value, actualResult.ResultError.ActionCodeValue);
@@ -133,7 +133,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.UnprocessableEntity,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
             Assert.Equal(ActionType.Validation.Value, actualResult.ResultError.ActionCodeValue);
@@ -150,7 +150,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("BADPHN")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("BADPHN"));
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
             Assert.Equal(ActionType.Validation.Value, actualResult.ResultError.ActionCodeValue);
@@ -167,7 +167,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.OK,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit(null)).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit(null));
             Assert.Equal(ResultType.ActionRequired, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
             Assert.Equal(ActionType.Validation.Value, actualResult.ResultError.ActionCodeValue);
@@ -184,7 +184,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.Unauthorized,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -199,7 +199,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.Forbidden,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 
@@ -214,7 +214,7 @@ namespace HealthGateway.LaboratoryTests.Services
             {
                 StatusCode = HttpStatusCode.BadGateway,
             };
-            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315")).ConfigureAwait(false);
+            RequestResult<PublicLabTestKit> actualResult = await this.GetLabTestKitService(httpResponse).RegisterLabTestKitAsync(CreatePublicLabTestKit("9735353315"));
             Assert.True(actualResult.ResultStatus == ResultType.Error);
         }
 

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.LaboratoryTests.Services
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
@@ -99,7 +98,7 @@ namespace HealthGateway.LaboratoryTests.Services
                     foreach (Covid19Order model in actualResult.ResourcePayload!.Covid19Orders)
                     {
                         count++;
-                        Assert.True(model.MessageId.Equals(MockedMessageId + count, StringComparison.Ordinal));
+                        Assert.Equal(model.MessageId, MockedMessageId + count);
                     }
 
                     Assert.Equal(2, count);

--- a/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
+++ b/Apps/Laboratory/test/unit/Services/LaboratoryServiceTests.cs
@@ -86,7 +86,7 @@ namespace HealthGateway.LaboratoryTests.Services
 
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, Token, canAccessDataSource).LaboratoryServiceMockInstance();
 
-            RequestResult<Covid19OrderResult> actualResult = await service.GetCovid19Orders(Hdid).ConfigureAwait(false);
+            RequestResult<Covid19OrderResult> actualResult = await service.GetCovid19Orders(Hdid);
 
             if (expectedResultType == ResultType.Success)
             {
@@ -196,7 +196,7 @@ namespace HealthGateway.LaboratoryTests.Services
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, Token, canAccessDataSource).LaboratoryServiceMockInstance();
 
             // Act
-            RequestResult<LaboratoryOrderResult> actualResult = await service.GetLaboratoryOrders(Hdid).ConfigureAwait(false);
+            RequestResult<LaboratoryOrderResult> actualResult = await service.GetLaboratoryOrders(Hdid);
 
             // Assert
             if (expectedResultType == ResultType.Success)
@@ -258,7 +258,7 @@ namespace HealthGateway.LaboratoryTests.Services
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, Token).LaboratoryServiceMockInstance();
 
             // Act
-            RequestResult<LaboratoryOrderResult> actualResult = await service.GetLaboratoryOrders(Hdid).ConfigureAwait(false);
+            RequestResult<LaboratoryOrderResult> actualResult = await service.GetLaboratoryOrders(Hdid);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -295,7 +295,7 @@ namespace HealthGateway.LaboratoryTests.Services
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, Token).LaboratoryServiceMockInstance();
 
             // Act
-            RequestResult<LaboratoryOrderResult> actualResult = await service.GetLaboratoryOrders(Hdid).ConfigureAwait(false);
+            RequestResult<LaboratoryOrderResult> actualResult = await service.GetLaboratoryOrders(Hdid);
 
             // Assert
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
@@ -327,7 +327,7 @@ namespace HealthGateway.LaboratoryTests.Services
 
             ILaboratoryService service = new LaboratoryServiceMock(delegateResult, Token).LaboratoryServiceMockInstance();
 
-            RequestResult<LaboratoryReport> actualResult = await service.GetLabReport("ReportId", string.Empty, true).ConfigureAwait(false);
+            RequestResult<LaboratoryReport> actualResult = await service.GetLabReport("ReportId", string.Empty, true);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Equal(MockedReportContent, actualResult.ResourcePayload!.Report);

--- a/Apps/Medication/test/unit/Controllers/MedicationStatementControllerTests.cs
+++ b/Apps/Medication/test/unit/Controllers/MedicationStatementControllerTests.cs
@@ -94,7 +94,7 @@ namespace HealthGateway.MedicationTests.Controllers
             MedicationStatementController controller = new(svcMock.Object);
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = await controller.GetMedicationStatements(hdid).ConfigureAwait(true);
+            RequestResult<IList<MedicationStatementHistory>> actual = await controller.GetMedicationStatements(hdid);
 
             // Verify
             Assert.NotNull(actual);

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
@@ -144,7 +144,7 @@ namespace HealthGateway.MedicationTests.Delegates
                                 string.Empty,
                                 string.Empty,
                                 string.Empty)
-                            .ConfigureAwait(true))
+                            )
                 .Result;
 
             Assert.Equal(ResultType.Success, response.ResultStatus);
@@ -201,7 +201,7 @@ namespace HealthGateway.MedicationTests.Delegates
                                 string.Empty,
                                 string.Empty,
                                 string.Empty)
-                            .ConfigureAwait(true))
+                            )
                 .Result;
 
             Assert.Equal(ResultType.Success, response.ResultStatus);
@@ -242,7 +242,7 @@ namespace HealthGateway.MedicationTests.Delegates
                                 string.Empty,
                                 string.Empty,
                                 string.Empty)
-                            .ConfigureAwait(true))
+                            )
                 .Result;
 
             Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
@@ -283,7 +283,7 @@ namespace HealthGateway.MedicationTests.Delegates
                                 string.Empty,
                                 string.Empty,
                                 string.Empty)
-                            .ConfigureAwait(true))
+                            )
                 .Result;
 
             Assert.True(response.ResultStatus == ResultType.Error);
@@ -323,7 +323,7 @@ namespace HealthGateway.MedicationTests.Delegates
                                 string.Empty,
                                 string.Empty,
                                 string.Empty)
-                            .ConfigureAwait(true))
+                            )
                 .Result;
 
             Assert.True(response.ResultStatus == ResultType.Error);
@@ -352,7 +352,7 @@ namespace HealthGateway.MedicationTests.Delegates
                             string.Empty,
                             string.Empty,
                             string.Empty)
-                        .ConfigureAwait(true));
+                        );
         }
 
         /// <summary>
@@ -377,7 +377,7 @@ namespace HealthGateway.MedicationTests.Delegates
                             string.Empty,
                             string.Empty,
                             string.Empty)
-                        .ConfigureAwait(true));
+                        );
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
@@ -70,8 +70,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationStatements - Happy Path.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ValidateGetMedicationStatement()
+        public async Task ValidateGetMedicationStatement()
         {
             MedicationHistory medicationHistory = new()
             {
@@ -109,7 +112,7 @@ namespace HealthGateway.MedicationTests.Delegates
                             },
                             GenericName = "Generic Name",
                             Id = 0,
-                            Practitioner = new Medication.Models.ODR.Name
+                            Practitioner = new Name
                             {
                                 GivenName = "Given",
                                 MiddleInitial = "I",
@@ -137,15 +140,12 @@ namespace HealthGateway.MedicationTests.Delegates
                 new Mock<ICacheProvider>().Object,
                 GetHashDelegate());
 
-            RequestResult<MedicationHistoryResponse> response = Task.Run(
-                    async () =>
-                        await medStatementDelegate.GetMedicationStatementsAsync(
-                                this.query,
-                                string.Empty,
-                                string.Empty,
-                                string.Empty)
-                            )
-                .Result;
+            RequestResult<MedicationHistoryResponse> response =
+                await medStatementDelegate.GetMedicationStatementsAsync(
+                    this.query,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty);
 
             Assert.Equal(ResultType.Success, response.ResultStatus);
             medicationHistory.Response.ShouldDeepEqual(response.ResourcePayload);
@@ -154,8 +154,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationStatements - Happy Path (Cached Keyword).
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ValidateGetMedicationStatementCachedKeyword()
+        public async Task ValidateGetMedicationStatementCachedKeyword()
         {
             MedicationHistory medicationHistory = new()
             {
@@ -194,15 +197,12 @@ namespace HealthGateway.MedicationTests.Delegates
                 mockCacheProvider.Object,
                 mockHashDelegate);
 
-            RequestResult<MedicationHistoryResponse> response = Task.Run(
-                    async () =>
-                        await medStatementDelegate.GetMedicationStatementsAsync(
-                                this.query,
-                                string.Empty,
-                                string.Empty,
-                                string.Empty)
-                            )
-                .Result;
+            RequestResult<MedicationHistoryResponse> response =
+                await medStatementDelegate.GetMedicationStatementsAsync(
+                    this.query,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty);
 
             Assert.Equal(ResultType.Success, response.ResultStatus);
             medicationHistory.Response.ShouldDeepEqual(response.ResourcePayload);
@@ -211,8 +211,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationStatements - Invalid Keyword.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void InvalidProtectiveWord()
+        public async Task InvalidProtectiveWord()
         {
             ProtectiveWord protectiveWord = this.GetProtectiveWord("ProtectiveWord");
 
@@ -235,15 +238,12 @@ namespace HealthGateway.MedicationTests.Delegates
                 mockCacheProvider.Object,
                 mockHashDelegate.Object);
 
-            RequestResult<MedicationHistoryResponse> response = Task.Run(
-                    async () =>
-                        await medStatementDelegate.GetMedicationStatementsAsync(
-                                this.query,
-                                string.Empty,
-                                string.Empty,
-                                string.Empty)
-                            )
-                .Result;
+            RequestResult<MedicationHistoryResponse> response =
+                await medStatementDelegate.GetMedicationStatementsAsync(
+                    this.query,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty);
 
             Assert.Equal(ResultType.ActionRequired, response.ResultStatus);
             Assert.Equal(ActionType.Protected, response.ResultError?.ActionCode);
@@ -253,8 +253,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationStatements - Http Error.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ValidateGetMedicationStatementHttpError()
+        public async Task ValidateGetMedicationStatementHttpError()
         {
             Mock<ICacheProvider> mockCacheProvider = new();
             Mock<IHashDelegate> mockHashDelegate = new();
@@ -276,15 +279,11 @@ namespace HealthGateway.MedicationTests.Delegates
                 mockCacheProvider.Object,
                 mockHashDelegate.Object);
 
-            RequestResult<MedicationHistoryResponse> response = Task.Run(
-                    async () =>
-                        await medStatementDelegate.GetMedicationStatementsAsync(
-                                this.query,
-                                string.Empty,
-                                string.Empty,
-                                string.Empty)
-                            )
-                .Result;
+            RequestResult<MedicationHistoryResponse> response = await medStatementDelegate.GetMedicationStatementsAsync(
+                this.query,
+                string.Empty,
+                string.Empty,
+                string.Empty);
 
             Assert.True(response.ResultStatus == ResultType.Error);
         }
@@ -292,8 +291,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationStatements - Http Exception.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ValidateGetMedicationStatementHttpException()
+        public async Task ValidateGetMedicationStatementHttpException()
         {
             Mock<ICacheProvider> mockCacheProvider = new();
             Mock<IHashDelegate> mockHashDelegate = new();
@@ -316,15 +318,12 @@ namespace HealthGateway.MedicationTests.Delegates
                 mockCacheProvider.Object,
                 mockHashDelegate.Object);
 
-            RequestResult<MedicationHistoryResponse> response = Task.Run(
-                    async () =>
-                        await medStatementDelegate.GetMedicationStatementsAsync(
-                                this.query,
-                                string.Empty,
-                                string.Empty,
-                                string.Empty)
-                            )
-                .Result;
+            RequestResult<MedicationHistoryResponse> response =
+                await medStatementDelegate.GetMedicationStatementsAsync(
+                    this.query,
+                    string.Empty,
+                    string.Empty,
+                    string.Empty);
 
             Assert.True(response.ResultStatus == ResultType.Error);
         }
@@ -347,12 +346,11 @@ namespace HealthGateway.MedicationTests.Delegates
             Assert.ThrowsAsync<NotImplementedException>(
                 async () => await
                     medStatementDelegate.SetProtectiveWordAsync(
-                            string.Empty,
-                            string.Empty,
-                            string.Empty,
-                            string.Empty,
-                            string.Empty)
-                        );
+                        string.Empty,
+                        string.Empty,
+                        string.Empty,
+                        string.Empty,
+                        string.Empty));
         }
 
         /// <summary>
@@ -373,11 +371,10 @@ namespace HealthGateway.MedicationTests.Delegates
             Assert.ThrowsAsync<NotImplementedException>(
                 async () => await
                     medStatementDelegate.DeleteProtectiveWordAsync(
-                            string.Empty,
-                            string.Empty,
-                            string.Empty,
-                            string.Empty)
-                        );
+                        string.Empty,
+                        string.Empty,
+                        string.Empty,
+                        string.Empty));
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Medication/test/unit/Delegates/SalesforceDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/SalesforceDelegateTests.cs
@@ -100,7 +100,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 MapperUtil.InitializeAutoMapper());
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn)).Result;
 
             // Verify
             Assert.Equal(ResultType.Success, response.ResultStatus);
@@ -159,7 +159,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 MapperUtil.InitializeAutoMapper());
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn)).Result;
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);
@@ -228,7 +228,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 MapperUtil.InitializeAutoMapper());
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn)).Result;
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);

--- a/Apps/Medication/test/unit/Delegates/SalesforceDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/SalesforceDelegateTests.cs
@@ -42,8 +42,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationRequests - Happy Path.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldRetrieveMedicationRequests()
+        public async Task ShouldRetrieveMedicationRequests()
         {
             // Input Parameters
             string phn = "9735361219";
@@ -100,7 +103,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 MapperUtil.InitializeAutoMapper());
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn)).Result;
+            RequestResult<IList<MedicationRequest>> response = await medDelegate.GetMedicationRequestsAsync(phn);
 
             // Verify
             Assert.Equal(ResultType.Success, response.ResultStatus);
@@ -111,8 +114,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationRequests - Unauthorized.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldErrorIfNoAuthToken()
+        public async Task ShouldErrorIfNoAuthToken()
         {
             // Setup
 
@@ -159,7 +165,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 MapperUtil.InitializeAutoMapper());
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn)).Result;
+            RequestResult<IList<MedicationRequest>> response = await medDelegate.GetMedicationRequestsAsync(phn);
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);
@@ -170,8 +176,11 @@ namespace HealthGateway.MedicationTests.Delegates
         /// <summary>
         /// GetMedicationRequests - Exception thrown.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldErrorIfException()
+        public async Task ShouldErrorIfException()
         {
             // Setup
 
@@ -228,7 +237,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 MapperUtil.InitializeAutoMapper());
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await medDelegate.GetMedicationRequestsAsync(phn)).Result;
+            RequestResult<IList<MedicationRequest>> response = await medDelegate.GetMedicationRequestsAsync(phn);
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);

--- a/Apps/Medication/test/unit/MedicationTests.csproj
+++ b/Apps/Medication/test/unit/MedicationTests.csproj
@@ -19,8 +19,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
@@ -87,7 +87,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object);
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid)).Result;
 
             // Verify
             Assert.Equal(ResultType.Success, response.ResultStatus);
@@ -129,7 +129,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object);
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid)).Result;
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);
@@ -173,7 +173,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object);
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid)).Result;
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);

--- a/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
@@ -42,10 +42,11 @@ namespace HealthGateway.MedicationTests.Services
         /// The value indicates whether the special authority request data source can be accessed or
         /// not.
         /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
-        public void ShouldGetMedications(bool canAccessDataSource)
+        public async Task ShouldGetMedications(bool canAccessDataSource)
         {
             // Setup
             string hdid = "123912390123012";
@@ -87,7 +88,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object);
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid)).Result;
+            RequestResult<IList<MedicationRequest>> response = await service.GetMedicationRequests(hdid);
 
             // Verify
             Assert.Equal(ResultType.Success, response.ResultStatus);
@@ -107,8 +108,11 @@ namespace HealthGateway.MedicationTests.Services
         /// <summary>
         /// GetMedicationRequests - No Patient Error.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldErrorIfNoPatient()
+        public async Task ShouldErrorIfNoPatient()
         {
             // Setup
             string hdid = "123912390123012";
@@ -129,7 +133,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object);
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid)).Result;
+            RequestResult<IList<MedicationRequest>> response = await service.GetMedicationRequests(hdid);
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);
@@ -138,8 +142,9 @@ namespace HealthGateway.MedicationTests.Services
         /// <summary>
         /// GetMedicationRequests - Delegate Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldErrorIfDelegateError()
+        public async Task ShouldErrorIfDelegateError()
         {
             // Setup
             string hdid = "123912390123012";
@@ -173,7 +178,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object);
 
             // Test
-            RequestResult<IList<MedicationRequest>> response = Task.Run(async () => await service.GetMedicationRequests(hdid)).Result;
+            RequestResult<IList<MedicationRequest>> response = await service.GetMedicationRequests(hdid);
 
             // Verify
             Assert.Equal(ResultType.Error, response.ResultStatus);

--- a/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
@@ -97,28 +97,28 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Run and Verify protective word too long
-            await this.VerifyProtectiveWordError("TOOLONG4U", ErrorMessages.ProtectiveWordTooLong, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("TOOLONG4U", ErrorMessages.ProtectiveWordTooLong, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT", ErrorMessages.ProtectiveWordTooShort, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("SHORT", ErrorMessages.ProtectiveWordTooShort, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT|", ErrorMessages.ProtectiveWordInvalidChars, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("SHORT|", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT~", ErrorMessages.ProtectiveWordInvalidChars, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("SHORT~", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT^", ErrorMessages.ProtectiveWordInvalidChars, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("SHORT^", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT\\", ErrorMessages.ProtectiveWordInvalidChars, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("SHORT\\", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT&", ErrorMessages.ProtectiveWordInvalidChars, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("SHORT&", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("      ", ErrorMessages.ProtectiveWordInvalidChars, service).ConfigureAwait(true);
+            await this.VerifyProtectiveWordError("      ", ErrorMessages.ProtectiveWordInvalidChars, service);
         }
 
         /// <summary>
@@ -176,7 +176,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object,
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null).ConfigureAwait(true);
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null);
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
             Assert.Equal(ActionType.Protected, actual.ResultError?.ActionCode);
             Assert.Equal(string.Empty, actual.ResultError?.ResultMessage);
@@ -229,7 +229,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Run and Verify
-            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, this.protectiveWord).ConfigureAwait(true);
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, this.protectiveWord);
             Assert.True(actual.ResultStatus == ResultType.Success);
         }
 
@@ -325,7 +325,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null)).Result;
 
             // Verify
             if (canAccessDataSource)
@@ -409,7 +409,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null)).Result;
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Success && actual.ResourcePayload?.Count == 1);
@@ -487,7 +487,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null).ConfigureAwait(true)).Result;
+            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null)).Result;
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Success && actual.ResourcePayload?.Count == 1);
@@ -544,7 +544,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null).ConfigureAwait(true);
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null);
 
             // Verify
             Assert.True(actual.ResourcePayload?.Count == 0);
@@ -595,7 +595,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null).ConfigureAwait(true);
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null);
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Error);
@@ -635,7 +635,7 @@ namespace HealthGateway.MedicationTests.Services
             IMedicationStatementService service)
         {
             // Run and Verify protective word too long
-            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, keyword).ConfigureAwait(true);
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, keyword);
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
             Assert.Equal(ActionType.Protected, actual.ResultError?.ActionCode);
             Assert.Equal(errorMessage, actual.ResultError?.ResultMessage);

--- a/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
@@ -240,11 +240,14 @@ namespace HealthGateway.MedicationTests.Services
         /// The value indicates whether the medication data source can be accessed or
         /// not.
         /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
         [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Team decision")]
-        public void ShouldGetMedications(bool canAccessDataSource)
+        public async Task ShouldGetMedications(bool canAccessDataSource)
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
 
@@ -325,7 +328,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null)).Result;
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null);
 
             // Verify
             if (canAccessDataSource)
@@ -341,8 +344,11 @@ namespace HealthGateway.MedicationTests.Services
         /// <summary>
         /// GetMedicationStatementsHistory - Happy Path (Missing Drug Info).
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetMedicationsDrugInfoMissing()
+        public async Task ShouldGetMedicationsDrugInfoMissing()
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
 
@@ -409,7 +415,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null)).Result;
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null);
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Success && actual.ResourcePayload?.Count == 1);
@@ -418,8 +424,9 @@ namespace HealthGateway.MedicationTests.Services
         /// <summary>
         /// GetMedicationStatementsHistory - Happy Path (Prov Drug Info).
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetMedicationsProvLookup()
+        public async Task ShouldGetMedicationsProvLookup()
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
             Mock<IPatientService> patientDelegateMock = new();
@@ -487,7 +494,7 @@ namespace HealthGateway.MedicationTests.Services
                 MapperUtil.InitializeAutoMapper());
 
             // Act
-            RequestResult<IList<MedicationStatementHistory>> actual = Task.Run(async () => await service.GetMedicationStatementsHistory(this.hdid, null)).Result;
+            RequestResult<IList<MedicationStatementHistory>> actual = await service.GetMedicationStatementsHistory(this.hdid, null);
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Success && actual.ResourcePayload?.Count == 1);

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -88,7 +88,7 @@ namespace HealthGateway.PatientTests.Controllers
             PatientController patientController = CreatePatientController();
 
             // Act
-            var actualResult = await patientController.GetPatientV2(MockedHdid).ConfigureAwait(false);
+            var actualResult = await patientController.GetPatientV2(MockedHdid);
 
             // Assert
             var ok = actualResult.Result.ShouldBeOfType<OkObjectResult>();

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -48,8 +48,11 @@ namespace HealthGateway.PatientTests.Controllers
         /// <summary>
         /// GetPatients Test.
         /// </summary>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous unit test.
+        /// </returns>
         [Fact]
-        public void ShouldGetPatientsV1()
+        public async Task ShouldGetPatientsV1()
         {
             // Arrange
             PatientController patientController = CreatePatientController();
@@ -71,7 +74,7 @@ namespace HealthGateway.PatientTests.Controllers
             };
 
             // Act
-            RequestResult<PatientModel> actualResult = patientController.GetPatient("123").Result;
+            RequestResult<PatientModel> actualResult = await patientController.GetPatient("123");
 
             // Assert
             expectedResult.ShouldDeepEqual(actualResult);
@@ -88,12 +91,12 @@ namespace HealthGateway.PatientTests.Controllers
             PatientController patientController = CreatePatientController();
 
             // Act
-            var actualResult = await patientController.GetPatientV2(MockedHdid);
+            ActionResult<PatientDetails> actualResult = await patientController.GetPatientV2(MockedHdid);
 
             // Assert
-            var ok = actualResult.Result.ShouldBeOfType<OkObjectResult>();
+            OkObjectResult ok = actualResult.Result.ShouldBeOfType<OkObjectResult>();
             ok.StatusCode.ShouldBe(StatusCodes.Status200OK);
-            var patientDetails = ok.Value.ShouldBeOfType<PatientDetails>();
+            PatientDetails patientDetails = ok.Value.ShouldBeOfType<PatientDetails>();
             patientDetails.HdId.ShouldBe(MockedHdid);
         }
 

--- a/Apps/Patient/test/unit/PatientTests.csproj
+++ b/Apps/Patient/test/unit/PatientTests.csproj
@@ -20,8 +20,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -145,7 +145,7 @@ namespace HealthGateway.PatientTests.Services
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
             PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None)
-                .ConfigureAwait(true);
+                ;
 
             if (canAccessDataSource)
             {
@@ -187,7 +187,7 @@ namespace HealthGateway.PatientTests.Services
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
             PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.BcCancerScreening }), CancellationToken.None)
-                .ConfigureAwait(true);
+                ;
 
             if (canAccessDataSource)
             {
@@ -233,7 +233,7 @@ namespace HealthGateway.PatientTests.Services
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
             PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.DiagnosticImaging }), CancellationToken.None)
-                .ConfigureAwait(true);
+                ;
 
             if (canAccessDataSource)
             {
@@ -270,7 +270,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientFileResponse? result = await sut.Query(new Patient.Services.PatientFileQuery(this.hdid, expected.FileId), CancellationToken.None).ConfigureAwait(true);
+            PatientFileResponse? result = await sut.Query(new Patient.Services.PatientFileQuery(this.hdid, expected.FileId), CancellationToken.None);
 
             PatientFileResponse actual = result.ShouldBeOfType<PatientFileResponse>();
             actual.Content.ShouldBe(expected.Content);
@@ -292,7 +292,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientFileResponse? result = await sut.Query(new Patient.Services.PatientFileQuery(this.hdid, fileId), CancellationToken.None).ConfigureAwait(true);
+            PatientFileResponse? result = await sut.Query(new Patient.Services.PatientFileQuery(this.hdid, fileId), CancellationToken.None);
 
             result.ShouldBeNull();
         }

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.PatientTests.Services
             IPatientService patientService = GetPatientService(patient);
 
             // Act
-            PatientDetails actual = Task.Run(async () => await patientService.GetPatientAsync(patient.Hdid).ConfigureAwait(true)).Result;
+            PatientDetails actual = Task.Run(async () => await patientService.GetPatientAsync(patient.Hdid)).Result;
 
             // Verify
             Assert.Equal(patient.Hdid, actual.HdId);
@@ -67,7 +67,7 @@ namespace HealthGateway.PatientTests.Services
             IPatientService patientService = GetPatientService(patient);
 
             // Act
-            PatientDetails actual = Task.Run(async () => await patientService.GetPatientAsync(patient.Phn, PatientIdentifierType.Phn).ConfigureAwait(true)).Result;
+            PatientDetails actual = Task.Run(async () => await patientService.GetPatientAsync(patient.Phn, PatientIdentifierType.Phn)).Result;
 
             // Verify
             Assert.Equal(patient.Phn, actual.Phn);
@@ -86,11 +86,11 @@ namespace HealthGateway.PatientTests.Services
             // Act
             async Task Actual()
             {
-                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn).ConfigureAwait(true);
+                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.ProblemDetails!.Detail);
         }
 
@@ -109,11 +109,11 @@ namespace HealthGateway.PatientTests.Services
             // Act
             async Task Actual()
             {
-                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn).ConfigureAwait(true);
+                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.ClientRegistryReturnedDeceasedPerson, exception.ProblemDetails!.Detail);
         }
 
@@ -133,11 +133,11 @@ namespace HealthGateway.PatientTests.Services
             // Act
             async Task Actual()
             {
-                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn).ConfigureAwait(true);
+                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.InvalidServicesCard, exception.ProblemDetails!.Detail);
         }
 
@@ -156,11 +156,11 @@ namespace HealthGateway.PatientTests.Services
             // Act
             async Task Actual()
             {
-                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn).ConfigureAwait(true);
+                await patientService.GetPatientAsync(Phn, PatientIdentifierType.Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.InvalidServicesCard, exception.ProblemDetails!.Detail);
         }
 
@@ -184,11 +184,11 @@ namespace HealthGateway.PatientTests.Services
             // Act
             async Task Actual()
             {
-                await patientService.GetPatientAsync(invalidPhn, PatientIdentifierType.Phn).ConfigureAwait(true);
+                await patientService.GetPatientAsync(invalidPhn, PatientIdentifierType.Phn);
             }
 
             // Verify
-            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual).ConfigureAwait(true);
+            ProblemDetailsException exception = await Assert.ThrowsAsync<ProblemDetailsException>(Actual);
             Assert.Equal(ErrorMessages.PhnInvalid, exception.ProblemDetails!.Detail);
         }
 

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -42,15 +42,16 @@ namespace HealthGateway.PatientTests.Services
         /// <summary>
         /// GetPatient - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetPatient()
+        public async Task ShouldGetPatient()
         {
             // Arrange
             PatientModel patient = GetPatient();
             IPatientService patientService = GetPatientService(patient);
 
             // Act
-            PatientDetails actual = Task.Run(async () => await patientService.GetPatientAsync(patient.Hdid)).Result;
+            PatientDetails actual = await patientService.GetPatientAsync(patient.Hdid);
 
             // Verify
             Assert.Equal(patient.Hdid, actual.HdId);
@@ -59,15 +60,16 @@ namespace HealthGateway.PatientTests.Services
         /// <summary>
         /// GetPatient - Valid Phn.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetPatientByValidPhn()
+        public async Task ShouldGetPatientByValidPhn()
         {
             // Arrange
             PatientModel patient = GetPatient();
             IPatientService patientService = GetPatientService(patient);
 
             // Act
-            PatientDetails actual = Task.Run(async () => await patientService.GetPatientAsync(patient.Phn, PatientIdentifierType.Phn)).Result;
+            PatientDetails actual = await patientService.GetPatientAsync(patient.Phn, PatientIdentifierType.Phn);
 
             // Verify
             Assert.Equal(patient.Phn, actual.Phn);

--- a/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
+++ b/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
@@ -18,8 +18,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.2.1" />
-        <PackageReference Include="xunit" Version="2.5.0" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit" Version="2.5.1" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -53,7 +53,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.OrganDonorRegistrationStatus }), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.OrganDonorRegistrationStatus }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.OrganDonorRegistration
@@ -90,7 +90,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.BcCancerScreening }), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.BcCancerScreening }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.BcCancerScreening exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.BcCancerScreening>();
@@ -130,7 +130,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging }), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.DiagnosticImagingExam exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.DiagnosticImagingExam>();
@@ -166,7 +166,7 @@ namespace PatientDataAccessTests
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
             PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening }), CancellationToken.None)
-                .ConfigureAwait(true);
+                ;
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.DiagnosticImagingExam diExam = result.Items.First().ShouldBeOfType<HealthGateway.PatientDataAccess.DiagnosticImagingExam>();
@@ -189,7 +189,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull();
             PatientFile actualFile = result.Items.ShouldHaveSingleItem().ShouldBeOfType<PatientFile>();
@@ -211,7 +211,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
@@ -225,12 +225,12 @@ namespace PatientDataAccessTests
 #pragma warning disable CA2000 // Dispose objects before losing scope
             patientApi
                 .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
-                .ThrowsAsync(await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, new HttpResponseMessage(HttpStatusCode.NotFound), new RefitSettings()).ConfigureAwait(true));
+                .ThrowsAsync(await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, new HttpResponseMessage(HttpStatusCode.NotFound), new RefitSettings()));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
@@ -248,7 +248,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None).ConfigureAwait(true);
+            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }

--- a/Apps/WebClient/test/unit/WebClientTests.csproj
+++ b/Apps/WebClient/test/unit/WebClientTests.csproj
@@ -23,8 +23,8 @@
     <PackageReference Include="DeepEqual" Version="4.2.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.18.4" />
-    <PackageReference Include="xunit" Version="2.5.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Testing/integration/tests/IntegrationTests.csproj
+++ b/Testing/integration/tests/IntegrationTests.csproj
@@ -30,9 +30,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
         <PackageReference Include="Testcontainers.PostgreSql" Version="3.5.0" />
         <PackageReference Include="Testcontainers.Redis" Version="3.5.0" />
-        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit" Version="2.5.1" />
         <PackageReference Include="xunit.categories" Version="2.0.8" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Testing/integration/tests/ScenarioBase.cs
+++ b/Testing/integration/tests/ScenarioBase.cs
@@ -65,7 +65,7 @@ public class WebAppFixture : IAsyncLifetime
                 };
                 // set or override configuration settings
                 builder.ConfigureAppConfiguration(
-                    (context, configBuilder) =>
+                    (_, configBuilder) =>
                     {
                         string? secretsPath = Environment.GetEnvironmentVariable("SECRETS_PATH");
                         configBuilder.AddInMemoryCollection(configOverrides);


### PR DESCRIPTION
# Fixes [AB#16142](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16142)

## Description
1. Remove ConfigureAwait from test code in accordance to warnings and errors reported.
2. Address non-async code and remove blocking statements.
3. Add Resharper disable for testing files that use functions that naturally throw exceptions without "work".
    * 


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

All tests still completing successfully without errors:

![image](https://github.com/bcgov/healthgateway/assets/19548348/2d23d67b-bf59-4178-bec0-880a1d8b8097)

Only non-test related warnings and errors left (will create new task for this in backlog):

![image](https://github.com/bcgov/healthgateway/assets/19548348/55d1290a-e9c1-4605-8ec0-d8fa38102273)

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
