### PR TITLE
Update ProtectedDependent report for AB#16269

### DIFF
--- a/Apps/Admin/Client/Api/IAdminReportApi.cs
+++ b/Apps/Admin/Client/Api/IAdminReportApi.cs
@@ -17,7 +17,7 @@ namespace HealthGateway.Admin.Client.Api
 {
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Common.Models.AdminReports;
     using Refit;
 
     /// <summary>

--- a/Apps/Admin/Client/Pages/ReportsPage.razor
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor
@@ -2,7 +2,7 @@
 @layout MainLayout
 @attribute [Authorize(Roles = $"{Roles.Admin}")]
 @using HealthGateway.Admin.Client.Store.AdminReport
-@using HealthGateway.Admin.Common.Models
+@using HealthGateway.Admin.Common.Models.AdminReports
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <PageTitle>Health Gateway Admin Reports</PageTitle>

--- a/Apps/Admin/Client/Pages/ReportsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor.cs
@@ -24,7 +24,7 @@ using HealthGateway.Admin.Client.Store;
 using HealthGateway.Admin.Client.Store.AdminReport;
 using HealthGateway.Admin.Client.Store.PatientSupport;
 using HealthGateway.Admin.Client.Utils;
-using HealthGateway.Admin.Common.Models;
+using HealthGateway.Admin.Common.Models.AdminReports;
 using HealthGateway.Common.Data.Constants;
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop;

--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -5,6 +5,7 @@
 @using HealthGateway.Common.Data.Constants
 @using HealthGateway.Common.Data.Utils
 @using HealthGateway.Common.Ui.Constants
+@using SortDirection = MudBlazor.SortDirection
 @using HealthGateway.Admin.Common.Constants
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportActions.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportActions.cs
@@ -17,7 +17,7 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Common.Models.AdminReports;
 
     /// <summary>
     /// Static class that implements all actions for the feature.

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
@@ -23,7 +23,7 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
     using Fluxor;
     using HealthGateway.Admin.Client.Api;
     using HealthGateway.Admin.Client.Utils;
-    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Common.Models.AdminReports;
     using Microsoft.Extensions.Logging;
     using Refit;
 

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportState.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportState.cs
@@ -18,7 +18,7 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
 {
     using System.Collections.Generic;
     using Fluxor;
-    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Common.Models.AdminReports;
 
     /// <summary>
     /// The state for the feature.

--- a/Apps/Admin/Common/Admin.Common.csproj
+++ b/Apps/Admin/Common/Admin.Common.csproj
@@ -3,7 +3,6 @@
     <RootNamespace>HealthGateway.Admin.Common</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
-    <UserSecretsId>80d44c01-acdf-4da6-b4ac-e2ff9a232b59</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Apps/Admin/Common/Admin.Common.csproj
+++ b/Apps/Admin/Common/Admin.Common.csproj
@@ -3,6 +3,7 @@
     <RootNamespace>HealthGateway.Admin.Common</RootNamespace>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(MSBuildThisFileName).xml</DocumentationFile>
+    <UserSecretsId>80d44c01-acdf-4da6-b4ac-e2ff9a232b59</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Apps/Admin/Common/Models/AdminReports/BlockedAccessRecord.cs
+++ b/Apps/Admin/Common/Models/AdminReports/BlockedAccessRecord.cs
@@ -1,0 +1,27 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models.AdminReports
+{
+    using System.Collections.Generic;
+    using HealthGateway.Common.Data.Constants;
+
+    /// <summary>
+    /// Represents a patient with blocked access to data sources.
+    /// </summary>
+    /// <param name="Hdid">Patient's HDID.</param>
+    /// <param name="BlockedSources">List of <see cref="DataSource"/> that are blocked</param>
+    public record BlockedAccessRecord(string Hdid, IList<DataSource> BlockedSources);
+}

--- a/Apps/Admin/Common/Models/AdminReports/ProtectedDependentRecord.cs
+++ b/Apps/Admin/Common/Models/AdminReports/ProtectedDependentRecord.cs
@@ -13,15 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Admin.Common.Models
+namespace HealthGateway.Admin.Common.Models.AdminReports
 {
-    using System.Collections.Generic;
-    using HealthGateway.Common.Data.Constants;
-
     /// <summary>
-    /// Represents a patient with blocked access to data sources.
+    /// Represents a protected dependent.
     /// </summary>
-    /// <param name="Hdid">Patient's HDID.</param>
-    /// <param name="BlockedSources">List of <see cref="DataSource"/> that are blocked</param>
-    public record BlockedAccessRecord(string Hdid, IList<DataSource> BlockedSources);
+    /// <param name="Hdid">The dependent's HDID.</param>
+    /// <param name="Phn">The dependent's personal health number.</param>
+    public record ProtectedDependentRecord(string Hdid, string? Phn);
 }

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -68,7 +68,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Retrieves a collection of user HDIDs that have dependents.
         /// </summary>
-        /// <param name="page">Page number of the protected dependents report.</param>
+        /// <param name="page">Page number of the protected dependents report (First page is zero).</param>
         /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
         /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
@@ -83,7 +83,7 @@ namespace HealthGateway.Admin.Server.Controllers
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IEnumerable<ProtectedDependentRecord>> ProtectedDependentsReport(
-            [FromQuery] int page,
+            [FromQuery] int page = 0,
             [FromQuery] int pageSize = 25,
             [FromQuery] SortDirection sortDirection = SortDirection.Ascending,
             CancellationToken ct = default)

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -18,8 +18,9 @@ namespace HealthGateway.Admin.Server.Controllers
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Common.Models.AdminReports;
     using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Common.Data.Constants;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
@@ -67,6 +68,9 @@ namespace HealthGateway.Admin.Server.Controllers
         /// <summary>
         /// Retrieves a collection of user HDIDs that have dependents.
         /// </summary>
+        /// <param name="page">Page number of the protected dependents report.</param>
+        /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
+        /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>List of user HDIDs that have dependents attached.</returns>
         /// <response code="200">Returns the list of user HDIDs that have dependents attached.</response>
@@ -78,9 +82,13 @@ namespace HealthGateway.Admin.Server.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IEnumerable<string>> ProtectedDependentsReport(CancellationToken ct)
+        public async Task<IEnumerable<ProtectedDependentRecord>> ProtectedDependentsReport(
+            [FromQuery] int page,
+            [FromQuery] int pageSize = 25,
+            [FromQuery] SortDirection sortDirection = SortDirection.Ascending,
+            CancellationToken ct = default)
         {
-            return await this.adminReportService.GetProtectedDependentsReportAsync(ct);
+            return await this.adminReportService.GetProtectedDependentsReportAsync(page, pageSize, sortDirection, ct);
         }
     }
 }

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -49,14 +49,13 @@ namespace HealthGateway.Admin.Server.Services
         public async Task<IList<ProtectedDependentRecord>> GetProtectedDependentsReportAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct)
         {
             IEnumerable<string> protectedHdids = await this.delegationDelegate.GetProtectedDependentHdidsAsync(page, pageSize, sortDirection, ct);
-            List<Task<ProtectedDependentRecord>> tasks = protectedHdids.Select(
-                    async hdid =>
-                    {
-                        PatientQuery query = new PatientDetailsQuery(Hdid: hdid, Source: PatientDetailSource.All);
-                        PatientQueryResult patient = await this.patientRepository.Query(query, ct);
-                        return new ProtectedDependentRecord(hdid, patient.Items.SingleOrDefault()?.Phn);
-                    })
-                .ToList();
+            IEnumerable<Task<ProtectedDependentRecord>> tasks = protectedHdids.Select(
+                async hdid =>
+                {
+                    PatientQuery query = new PatientDetailsQuery(Hdid: hdid, Source: PatientDetailSource.All);
+                    PatientQueryResult patient = await this.patientRepository.Query(query, ct);
+                    return new ProtectedDependentRecord(hdid, patient.Items.SingleOrDefault()?.Phn);
+                });
             return await Task.WhenAll(tasks);
         }
 

