### PR TITLE
Add functional test for admin reports AB#15620

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/reports.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/reports.cy.js
@@ -1,0 +1,37 @@
+import { getTableRows } from "../../utilities/sharedUtilities";
+
+const blockedHdid = "GO4DOSMRJ7MFKPPADDZ3FK2MOJ45SFKONJWR67XNLMZQFNEHDKDA";
+
+describe("Reports", () => {
+    beforeEach(() => {
+        cy.login(
+            Cypress.env("keycloak_username"),
+            Cypress.env("keycloak_password"),
+            "/reports"
+        );
+    });
+
+    it("Verify reports", () => {
+        cy.log("Checking protected dependents table");
+        getTableRows("[data-testid=protected-dependents-table]").should(
+            "have.length.gt",
+            0
+        );
+
+        cy.log("Checking blocked access table");
+        getTableRows("[data-testid=blocked-access-table]").should(
+            "have.length.gt",
+            0
+        );
+
+        cy.log("Checking blocked access row click goes to patient details");
+        cy.contains("[data-testid=blocked-access-hdid]", blockedHdid)
+            .should("be.visible")
+            .click();
+
+        cy.url().should("include", "/patient-details");
+        cy.contains("[data-testid=patient-hdid]", blockedHdid).should(
+            "be.visible"
+        );
+    });
+});

--- a/Apps/HealthGateway.code-workspace
+++ b/Apps/HealthGateway.code-workspace
@@ -13,6 +13,10 @@
             "path": "../Testing/functional/tests"
         },
         {
+            "name": "Admin/Tests/Functional",
+            "path": "Admin/Tests/Functional"
+        },
+        {
             "name": "../Tools",
             "path": "../Tools"
         },

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -216,7 +216,7 @@ VALUES (
 	'Web'
 );
 
-/* PHN: 9735352535 used for admin covid assessment */
+/* PHN: 9735352535 used for admin covid assessment and blocked dataset tests */
 INSERT INTO gateway."UserProfile"(
 	"UserProfileId", 
 	"CreatedBy", 
@@ -1569,7 +1569,7 @@ INSERT INTO gateway."BlockedAccess"(
 	"UpdatedBy", 
 	"UpdatedDateTime")
 VALUES (
-		'EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ', 
+		'GO4DOSMRJ7MFKPPADDZ3FK2MOJ45SFKONJWR67XNLMZQFNEHDKDA', 
 		'["ClinicalDocument","Covid19TestResult"]', 
 		'System', 
 		current_timestamp - INTERVAL '2 day', 

--- a/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
+++ b/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
@@ -35,7 +35,7 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
         IList<BlockedAccessRecord> expectedRecords = new List<BlockedAccessRecord>
         {
             new(
-                "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ",
+                "GO4DOSMRJ7MFKPPADDZ3FK2MOJ45SFKONJWR67XNLMZQFNEHDKDA",
                 new List<DataSource> { DataSource.ClinicalDocument, DataSource.Covid19TestResult }),
         };
 


### PR DESCRIPTION
# Implements [AB#15620](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15620)

## Description

- updates DB seed script to populate blocked access user with valid dev HDID
  - replaces one previously introduced for the integration test that did not have a valid HDID in dev
- updates vscode workspace to include folder for Admin functional tests
- adds functional test for admin reports

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
