### PR TITLE
Add AdminReports integration tests for AB#15618

### DIFF
--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.Admin.Server.Controllers
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
     using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
 
     /// <summary>
@@ -31,7 +32,7 @@ namespace HealthGateway.Admin.Server.Controllers
     [Route("v{version:apiVersion}/api/[controller]")]
     [Produces("application/json")]
     [Authorize(Roles = "AdminUser")]
-    public class AdminReportController : Controller
+    public class AdminReportController
     {
         private readonly IAdminReportService adminReportService;
 
@@ -45,20 +46,6 @@ namespace HealthGateway.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Retrieves a collection of user HDIDs that have dependents.
-        /// </summary>
-        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>List of user HDIDs that have dependents attached.</returns>
-        /// <response code="200">Returns the list of user HDIDs that have dependents attached.</response>
-        /// <response code="401">The client must authenticate itself to get the requested response.</response>
-        /// <response code="403">The client does not have access rights to the content.</response>
-        [HttpGet]
-        public async Task<IEnumerable<string>> GetProtectedDependentsReport(CancellationToken ct)
-        {
-            return await this.adminReportService.GetProtectedDependentsReportAsync(ct);
-        }
-
-        /// <summary>
         /// Retrieves a collection of user HDIDs and their blocked data sources.
         /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
@@ -67,9 +54,33 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">The client does not have access rights to the content.</response>
         [HttpGet]
-        public async Task<IEnumerable<BlockedAccessRecord>> GetBlockedAccessReport(CancellationToken ct)
+        [Route("BlockedAccess")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IEnumerable<BlockedAccessRecord>> BlockedAccessReport(CancellationToken ct)
         {
             return await this.adminReportService.GetBlockedAccessReportAsync(ct);
+        }
+
+        /// <summary>
+        /// Retrieves a collection of user HDIDs that have dependents.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>List of user HDIDs that have dependents attached.</returns>
+        /// <response code="200">Returns the list of user HDIDs that have dependents attached.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">The client does not have access rights to the content.</response>
+        [HttpGet]
+        [Route("ProtectedDependents")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IEnumerable<string>> ProtectedDependentsReport(CancellationToken ct)
+        {
+            return await this.adminReportService.GetProtectedDependentsReportAsync(ct);
         }
     }
 }

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -153,6 +153,7 @@ namespace HealthGateway.Admin.Server
             services.AddTransient<IAgentAccessService, AgentAccessService>();
             services.AddTransient<IDelegationService, DelegationService>();
             services.AddTransient<ICovidSupportService, CovidSupportService>();
+            services.AddTransient<IAdminReportService, AdminReportService>();
             services.AddPatientRepositoryConfiguration(new AccountDataAccessConfiguration(configuration.GetSection("PhsaV2:BaseUrl").Get<Uri>()!));
         }
 

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -50,7 +50,9 @@ namespace HealthGateway.Admin.Server.Services
         public async Task<IEnumerable<BlockedAccessRecord>> GetBlockedAccessReportAsync(CancellationToken ct)
         {
             IList<BlockedAccess> records = await this.blockedAccessDelegate.GetAllAsync(ct);
-            return records.Select(r => new BlockedAccessRecord(r.Hdid, r.DataSources.ToList()));
+            return records
+                .Where(r => r.DataSources.Count > 0)
+                .Select(r => new BlockedAccessRecord(r.Hdid, r.DataSources.ToList()));
         }
     }
 }

--- a/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
@@ -98,7 +98,6 @@ namespace HealthGateway.Database.Delegates
         public async Task<IList<BlockedAccess>> GetAllAsync(CancellationToken ct)
         {
             return await this.dbContext.BlockedAccess
-                .Where(ba => ba.DataSources.Any())
                 .ToListAsync(ct);
         }
     }

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -1559,3 +1559,36 @@ VALUES (
 	'System',
 	current_timestamp - INTERVAL '2 day'
 );
+
+
+INSERT INTO gateway."BlockedAccess"(
+	"Hdid", 
+	"DataSources", 
+	"CreatedBy", 
+	"CreatedDateTime", 
+	"UpdatedBy", 
+	"UpdatedDateTime")
+VALUES (
+		'EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ', 
+		'["ClinicalDocument","Covid19TestResult"]', 
+		'System', 
+		current_timestamp - INTERVAL '2 day', 
+		'System', 
+		current_timestamp - INTERVAL '2 day'
+);
+
+INSERT INTO gateway."BlockedAccess"(
+	"Hdid", 
+	"DataSources", 
+	"CreatedBy", 
+	"CreatedDateTime", 
+	"UpdatedBy", 
+	"UpdatedDateTime")
+VALUES (
+		'S22BPV6WHS5TRLBL4XKGQDBVDUKLPIRSBGYSEJAHYMYRP22SP2TA', 
+		'[]', 
+		'System', 
+		current_timestamp - INTERVAL '2 day', 
+		'System', 
+		current_timestamp - INTERVAL '2 day'
+);

--- a/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
+++ b/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
@@ -1,0 +1,66 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.IntegrationTests.AdminReports;
+
+using Alba;
+using HealthGateway.Admin.Common.Models;
+using HealthGateway.Admin.Server;
+using HealthGateway.Common.Data.Constants;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[IntegrationTest]
+public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
+{
+    public AdminApiAdminReportsTests(ITestOutputHelper output, WebAppFixture fixture) : base(output, TestConfiguration.AdminConfigSection, fixture)
+    {
+    }
+
+    [Fact]
+    public async Task RetrieveBlockedAccessReport()
+    {
+        IList<BlockedAccessRecord> expectedRecords = new List<BlockedAccessRecord>
+        {
+            new(
+                "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ",
+                new List<DataSource> { DataSource.ClinicalDocument, DataSource.Covid19TestResult }),
+        };
+
+        IScenarioResult scenarioResponse = await this.Host.Scenario(
+            scenario => { scenario.Get.Url("/v1/api/AdminReport/BlockedAccess"); });
+
+        IList<BlockedAccessRecord> blockedAccessRecords = (await scenarioResponse.ReadAsJsonAsync<IList<BlockedAccessRecord>>()).ShouldNotBeNull();
+        blockedAccessRecords.Count.ShouldBe(1);
+        blockedAccessRecords.ShouldBeEquivalentTo(expectedRecords);
+    }
+
+    [Fact]
+    public async Task RetrieveProtectedDependentsReport()
+    {
+        IEnumerable<string> expectedHdids = new List<string>
+        {
+            "508820774378599978",
+            "35224807075386271",
+        };
+
+        IScenarioResult scenarioResponse = await this.Host.Scenario(
+            scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents"); });
+
+        IEnumerable<string> protectedHdids = (await scenarioResponse.ReadAsJsonAsync<IEnumerable<string>>()).ShouldNotBeNull();
+        protectedHdids.Count().ShouldBe(2);
+        protectedHdids.ShouldBeEquivalentTo(expectedHdids);
+    }
+}


### PR DESCRIPTION
# Implements [AB#15618](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15618)

## Description
1. Add routes to AdminReports Controller.
2. Reordered AdminReports endpoints to be alphabetical.
3. Move filtering logic to AdminReportService level.
4. Add seed data for lockedAccess (HDIDs are not currently used for any other tests).
5. Add integration tests for the AdminReports controller..

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

![image](https://github.com/bcgov/healthgateway/assets/19548348/afa471b4-4ce3-41fb-a251-86727dd11760)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
