### PR TITLE
Swap timeline card attachment icon into download button AB#16195

### DIFF
--- a/Apps/HealthGateway.code-workspace
+++ b/Apps/HealthGateway.code-workspace
@@ -135,10 +135,10 @@
         },
         "[vue][typescript][javascript]": {
             "editor.formatOnSave": false,
-            "editor.codeActionsOnSave": [
-                "source.addMissingImports",
-                "source.fixAll.eslint"
-            ]
+            "editor.codeActionsOnSave": {
+                "source.addMissingImports": "explicit",
+                "source.fixAll.eslint": "explicit"
+            }
         },
         "omnisharp.defaultLaunchSolution": "HealthGateway.sln",
         "typescript.preferences.importModuleSpecifier": "non-relative"

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 
+import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
 import CommentSectionComponent from "@/components/private/timeline/comment/CommentSectionComponent.vue";
 import TimelineEntry from "@/models/timeline/timelineEntry";
 import { useAppStore } from "@/stores/app";
@@ -27,6 +28,10 @@ const props = withDefaults(defineProps<Props>(), {
     isMobileDetails: false,
     subtitle: "",
 });
+
+const emit = defineEmits<{
+    (e: "click-attachment-button"): void;
+}>();
 
 const appStore = useAppStore();
 const eventStore = useEventStore();
