### PR TITLE
Add dependent table to patient details page AB#15578

### DIFF
--- a/Apps/Admin/Client/Components/Support/DependentTable.razor
+++ b/Apps/Admin/Client/Components/Support/DependentTable.razor
@@ -1,0 +1,75 @@
+@using HealthGateway.Common.Data.Utils
+@inherits Fluxor.Blazor.Web.Components.FluxorComponent
+
+<MudText Class="mt-4" Typo="Typo.subtitle1">
+    Dependents
+</MudText>
+
+<MudTable Class="mt-4"
+          Items="@Rows"
+          Loading="@IsLoading"
+          AllowUnsorted="false"
+          Breakpoint="@Breakpoint.Md"
+          HorizontalScrollbar="true"
+          Striped="true"
+          Dense="true"
+          data-testid="dependent-table">
+    <ColGroup>
+        <MudHidden Breakpoint="@Breakpoint.MdAndDown">
+            <col />
+            <col style="width: 125px;" />
+            <col />
+            <col />
+            <col style="width: 145px;" />
+            <col />
+        </MudHidden>
+    </ColGroup>
+    <HeaderContent>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<DependentRow, object>(x => x.Name)">
+                Name
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<DependentRow, object>(x => x.Birthdate)" InitialDirection="@SortDirection.Ascending">
+                DOB
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<DependentRow, object>(x => x.Phn)">
+                PHN
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<DependentRow, object>(x => x.Address)">
+                Address
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<DependentRow, object>(x => x.ExpiryDate)">
+                Expiry Date
+            </MudTableSortLabel>
+        </MudTh>
+        <MudTh>
+            <MudTableSortLabel SortBy="new Func<DependentRow, object>(x => x.Protected)">
+                Protected
+            </MudTableSortLabel>
+        </MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd data-testid="dependent-name" DataLabel="Name">@context.Name</MudTd>
+        <MudTd data-testid="dependent-dob" DataLabel="DOB">@DateFormatter.ToShortDate(context.Birthdate)</MudTd>
+        <MudTd data-testid="dependent-phn" DataLabel="PHN">@context.Phn</MudTd>
+        <MudTd data-testid="dependent-address" DataLabel="Address">@context.Address</MudTd>
+        <MudTd data-testid="dependent-expiry-date" DataLabel="Expiry Date">@DateFormatter.ToShortDate(context.ExpiryDate)</MudTd>
+        <MudTd data-testid="dependent-protected" DataLabel="Protected">
+            @if (context.Protected)
+            {
+                <MudIcon data-testid="dependent-protected-icon" Icon="fas fa-check" Color="@Color.Primary" />
+            }
+        </MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager />
+    </PagerContent>
+</MudTable>

--- a/Apps/Admin/Client/Components/Support/DependentTable.razor.cs
+++ b/Apps/Admin/Client/Components/Support/DependentTable.razor.cs
@@ -1,0 +1,75 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Components.Support
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Fluxor.Blazor.Web.Components;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Common.Data.Utils;
+    using Microsoft.AspNetCore.Components;
+
+    /// <summary>
+    /// Backing logic for the dependent table.
+    /// </summary>
+    public partial class DependentTable : FluxorComponent
+    {
+        /// <summary>
+        /// Gets or sets the data with which to populate the table.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public IEnumerable<PatientSupportDependentInfo> Data { get; set; } = Enumerable.Empty<PatientSupportDependentInfo>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether data is loading.
+        /// </summary>
+        [Parameter]
+        [EditorRequired]
+        public bool IsLoading { get; set; } = true;
+
+        private IEnumerable<DependentRow> Rows => this.Data.Select(mv => new DependentRow(mv));
+
+        private sealed record DependentRow
+        {
+            public DependentRow(PatientSupportDependentInfo model)
+            {
+                this.Hdid = model.Hdid;
+                this.Phn = model.Phn;
+                this.Name = StringManipulator.JoinWithoutBlanks(new[] { model.FirstName, model.LastName });
+                this.Birthdate = DateOnly.FromDateTime(model.Birthdate);
+                this.Address = AddressUtility.GetAddressAsSingleLine(model.PhysicalAddress ?? model.PostalAddress);
+                this.Protected = model.Protected;
+                this.ExpiryDate = model.ExpiryDate;
+            }
+
+            public string Hdid { get; } = string.Empty;
+
+            public string Phn { get; } = string.Empty;
+
+            public string Name { get; } = string.Empty;
+
+            public DateOnly Birthdate { get; }
+
+            public string Address { get; } = string.Empty;
+
+            public bool Protected { get; }
+
+            public DateOnly ExpiryDate { get; }
+        }
+    }
+}

