### PR TITLE
Add density to dashboard cards for AB#16225

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/dependent/tabs/DependentDashboardTabComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/dependent/tabs/DependentDashboardTabComponent.vue
@@ -142,6 +142,7 @@ watch(vaccineRecordState, () => {
         <v-col v-if="showRecommendations" :cols="getGridCols" class="d-flex">
             <HgCardComponent
                 title="Vaccine Recommendations"
+                density="compact"
                 class="flex-grow-1 ma-1"
                 :data-testid="`recommendations-card-${dependent.ownerId}`"
                 @click="showRecommendationsDialog()"
@@ -162,6 +163,7 @@ watch(vaccineRecordState, () => {
         >
             <HgCardComponent
                 title="Proof of Vaccination"
+                density="compact"
                 class="flex-grow-1 ma-1"
                 :data-testid="`proof-vaccination-card-btn-${dependent.ownerId}`"
                 @click="showSensitiveDocumentDownloadModal()"


### PR DESCRIPTION
# Fixes or Implements [AB#16225](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16225)

## Description
1. Add missing density setting to dependent dashboard cards


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/fda7d754-3c41-4990-a917-d20b0d0b12aa)

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