@@ -122,30 +127,33 @@ watch(
                                     {{ subtitle }}
                                 </slot>
                             </v-col>
-                            <v-col cols="auto" class="text-primary">
+                            <v-col
+                                cols="auto"
+                                class="text-primary d-flex align-center all-pointer-events"
+                            >
                                 <span
                                     v-if="commentCount > 1"
-                                    class="pr-2"
                                     data-testid="commentCount"
                                 >
                                     {{ commentCount }}
                                 </span>
                                 <v-icon
                                     v-if="commentCount > 0"
+                                    class="pa-2"
                                     icon="far fa-comment"
                                     size="x-small"
                                     data-testid="commentIcon"
                                 />
-                                <v-icon
+                                <HgIconButtonComponent
                                     v-if="hasAttachment"
-                                    class="ml-2"
                                     icon="paperclip"
                                     size="x-small"
-                                    data-testid="attachmentIcon"
+                                    data-testid="attachment-button"
+                                    @click.stop="
+                                        emit('click-attachment-button')
+                                    "
                                 />
-                                <span class="all-pointer-events ml-2">
-                                    <slot name="header-menu" />
-                                </span>
+                                <slot name="header-menu" />
                             </v-col>
                         </v-row>
                     </v-col>

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
@@ -29,7 +29,8 @@ const props = withDefaults(defineProps<Props>(), {
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const patientDataStore = usePatientDataStore();
-const messageModal = ref<InstanceType<typeof MessageModalComponent>>();
+const sensitiveDocumentModal =
+    ref<InstanceType<typeof MessageModalComponent>>();
 
 const entryIcon = computed(
     () => entryTypeMap.get(EntryType.BcCancerScreening)?.icon
@@ -39,12 +40,10 @@ const isLoadingFile = computed(
         props.entry.fileId !== undefined &&
         patientDataStore.isPatientDataFileLoading(props.entry.fileId)
 );
-const hasFile = computed(
-    () => props.entry.fileId !== undefined && props.entry.fileId !== ""
-);
+const hasFile = computed(() => Boolean(props.entry.fileId));
 
 function showConfirmationModal(): void {
-    messageModal.value?.showModal();
+    sensitiveDocumentModal.value?.showModal();
 }
 
 function downloadFile(): void {
@@ -72,6 +71,7 @@ function downloadFile(): void {
 
 <template>
     <TimelineEntryComponent
+        v-bind="$attrs"
         :card-id="`${index}-${datekey}`"
         :entry-icon="entryIcon"
         icon-class="bg-primary"
@@ -80,7 +80,8 @@ function downloadFile(): void {
         :entry="entry"
         :is-mobile-details="isMobileDetails"
         :allow-comment="commentsAreEnabled"
-        :has-attachment="Boolean(entry.fileId)"
+        :has-attachment="hasFile"
+        @click-attachment-button="showConfirmationModal"
     >
         <p class="text-body-1 mb-3">
             <span
@@ -125,13 +126,13 @@ function downloadFile(): void {
             :text="entry.callToActionText"
             prepend-icon="eye"
             :loading="isLoadingFile"
-            @click="showConfirmationModal()"
-        />
-        <MessageModalComponent
-            ref="messageModal"
-            title="Sensitive Document"
-            message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
-            @submit="downloadFile"
+            @click="showConfirmationModal"
         />
     </TimelineEntryComponent>
+    <MessageModalComponent
+        ref="sensitiveDocumentModal"
+        title="Sensitive Document"
+        message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
+        @submit="downloadFile"
+    />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/ClinicalDocumentTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/ClinicalDocumentTimelineComponent.vue
@@ -34,7 +34,8 @@ const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const clinicalDocumentStore = useClinicalDocumentStore();
 const timelineStore = useTimelineStore();
 
-const messageModal = ref<InstanceType<typeof MessageModalComponent>>();
+const sensitiveDocumentModal =
+    ref<InstanceType<typeof MessageModalComponent>>();
 
 const cols = computed(() => timelineStore.columnCount);
 const isLoadingFile = computed(() => {
@@ -52,7 +53,7 @@ const entryIcon = computed(
 );
 
 function showConfirmationModal(): void {
-    messageModal.value?.showModal();
+    sensitiveDocumentModal.value?.showModal();
 }
 
 function downloadFile(): void {
@@ -77,6 +78,7 @@ function downloadFile(): void {
 
 <template>
     <TimelineEntryComponent
+        v-bind="$attrs"
         :card-id="index + '-' + datekey"
         :entry-icon="entryIcon"
         icon-class="bg-primary"
@@ -86,6 +88,7 @@ function downloadFile(): void {
         :is-mobile-details="isMobileDetails"
         :allow-comment="commentsAreEnabled"
         has-attachment
+        @click-attachment-button="showConfirmationModal"
     >
         <v-row>
             <v-col :cols="cols">
@@ -117,11 +120,11 @@ function downloadFile(): void {
                 />
             </v-col>
         </v-row>
-        <MessageModalComponent
-            ref="messageModal"
-            title="Sensitive Document"
-            message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
-            @submit="downloadFile"
-        />
     </TimelineEntryComponent>
+    <MessageModalComponent
+        ref="sensitiveDocumentModal"
+        title="Sensitive Document"
+        message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
+        @submit="downloadFile"
+    />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/Covid19TestResultTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/Covid19TestResultTimelineComponent.vue
@@ -64,6 +64,10 @@ function getOutcomeClasses(outcome: string): string[] {
     }
 }
 
+function showConfirmationModal(): void {
+    sensitiveDocumentModal.value?.showModal();
+}
+
 function getReport(): void {
     SnowPlow.trackEvent({
         action: "download_report",
@@ -101,6 +105,7 @@ function getReport(): void {
 
 <template>
     <TimelineEntryComponent
+        v-bind="$attrs"
         :card-id="index + '-' + datekey"
         :entry-icon="entryIcon"
         icon-class="bg-primary"
@@ -108,7 +113,8 @@ function getReport(): void {
         :entry="entry"
         :is-mobile-details="isMobileDetails"
         :allow-comment="commentsAreEnabled"
-        :has-attachment="entry.reportAvailable"
+        :has-attachment="entry.reportAvailable && entry.resultReady"
+        @click-attachment-button="showConfirmationModal"
     >
         <template
             v-if="entry.resultReady && entry.tests.length === 1"
@@ -129,7 +135,7 @@ function getReport(): void {
             text="Download Full Report"
             prepend-icon="download"
             :loading="isLoadingDocument"
-            @click="sensitiveDocumentModal?.showModal()"
+            @click="showConfirmationModal"
         />
         <v-row>
             <v-col>
@@ -204,11 +210,11 @@ function getReport(): void {
                 </v-col>
             </v-row>
         </template>
-        <MessageModalComponent
-            ref="sensitiveDocumentModal"
-            title="Sensitive Document"
-            message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
-            @submit="getReport"
-        />
     </TimelineEntryComponent>
+    <MessageModalComponent
+        ref="sensitiveDocumentModal"
+        title="Sensitive Document"
+        message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
+        @submit="getReport"
+    />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/DiagnosticImagingTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/DiagnosticImagingTimelineComponent.vue
@@ -33,7 +33,8 @@ const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const patientDataStore = usePatientDataStore();
 const timelineStore = useTimelineStore();
 
-const messageModal = ref<InstanceType<typeof MessageModalComponent>>();
+const sensitiveDocumentModal =
+    ref<InstanceType<typeof MessageModalComponent>>();
 
 const cols = computed(() => timelineStore.columnCount);
 const entryIcon = computed(
@@ -44,12 +45,10 @@ const isLoadingFile = computed(
         props.entry.fileId !== undefined &&
         patientDataStore.isPatientDataFileLoading(props.entry.fileId)
 );
-const hasFile = computed(
-    () => props.entry.fileId !== undefined && props.entry.fileId !== ""
-);
+const hasFile = computed(() => Boolean(props.entry.fileId));
 
 function showConfirmationModal(): void {
-    messageModal.value?.showModal();
+    sensitiveDocumentModal.value?.showModal();
 }
 
 function downloadFile(): void {
@@ -75,6 +74,7 @@ function downloadFile(): void {
 
 <template>
     <TimelineEntryComponent
+        v-bind="$attrs"
         :card-id="`${index}-${datekey}`"
         :entry-icon="entryIcon"
         icon-class="bg-primary"
@@ -83,7 +83,8 @@ function downloadFile(): void {
         :entry="entry"
         :is-mobile-details="isMobileDetails"
         :allow-comment="commentsAreEnabled"
-        :has-attachment="Boolean(entry.fileId)"
+        :has-attachment="hasFile"
+        @click-attachment-button="showConfirmationModal"
     >
         <v-row class="mb-3">
             <v-col :cols="cols">
@@ -111,7 +112,7 @@ function downloadFile(): void {
             text="Download Full Report"
             prepend-icon="download"
             :loading="isLoadingFile"
-            @click="showConfirmationModal()"
+            @click="showConfirmationModal"
         />
         <p class="text-body-1">
             If you have questions about your imaging report: Contact your
@@ -143,11 +144,11 @@ function downloadFile(): void {
                 </a>
             </li>
         </ul>
-        <MessageModalComponent
-            ref="messageModal"
-            title="Sensitive Document"
-            message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
-            @submit="downloadFile"
-        />
     </TimelineEntryComponent>
+    <MessageModalComponent
+        ref="sensitiveDocumentModal"
+        title="Sensitive Document"
+        message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
+        @submit="downloadFile"
+    />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/LabResultTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/LabResultTimelineComponent.vue
@@ -59,7 +59,8 @@ const timelineStore = useTimelineStore();
 
 const isLoadingDocument = ref(false);
 const showInfoDetails = ref(false);
-const messageModal = ref<InstanceType<typeof MessageModalComponent>>();
+const sensitiveDocumentModal =
+    ref<InstanceType<typeof MessageModalComponent>>();
 
 const cols = computed(() => timelineStore.columnCount);
 const entryIcon = computed<string | undefined>(
@@ -72,7 +73,7 @@ function getStatusInfoId(labPdfId: string, index: number): string {
 }
 
 function showConfirmationModal(): void {
-    messageModal.value?.showModal();
+    sensitiveDocumentModal.value?.showModal();
 }
 
 function formatDate(date?: DateWrapper): string | undefined {
@@ -116,6 +117,7 @@ function getReport(): void {
 
 <template>
     <TimelineEntryComponent
+        v-bind="$attrs"
         :card-id="index + '-' + datekey"
         :entry-icon="entryIcon"
         icon-class="bg-primary"
@@ -125,6 +127,7 @@ function getReport(): void {
         :is-mobile-details="isMobileDetails"
         :has-attachment="entry.reportAvailable"
         :allow-comment="commentsAreEnabled"
+        @click-attachment-button="showConfirmationModal"
     >
         <v-row>
             <v-col :cols="cols">
@@ -281,11 +284,11 @@ function getReport(): void {
                 </InfoTooltipComponent>
             </template>
         </HgDataTableComponent>
-        <MessageModalComponent
-            ref="messageModal"
-            title="Sensitive Document"
-            message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
-            @submit="getReport"
-        />
     </TimelineEntryComponent>
+    <MessageModalComponent
+        ref="sensitiveDocumentModal"
+        title="Sensitive Document"
+        message="The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off."
+        @submit="getReport"
+    />
 </template>

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -20,7 +20,7 @@ describe("Diagnostic Imaging", () => {
 
     it("Validate card details with a file", () => {
         cy.get("[data-testid=timelineCard")
-            .filter(":has([data-testid=attachmentIcon])")
+            .filter(":has([data-testid=attachment-button])")
             .first()
             .within(() => {
                 cy.get("[data-testid=diagnosticimagingTitle]")
@@ -40,7 +40,7 @@ describe("Diagnostic Imaging", () => {
 
     it("Validate card details without a file", () => {
         cy.get("[data-testid=timelineCard")
-            .not(":has([data-testid=attachmentIcon])")
+            .not(":has([data-testid=attachment-button])")
             .first()
             .within(() => {
                 cy.get("[data-testid=diagnosticimagingTitle]")
@@ -60,7 +60,7 @@ describe("Diagnostic Imaging", () => {
 
     it("Validate file download", () => {
         cy.get("[data-testid=timelineCard")
-            .filter(":has([data-testid=attachmentIcon])")
+            .filter(":has([data-testid=attachment-button])")
             .first()
             .within(() => {
                 cy.get("[data-testid=diagnosticimagingTitle]")

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
@@ -71,11 +71,11 @@ describe("COVID-19 Orders", () => {
                         expect($div.text().trim()).equal(finalStatus);
                     });
 
-                // Validate Report Attachment Icon
-                cy.log("Card with reports should have an attachment icon.");
-                cy.get("[data-testid=attachmentIcon]").should("exist");
+                // Validate Report Attachment Button
+                cy.log("Card with reports should have an attachment button.");
+                cy.get("[data-testid=attachment-button]").should("exist");
 
-                cy.log("Card with attachment icon should have a report.");
+                cy.log("Card with attachment button should have a report.");
                 cy.get("[data-testid=covid-result-download-btn]").should(
                     "exist"
                 );
@@ -146,11 +146,11 @@ describe("COVID-19 Orders", () => {
                         expect($div.text().trim()).equal(correctedStatus);
                     });
 
-                // Validate Report Attachment Icon
-                cy.log("Card with reports should have an attachment icon.");
-                cy.get("[data-testid=attachmentIcon]").should("exist");
+                // Validate Report Attachment Button
+                cy.log("Card with reports should have an attachment button.");
+                cy.get("[data-testid=attachment-button]").should("exist");
 
-                cy.log("Card with attachment icon should have a report.");
+                cy.log("Card with attachment button should have a report.");
                 cy.get("[data-testid=covid-result-download-btn]").should(
                     "exist"
                 );
@@ -188,9 +188,9 @@ describe("COVID-19 Orders", () => {
                         expect($div.text().trim()).equal(amendedStatus);
                     });
 
-                // Validate Report Attachment Icon
-                cy.log("Card with reports should have an attachment icon.");
-                cy.get("[data-testid=attachmentIcon]").should("exist");
+                // Validate Report Attachment Button
+                cy.log("Card with reports should have an attachment button.");
+                cy.get("[data-testid=attachment-button]").should("exist");
 
                 cy.log("Card with attachment icon should have a report.");
                 cy.get("[data-testid=covid-result-download-btn]").should(


### PR DESCRIPTION
# Implements [AB#16195](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16195)

## Description

- swaps timeline card attachment icon into download button
  - updates COVID-19 test timeline cards so attachment button is only displayed when report is ready (to match the logic that determines if the other download button should be shown)
  - moves `<MessageModalComponent>` declarations outside the default slot of TimelineEntryComponent, to ensure clicks on the attachment button will work on unexpanded cards (the default slot is only displayed when the cards are expanded)
  - updates data-testid in the component and tests to reflect that the icon is now a button
- fixes code formatting to work with vscode September update changes
  - developers should ensure they update to the latest vscode version after this is merged

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/e8627314-f32e-4fdc-861d-96a6f7f9aa8c)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
