### PR TITLE
Include COVID-19 details for patients w/o HG accounts AB#16170

### DIFF
--- a/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor
+++ b/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor
@@ -1,10 +1,11 @@
 ﻿@using HealthGateway.Common.Data.Constants
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
 <MudText Class="mt-4" Typo="Typo.subtitle1">
     Dataset Access
 </MudText>
 
-<MudGrid Class="mt-2">
+<MudGrid Spacing="2" Class="mt-2">
     <MudItem xs="12">
         <MudPaper>
             <MudProgressLinear

--- a/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor
+++ b/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor
@@ -75,7 +75,7 @@
         </MudItem>
     </MudGrid>
 
-    @if (Patient.Status == PatientStatus.Default)
+    @if (Patient.Status is PatientStatus.Default or PatientStatus.NotUser)
     {
         <MudForm @ref="Form">
             <MudPaper Elevation="0" Class="mt-4 py-4 px-10">

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -37,7 +37,7 @@
     Severity="@Severity.Info"
     IsEnabled="HasPatientsWarning"
     TResetAction="PatientSupportActions.ResetStateAction"
-    Class="mt-3"
+    Class="mt-4"
     DataTestId="user-banner-feedback-warning-message">
     <ul>
         @foreach (string warning in PatientSupportState.Value.WarningMessages)
@@ -51,14 +51,14 @@
     Severity="@Severity.Info"
     IsEnabled="@(StatusWarning != null)"
     TResetAction="PatientSupportActions.ResetStateAction"
-    Class="mt-3"
+    Class="mt-4"
     DataTestId="user-banner-feedback-status-warning-message">
     @StatusWarning
 </HgBannerFeedback>
 
 @if (Patient != null)
 {
-    <HgPageHeading Class="mt-3">User Details</HgPageHeading>
+    <HgPageHeading TopMargin="Breakpoint.Always">User Details</HgPageHeading>
     <MudGrid Spacing="2">
         <MudItem xs="12" lg="4">
             <HgField Label="Name" Value="@PatientName" data-testid="patient-name" />
@@ -83,10 +83,10 @@
     {
         if (CanViewAccountDetails)
         {
-            <MudText Class="my-3" Typo="Typo.subtitle1">
+            <MudText Class="mt-4" Typo="Typo.subtitle1">
                 Account Details
             </MudText>
-            <MudGrid Spacing="2">
+            <MudGrid Spacing="2" Class="mt-2">
                 <MudItem xs="12" lg="6">
                     <HgField Label="Account Created" Value="@ProfileCreatedDateTime.ToString()" data-testid="profile-created-datetime" />
                 </MudItem>
@@ -113,10 +113,10 @@
     }
     else if (CanViewAccountDetails)
     {
-        <MudText Class="my-3" Typo="Typo.subtitle1">
+        <MudText Class="mt-4" Typo="Typo.subtitle1">
             Account Details
         </MudText>
-        <MudText Class="my-3" data-testid="no-hg-profile">
+        <MudText Class="mt-4" data-testid="no-hg-profile">
             No Health Gateway Profile
         </MudText>
     }
@@ -127,11 +127,11 @@
 }
 else if (PatientsLoaded)
 {
-    <MudText Class="my-3" Typo="Typo.subtitle1">
+    <MudText Class="mt-4" Typo="Typo.subtitle1">
         No user found with the specified HDID.
     </MudText>
 }
 else
 {
-    <MudProgressCircular Indeterminate="true" Size="Size.Large" Class="mt-3" />
+    <MudProgressCircular Indeterminate="true" Size="Size.Large" Class="mt-4" />
 }

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -110,10 +110,6 @@
         {
             <AgentAuditHistory Title="Agent Reason History" AgentActions="@AgentAuditHistory" IsLoading="@PatientSupportDetailsLoading" />
         }
-
-        <Covid19ImmunizationSection Phn="@Patient.PersonalHealthNumber" Data="@VaccineDoses" IsLoading="@PatientSupportDetailsLoading" MailAddress="@MailAddress" />
-
-        <Covid19AssessmentSection Data="@AssessmentDetails" IsLoading="@PatientSupportDetailsLoading" AssessmentPagePath="@Covid19TreatmentAssessmentPath" />
     }
     else if (CanViewAccountDetails)
     {
@@ -124,6 +120,10 @@
             No Health Gateway Profile
         </MudText>
     }
+
+    <Covid19ImmunizationSection Phn="@Patient.PersonalHealthNumber" Data="@VaccineDoses" IsLoading="@PatientSupportDetailsLoading" MailAddress="@MailAddress" />
+
+    <Covid19AssessmentSection Data="@AssessmentDetails" IsLoading="@PatientSupportDetailsLoading" AssessmentPagePath="@Covid19TreatmentAssessmentPath" />
 }
 else if (PatientsLoaded)
 {


### PR DESCRIPTION
# Fixes [AB#16170](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16170)

## Description

Provides access to COVID-19 functionality on the patient details and COVID-19 treatment assessment pages for patients without Health Gateway accounts.  Also tidies up inconsistent spacing on the patient details page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![localhost-2023-09-26-141730](https://github.com/bcgov/healthgateway/assets/16570293/8dad05bd-876f-426d-84f4-a2726f3900f9)

![localhost-2023-09-26-141739](https://github.com/bcgov/healthgateway/assets/16570293/446ffcee-b2b7-472c-a490-80da8f435da6)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
