### PR TITLE
Implement new protected dependent report structure for AB#16271

### DIFF
--- a/Apps/Admin/Client/Api/IAdminReportApi.cs
+++ b/Apps/Admin/Client/Api/IAdminReportApi.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Admin.Client.Api
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Common.Models.AdminReports;
+    using HealthGateway.Common.Data.Constants;
     using Refit;
 
     /// <summary>
@@ -35,8 +36,11 @@ namespace HealthGateway.Admin.Client.Api
         /// <summary>
         /// Retrieves a collection of user HDIDs that have dependents.
         /// </summary>
+        /// <param name="page">Page number of the protected dependents report (First page is zero).</param>
+        /// <param name="pageSize">Number or records per page to return from the protected dependents report.</param>
+        /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <returns>Collection of user HDIDs that have dependents attached.</returns>
         [Get("/ProtectedDependents")]
-        Task<IEnumerable<string>> GetProtectedDependentsReport();
+        Task<ProtectedDependentReport> GetProtectedDependentsReport(int? page = 0, int? pageSize = 25, SortDirection? sortDirection = SortDirection.Ascending);
     }
 }

--- a/Apps/Admin/Client/Pages/DelegationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor.cs
@@ -29,6 +29,8 @@ namespace HealthGateway.Admin.Client.Pages
     using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Data.Validations;
     using Microsoft.AspNetCore.Components;
+    using Microsoft.AspNetCore.WebUtilities;
+    using Microsoft.Extensions.Primitives;
     using MudBlazor;
 
     /// <summary>
@@ -62,6 +64,9 @@ namespace HealthGateway.Admin.Client.Pages
         [Inject]
         private IDialogService Dialog { get; set; } = default!;
 
+        [Inject]
+        private NavigationManager NavigationManager { get; set; } = default!;
+
         private MudForm Form { get; set; } = default!;
 
         private string QueryParameter { get; set; } = string.Empty;
@@ -87,7 +92,16 @@ namespace HealthGateway.Admin.Client.Pages
         protected override void OnInitialized()
         {
             base.OnInitialized();
-            this.ResetDelegationState();
+            Uri uri = this.NavigationManager.ToAbsoluteUri(this.NavigationManager.Uri);
+            if (QueryHelpers.ParseQuery(uri.Query).TryGetValue("phn", out StringValues phn) && phn != StringValues.Empty)
+            {
+                this.QueryParameter = phn.ToString();
+                this.Dispatcher.Dispatch(new DelegationActions.SearchAction { Phn = StringManipulator.StripWhitespace(this.QueryParameter) });
+            }
+            else
+            {
+                this.ResetDelegationState();
+            }
         }
 
         /// <summary>

--- a/Apps/Admin/Client/Pages/DelegationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor.cs
@@ -92,15 +92,13 @@ namespace HealthGateway.Admin.Client.Pages
         protected override void OnInitialized()
         {
             base.OnInitialized();
+            this.ResetDelegationState();
+
             Uri uri = this.NavigationManager.ToAbsoluteUri(this.NavigationManager.Uri);
             if (QueryHelpers.ParseQuery(uri.Query).TryGetValue("phn", out StringValues phn) && phn != StringValues.Empty)
             {
                 this.QueryParameter = phn.ToString();
                 this.Dispatcher.Dispatch(new DelegationActions.SearchAction { Phn = StringManipulator.StripWhitespace(this.QueryParameter) });
-            }
-            else
-            {
-                this.ResetDelegationState();
             }
         }
 

--- a/Apps/Admin/Client/Pages/ReportsPage.razor
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor
@@ -29,11 +29,14 @@
 </MudText>
 <MudTable
     Class="mt-4"
+    T="ProtectedDependentRecord"
     ServerData="@GetProtectedDependentsTableData"
     AllowUnsorted="@false"
     Striped="@true"
     Dense="@true"
     RowsPerPage="20"
