### PR TITLE
Fix Admin support COVID-19 dates and form AB#16202

### DIFF
--- a/Apps/Admin/Client/Components/Support/Covid19ImmunizationSection.razor
+++ b/Apps/Admin/Client/Components/Support/Covid19ImmunizationSection.razor
@@ -16,7 +16,7 @@
           data-testid="immunization-table">
     <HeaderContent>
         <MudTh>
-            <MudTableSortLabel SortBy="new Func<VaccineDoseRow, object>(x => x.Date?.Date ?? DateTime.MinValue)"
+            <MudTableSortLabel SortBy="new Func<VaccineDoseRow, object>(x => x.Date ?? DateOnly.MinValue)"
                                InitialDirection="@SortDirection.Descending">
                 Date
             </MudTableSortLabel>
@@ -38,7 +38,12 @@
         </MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd data-testid="immunization-date" DataLabel="Date">@DateFormatter.ToShortDateAndTime(ConvertDateTime(context.Date))</MudTd>
+        <MudTd data-testid="immunization-date" DataLabel="Date">
+            @if (context.Date != null)
+            {
+                @(DateFormatter.ToShortDate(context.Date.Value))
+            }
+        </MudTd>
         <MudTd data-testid="immunization-product" DataLabel="Product">@context.Product</MudTd>
         <MudTd data-testid="immunization-lot-number" DataLabel="Lot Number">@context.Lot</MudTd>
         <MudTd data-testid="immunization-location" DataLabel="Clinic">@context.Location</MudTd>

--- a/Apps/Admin/Client/Components/Support/Covid19ImmunizationSection.razor.cs
+++ b/Apps/Admin/Client/Components/Support/Covid19ImmunizationSection.razor.cs
@@ -24,14 +24,12 @@ namespace HealthGateway.Admin.Client.Components.Support
     using HealthGateway.Admin.Client.Store.VaccineCard;
     using HealthGateway.Admin.Common.Models.CovidSupport;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Data.Utils;
     using Microsoft.AspNetCore.Components;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.JSInterop;
     using MudBlazor;
     using MailVaccineCardAddressConfirmationDialog = AddressConfirmationDialog<
-        Store.VaccineCard.VaccineCardActions.MailVaccineCardFailureAction,
-        Store.VaccineCard.VaccineCardActions.MailVaccineCardSuccessAction>;
+        HealthGateway.Admin.Client.Store.VaccineCard.VaccineCardActions.MailVaccineCardFailureAction,
+        HealthGateway.Admin.Client.Store.VaccineCard.VaccineCardActions.MailVaccineCardSuccessAction>;
 
     /// <summary>
     /// Backing logic for the COVID-19 immunization section.
@@ -68,9 +66,6 @@ namespace HealthGateway.Admin.Client.Components.Support
 
         [Inject]
         private IActionSubscriber ActionSubscriber { get; set; } = default!;
-
-        [Inject]
-        private IConfiguration Configuration { get; set; } = default!;
 
         [Inject]
         private IDialogService Dialog { get; set; } = default!;
@@ -144,16 +139,6 @@ namespace HealthGateway.Admin.Client.Components.Support
             await dialog.Result.ConfigureAwait(true);
         }
 
-        private DateTime? ConvertDateTime(DateTime? utcDateTime)
-        {
-            if (utcDateTime != null)
-            {
-                return TimeZoneInfo.ConvertTimeFromUtc((DateTime)utcDateTime, this.GetTimeZone());
-            }
-
-            return null;
-        }
-
         private void DisplayMailVaccineCardSuccessful(VaccineCardActions.MailVaccineCardSuccessAction action)
         {
             this.Snackbar.Add("BC Vaccine Card mailed successfully.", Severity.Success);
@@ -167,11 +152,6 @@ namespace HealthGateway.Admin.Client.Components.Support
         private void ResetVaccineCardState()
         {
             this.Dispatcher.Dispatch(new VaccineCardActions.ResetStateAction());
-        }
-
-        private TimeZoneInfo GetTimeZone()
-        {
-            return DateFormatter.GetLocalTimeZone(this.Configuration);
         }
 
         private void MailVaccineCard(Address address)
@@ -194,7 +174,7 @@ namespace HealthGateway.Admin.Client.Components.Support
                 this.Location = model.Location;
             }
 
-            public DateTime? Date { get; }
+            public DateOnly? Date { get; }
 
             public string? Product { get; }
 

--- a/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor
+++ b/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor
@@ -195,7 +195,7 @@
                     OptionThatIndicatesBenefit="CovidTherapyAssessmentOption.No" />
             </AssessmentQuestion>
             <AssessmentQuestion Number="10" Title="Do you agree to the information being added to your CareConnect electronic health record as part of the process to obtain COVID‑19 treatment? *">
