### PR TITLE
Refine recommendations dialog for AB#16149

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/AddQuickLinkComponent.vue
@@ -4,7 +4,11 @@ import { computed, nextTick, ref } from "vue";
 import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
 import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
 import TooManyRequestsComponent from "@/components/error/TooManyRequestsComponent.vue";
-import { entryTypeMap, getEntryTypeByModule } from "@/constants/entryType";
+import {
+    EntryType,
+    entryTypeMap,
+    getEntryTypeByModule,
+} from "@/constants/entryType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { ServiceName } from "@/constants/serviceName";
 import UserPreferenceType from "@/constants/userPreferenceType";
@@ -13,6 +17,7 @@ import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { BannerError, isTooManyRequestsError } from "@/models/errors";
 import { QuickLink } from "@/models/quickLink";
 import { ILogger } from "@/services/interfaces";
+import { useConfigStore } from "@/stores/config";
 import { useErrorStore } from "@/stores/error";
 import { useUserStore } from "@/stores/user";
 import ConfigUtil from "@/utility/configUtil";
@@ -37,6 +42,7 @@ interface QuickLinkFilter {
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const errorStore = useErrorStore();
 const userStore = useUserStore();
+const configStore = useConfigStore();
 
 const isVisible = ref(false);
 const isLoading = ref(false);
@@ -72,8 +78,11 @@ const showVaccineCard = computed(
         user.value.preferences[UserPreferenceType.HideVaccineCardQuickLink]
             ?.value === "true"
 );
-const showRecommendationsDialogCard = computed(
+const showRecommendationsDialog = computed(
     () =>
+        ConfigUtil.isDatasetEnabled(EntryType.Immunization) &&
+        configStore.webConfig.featureToggleConfiguration.homepage
+            .showRecommendationsLink &&
         user.value.preferences[UserPreferenceType.HideRecommendationsQuickLink]
             ?.value === "true"
 );
@@ -329,7 +338,7 @@ function hideModal(): void {
                         color="primary"
                     />
                     <v-checkbox
-                        v-if="showRecommendationsDialogCard"
+                        v-if="showRecommendationsDialog"
                         id="recommendations-dialog-filter"
                         v-model="selectedQuickLinks"
                         data-testid="recommendations-dialog-filter"

--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -10,6 +10,7 @@ import PageTitleComponent from "@/components/common/PageTitleComponent.vue";
 import AddQuickLinkComponent from "@/components/private/home/AddQuickLinkComponent.vue";
 import RecommendationsDialogComponent from "@/components/private/reports/RecommendationsDialogComponent.vue";
 import {
+    EntryType,
     EntryTypeDetails,
     entryTypeMap,
     getEntryTypeByModule,
@@ -118,6 +119,7 @@ const showRecommendationsCardButton = computed(
     () =>
         configStore.webConfig.featureToggleConfiguration.homepage
             .showRecommendationsLink &&
+        ConfigUtil.isDatasetEnabled(EntryType.Immunization) &&
         !preferenceRecommendationsLinkHidden.value
 );
 const showVaccineCardButton = computed(

--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/ImmunizationReportComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/ImmunizationReportComponent.vue
@@ -24,12 +24,14 @@ interface Props {
     hideImmunizations?: boolean;
     hideRecommendations?: boolean;
     hideRecommendationHeader?: boolean;
+    forceShow?: boolean;
 }
 const props = withDefaults(defineProps<Props>(), {
     isDependent: false,
     hideImmunizations: false,
     hideRecommendations: false,
     hideRecommendationHeader: false,
+    forceShow: false,
 });
 
 const emit = defineEmits<{
@@ -206,7 +208,10 @@ immunizationStore
         <div v-if="isRecommendationEmpty && isEmpty && !isLoading">
             No records found.
         </div>
-        <section v-else-if="!isDependent" class="d-none d-md-block">
+        <section
+            v-else-if="!isDependent || forceShow"
+            class="d-none d-md-block"
+        >
             <template v-if="!hideImmunizations">
                 <h4 class="text-h6 font-weight-bold mb-2">
                     Immunization History

--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/RecommendationsDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/RecommendationsDialogComponent.vue
@@ -135,6 +135,8 @@ function showDialog() {
                         ref="recommendationsReportComponent"
                         :hdid="hdid"
                         :filter="reportFilter"
+                        :is-dependent="isDependent"
+                        force-show
                         hide-immunizations
                         hide-recommendation-header
                         @on-is-empty-changed="hasRecords = !$event"

--- a/Testing/functional/tests/cypress/integration/e2e/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/home.js
@@ -144,3 +144,63 @@ describe("Home page - Recommendations", () => {
         cy.get("[data-testid=recommendations-dialog]").should("not.exist");
     });
 });
+
+describe("Home page - Recommendations Configurations", () => {
+    it("Recommendation Quick link should not exist when homepage showRecommendationsLink true and imms false ", () => {
+        cy.configureSettings({
+            homepage: {
+                showRecommendationsLink: true,
+            },
+            datasets: [
+                {
+                    name: "medication",
+                    enabled: true,
+                },
+                {
+                    name: "immunization",
+                    enabled: false,
+                },
+            ],
+        });
+
+        cy.login(
+            Cypress.env("keycloak.hthgtwy20.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homeUrl
+        );
+        cy.get("[data-testid=recommendations-card-button]").should("not.exist");
+        cy.get("[data-testid=add-quick-link-button]").should("be.disabled");
+
+        // Remove medication quick link to activate add quick link button
+        cy.get("[data-testid=quick-link-card]")
+            .first()
+            .within(() => {
+                cy.get("[data-testid=card-menu-button]")
+                    .should("be.visible")
+                    .click();
+                cy.document()
+                    .find("[data-testid=remove-quick-link-button")
+                    .should("be.visible")
+                    .click();
+            });
+
+        cy.get("[data-testid=add-quick-link-button]")
+            .should("be.enabled")
+            .click();
+
+        // Ensure recommendations dialog filter doesn't exist if add quick link dialog is shown
+        cy.get("[data-testid=recommendations-dialog-filter]").should(
+            "not.exist"
+        );
+
+        // Clean up test
+        cy.get("[data-testid=Medication-filter]")
+            .should("be.visible")
+            .find("input")
+            .should("not.to.be.checked")
+            .check({ force: true });
+
+        cy.get("[data-testid=add-quick-link-btn]").click();
+    });
+});


### PR DESCRIPTION
# Fixes [AB#16149](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16149) and [AB#16159](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16159)

## Description
1. Add tracking to report download.
2. Make both imms. dataset config and homepage config mandatory for recommendation link to be visible (card and filter).
3. Make dependent recommendations dialog visible for dependents by allow to `force-show` prop.
4. use `is-dependent` prop on recommendation dialog for dependent implementation to use the correct template for the report on download.
5. Add recommendation and immunization configuration functional test.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

![image](https://github.com/bcgov/healthgateway/assets/19548348/c9397ead-6877-4d1e-9fad-ca22fada49d3)


## UI Changes

Dependent recommendation data now being displayed:
![image](https://github.com/bcgov/healthgateway/assets/19548348/6b7db705-5b23-4f29-8351-7619ce1b4e00)

Dependent report data not shown on export records:
![image](https://github.com/bcgov/healthgateway/assets/19548348/ed0594ba-a7ff-43dc-9764-6b7ab1115906)

## Notes
Tracking added:
![image](https://github.com/bcgov/healthgateway/assets/19548348/34901ab4-a044-4a2c-a81b-b89c47f02088)

Dependent recommendation dialog download:
[HealthGatewayDependentImmunizationReport (3).pdf](https://github.com/bcgov/healthgateway/files/12678325/HealthGatewayDependentImmunizationReport.3.pdf)

user recommendation dialog download:
[HealthGatewayImmunizationReport (11).pdf](https://github.com/bcgov/healthgateway/files/12678326/HealthGatewayImmunizationReport.11.pdf)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
