### PR TITLE
Implement change feed for blocked data sources for AB#15397.

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -86,7 +86,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="command">The command details used to block access.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>The agent audit entry created from the operation.</returns>
-        Task BlockAccess(BlockAccessCommand command, CancellationToken ct = default);
+        Task BlockAccessAsync(BlockAccessCommand command, CancellationToken ct = default);
     }
 
     /// <summary>

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -80,7 +80,7 @@ namespace HealthGateway.AccountDataAccess.Patient
             this.patientQueryFactory = patientQueryFactory;
             this.messageSender = messageSender;
             this.blockedAccessCacheTtl = configuration.GetValue($"{BlockedAccessKey}:{CacheTtlKey}", 30);
-            this.changeFeedEnabled = configuration.GetSection(ChangeFeedConfigSection).GetValue($"{BlockedDataSourceChangeFeedKey}:Enabled", false);
+            this.changeFeedEnabled = configuration.GetValue($"{ChangeFeedConfigSection}:{BlockedDataSourceChangeFeedKey}:Enabled", false);
         }
 
         /// <inheritdoc/>

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -146,7 +146,8 @@ namespace HealthGateway.AccountDataAccess.Patient
 
             if (this.changeFeedEnabled)
             {
-                await this.messageSender.SendAsync(new[] { new MessageEnvelope(new DataSourcesBlockedEvent(command.Hdid, blockedAccess.DataSources), command.Hdid) }, ct);
+                IEnumerable<string> dataSourceValues = blockedAccess.DataSources.Select(ds => Enum.GetName(typeof(DataSource), ds))!;
+                await this.messageSender.SendAsync(new[] { new MessageEnvelope(new DataSourcesBlockedEvent(command.Hdid, dataSourceValues), command.Hdid) }, ct);
             }
         }
 

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -419,7 +419,7 @@ namespace AccountDataAccessTest
         private static bool AssertDataSourcesBlockedEvent(BlockedAccess expected, DataSourcesBlockedEvent actual)
         {
             Assert.Equal(expected.Hdid, actual.Hdid);
-            Assert.Equal(expected.DataSources, actual.DataSources);
+            Assert.Equal(GetDataSourceValues(expected.DataSources), actual.DataSources);
             return true;
         }
 
@@ -453,7 +453,7 @@ namespace AccountDataAccessTest
             {
                 IEnumerable<MessageEnvelope> events = new MessageEnvelope[]
                 {
-                    new(new DataSourcesBlockedEvent(blockedAccess.Hdid, blockedAccess.DataSources), blockedAccess.Hdid),
+                    new(new DataSourcesBlockedEvent(blockedAccess.Hdid, GetDataSourceValues(blockedAccess.DataSources)), blockedAccess.Hdid),
                 };
                 messageSender.Setup(ms => ms.SendAsync(events, It.IsAny<CancellationToken>()));
             }
@@ -551,6 +551,11 @@ namespace AccountDataAccessTest
 
             ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
             return new(serviceProvider);
+        }
+
+        private static IEnumerable<string> GetDataSourceValues(HashSet<DataSource> dataSources)
+        {
+            return dataSources.Select(ds => Enum.GetName(typeof(DataSource), ds))!;
         }
     }
 }

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -30,6 +30,8 @@ namespace AccountDataAccessTest
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
+    using HealthGateway.Common.Messaging;
+    using HealthGateway.Common.Models.Events;
     using HealthGateway.Common.Utils;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
@@ -231,14 +233,22 @@ namespace AccountDataAccessTest
         /// <summary>
         /// Block access.
         /// </summary>
