### PR TITLE
Add AdminReports for AB#15617

### DIFF
--- a/Apps/Admin/Common/Models/BlockedAccessRecord.cs
+++ b/Apps/Admin/Common/Models/BlockedAccessRecord.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models
+{
+    using System.Collections.Generic;
+    using HealthGateway.Common.Data.Constants;
+
+    /// <summary>
+    /// Represents a patient with blocked access to data sources.
+    /// </summary>
+    /// <param name="Hdid">Patient's HDID.</param>
+    /// <param name="BlockedSources">List of <see cref="DataSource"/> that are blocked</param>
+    public record BlockedAccessRecord(string Hdid, IList<DataSource> BlockedSources);
+}

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -30,7 +30,7 @@ namespace HealthGateway.Admin.Server.Controllers
     [ApiVersion("1.0")]
     [Route("v{version:apiVersion}/api/[controller]")]
     [Produces("application/json")]
-    [Authorize(Roles = "AdminUser,AdminReviewer")]
+    [Authorize(Roles = "AdminUser")]
     public class AdminReportController : Controller
     {
         private readonly IAdminReportService adminReportService;
@@ -59,7 +59,7 @@ namespace HealthGateway.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Retrieves a collection of user HDIDs with a collection of blocked data sources.
+        /// Retrieves a collection of user HDIDs and their blocked data sources.
         /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A collection of <see cref="BlockedAccess"/> records.</returns>

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -18,8 +18,8 @@ namespace HealthGateway.Admin.Server.Controllers
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
-    using HealthGateway.Database.Models;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
 
@@ -62,12 +62,12 @@ namespace HealthGateway.Admin.Server.Controllers
         /// Retrieves a collection of user HDIDs and their blocked data sources.
         /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A collection of <see cref="BlockedAccess"/> records.</returns>
+        /// <returns>A collection of <see cref="BlockedAccessRecord"/> records.</returns>
         /// <response code="200">Returns the collection of hdids with the blocked data sources.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content.</response>
         [HttpGet]
-        public async Task<IEnumerable<BlockedAccess>> GetBlockedAccessReport(CancellationToken ct)
+        public async Task<IEnumerable<BlockedAccessRecord>> GetBlockedAccessReport(CancellationToken ct)
         {
             return await this.adminReportService.GetBlockedAccessReportAsync(ct);
         }

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -38,7 +38,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Initializes a new instance of the <see cref="AdminReportController"/> class.
         /// </summary>
-        /// <param name="adminReportService">then injected admin report service.</param>
+        /// <param name="adminReportService">The injected admin report service.</param>
         public AdminReportController(IAdminReportService adminReportService)
         {
             this.adminReportService = adminReportService;

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -1,0 +1,75 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Controllers
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Database.Models;
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+
+    /// <summary>
+    /// Web API to handle admin reports.
+    /// </summary>
+    [ApiController]
+    [ApiVersion("1.0")]
+    [Route("v{version:apiVersion}/api/[controller]")]
+    [Produces("application/json")]
+    [Authorize(Roles = "AdminUser,AdminReviewer")]
+    public class AdminReportController : Controller
+    {
+        private readonly IAdminReportService adminReportService;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdminReportController"/> class.
+        /// </summary>
+        /// <param name="adminReportService">then injected admin report service.</param>
+        public AdminReportController(IAdminReportService adminReportService)
+        {
+            this.adminReportService = adminReportService;
+        }
+
+        /// <summary>
+        /// Retrieves a collection of user HDIDs that have dependents.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>List of user HDIDs that have dependents attached.</returns>
+        /// <response code="200">Returns the list of user HDIDs that have dependents attached.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content.</response>
+        [HttpGet]
+        public async Task<IEnumerable<string>> GetProtectedDependentsReport(CancellationToken ct)
+        {
+            return await this.adminReportService.GetProtectedDependentsReportAsync(ct);
+        }
+
+        /// <summary>
+        /// Retrieves a collection of user HDIDs with a collection of blocked data sources.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A collection of <see cref="BlockedAccess"/> records.</returns>
+        /// <response code="200">Returns the collection of hdids with the blocked data sources.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content.</response>
+        [HttpGet]
+        public async Task<IEnumerable<BlockedAccess>> GetBlockedAccessReport(CancellationToken ct)
+        {
+            return await this.adminReportService.GetBlockedAccessReportAsync(ct);
+        }
+    }
+}

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -1,0 +1,53 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Services
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+
+    /// <inheritdoc/>
+    public class AdminReportService : IAdminReportService
+    {
+        private readonly IDelegationDelegate delegationDelegate;
+        private readonly IBlockedAccessDelegate blockedAccessDelegate;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AdminReportService"/> class.
+        /// </summary>
+        /// <param name="delegationDelegate">The ResourceDelegate delegate to communicate with DB.</param>
+        /// <param name="blockedAccessDelegate">The BlockedAccess delegate to communicate with DB.</param>
+        public AdminReportService(IDelegationDelegate delegationDelegate, IBlockedAccessDelegate blockedAccessDelegate)
+        {
+            this.delegationDelegate = delegationDelegate;
+            this.blockedAccessDelegate = blockedAccessDelegate;
+        }
+
+        /// <inheritdoc/>
+        public Task<IEnumerable<string>> GetProtectedDependentsReportAsync(CancellationToken ct)
+        {
+            return this.delegationDelegate.GetProtectedDependentHdidsAsync(ct);
+        }
+
+        /// <inheritdoc/>
+        public Task<IEnumerable<BlockedAccess>> GetBlockedAccessReportAsync(CancellationToken ct)
+        {
+            return this.blockedAccessDelegate.GetAllAsync(ct);
+        }
+    }
+}

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -16,8 +16,10 @@
 namespace HealthGateway.Admin.Server.Services
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
 