--- a/Apps/Admin/Client/Components/Support/MessageVerificationTable.razor.cs
+++ b/Apps/Admin/Client/Components/Support/MessageVerificationTable.razor.cs
@@ -26,7 +26,7 @@ namespace HealthGateway.Admin.Client.Components.Support
     using Microsoft.Extensions.Configuration;
 
     /// <summary>
-    /// Backing logic for the messaging verification table page.
+    /// Backing logic for the messaging verification table.
     /// </summary>
     public partial class MessageVerificationTable : FluxorComponent
     {

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -117,6 +117,11 @@
         {
             <AgentAuditHistory Title="Agent Reason History" AgentActions="@AgentAuditHistory" IsLoading="@PatientSupportDetailsLoading" />
         }
+
+        if (CanViewDependents)
+        {
+            <DependentTable Data="@Dependents" IsLoading="@PatientSupportDetailsLoading" />
+        }
     }
     else if (CanViewAccountDetails)
     {

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -72,6 +72,8 @@ namespace HealthGateway.Admin.Client.Pages
         private IEnumerable<AgentAction> AgentAuditHistory =>
             this.PatientDetailsState.Value.AgentActions?.OrderByDescending(a => a.TransactionDateTime) ?? Enumerable.Empty<AgentAction>();
 
+        private IEnumerable<PatientSupportDependentInfo> Dependents => this.PatientDetailsState.Value.Dependents ?? Enumerable.Empty<PatientSupportDependentInfo>();
+
         private VaccineDetails? VaccineDetails => this.PatientDetailsState.Value.VaccineDetails;
 
         private CovidAssessmentDetailsResponse? AssessmentInfo => this.PatientDetailsState.Value.Result?.CovidAssessmentDetails;
@@ -111,6 +113,8 @@ namespace HealthGateway.Admin.Client.Pages
         private bool CanEditDatasetAccess => this.UserHasRole(Roles.Admin);
 
         private bool CanViewAgentAuditHistory => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
+
+        private bool CanViewDependents => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
 
         private bool CanViewHdid => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
 

--- a/Apps/Admin/Client/Store/PatientDetails/PatientDetailsReducers.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientDetailsReducers.cs
@@ -41,6 +41,7 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
                 MessagingVerifications = action.Data.MessagingVerifications?.ToImmutableList(),
                 BlockedDataSources = action.Data.BlockedDataSources?.ToImmutableList(),
                 AgentActions = action.Data.AgentActions?.ToImmutableList(),
+                Dependents = action.Data.Dependents?.ToImmutableList(),
                 VaccineDetails = action.Data.VaccineDetails,
                 CovidAssessmentDetails = action.Data.CovidAssessmentDetails,
             };
@@ -67,6 +68,7 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
                 MessagingVerifications = null,
                 BlockedDataSources = null,
                 AgentActions = null,
+                Dependents = null,
                 VaccineDetails = null,
                 CovidAssessmentDetails = null,
             };

--- a/Apps/Admin/Client/Store/PatientDetails/PatientDetailsState.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientDetailsState.cs
@@ -41,6 +41,11 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
         public ImmutableList<AgentAction>? AgentActions { get; init; }
 
         /// <summary>
+        /// Gets the dependents linked to the patient support details.
+        /// </summary>
+        public ImmutableList<PatientSupportDependentInfo>? Dependents { get; init; }
+
+        /// <summary>
         /// Gets the blocked data sources linked to the patient support details.
         /// </summary>
         public ImmutableList<DataSource>? BlockedDataSources { get; init; }


### PR DESCRIPTION
# Implements [AB#15578](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/15578)

## Description

Displays dependents underneath agent actions on the patient details page, for users with the AdminUser or AdminReviewer role.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![scrnli_10_26_2023_5-34-50 PM](https://github.com/bcgov/healthgateway/assets/16570293/5de913e2-db50-4707-b54a-cf9c7e5f97a2)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