+        /// <param name="blockedDataSourcesEnabled">
+        /// The value indicates whether blocked data sources change feed should be enabled
+        /// or not.
+        /// </param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        [Fact]
-        public async Task ShouldBlockAccess()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ShouldBlockAccess(bool blockedDataSourcesEnabled)
         {
             // Arrange
-            string reason = "Unit Test Block Access";
+            const string reason = "Unit Test Block Access";
+            bool commit = !blockedDataSourcesEnabled;
 
             Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
+            Mock<IMessageSender> messageSender = new();
             HashSet<DataSource> dataSources = new()
             {
                 DataSource.Immunization,
@@ -260,16 +270,28 @@ namespace AccountDataAccessTest
             };
 
             BlockAccessCommand command = new(Hdid, dataSources, reason);
-            PatientRepository patientRepository = GetPatientRepository(blockedAccess, blockedAccessDelegate);
+            PatientRepository patientRepository = GetPatientRepository(blockedAccess, blockedAccessDelegate, blockedDataSourcesEnabled, messageSender);
 
             // Act
-            await patientRepository.BlockAccess(command);
+            await patientRepository.BlockAccessAsync(command);
 
             // Verify
             blockedAccessDelegate.Verify(
-                v => v.UpdateBlockedAccessAsync(
+                d => d.UpdateBlockedAccessAsync(
                     It.Is<BlockedAccess>(ba => AssertBlockedAccess(blockedAccess, ba)),
-                    It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa))));
+                    It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa)),
+                    commit));
+
+            if (blockedDataSourcesEnabled)
+            {
+                messageSender.Verify(
+                    s => s.SendAsync(
+                        It.Is<IEnumerable<MessageEnvelope>>(
+                            me => AssertDataSourcesBlockedEvent(
+                                blockedAccess,
+                                me.Select(envelope => envelope.Content as DataSourcesBlockedEvent)!.First())),
+                        It.IsAny<CancellationToken>()));
+            }
         }
 
         /// <summary>
@@ -394,11 +416,19 @@ namespace AccountDataAccessTest
             return true;
         }
 
-        private static IConfigurationRoot GetIConfigurationRoot()
+        private static bool AssertDataSourcesBlockedEvent(BlockedAccess expected, DataSourcesBlockedEvent actual)
+        {
+            Assert.Equal(expected.Hdid, actual.Hdid);
+            Assert.Equal(expected.DataSources, actual.DataSources);
+            return true;
+        }
+
+        private static IConfigurationRoot GetIConfigurationRoot(bool blockedDataSourcesEnabled = false)
         {
             Dictionary<string, string?> myConfiguration = new()
             {
                 { "BlockedAccess:CacheTtl", "5" },
+                { "ChangeFeed:BlockedDataSources:Enabled", blockedDataSourcesEnabled.ToString() },
             };
 
             return new ConfigurationBuilder()
@@ -408,11 +438,25 @@ namespace AccountDataAccessTest
 
         private static PatientRepository GetPatientRepository(
             BlockedAccess blockedAccess,
-            Mock<IBlockedAccessDelegate>? blockedAccessDelegate = null)
+            Mock<IBlockedAccessDelegate>? blockedAccessDelegate = null,
+            bool? blockedDataSourcesEnabled = null,
+            Mock<IMessageSender>? messageSender = null)
         {
-            blockedAccessDelegate = blockedAccessDelegate ?? new();
+            blockedAccessDelegate ??= new();
             blockedAccessDelegate.Setup(p => p.GetBlockedAccessAsync(It.IsAny<string>())).ReturnsAsync(blockedAccess);
             blockedAccessDelegate.Setup(p => p.GetDataSourcesAsync(It.IsAny<string>())).ReturnsAsync(blockedAccess.DataSources);
+
+            bool changeFeedEnabled = blockedDataSourcesEnabled ?? false;
+            messageSender ??= new();
+
+            if (changeFeedEnabled)
+            {
+                IEnumerable<MessageEnvelope> events = new MessageEnvelope[]
+                {
+                    new(new DataSourcesBlockedEvent(blockedAccess.Hdid, blockedAccess.DataSources), blockedAccess.Hdid),
+                };
+                messageSender.Setup(ms => ms.SendAsync(events, It.IsAny<CancellationToken>()));
+            }
 
             string blockedAccessCacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, blockedAccess.Hdid);
             Mock<ICacheProvider> cacheProvider = new();
@@ -428,10 +472,11 @@ namespace AccountDataAccessTest
                 blockedAccessDelegate.Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 cacheProvider.Object,
-                GetIConfigurationRoot(),
+                GetIConfigurationRoot(blockedDataSourcesEnabled ?? false),
                 GetPatientQueryFactory(
                     new PatientModel(),
-                    new PatientDetailsQuery(Hdid: Hdid, Source: PatientDetailSource.All, UseCache: false)));
+                    new PatientDetailsQuery(Hdid: Hdid, Source: PatientDetailSource.All, UseCache: false)),
+                messageSender.Object);
             return patientRepository;
         }
 
@@ -447,7 +492,8 @@ namespace AccountDataAccessTest
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<ICacheProvider>().Object,
                 GetIConfigurationRoot(),
