### PR TITLE
Fix quick link functional test trying to click too many things AB#16223

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
@@ -195,17 +195,15 @@ describe("Quick Links", () => {
                 .click();
         });
         cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        cy.contains(cardButtonTitleSelector, encounterTitle).should(
+            "not.exist"
+        );
         getQuickLinkCard(immunizationTitle).within(() => {
             cy.get(quickLinkMenuButtonSelector)
                 .should("be.visible", "be.enabled")
                 .click();
         });
         cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
-
-        cy.log("Verifying quick link cards no longer exists");
-        cy.contains(cardButtonTitleSelector, encounterTitle).should(
-            "not.exist"
-        );
         cy.contains(cardButtonTitleSelector, immunizationTitle).should(
             "not.exist"
         );


### PR DESCRIPTION
# Fixes [AB#16223](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16223)

## Description

A functional test was clicking the button to remove the health visit quick link and then opening the menu for the immunization quick link and clicking the button to remove it.  This failed in dev test runs because the page hadn't yet updated to remove the health visit quick link before the other menu was opened, so the selector for retrieving the remove button was returning 2 items (the remove button for health visits and the remove button for immunizations).  The failure prevented the immunizations quick link from being removed in this test, which caused later tests to fail as well.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
