### PR TITLE
Remove unncessary resource delegate for AB#16189.

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
@@ -10,7 +10,7 @@ describe("Dashboard", () => {
     it("Verify dashboard counts from seeded data.", () => {
         cy.log("Dashboard test started.");
         cy.get("[data-testid=total-registered-users]").contains(7);
-        cy.get("[data-testid=total-dependents]").contains(6);
+        cy.get("[data-testid=total-dependents]").contains(5);
         cy.get("[data-testid=total-unique-users]").contains(2);
         cy.get("[data-testid=total-mobile-users]").contains(3);
         cy.get("[data-testid=total-web-users]").contains(4);
@@ -25,7 +25,7 @@ describe("Dashboard", () => {
                 cy.get(
                     "[data-testid=daily-data-total-logged-in-users]"
                 ).contains("6");
-                cy.get("[data-testid=daily-data-dependents]").contains("6");
+                cy.get("[data-testid=daily-data-dependents]").contains("5");
             });
 
         cy.log("Change value in unique days input field.");

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -851,27 +851,6 @@ INSERT INTO gateway."ResourceDelegate"(
 	"ReasonObjectType", 
 	"ReasonObject")
 VALUES (
-	'BNV554213556', 
-	'P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A', 
-	'Guardian', 
-	'System', 
-	current_timestamp, 
-	'System', 
-	current_timestamp, 
-	'System.DateTime, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e', 
-	'"2023-03-27T00:00:00"'
-);
-INSERT INTO gateway."ResourceDelegate"(
-	"ResourceOwnerHdid", 
-	"ProfileHdid", 
-	"ReasonCode", 
-	"CreatedBy", 
-	"CreatedDateTime", 
-	"UpdatedBy", 
-	"UpdatedDateTime", 
-	"ReasonObjectType", 
-	"ReasonObject")
-VALUES (
 	'727302800477298080', 
 	'P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A', 
 	'Guardian', 


### PR DESCRIPTION
# Fixes [AB#16189](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16189)

## Description

Removed unnecessary resource delegate data that was added in commit #4936 but not used:

- causing issues as hdid associated to resource is returning warning from client registry, which then invalidates the list being returned back via DependentService.GetDependentsAsync
- updated functional test

Note: @sslaws also encountered this issue when using seed data script.  Also, #16173 has been created to address some additional issues regarding the handling of warnings from Client Registry.

<img width="934" alt="Screenshot 2023-09-22 at 4 48 43 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/1d868006-8f9d-4798-9b81-2d82f09a3571">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