+    RowClassFunc="@((row, _) => !string.IsNullOrEmpty(row.Phn) ? "cursor-pointer" : string.Empty)"
+    OnRowClick="@HandleProtectedDependentsRowClick"
     data-testid="protected-dependents-table">
     <HeaderContent>
         <MudTh>

--- a/Apps/Admin/Client/Pages/ReportsPage.razor
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor
@@ -53,7 +53,7 @@
     </HeaderContent>
     <RowTemplate>
         <MudTd data-testid="protected-dependent-hdid" DataLabel="HDID">@context.Hdid</MudTd>
-        <MudTd data-testid="protected-dependent-phn" DataLabel="HDID">@context.Phn</MudTd>
+        <MudTd data-testid="protected-dependent-phn" DataLabel="PHN">@context.Phn</MudTd>
     </RowTemplate>
     <PagerContent>
         <MudTablePager PageSizeOptions="new[]{20, 50, 100}" />

--- a/Apps/Admin/Client/Pages/ReportsPage.razor
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor
@@ -29,8 +29,7 @@
 </MudText>
 <MudTable
     Class="mt-4"
-    Loading="@(ProtectedDependentsState.IsLoading)"
-    Items="@ProtectedDependentHdids"
+    ServerData="@GetProtectedDependentsTableData"
     AllowUnsorted="@false"
     Striped="@true"
     Dense="@true"
@@ -39,14 +38,19 @@
     <HeaderContent>
         <MudTh>
             <MudTableSortLabel
-                SortBy="new Func<string, object>(x => x)"
+                T="ProtectedDependentRecord"
+                SortLabel="Hdid"
                 InitialDirection="@SortDirection.Ascending">
                 HDID
             </MudTableSortLabel>
         </MudTh>
+        <MudTh>
+            PHN
+        </MudTh>
     </HeaderContent>
     <RowTemplate>
-        <MudTd data-testid="protected-dependent-hdid" DataLabel="HDID">@context</MudTd>
+        <MudTd data-testid="protected-dependent-hdid" DataLabel="HDID">@context.Hdid</MudTd>
+        <MudTd data-testid="protected-dependent-phn" DataLabel="HDID">@context.Phn</MudTd>
     </RowTemplate>
     <PagerContent>
         <MudTablePager PageSizeOptions="new[]{20, 50, 100}" />

--- a/Apps/Admin/Client/Pages/ReportsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor.cs
@@ -82,7 +82,7 @@ public partial class ReportsPage : FluxorComponent
     private async Task<TableData<ProtectedDependentRecord>> GetProtectedDependentsTableData(TableState tableState)
     {
         SortDirection sortDirection = tableState.SortDirection == MudBlazor.SortDirection.Descending ? SortDirection.Descending : SortDirection.Ascending;
-        ProtectedDependentReport report = new(ImmutableArray<ProtectedDependentRecord>.Empty, new ReportMetaData(0, tableState.Page, tableState.PageSize));
+        ProtectedDependentReport report = new(ImmutableArray<ProtectedDependentRecord>.Empty, new ReportMetadata(0, tableState.Page, tableState.PageSize));
         try
         {
             report = await this.AdminReportApi.GetProtectedDependentsReport(tableState.Page, tableState.PageSize, sortDirection);
@@ -96,7 +96,7 @@ public partial class ReportsPage : FluxorComponent
         return new TableData<ProtectedDependentRecord>
         {
             Items = report.Records,
-            TotalItems = report.MetaData.TotalCount,
+            TotalItems = report.Metadata.TotalCount,
         };
     }
 

--- a/Apps/Admin/Client/Pages/ReportsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/ReportsPage.razor.cs
@@ -106,6 +106,14 @@ public partial class ReportsPage : FluxorComponent
         this.ActionSubscriber.SubscribeToAction<PatientSupportActions.LoadSuccessAction>(this, this.NavigateToPatientDetails);
     }
 