-                GetPatientQueryFactory(patient, patientDetailsQuery, patientIdentity, cachedPatient));
+                GetPatientQueryFactory(patient, patientDetailsQuery, patientIdentity, cachedPatient),
+                new Mock<IMessageSender>().Object);
             return patientRepository;
         }
 

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -208,7 +208,7 @@ namespace HealthGateway.Admin.Server.Services
         public async Task BlockAccessAsync(string hdid, IEnumerable<DataSource> dataSources, string reason, CancellationToken ct = default)
         {
             BlockAccessCommand blockAccessCommand = new(hdid, dataSources, reason);
-            await this.patientRepository.BlockAccess(blockAccessCommand, ct).ConfigureAwait(true);
+            await this.patientRepository.BlockAccessAsync(blockAccessCommand, ct).ConfigureAwait(true);
         }
 
         private async Task<IEnumerable<UserProfile>> GetDelegateProfilesAsync(string dependentPhn, CancellationToken ct)

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -208,7 +208,7 @@ namespace HealthGateway.Admin.Server.Services
         public async Task BlockAccessAsync(string hdid, IEnumerable<DataSource> dataSources, string reason, CancellationToken ct = default)
         {
             BlockAccessCommand blockAccessCommand = new(hdid, dataSources, reason);
-            await this.patientRepository.BlockAccessAsync(blockAccessCommand, ct).ConfigureAwait(true);
+            await this.patientRepository.BlockAccessAsync(blockAccessCommand, ct);
         }
 
         private async Task<IEnumerable<UserProfile>> GetDelegateProfilesAsync(string dependentPhn, CancellationToken ct)

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -50,6 +50,9 @@
     "ChangeFeed": {
         "Dependents": {
             "Enabled": true
+        },
+        "BlockedDataSources": {
+            "Enabled": true
         }
     }
 }

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -47,5 +47,13 @@
     "BCMailPlus": {
         "JobEnvironment": "JOB_TEST"
     },
+    "ChangeFeed": {
+        "Dependents": {
+            "Enabled": true
+        },
+        "BlockedDataSources": {
+            "Enabled": true
+        }
+    },
     "RedisAuditing": true
 }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -139,5 +139,13 @@
     "Delegation": {
         "MaxDependentAge": 12,
         "MinDelegateAge": 12
+    },
+    "ChangeFeed": {
+        "Dependents": {
+            "Enabled": false
+        },
+        "BlockedDataSources": {
+            "Enabled": false
+        }
     }
 }

--- a/Apps/Common/src/Models/Events/DataSourcesBlockedEvent.cs
+++ b/Apps/Common/src/Models/Events/DataSourcesBlockedEvent.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Common.Models.Events;
 
 using System.Collections.Generic;
-using HealthGateway.Common.Data.Constants;
 using HealthGateway.Common.Messaging;
 
 /// <summary>
@@ -24,4 +23,4 @@ using HealthGateway.Common.Messaging;
 /// </summary>
 /// <param name="Hdid">The hdid associated with the blocked data source(s)</param>
 /// <param name="DataSources">The data sources to block.</param>
-public record DataSourcesBlockedEvent(string Hdid, IEnumerable<DataSource> DataSources) : MessageBase;
+public record DataSourcesBlockedEvent(string Hdid, IEnumerable<string> DataSources) : MessageBase;

--- a/Apps/Common/src/Models/Events/DataSourcesBlockedEvent.cs
+++ b/Apps/Common/src/Models/Events/DataSourcesBlockedEvent.cs
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Models.Events;
+
+using System.Collections.Generic;
+using HealthGateway.Common.Data.Constants;
+using HealthGateway.Common.Messaging;
+
+/// <summary>
+/// Represents a data source(s) blocked event
+/// </summary>
+/// <param name="Hdid">The hdid associated with the blocked data source(s)</param>
+/// <param name="DataSources">The data sources to block.</param>
+public record DataSourcesBlockedEvent(string Hdid, IEnumerable<DataSource> DataSources) : MessageBase;

--- a/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task DeleteBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit)
+        public async Task DeleteBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true)
         {
             this.logger.LogDebug("Blocked access version: {Version} for hdid: {Hdid}", blockedAccess.Version, blockedAccess.Hdid);
 
@@ -56,7 +56,7 @@ namespace HealthGateway.Database.Delegates
 
             this.dbContext.AgentAudit.Add(agentAudit);
 
-            await this.dbContext.SaveChangesAsync().ConfigureAwait(true);
+            await this.dbContext.SaveChangesAsync();
         }
 
         /// <inheritdoc/>