-                <AssessmentOptionRadio @bind-SelectedOption="Request.ConsentToSendCc" />
+                <AssessmentOptionRadio @bind-SelectedOption="Request.ConsentToSendCc" Validation="@ValidateRequiredOption" />
             </AssessmentQuestion>
             <MudPaper Elevation="0" Class="mt-4 py-4 px-10">
                 <MudTextField

--- a/Apps/Admin/Common/Models/CovidSupport/VaccineDose.cs
+++ b/Apps/Admin/Common/Models/CovidSupport/VaccineDose.cs
@@ -45,6 +45,6 @@ namespace HealthGateway.Admin.Common.Models.CovidSupport
         /// Gets or sets the date the dose was administered.
         /// </summary>
         [JsonPropertyName("date")]
-        public DateTime? Date { get; set; }
+        public DateOnly? Date { get; set; }
     }
 }

--- a/Apps/Admin/Server/MapProfiles/VaccineDoseProfile.cs
+++ b/Apps/Admin/Server/MapProfiles/VaccineDoseProfile.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Server.MapProfiles
 {
+    using System;
     using AutoMapper;
     using HealthGateway.Admin.Common.Models.CovidSupport;
     using HealthGateway.Admin.Server.Models.Immunization;
@@ -29,7 +30,8 @@ namespace HealthGateway.Admin.Server.MapProfiles
         /// </summary>
         public VaccineDoseProfile()
         {
-            this.CreateMap<VaccineDoseResponse, VaccineDose>();
+            this.CreateMap<VaccineDoseResponse, VaccineDose>()
+                .ForMember(dest => dest.Date, opt => opt.MapFrom(src => src.Date == null ? null : (DateOnly?)DateOnly.FromDateTime(src.Date.Value)));
         }
     }
 }

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -782,11 +782,11 @@ namespace HealthGateway.Admin.Tests.Services
             };
         }
 
-        private static VaccineDose GenerateVaccineDose(DateTime dateTime = default, string location = "BC Canada", string lot = "300042698", string product = "Moderna mRNA-1273")
+        private static VaccineDose GenerateVaccineDose(DateOnly date = default, string location = "BC Canada", string lot = "300042698", string product = "Moderna mRNA-1273")
         {
             return new()
             {
-                Date = dateTime,
+                Date = date,
                 Location = location,
                 Lot = lot,
                 Product = product,

--- a/Apps/CommonData/src/Utils/DateFormatter.cs
+++ b/Apps/CommonData/src/Utils/DateFormatter.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.Data.Utils;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.Configuration;
@@ -115,9 +116,10 @@ public static class DateFormatter
     /// </summary>
     /// <param name="dateTime">The DateTime to modify.</param>
     /// <returns>The supplied DateTime, no longer with an unspecified kind.</returns>
-    public static DateTime SpecifyUtc(DateTime dateTime)
+    [return: NotNullIfNotNull(nameof(dateTime))]
+    public static DateTime? SpecifyUtc(DateTime? dateTime)
     {
-        return dateTime.Kind != DateTimeKind.Unspecified ? dateTime : DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+        return dateTime?.Kind != DateTimeKind.Unspecified ? dateTime : DateTime.SpecifyKind(dateTime.Value, DateTimeKind.Utc);
     }
 
     /// <summary>

--- a/Apps/GatewayApi/src/MapProfiles/WebAlertProfile.cs
+++ b/Apps/GatewayApi/src/MapProfiles/WebAlertProfile.cs
@@ -15,8 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.MapProfiles
 {
-    using System;
     using AutoMapper;
+    using HealthGateway.Common.Data.Utils;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Models.Phsa;
 
@@ -30,8 +30,8 @@ namespace HealthGateway.GatewayApi.MapProfiles
         /// </summary>
         public WebAlertProfile()
         {
-            _ = this.CreateMap<PhsaWebAlert, WebAlert>()
-              .ForMember(d => d.ScheduledDateTimeUtc, opts => opts.MapFrom(s => s.ScheduledDateTimeUtc.Kind != DateTimeKind.Unspecified ? s.ScheduledDateTimeUtc : DateTime.SpecifyKind(s.ScheduledDateTimeUtc, DateTimeKind.Utc)));
+            this.CreateMap<PhsaWebAlert, WebAlert>()
+                .ForMember(d => d.ScheduledDateTimeUtc, opts => opts.MapFrom(s => DateFormatter.SpecifyUtc(s.ScheduledDateTimeUtc)));
         }
     }
 }


### PR DESCRIPTION
# Fixes [AB#16202](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16202)

## Description

- updates DateFormatter.SpecifyUtc to support nullable DateTimes
- converts VaccineDose Date from DateTime to DateOnly
- fixes validation not triggering on question 10 of treatment assessment form

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

Date comparison.

![dev healthgateway gov bc ca-2023-10-03-154721](https://github.com/bcgov/healthgateway/assets/16570293/b73a5977-3e25-4899-8670-c3b3ce653956)

![localhost-2023-10-03-154727](https://github.com/bcgov/healthgateway/assets/16570293/d3532884-bcc3-408e-a3b7-4029ce9b67e8)

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
