### PR TITLE
Add timezone to comments and remove timezone alert AB#16341

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -20,7 +20,6 @@ import { ServiceName } from "@/constants/serviceName";
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
-import { DateWrapper } from "@/models/dateWrapper";
 import { QuickLink } from "@/models/quickLink";
 import { LoadStatus } from "@/models/storeOperations";
 import { TimelineFilterBuilder } from "@/models/timeline/timelineFilter";
@@ -78,9 +77,6 @@ const unverifiedEmail = computed(
 );
 const unverifiedSms = computed(
     () => !user.value.verifiedSms && user.value.hasSms
-);
-const isPacificTime = computed(
-    () => DateWrapper.now().offset() === DateWrapper.now().toLocal().offset()
 );
 const showFederalCardButton = computed(
     () =>
@@ -385,17 +381,6 @@ watch(vaccineRecordState, () => {
             to complete your verification.
         </span>
     </v-alert>
-    <v-alert
-        v-if="!isPacificTime"
-        closable
-        type="info"
-        title="Looks like you're in a different timezone."
-        text="Heads up: your health records are recorded and displayed in
-                Pacific Time."
-        class="d-print-none mb-4"
-        variant="outlined"
-        border
-    />
     <PageTitleComponent title="Home">
         <template #append>
             <AddQuickLinkComponent :disabled="isAddQuickLinkButtonDisabled" />

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/ActiveUserProfileComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/ActiveUserProfileComponent.vue
@@ -7,21 +7,20 @@ import UserProfileEmailComponent from "@/components/private/profile/UserProfileE
 import UserProfileManageAccountComponent from "@/components/private/profile/UserProfileManageAccountComponent.vue";
 import UserProfileSmsComponent from "@/components/private/profile/UserProfileSmsComponent.vue";
 import { DateWrapper } from "@/models/dateWrapper";
+import { useAppStore } from "@/stores/app";
 import { useUserStore } from "@/stores/user";
 
 const emit = defineEmits<{
     (e: "email-updated", value: string): void;
 }>();
 
+const appStore = useAppStore();
 const userStore = useUserStore();
 
-const isPacificTime = computed(
-    () => DateWrapper.now().offset() === DateWrapper.now().toLocal().offset()
-);
 const formattedLoginDateTimes = computed(() =>
     userStore.user.lastLoginDateTimes.map((time) =>
         DateWrapper.fromIso(time).format(
-            isPacificTime.value ? "yyyy-MMM-dd, t" : "yyyy-MMM-dd, t ZZZZ"
+            appStore.isPacificTime ? "yyyy-MMM-dd, t" : "yyyy-MMM-dd, t ZZZZ"
         )
     )
 );

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentComponent.vue
@@ -29,7 +29,9 @@ const isUpdating = ref(false);
 const isMobile = computed(() => appStore.isMobile);
 
 function formatDate(date: string): string {
-    return DateWrapper.fromIso(date).format("yyyy-MMM-dd, t");
+    return DateWrapper.fromIso(date).format(
+        appStore.isPacificTime ? "yyyy-MMM-dd, t" : "yyyy-MMM-dd, t ZZZZ"
+    );
 }
 
 function onCancel(): void {

--- a/Apps/WebClient/src/ClientApp/src/stores/app.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/app.ts
@@ -3,6 +3,7 @@ import { computed, ref } from "vue";
 import { useDisplay } from "vuetify";
 
 import { AppErrorType } from "@/constants/errorType";
+import { DateWrapper } from "@/models/dateWrapper";
 
 export const useAppStore = defineStore("app", () => {
     const display = useDisplay();
@@ -11,6 +12,11 @@ export const useAppStore = defineStore("app", () => {
     const isIdle = ref(false);
 
     const isMobile = computed(() => !display.mdAndUp.value);
+    const isPacificTime = computed(
+        () =>
+            DateWrapper.now().offset() === DateWrapper.now().toLocal().offset()
+    );
+
     function setAppError(errorType: AppErrorType): void {
         appError.value = errorType;
     }
@@ -23,6 +29,7 @@ export const useAppStore = defineStore("app", () => {
         appError,
         isMobile,
         isIdle,
+        isPacificTime,
         setAppError,
         setIsIdle,
     };


### PR DESCRIPTION
# Implements [AB#16341](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16341)

## Description

- removes different timezone alert from home page
- displays timezone next to comment time when browser is not in Pacific Time

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/b96d7125-02d7-4e1c-b0ba-e327af1420c1)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