+    private void HandleProtectedDependentsRowClick(TableRowClickEventArgs<ProtectedDependentRecord> args)
+    {
+        if (args.Item.Phn != null)
+        {
+            this.NavigationManager.NavigateTo("/delegation?Phn=" + args.Item.Phn);
+        }
+    }
+
     private void NavigateToPatientDetails(PatientSupportActions.LoadSuccessAction action)
     {
         if (action.Data.Count == 1)

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
@@ -56,22 +56,5 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
                 dispatcher.Dispatch(new AdminReportActions.GetProtectedDependentsFailureAction { Error = error });
             }
         }
-
-        [EffectMethod(typeof(AdminReportActions.GetProtectedDependentsAction))]
-        public async Task HandleGetProtectedDependentsAction(IDispatcher dispatcher)
-        {
-            this.Logger.LogInformation("Retrieving protected dependents");
-            try
-            {
-                IEnumerable<string> report = await this.AdminReportApi.GetProtectedDependentsReport().ConfigureAwait(true);
-                dispatcher.Dispatch(new AdminReportActions.GetProtectedDependentsSuccessAction { Data = report });
-            }
-            catch (Exception e) when (e is ApiException or HttpRequestException)
-            {
-                this.Logger.LogError("Error retrieving protected dependents: {Exception}", e.ToString());
-                RequestError error = StoreUtility.FormatRequestError(e);
-                dispatcher.Dispatch(new AdminReportActions.GetProtectedDependentsFailureAction { Error = error });
-            }
-        }
     }
 }

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportReducers.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportReducers.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
             return state with
             {
                 BlockedAccess = new(),
-                ProtectedDependents = new(),
             };
         }
 