--- a/Apps/Admin/Server/Services/IAdminReportService.cs
+++ b/Apps/Admin/Server/Services/IAdminReportService.cs
@@ -18,7 +18,8 @@ namespace HealthGateway.Admin.Server.Services
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Common.Models.AdminReports;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Models;
 
     /// <summary>
@@ -29,9 +30,12 @@ namespace HealthGateway.Admin.Server.Services
         /// <summary>
         /// Retrieves a collection of protected dependent HDIDs.
         /// </summary>
+        /// <param name="page">Page number of the protected dependents report.</param>
+        /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
+        /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct">Cancellation token to manage async request.</param>
         /// <returns>A collection of HDID strings.</returns>
-        Task<IList<string>> GetProtectedDependentsReportAsync(CancellationToken ct);
+        Task<IList<ProtectedDependentRecord>> GetProtectedDependentsReportAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct);
 
         /// <summary>
         /// Retrieves a collection of user HDIDs and their blocked data sources.

--- a/Apps/Admin/Server/Services/IAdminReportService.cs
+++ b/Apps/Admin/Server/Services/IAdminReportService.cs
@@ -30,7 +30,7 @@ namespace HealthGateway.Admin.Server.Services
         /// <summary>
         /// Retrieves a collection of protected dependent HDIDs.
         /// </summary>
-        /// <param name="page">Page number of the protected dependents report.</param>
+        /// <param name="page">Page number of the protected dependents report (First page is zero).</param>
         /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
         /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct">Cancellation token to manage async request.</param>

