### PR TITLE
fix for null arrays in client registry parsing to address AB#16150

### DIFF
--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -407,7 +407,7 @@ namespace HealthGateway.Common.Delegates
 
         private bool PopulateIdentifiers(HCIM_IN_GetDemographicsResponseIdentifiedPerson retrievedPerson, PatientModel patient)
         {
-            II? identifiedPersonId = Array.Find(retrievedPerson.identifiedPerson.id, x => x.root == OidType.Phn.ToString());
+            II? identifiedPersonId = Array.Find(retrievedPerson.identifiedPerson.id ?? Array.Empty<II>(), x => x.root == OidType.Phn.ToString());
             if (identifiedPersonId == null)
             {
                 this.logger.LogWarning("Client Registry returned a person without a PHN");
@@ -417,7 +417,7 @@ namespace HealthGateway.Common.Delegates
                 patient.PersonalHealthNumber = identifiedPersonId.extension;
             }
 
-            II? subjectId = Array.Find(retrievedPerson.id, x => x.displayable && x.root == OidType.Hdid.ToString());
+            II? subjectId = Array.Find(retrievedPerson.id ?? Array.Empty<II>(), x => x.displayable && x.root == OidType.Hdid.ToString());
             if (subjectId == null)
             {
                 this.logger.LogWarning("Client Registry returned a person without an HDID");


### PR DESCRIPTION
# Fixes or Implements [AB#16150](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16150)

## Description

Fixed handling of null array coming from client registry

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