@@ -62,45 +61,6 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
             return state with
             {
                 BlockedAccess = state.BlockedAccess with
-                {
-                    IsLoading = false,
-                    Error = action.Error,
-                },
-            };
-        }
-
-        [ReducerMethod(typeof(AdminReportActions.GetProtectedDependentsAction))]
-        public static AdminReportState ReduceGetProtectedDependentsAction(AdminReportState state)
-        {
-            return state with
-            {
-                ProtectedDependents = state.ProtectedDependents with
-                {
-                    IsLoading = true,
-                },
-            };
-        }
-
-        [ReducerMethod]
-        public static AdminReportState ReduceGetProtectedDependentsSuccessAction(AdminReportState state, AdminReportActions.GetProtectedDependentsSuccessAction action)
-        {
-            return state with
-            {
-                ProtectedDependents = state.ProtectedDependents with
-                {
-                    IsLoading = false,
-                    Error = null,
-                    Result = action.Data,
-                },
-            };
-        }
-
-        [ReducerMethod]
-        public static AdminReportState ReduceGetProtectedDependentsFailureAction(AdminReportState state, AdminReportActions.GetProtectedDependentsFailureAction action)
-        {
-            return state with
-            {
-                ProtectedDependents = state.ProtectedDependents with
                 {
                     IsLoading = false,
                     Error = action.Error,

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportState.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportState.cs
@@ -28,11 +28,6 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
     public record AdminReportState
     {
         /// <summary>
-        /// Gets the request state for retrieving protected dependents.
-        /// </summary>
-        public BaseRequestState<IEnumerable<string>> ProtectedDependents { get; init; } = new();
-
-        /// <summary>
         /// Gets the request state for retrieving users with blocked data sources.
         /// </summary>
         public BaseRequestState<IEnumerable<BlockedAccessRecord>> BlockedAccess { get; init; } = new();

--- a/Apps/Admin/Common/Models/AdminReports/ProtectedDependentReport.cs
+++ b/Apps/Admin/Common/Models/AdminReports/ProtectedDependentReport.cs
@@ -21,8 +21,8 @@ namespace HealthGateway.Admin.Common.Models.AdminReports
     /// Represents a protected dependent report.
     /// </summary>
     /// <param name="Records">The list of records to display.</param>
-    /// <param name="MetaData">Metadata describing the dataset metrics.</param>
-    public record ProtectedDependentReport(IList<ProtectedDependentRecord> Records, ReportMetaData MetaData);
+    /// <param name="Metadata">Metadata describing the dataset metrics.</param>
+    public record ProtectedDependentReport(IList<ProtectedDependentRecord> Records, ReportMetadata Metadata);
 
     /// <summary>
     /// Represents a protected dependent.

--- a/Apps/Admin/Common/Models/AdminReports/ProtectedDependentReport.cs
+++ b/Apps/Admin/Common/Models/AdminReports/ProtectedDependentReport.cs
@@ -1,0 +1,33 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models.AdminReports
+{
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Represents a protected dependent report.
+    /// </summary>
+    /// <param name="Records">The list of records to display.</param>
+    /// <param name="MetaData">Metadata describing the dataset metrics.</param>
+    public record ProtectedDependentReport(IList<ProtectedDependentRecord> Records, ReportMetaData MetaData);
+
+    /// <summary>
+    /// Represents a protected dependent.
+    /// </summary>
+    /// <param name="Hdid">The dependent's HDID.</param>
+    /// <param name="Phn">The dependent's personal health number.</param>
+    public record ProtectedDependentRecord(string Hdid, string? Phn);
+}

--- a/Apps/Admin/Common/Models/AdminReports/ReportMetaData.cs
+++ b/Apps/Admin/Common/Models/AdminReports/ReportMetaData.cs
@@ -15,5 +15,11 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Common.Models.AdminReports
 {
+    /// <summary>
+    /// Meta data describing the metrics of a report dataset.
+    /// </summary>
+    /// <param name="TotalCount">Total number of applicable records within report.</param>
+    /// <param name="Page">The current page of the dataset (Zero is the first page).</param>
+    /// <param name="PageSize">The total number of records to be returned per page.</param>
     public record ReportMetaData(int TotalCount, int? Page, int? PageSize);
 }

--- a/Apps/Admin/Common/Models/AdminReports/ReportMetaData.cs
+++ b/Apps/Admin/Common/Models/AdminReports/ReportMetaData.cs
@@ -15,10 +15,5 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Common.Models.AdminReports
 {
-    /// <summary>
-    /// Represents a protected dependent.
-    /// </summary>
-    /// <param name="Hdid">The dependent's HDID.</param>
-    /// <param name="Phn">The dependent's personal health number.</param>
-    public record ProtectedDependentRecord(string Hdid, string? Phn);
+    public record ReportMetaData(int TotalCount, int? Page, int? PageSize);
 }

--- a/Apps/Admin/Common/Models/AdminReports/ReportMetadata.cs
+++ b/Apps/Admin/Common/Models/AdminReports/ReportMetadata.cs
@@ -21,5 +21,5 @@ namespace HealthGateway.Admin.Common.Models.AdminReports
     /// <param name="TotalCount">Total number of applicable records within report.</param>
     /// <param name="Page">The current page of the dataset (Zero is the first page).</param>
     /// <param name="PageSize">The total number of records to be returned per page.</param>
-    public record ReportMetaData(int TotalCount, int? Page, int? PageSize);
+    public record ReportMetadata(int TotalCount, int? Page, int? PageSize);
 }

--- a/Apps/Admin/Server/Controllers/AdminReportController.cs
+++ b/Apps/Admin/Server/Controllers/AdminReportController.cs
@@ -82,7 +82,7 @@ namespace HealthGateway.Admin.Server.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IEnumerable<ProtectedDependentRecord>> ProtectedDependentsReport(
+        public async Task<ProtectedDependentReport> ProtectedDependentsReport(
             [FromQuery] int page = 0,
             [FromQuery] int pageSize = 25,
             [FromQuery] SortDirection sortDirection = SortDirection.Ascending,

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -71,7 +71,7 @@ namespace HealthGateway.Admin.Server.Services
 
                         return new ProtectedDependentRecord(hdid, patient?.Items.SingleOrDefault()?.Phn);
                     });
-            return new ProtectedDependentReport(await Task.WhenAll(tasks), new ReportMetaData(protectedHdids.TotalHdids, page, pageSize));
+            return new ProtectedDependentReport(await Task.WhenAll(tasks), new ReportMetadata(protectedHdids.TotalHdids, page, pageSize));
         }
 
         /// <inheritdoc/>

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -41,6 +41,7 @@ namespace HealthGateway.Admin.Server.Services
         /// <param name="delegationDelegate">The ResourceDelegate delegate to communicate with DB.</param>
         /// <param name="blockedAccessDelegate">The BlockedAccess delegate to communicate with DB.</param>
         /// <param name="patientRepository">The patient repository used to retrieve patient details.</param>
+        /// <param name="logger">Injected Logger.</param>
         public AdminReportService(IDelegationDelegate delegationDelegate, IBlockedAccessDelegate blockedAccessDelegate, IPatientRepository patientRepository, ILogger logger)
         {
             this.delegationDelegate = delegationDelegate;

--- a/Apps/Admin/Server/Services/IAdminReportService.cs
+++ b/Apps/Admin/Server/Services/IAdminReportService.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.Admin.Server.Services
         /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct">Cancellation token to manage async request.</param>
         /// <returns>A collection of HDID strings.</returns>
-        Task<IList<ProtectedDependentRecord>> GetProtectedDependentsReportAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct);
+        Task<ProtectedDependentReport> GetProtectedDependentsReportAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct);
 
         /// <summary>
         /// Retrieves a collection of user HDIDs and their blocked data sources.

--- a/Apps/Database/src/Delegates/DbDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDelegationDelegate.cs
@@ -103,7 +103,7 @@ namespace HealthGateway.Database.Delegates
                 .Take(safePageSize)
                 .Select(d => d.HdId)
                 .ToListAsync(ct);
-            int totalCount = this.dbContext.Dependent.Count(d => d.Protected);
+            int totalCount = await this.dbContext.Dependent.CountAsync(d => d.Protected, ct);
             return (records, totalCount);
         }
     }

