### PR TITLE
Correct null handling in dateWrapper for AB#16356

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/models/dateWrapper.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/dateWrapper.ts
@@ -241,7 +241,7 @@ export class DateWrapper implements IDateWrapper {
         defaultZone: string = pacificTimeZone
     ): DateWrapper {
         return new DateWrapper(
-            DateTime.fromISO(dateString!, { zone: defaultZone }).setZone(
+            DateTime.fromISO(dateString || "", { zone: defaultZone }).setZone(
                 pacificTimeZone
             )
         );
@@ -255,9 +255,13 @@ export class DateWrapper implements IDateWrapper {
      */
     public static fromIsoDate(dateString?: string | null): DateWrapper {
         return new DateWrapper(
-            DateTime.fromFormat(dateString?.substring(0, 10)!, "yyyy-MM-dd", {
-                zone: pacificTimeZone,
-            })
+            DateTime.fromFormat(
+                (dateString || "").substring(0, 10),
+                "yyyy-MM-dd",
+                {
+                    zone: pacificTimeZone,
+                }
+            )
         );
     }
 

--- a/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
@@ -59,63 +59,6 @@ describe("Reports - Medication", () => {
                     });
             });
     });
-
-    it("Validate Immunization Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/Immunization?hdid=${HDID}`, {
-            fixture: "Report/immunizationUnSorted.json",
-        });
-        cy.vSelect("[data-testid=report-type]", "Immunizations");
-
-        cy.get("[data-testid=report-sample]").should("be.visible");
-
-        cy.get("[data-testid=immunizationDateItem]")
-            .first()
-            .then(($dateItem) => {
-                // Column date in the 1st row in the table
-                const firstDate = new Date($dateItem.text().trim());
-                cy.get("[data-testid=immunizationDateItem]")
-                    .eq(1)
-                    .then(($dateItem) => {
-                        // Column date in the 2nd row in the table
-                        const secondDate = new Date($dateItem.text().trim());
-                        expect(firstDate).to.be.gte(secondDate);
-                        // Column date in the last row in the table
-                        cy.get("[data-testid=immunizationDateItem]")
-                            .eq(2)
-                            .then(($dateItem) => {
-                                // Column date in the last row in the table
-                                const lastDate = new Date(
-                                    $dateItem.text().trim()
-                                );
-                                expect(firstDate).to.be.gte(lastDate);
-                                expect(secondDate).to.be.gte(lastDate);
-                            });
-                    });
-            });
-
-        cy.get("[data-testid=recommendationDateItem]")
-            .first()
-            .then(($dateItem) => {
-                // Column date in the 1st row in the table
-                const firstDate = getDate($dateItem.text());
-                cy.get("[data-testid=recommendationDateItem]")
-                    .eq(1)
-                    .then(($dateItem) => {
-                        // Column date in the 2nd row in the table
-                        const secondDate = getDate($dateItem.text());
-                        expect(firstDate).to.be.gte(secondDate);
-                        // Column date in the last row in the table
-                        cy.get("[data-testid=recommendationDateItem]")
-                            .eq(4)
-                            .then(($dateItem) => {
-                                // Column date in the last row in the table
-                                const lastDate = getDate($dateItem.text());
-                                expect(firstDate).to.be.gte(lastDate);
-                                expect(secondDate).to.be.gte(lastDate);
-                            });
-                    });
-            });
-    });
 });
 
 describe("Reports - Covid19", () => {


### PR DESCRIPTION
# Fixes [AB#16356](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16356)

## Description
1. Correctly handle null passed to `DateWrapper.fromIsoDate`
2. Removed duplicate immunization test from reportSorting.js

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

![image](https://github.com/bcgov/healthgateway/assets/19548348/91c8d1a7-2f13-4628-a300-305a6f520683)

![image](https://github.com/bcgov/healthgateway/assets/19548348/69945f1f-37c3-486a-8019-dd3249cf440a)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
