### PR TITLE
Correct web alert link handling for AB#16192

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/site/NotificationCentreComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/NotificationCentreComponent.vue
@@ -63,8 +63,15 @@ function handleClickNotificationAction(notification: Notification): void {
         router.push({ path: "/timeline" });
     } else if (notification.categoryName === AlertCategory.BctOdr) {
         router.push({ path: "/services" });
+    } else if (
+        notification.actionType === NotificationActionType.InternalLink
+    ) {
+        const fullInternalUrl = new URL(notification.actionUrl);
+        router.push({
+            path: fullInternalUrl.href.replace(fullInternalUrl.origin, ""),
+        });
     } else {
-        router.push({ path: notification.actionUrl });
+        window.open(notification.actionUrl, "_blank", "noopener");
     }
     notificationStore.isNotificationCenterOpen = false;
 }

--- a/Testing/functional/tests/cypress/fixtures/NotificationService/notifications.json
+++ b/Testing/functional/tests/cypress/fixtures/NotificationService/notifications.json
@@ -35,7 +35,7 @@
         "id": "37592c14-4cc1-4bd0-0b13-08db340e7e77",
         "categoryName": "Welcome",
         "displayText": "We added a new feature which allows you to view your lab results",
-        "actionUrl": "/reports",
+        "actionUrl": "https://throwawaydomain.com/reports",
         "actionType": "InternalLink",
         "scheduledDateTimeUtc": "2021-11-24T01:10:01"
     }


### PR DESCRIPTION
# Fixes [AB#16192](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16192)

## Description
1. Check for internal vs external link for `handleClickNotificationAction`
    * Internal will strip the origin (protocol + domain) and attempt vue-router's push.
    * External will open in new tab
 2. Update UI fixture data to correctly represent the data which is stored in the database and being returned from the API.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

e2e test (no change):
![image](https://github.com/bcgov/healthgateway/assets/19548348/1b5c31c0-0987-41a1-a2df-b4001bc95c78)

UI test:
fixture updated
![image](https://github.com/bcgov/healthgateway/assets/19548348/79ec2c3a-2c02-4568-a50b-b112a2f4ea9a)


## Notes
![image](https://github.com/bcgov/healthgateway/assets/19548348/856b3577-c480-4dba-ad79-7c26fb61ccb4)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