--- a/Apps/Database/src/Delegates/DbDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDelegationDelegate.cs
@@ -84,7 +84,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IList<string>> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct)
+        public async Task<(IList<string> Hdids, int TotalHdids)> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct)
         {
             int safePageSize = pageSize > 0 ? pageSize : 25;
             int recordsToSkip = int.Max(page, 0) * safePageSize;
@@ -99,10 +99,12 @@ namespace HealthGateway.Database.Delegates
                 : query.OrderByDescending(d => d.HdId);
 
             // Get the records for the page
-            return await query.Skip(recordsToSkip)
+            List<string> records = await query.Skip(recordsToSkip)
                 .Take(safePageSize)
                 .Select(d => d.HdId)
                 .ToListAsync(ct);
+            int totalCount = this.dbContext.Dependent.Count(d => d.Protected);
+            return (records, totalCount);
         }
     }
 }

--- a/Apps/Database/src/Delegates/IDelegationDelegate.cs
+++ b/Apps/Database/src/Delegates/IDelegationDelegate.cs
@@ -56,6 +56,6 @@ namespace HealthGateway.Database.Delegates
         /// <param name="sortDirection">The sort direction for the records in the protected dependents report.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of HDID strings.</returns>
-        Task<IList<string>> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct);
+        Task<(IList<string> Hdids, int TotalHdids)> GetProtectedDependentHdidsAsync(int page, int pageSize, SortDirection sortDirection, CancellationToken ct);
     }
 }

