### PR TITLE
Add recommendations dialog mobile test for AB#16217

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/home.js
@@ -144,3 +144,41 @@ describe("Home page - Recommendations", () => {
         cy.get("[data-testid=recommendations-dialog]").should("not.exist");
     });
 });
+
+describe("MOBILE - Home page - Recommendations", () => {
+    beforeEach(() => {
+        cy.configureSettings({
+            homepage: {
+                showRecommendationsLink: true,
+            },
+            datasets: [
+                {
+                    name: "immunization",
+                    enabled: true,
+                },
+            ],
+        });
+        cy.viewport("iphone-6");
+
+        cy.login(
+            Cypress.env("keycloak.hthgtwy20.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homeUrl
+        );
+    });
+
+    it("Mobile - Link should open recommendations dialog with content", () => {
+        cy.get("[data-testid=recommendations-card-button]").click();
+        cy.get("[data-testid=recommendations-dialog]")
+            .should("be.visible")
+            .within(() => {
+                cy.get("[data-testid=recommendation-history-report-table]");
+                cy.get("tbody tr").should("have.length.least", 1);
+                cy.get(
+                    "[data-testid=close-recommendations-dialog-button]"
+                ).click();
+            });
+        cy.get("[data-testid=recommendations-dialog]").should("not.exist");
+    });
+});


### PR DESCRIPTION
# Fixes or Implements [AB#16217](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16217)

## Description
1. Add test to ensure that recommendations opened on a mobile devices show the correct table.


## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

![image](https://github.com/bcgov/healthgateway/assets/19548348/05e7509c-c108-41ae-8a4b-2991847e2fa6)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
