### PR TITLE
Fixed admin support patient details when multiple results for AB#16289.

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
@@ -40,6 +40,7 @@ describe("Support", () => {
         performSearch("SMS", sms);
         verifySupportTableResults(hdid, phn, 2);
         verifySearchInput("Sms", sms);
+        getTableRows("[data-testid=user-table]").should("have.length", 2);
 
         performSearch("Email", email);
         verifySingleSupportResult(emailHdid, emailPhn);


### PR DESCRIPTION
# Fixes [AB#16289](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16289)

## Description

Fixed admin support patient details issue when the following occurs:

1. - User query in support returns more than one row
2. - User then navigates to patient details
3. - User then navigates back to support at this point the query type, query value and query results may not match what what entered in step 1

Also updated functional test.

**Test Video:**

https://github.com/bcgov/healthgateway/assets/58790456/cef9b25d-744d-4b93-9000-d3bae3cfafc9

**Support ui:**

<img width="1049" alt="Screenshot 2023-10-11 at 10 33 41 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/afc3fc6e-badf-4c28-b741-643efcf2a5ea">

**Support e2e:**

<img width="1030" alt="Screenshot 2023-10-11 at 10 33 24 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/5172f9c4-258e-40a6-abe1-9db2a32da731">

**Patient Details ui:**

<img width="1434" alt="Screenshot 2023-10-11 at 10 33 00 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/e83c1470-8943-40c7-bc9e-9219c9afc159">

**Patient Details e2e:**

<img width="1816" alt="Screenshot 2023-10-11 at 10 32 48 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/8ba13659-e768-45a6-9612-262eec1b359e">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