@@ -39,15 +41,16 @@ namespace HealthGateway.Admin.Server.Services
         }
 
         /// <inheritdoc/>
-        public Task<IEnumerable<string>> GetProtectedDependentsReportAsync(CancellationToken ct)
+        public Task<IList<string>> GetProtectedDependentsReportAsync(CancellationToken ct)
         {
             return this.delegationDelegate.GetProtectedDependentHdidsAsync(ct);
         }
 
         /// <inheritdoc/>
-        public Task<IEnumerable<BlockedAccess>> GetBlockedAccessReportAsync(CancellationToken ct)
+        public async Task<IEnumerable<BlockedAccessRecord>> GetBlockedAccessReportAsync(CancellationToken ct)
         {
-            return this.blockedAccessDelegate.GetAllAsync(ct);
+            IList<BlockedAccess> records = await this.blockedAccessDelegate.GetAllAsync(ct);
+            return records.Select(r => new BlockedAccessRecord(r.Hdid, r.DataSources.ToList()));
         }
     }
 }

--- a/Apps/Admin/Server/Services/IAdminReportService.cs
+++ b/Apps/Admin/Server/Services/IAdminReportService.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Admin.Server.Services
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Database.Models;
 
     /// <summary>
@@ -30,13 +31,13 @@ namespace HealthGateway.Admin.Server.Services
         /// </summary>
         /// <param name="ct">Cancellation token to manage async request.</param>
         /// <returns>A collection of HDID strings.</returns>
-        Task<IEnumerable<string>> GetProtectedDependentsReportAsync(CancellationToken ct);
+        Task<IList<string>> GetProtectedDependentsReportAsync(CancellationToken ct);
 
         /// <summary>
         /// Retrieves a collection of user HDIDs and their blocked data sources.
         /// </summary>
         /// <param name="ct">Cancellation token to manage async request.</param>
         /// <returns>A collection of <see cref="BlockedAccess"/></returns>
-        Task<IEnumerable<BlockedAccess>> GetBlockedAccessReportAsync(CancellationToken ct);
+        Task<IEnumerable<BlockedAccessRecord>> GetBlockedAccessReportAsync(CancellationToken ct);
     }
 }

--- a/Apps/Admin/Server/Services/IAdminReportService.cs
+++ b/Apps/Admin/Server/Services/IAdminReportService.cs
@@ -33,7 +33,7 @@ namespace HealthGateway.Admin.Server.Services
         Task<IEnumerable<string>> GetProtectedDependentsReportAsync(CancellationToken ct);
 
         /// <summary>
-        /// Retrieves a collection of user HDIDs with a collection of blocked data sources.
+        /// Retrieves a collection of user HDIDs and their blocked data sources.
         /// </summary>
         /// <param name="ct">Cancellation token to manage async request.</param>
         /// <returns>A collection of <see cref="BlockedAccess"/></returns>