@@ -65,7 +65,7 @@ namespace HealthGateway.Database.Delegates
             IQueryable<BlockedAccess> query = this.dbContext.BlockedAccess
                 .Where(d => d.Hdid == hdid);
 
-            return await query.SingleOrDefaultAsync().ConfigureAwait(true);
+            return await query.SingleOrDefaultAsync();
         }
 
         /// <inheritdoc/>
@@ -78,7 +78,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit)
+        public async Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true)
         {
             if (blockedAccess.Version == 0)
             {
@@ -91,7 +91,10 @@ namespace HealthGateway.Database.Delegates
 
             this.dbContext.AgentAudit.Add(agentAudit);
 
-            await this.dbContext.SaveChangesAsync().ConfigureAwait(true);
+            if (commit)
+            {
+                await this.dbContext.SaveChangesAsync();
+            }
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
@@ -31,8 +31,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="blockedAccess">The blocked access object to delete.</param>
         /// <param name="agentAudit">The agent audit to create.</param>
+        /// <param name="commit">Should commit, default to true.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task DeleteBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit);
+        Task DeleteBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true);
 
         /// <summary>
         /// Fetches the blocked access by hdid from the database.
@@ -53,8 +54,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="blockedAccess">The blocked access object to add or update.</param>
         /// <param name="agentAudit">The agent audit to create.</param>
+        /// <param name="commit">Should commit, default to true.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit);
+        Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true);
 
         /// <summary>
         /// Retrieves all blocked access records.

--- a/Testing/integration/tests/AdminSupport/PatientRepositoryBlockAccessTests.cs
+++ b/Testing/integration/tests/AdminSupport/PatientRepositoryBlockAccessTests.cs
@@ -1,0 +1,58 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.IntegrationTests.AdminSupport;
+
+using Alba;
+using HealthGateway.Admin.Common.Models;
+using HealthGateway.Admin.Server;
+using HealthGateway.Common.Data.Constants;
+using HealthGateway.Common.Models.Events;
+using HealthGateway.Database.Models;
+using Microsoft.EntityFrameworkCore;
+using Xunit.Abstractions;
+using Xunit.Categories;
+
+[IntegrationTest]
+public class PatientRepositoryBlockAccessTests : ScenarioContextBase<Program>
+{
+    private readonly string hdid = "e3d1b6ce-781d-4adc-ab40-a9e9ae847d93";
+
+    public PatientRepositoryBlockAccessTests(ITestOutputHelper output, WebAppFixture fixture) : base(output, TestConfiguration.AdminConfigSection, fixture)
+    {
+    }
+
+    [Fact]
+    public async Task BlockAccess()
+    {
+        await this.Host.Scenario(
+            scenario =>
+            {
+                scenario.Put.Json(
+                        new BlockAccessRequest(
+                            new List<DataSource> { DataSource.ClinicalDocument },
+                            "Block data source for integration test."))
+                    .ToUrl($"/v1/api/Support/{this.hdid}/BlockAccess");
+                scenario.StatusCodeShouldBeOk();
+            });
+
+        await this.Assert(
+            async ctx =>
+            {
+                List<OutboxItem> outboxItems = await ctx.Outbox.Where(i => i.Metadata.SessionId == this.hdid && i.Metadata.Type == nameof(DataSourcesBlockedEvent)).ToListAsync();
+                outboxItems.Count.ShouldBe(1);
+            });
+    }
+}


### PR DESCRIPTION
# Implements [AB#15397](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15397)

## Description

- Implemented change feed functionality for block access
- Renamed BlockAccess to BlockAccessAsync in PatientRepository
- Removed ConfigureAwait(true) as it is no longer required in touched. code and areas around touched code 
- Updated unit tests to include change feed functionality
- Added integration test for Block Access and change feed

**Unit and Integration Tests:**

<img width="1273" alt="Screenshot 2023-10-25 at 6 23 55 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/4ef2a0b8-e316-4cfa-9740-afc4cdc24e1b">

**Functional Tests:**

<img width="1254" alt="Screenshot 2023-10-25 at 5 10 56 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/d8add663-5fb3-4565-971e-86737f57f2c0">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