--- a/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
+++ b/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
@@ -56,7 +56,7 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
     [Fact]
     public async Task RetrieveProtectedDependentsReport()
     {
-        ReportMetaData expectedMetaData = new(2, 1, 25);
+        ReportMetaData expectedMetaData = new(2, 0, 25);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents"); });
 
@@ -70,7 +70,7 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
     public async Task RetrieveProtectedDependentsReportDescending()
     {
         List<ProtectedDependentRecord> expectedRecords = this.protectedDependentRecords.Reverse().ToList();
-        ReportMetaData expectedMetaData = new(2, 1, 25);
+        ReportMetaData expectedMetaData = new(2, 0, 25);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?sortDirection=Descending"); });
 
@@ -87,9 +87,9 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
         {
             this.protectedDependentRecords[1],
         };
-        ReportMetaData expectedMetaData = new(2, 2, 1);
+        ReportMetaData expectedMetaData = new(2, 1, 1);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
-            scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?page=2&pageSize=1"); });
+            scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?page=1&pageSize=1"); });
 
         ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
         protectedDependents.Records.Count.ShouldBe(1);

--- a/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
+++ b/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
@@ -56,28 +56,28 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
     [Fact]
     public async Task RetrieveProtectedDependentsReport()
     {
-        ReportMetaData expectedMetaData = new(2, 0, 25);
+        ReportMetadata expectedMetadata = new(2, 0, 25);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents"); });
 
         ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
         protectedDependents.Records.Count.ShouldBe(2);
         protectedDependents.Records.ShouldBeEquivalentTo(this.protectedDependentRecords);
-        protectedDependents.MetaData.ShouldBeEquivalentTo(expectedMetaData);
+        protectedDependents.Metadata.ShouldBeEquivalentTo(expectedMetadata);
     }
 
     [Fact]
     public async Task RetrieveProtectedDependentsReportDescending()
     {
         List<ProtectedDependentRecord> expectedRecords = this.protectedDependentRecords.Reverse().ToList();
-        ReportMetaData expectedMetaData = new(2, 0, 25);
+        ReportMetadata expectedMetadata = new(2, 0, 25);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?sortDirection=Descending"); });
 
         ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
         protectedDependents.Records.Count.ShouldBe(2);
         protectedDependents.Records.ShouldBeEquivalentTo(expectedRecords);
-        protectedDependents.MetaData.ShouldBeEquivalentTo(expectedMetaData);
+        protectedDependents.Metadata.ShouldBeEquivalentTo(expectedMetadata);
     }
 
     [Fact]
@@ -87,13 +87,13 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
         {
             this.protectedDependentRecords[1],
         };
-        ReportMetaData expectedMetaData = new(2, 1, 1);
+        ReportMetadata expectedMetadata = new(2, 1, 1);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?page=1&pageSize=1"); });
 
         ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
         protectedDependents.Records.Count.ShouldBe(1);
         protectedDependents.Records.ShouldBeEquivalentTo(expectedResults);
-        protectedDependents.MetaData.ShouldBeEquivalentTo(expectedMetaData);
+        protectedDependents.Metadata.ShouldBeEquivalentTo(expectedMetadata);
     }
 }

--- a/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
+++ b/Testing/integration/tests/AdminReports/AdminApiAdminReportTests.cs
@@ -47,7 +47,7 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
         blockedAccessRecords.ShouldBeEquivalentTo(expectedRecords);
     }
 
