### PR TITLE
Re-query data when current/previous Hdid are different for AB#16169.

### DIFF
--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -118,6 +118,8 @@ namespace HealthGateway.Admin.Client.Pages
 
         private string Hdid { get; set; } = string.Empty;
 
+        private string PreviousSearchedHdid { get; set; } = string.Empty;
+
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
@@ -155,17 +157,15 @@ namespace HealthGateway.Admin.Client.Pages
 
         private void RetrievePatientDetails()
         {
-            if (this.Patient == null)
+            if (this.Patient?.Hdid != this.PreviousSearchedHdid)
             {
                 this.Dispatcher.Dispatch(new PatientSupportActions.ResetStateAction());
                 this.Dispatcher.Dispatch(new PatientSupportActions.LoadAction { QueryType = PatientQueryType.Hdid, QueryString = this.Hdid });
-            }
-
-            if (this.AssessmentInfo == null)
-            {
                 this.Dispatcher.Dispatch(new PatientDetailsActions.ResetStateAction());
                 this.Dispatcher.Dispatch(new PatientDetailsActions.LoadAction { Hdid = this.Hdid });
             }
+
+            this.PreviousSearchedHdid = this.Hdid;
         }
 
         private bool UserHasRole(string role)


### PR DESCRIPTION
# Fixes [AB#16169](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16169)

## Description

Re-query user details when new search is executed on Admin support query page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

NO

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