--- a/Apps/CommonData/src/Constants/SortDirection.cs
+++ b/Apps/CommonData/src/Constants/SortDirection.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Data.Constants
+{
+    /// <summary>
+    /// Represents the sort direction.
+    /// </summary>
+    public enum SortDirection
+    {
+        /// <summary>
+        /// Ascending sort direction.
+        /// </summary>
+        Ascending,
+
+        /// <summary>
+        /// Descending sort direction.
+        /// </summary>
+        Descending,
+    }
+}

--- a/Apps/Database/src/Delegates/DbDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDelegationDelegate.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Database.Delegates
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
     using Microsoft.EntityFrameworkCore;
@@ -83,9 +84,25 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IList<string>> GetProtectedDependentHdidsAsync(CancellationToken ct)
+        public async Task<IList<string>> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct)
         {
-            return await this.dbContext.Dependent.Where(d => d.Protected).Select(d => d.HdId).ToListAsync(ct);
+            int safePageSize = pageSize > 0 ? pageSize : 25;
+            int recordsToSkip = int.Max(page - 1, 0) * safePageSize;
+
+            // Begin query for protected dependents only
+            IQueryable<Dependent> query = this.dbContext.Dependent
+                .Where(d => d.Protected);
+
+            // Configure the sort direction
+            query = sortDirection == SortDirection.Ascending
+                ? query.OrderBy(d => d.HdId)
+                : query.OrderByDescending(d => d.HdId);
+
+            // Get the records for the page
+            return await query.Skip(recordsToSkip)
+                .Take(safePageSize)
+                .Select(d => d.HdId)
+                .ToListAsync(ct);
         }
     }
 }

--- a/Apps/Database/src/Delegates/DbDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDelegationDelegate.cs
@@ -87,7 +87,7 @@ namespace HealthGateway.Database.Delegates
         public async Task<IList<string>> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct)
         {
             int safePageSize = pageSize > 0 ? pageSize : 25;
-            int recordsToSkip = int.Max(page - 1, 0) * safePageSize;
+            int recordsToSkip = int.Max(page, 0) * safePageSize;
 
             // Begin query for protected dependents only
             IQueryable<Dependent> query = this.dbContext.Dependent

--- a/Apps/Database/src/Delegates/IDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/IDelegationDelegate.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.Database.Delegates
         /// <summary>
         /// Retrieve all user HDIDs of protected dependents from the database.
         /// </summary>
-        /// <param name="page">Page number of the protected dependents report.</param>
+        /// <param name="page">Page number of the protected dependents report (First page is zero).</param>
         /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
         /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>

--- a/Apps/Database/src/Delegates/IDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/IDelegationDelegate.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Database.Models;
 
     /// <summary>
@@ -50,8 +51,11 @@ namespace HealthGateway.Database.Delegates
         /// <summary>
         /// Retrieve all user HDIDs of protected dependents from the database.
         /// </summary>
+        /// <param name="page">Page number of the protected dependents report.</param>
+        /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
+        /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of HDID strings.</returns>
-        Task<IList<string>> GetProtectedDependentHdidsAsync(CancellationToken ct);
+        Task<IList<string>> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct);
     }
 }

--- a/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
+++ b/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.IntegrationTests.AdminReports;
 
 using Alba;
-using HealthGateway.Admin.Common.Models;
+using HealthGateway.Admin.Common.Models.AdminReports;
 using HealthGateway.Admin.Server;
 using HealthGateway.Common.Data.Constants;
 using Xunit.Abstractions;


### PR DESCRIPTION
# Implements [AB#16269](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16269)

## Description
1. Updated protected dependent report endpoint to include pagination parameters.
2. Updated return type to query patientRepo for the phn per hdid returned.
    * PHN should be null if no result returned from repo query.
4. Added SortDirection enum
5. Added defensive checks in DBDelegate
    * Page < 0 -> 0 (in skip calculation)
    * pageSize < 0 -> 25


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

Other story tickets will handle tests

## Notes
### Allowing Defaults to apply (page 1, size 25, ascending): 
![image](https://github.com/bcgov/healthgateway/assets/19548348/4b6e3a71-5cb3-4443-ab99-17377fce4255)

### Parameters explicitly applied:
![image](https://github.com/bcgov/healthgateway/assets/19548348/c897aacd-b225-4f02-97d1-3ce00897d2e1)

### Descending
![image](https://github.com/bcgov/healthgateway/assets/19548348/9fdefad4-7f77-4900-b7d4-73f3ebe330c3)

### Using paging
![image](https://github.com/bcgov/healthgateway/assets/19548348/917ec4c4-bde8-43fd-8c3a-6e0616f4b2fd)

### Postman updated:
![image](https://github.com/bcgov/healthgateway/assets/19548348/1c21d3f5-acdf-4e42-9387-2ca57f518c65)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