-    private readonly IList<ProtectedDependentRecord> protectedDependentReport = new List<ProtectedDependentRecord>
+    private readonly IList<ProtectedDependentRecord> protectedDependentRecords = new List<ProtectedDependentRecord>
     {
         new("35224807075386271", "9872868128"),
         new("508820774378599978", "9872868103"),
@@ -56,24 +56,28 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
     [Fact]
     public async Task RetrieveProtectedDependentsReport()
     {
+        ReportMetaData expectedMetaData = new(2, 1, 25);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents"); });
 
-        IEnumerable<ProtectedDependentRecord> protectedDependents = (await scenarioResponse.ReadAsJsonAsync<IEnumerable<ProtectedDependentRecord>>()).ShouldNotBeNull();
-        protectedDependents.Count().ShouldBe(2);
-        protectedDependents.ShouldBeEquivalentTo(this.protectedDependentReport);
+        ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
+        protectedDependents.Records.Count.ShouldBe(2);
+        protectedDependents.Records.ShouldBeEquivalentTo(this.protectedDependentRecords);
+        protectedDependents.MetaData.ShouldBeEquivalentTo(expectedMetaData);
     }
 
     [Fact]
     public async Task RetrieveProtectedDependentsReportDescending()
     {
-        List<ProtectedDependentRecord> expectedResults = this.protectedDependentReport.Reverse().ToList();
+        List<ProtectedDependentRecord> expectedRecords = this.protectedDependentRecords.Reverse().ToList();
+        ReportMetaData expectedMetaData = new(2, 1, 25);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?sortDirection=Descending"); });
 
-        IEnumerable<ProtectedDependentRecord> protectedDependents = (await scenarioResponse.ReadAsJsonAsync<IEnumerable<ProtectedDependentRecord>>()).ShouldNotBeNull();
-        protectedDependents.Count().ShouldBe(2);
-        protectedDependents.ShouldBeEquivalentTo(expectedResults);
+        ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
+        protectedDependents.Records.Count.ShouldBe(2);
+        protectedDependents.Records.ShouldBeEquivalentTo(expectedRecords);
+        protectedDependents.MetaData.ShouldBeEquivalentTo(expectedMetaData);
     }
 
     [Fact]
@@ -81,13 +85,15 @@ public class AdminApiAdminReportsTests : ScenarioContextBase<Program>
     {
         IList<ProtectedDependentRecord> expectedResults = new List<ProtectedDependentRecord>
         {
-            this.protectedDependentReport[1],
+            this.protectedDependentRecords[1],
         };
+        ReportMetaData expectedMetaData = new(2, 2, 1);
         IScenarioResult scenarioResponse = await this.Host.Scenario(
             scenario => { scenario.Get.Url("/v1/api/AdminReport/ProtectedDependents?page=2&pageSize=1"); });
 
-        IEnumerable<ProtectedDependentRecord> protectedDependents = (await scenarioResponse.ReadAsJsonAsync<IEnumerable<ProtectedDependentRecord>>()).ShouldNotBeNull();
-        protectedDependents.Count().ShouldBe(1);
-        protectedDependents.ShouldBeEquivalentTo(expectedResults);
+        ProtectedDependentReport protectedDependents = (await scenarioResponse.ReadAsJsonAsync<ProtectedDependentReport>()).ShouldNotBeNull();
+        protectedDependents.Records.Count.ShouldBe(1);
+        protectedDependents.Records.ShouldBeEquivalentTo(expectedResults);
+        protectedDependents.MetaData.ShouldBeEquivalentTo(expectedMetaData);
     }
 }


### PR DESCRIPTION
# Implements [AB#16271](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16271)

## Description
1. Implement server side data and pagination for protected dependent report.
2. Update structure of report response endpoint to include report meta data for MudTable pagination.
3. Update current integration tests to consume new report response type.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

### Unit tests:
![image](https://github.com/bcgov/healthgateway/assets/19548348/b1e22a0f-3409-4e3c-a5af-aec30fc14de9)

### Functional tests
Functional tests to be implemented by next task in story.

## UI Changes

Demo notes:
1. Rows are clickable only if Phn is present.
2. New Phn value is visisble in table
3. If Phn is not available in the table the hdid is still displayed.

https://github.com/bcgov/healthgateway/assets/19548348/d38b7725-992f-422c-b201-6ec6cd5b901e

Error's are still reported on failures in the Endpoint:
![image](https://github.com/bcgov/healthgateway/assets/19548348/4bbc12eb-13f9-4281-9793-873f6217c350)

## Notes

### Regarding Server side implementation
1. We abandon the store when implementing the ServerData property on the MudTable component.
2. Keeping with the store and pagination is complicated and the tradeoff isn't worth it.
3. The following tutorial is a good step by step to follow for server side table:
    * https://code-maze.com/blazor-material-table-paging-searching-sorting/

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