--- a/Apps/Admin/Server/Services/IAdminReportService.cs
+++ b/Apps/Admin/Server/Services/IAdminReportService.cs
@@ -1,0 +1,42 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Services
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Database.Models;
+
+    /// <summary>
+    /// Service to manage admin reports.
+    /// </summary>
+    public interface IAdminReportService
+    {
+        /// <summary>
+        /// Retrieves a collection of protected dependent HDIDs.
+        /// </summary>
+        /// <param name="ct">Cancellation token to manage async request.</param>
+        /// <returns>A collection of HDID strings.</returns>
+        Task<IEnumerable<string>> GetProtectedDependentsReportAsync(CancellationToken ct);
+
+        /// <summary>
+        /// Retrieves a collection of user HDIDs with a collection of blocked data sources.
+        /// </summary>
+        /// <param name="ct">Cancellation token to manage async request.</param>
+        /// <returns>A collection of <see cref="BlockedAccess"/></returns>
+        Task<IEnumerable<BlockedAccess>> GetBlockedAccessReportAsync(CancellationToken ct);
+    }
+}

--- a/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
@@ -95,7 +95,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<BlockedAccess>> GetAllAsync(CancellationToken ct)
+        public async Task<IList<BlockedAccess>> GetAllAsync(CancellationToken ct)
         {
             return await this.dbContext.BlockedAccess
                 .Where(ba => ba.DataSources.Any())

--- a/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Database.Delegates
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Context;
@@ -91,6 +92,14 @@ namespace HealthGateway.Database.Delegates
             this.dbContext.AgentAudit.Add(agentAudit);
 
             await this.dbContext.SaveChangesAsync().ConfigureAwait(true);
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<BlockedAccess>> GetAllAsync(CancellationToken ct)
+        {
+            return await this.dbContext.BlockedAccess
+                .Where(ba => ba.DataSources.Any())
+                .ToListAsync(ct);
         }
     }
 }

--- a/Apps/Database/src/Delegates/DbDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDelegationDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Database.Delegates
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
@@ -79,6 +80,12 @@ namespace HealthGateway.Database.Delegates
             {
                 await this.dbContext.SaveChangesAsync();
             }
+        }
+
+        /// <inheritdoc/>
+        public async Task<IEnumerable<string>> GetProtectedDependentHdidsAsync(CancellationToken ct)
+        {
+            return await this.dbContext.Dependent.Where(d => d.Protected).Select(d => d.HdId).ToListAsync(ct);
         }
     }
 }

--- a/Apps/Database/src/Delegates/DbDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDelegationDelegate.cs
@@ -83,7 +83,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<string>> GetProtectedDependentHdidsAsync(CancellationToken ct)
+        public async Task<IList<string>> GetProtectedDependentHdidsAsync(CancellationToken ct)
         {
             return await this.dbContext.Dependent.Where(d => d.Protected).Select(d => d.HdId).ToListAsync(ct);
         }

--- a/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Database.Delegates
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Models;
@@ -54,5 +55,12 @@ namespace HealthGateway.Database.Delegates
         /// <param name="agentAudit">The agent audit to create.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit);
+
+        /// <summary>
+        /// Retrieves all blocked access records.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A collection of records of user HDIDs with the data sources currently blocked.</returns>
+        Task<IEnumerable<BlockedAccess>> GetAllAsync(CancellationToken ct);
     }
 }

--- a/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
@@ -61,6 +61,6 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A collection of records of user HDIDs with the data sources currently blocked.</returns>
-        Task<IEnumerable<BlockedAccess>> GetAllAsync(CancellationToken ct);
+        Task<IList<BlockedAccess>> GetAllAsync(CancellationToken ct);
     }
 }

--- a/Apps/Database/src/Delegates/IDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/IDelegationDelegate.cs
@@ -52,6 +52,6 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of HDID strings.</returns>
-        Task<IEnumerable<string>> GetProtectedDependentHdidsAsync(CancellationToken ct);
+        Task<IList<string>> GetProtectedDependentHdidsAsync(CancellationToken ct);
     }
 }

--- a/Apps/Database/src/Delegates/IDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/IDelegationDelegate.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Database.Delegates
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Database.Models;
 
@@ -45,5 +46,12 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">Should commit, default to true.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
         Task UpdateDelegationAsync(Dependent dependent, IEnumerable<ResourceDelegate> resourceDelegatesToRemove, AgentAudit agentAudit, bool commit = true);
+
+        /// <summary>
+        /// Retrieve all user HDIDs of protected dependents from the database.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A list of HDID strings.</returns>
+        Task<IEnumerable<string>> GetProtectedDependentHdidsAsync(CancellationToken ct);
     }
 }


### PR DESCRIPTION
# Implements [AB#15617](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15617)

## Description
1. Add new AdminReport Controller
2. Add new AdminReport Service interface and concrete implementation.
3. Extend IResourceDelegateDelegate to retrieve required data for dependents report.
4. Extend IBlockedAccessDelegate to retrieve required data for the blocked access report.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

Tests will not bring value to these simple DB queries. They will be better tested through integration tests later.


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
