### PR TITLE
Bind feed settings to class for AB#16372

### DIFF
--- a/Apps/Common/src/Constants/ChangeFeedOptions.cs
+++ b/Apps/Common/src/Constants/ChangeFeedOptions.cs
@@ -18,26 +18,36 @@ namespace HealthGateway.Common.Constants
     /// <summary>
     /// Change feed configuration constants.
     /// </summary>
-    public static class ChangeFeedConfiguration
+    public class ChangeFeedOptions
     {
         /// <summary>
         /// The configuration section key.
         /// </summary>
-        public static readonly string ConfigurationSectionKey = "ChangeFeed";
+        public const string ChangeFeed = "ChangeFeed";
 
         /// <summary>
-        /// The internal change feed configuration key for dependent events.
+        /// Gets or sets the configuration for users events.
         /// </summary>
-        public static readonly string DependentsKey = "Dependents";
+        public ChangeFeedConfiguration Dependents { get; set; } = new(false);
 
         /// <summary>
-        /// The internal change feed configuration key for account events.
+        /// Gets or sets the configuration for accounts events.
         /// </summary>
-        public static readonly string AccountsKey = "Accounts";
+        public ChangeFeedConfiguration Accounts { get; set; } = new(false);
 
         /// <summary>
-        /// The internal change feed configuration key for notification verification events.
+        /// Gets or sets the configuration for notifications events.
         /// </summary>
-        public static readonly string NotificationChannelVerifiedKey = "NotificationChannelVerified";
+        public ChangeFeedConfiguration Notifications { get; set; } = new(false);
+
+        /// <summary>
+        /// Gets or sets the configuration for blocked data sources events.
+        /// </summary>
+        public ChangeFeedConfiguration BlockedDataSources { get; set; } = new(false);
     }
+
+    /// <summary>
+    /// Change feed event configuration.
+    /// </summary>
+    public record ChangeFeedConfiguration(bool Enabled);
 }

--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -55,7 +55,7 @@ namespace HealthGateway.GatewayApi.Services
         private readonly IMapper autoMapper;
         private readonly ILogger logger;
         private readonly int maxDependentAge;
-        private readonly bool changeFeedEnabled;
+        private readonly bool dependentsChangeFeedEnabled;
         private readonly INotificationSettingsService notificationSettingsService;
         private readonly IPatientService patientService;
         private readonly IDelegationDelegate delegationDelegate;
@@ -94,8 +94,8 @@ namespace HealthGateway.GatewayApi.Services
             this.userProfileDelegate = userProfileDelegate;
             this.messageSender = messageSender;
             this.maxDependentAge = configuration.GetSection(WebClientConfigSection).GetValue(MaxDependentAgeKey, 12);
-            this.changeFeedEnabled = configuration.GetSection(ChangeFeedConfiguration.ConfigurationSectionKey)
-                .GetValue($"{ChangeFeedConfiguration.DependentsKey}:Enabled", false);
+            ChangeFeedOptions? changeFeedConfiguration = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>();
+            this.dependentsChangeFeedEnabled = changeFeedConfiguration?.Dependents.Enabled ?? false;
             this.autoMapper = autoMapper;
         }
 
@@ -129,14 +129,14 @@ namespace HealthGateway.GatewayApi.Services
 
             // commit to the database if change feed is disabled; if change feed enabled, commit will happen when message sender is called
             // this is temporary and will be changed when we introduce a proper unit of work to manage transactionality.
-            DbResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Insert(resourceDelegate, !this.changeFeedEnabled);
+            DbResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Insert(resourceDelegate, !this.dependentsChangeFeedEnabled);
             if (dbDependent.Status == DbStatusCode.Error)
             {
                 throw new ProblemDetailsException(ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", dbDependent.Message));
             }
 
             this.UpdateNotificationSettings(dependentHdid, delegateHdid);
-            if (this.changeFeedEnabled)
+            if (this.dependentsChangeFeedEnabled)
             {
                 await this.messageSender.SendAsync(new[] { new MessageEnvelope(new DependentAddedEvent(delegateHdid, dependentHdid), delegateHdid) }, ct);
             }
@@ -244,7 +244,7 @@ namespace HealthGateway.GatewayApi.Services
 
             // commit to the database if change feed is disabled; if change feed enabled, commit will happen when message sender is called
             // this is temporary and will be changed when we introduce a proper unit of work to manage transactionality.
-            DbResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Delete(resourceDelegate, !this.changeFeedEnabled);
+            DbResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Delete(resourceDelegate, !this.dependentsChangeFeedEnabled);
             if (dbDependent.Status == DbStatusCode.Error)
             {
                 throw new ProblemDetailsException(ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", dbDependent.Message));
@@ -252,7 +252,7 @@ namespace HealthGateway.GatewayApi.Services
 
             this.UpdateNotificationSettings(dependent.OwnerId, dependent.DelegateId, true);
 
-            if (this.changeFeedEnabled)
+            if (this.dependentsChangeFeedEnabled)
             {
                 await this.messageSender.SendAsync(new[] { new MessageEnvelope(new DependentRemovedEvent(dependent.DelegateId, dependent.OwnerId), dependent.DelegateId) }, ct);
             }

--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.GatewayApi.Services
         private readonly INotificationSettingsService notificationSettingsService;
         private readonly IUserProfileDelegate profileDelegate;
         private readonly string webClientConfigSection = "WebClient";
-        private readonly bool changeFeedEnabled;
+        private readonly bool notificationsChangeFeedEnabled;
         private readonly IMessageSender messageSender;
 
         /// <summary>
@@ -83,8 +83,9 @@ namespace HealthGateway.GatewayApi.Services
 
             this.httpContextAccessor = httpContextAccessor;
             this.messageSender = messageSender;
-            this.changeFeedEnabled = configuration.GetSection(ChangeFeedConfiguration.ConfigurationSectionKey)
-                .GetValue($"{ChangeFeedConfiguration.NotificationChannelVerifiedKey}:Enabled", false);
+            ChangeFeedOptions? changeFeedConfiguration = configuration.GetSection(ChangeFeedOptions.ChangeFeed)
+                .Get<ChangeFeedOptions>();
+            this.notificationsChangeFeedEnabled = changeFeedConfiguration?.Notifications.Enabled ?? false;
         }
 
         /// <inheritdoc/>
@@ -152,11 +153,11 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             matchingVerification.Validated = true;
-            await this.messageVerificationDelegate.UpdateAsync(matchingVerification, !this.changeFeedEnabled, ct);
+            await this.messageVerificationDelegate.UpdateAsync(matchingVerification, !this.notificationsChangeFeedEnabled, ct);
             userProfile.Email = matchingVerification.Email!.To; // Gets the user email from the email sent.
-            this.profileDelegate.Update(userProfile, !this.changeFeedEnabled);
+            this.profileDelegate.Update(userProfile, !this.notificationsChangeFeedEnabled);
 
-            if (this.changeFeedEnabled)
+            if (this.notificationsChangeFeedEnabled)
             {
                 MessageEnvelope[] events =
                 {

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -77,7 +77,7 @@ namespace HealthGateway.GatewayApi.Services
         private readonly IUserSmsService userSmsService;
         private readonly IPatientRepository patientRepository;
         private readonly bool accountsChangeFeedEnabled;
-        private readonly bool notificationChannelChangeFeedEnabled;
+        private readonly bool notificationsChangeFeedEnabled;
         private readonly IMessageSender messageSender;
 
         /// <summary>
@@ -144,10 +144,9 @@ namespace HealthGateway.GatewayApi.Services
             this.cacheProvider = cacheProvider;
             this.patientRepository = patientRepository;
             this.messageSender = messageSender;
-            this.accountsChangeFeedEnabled = configuration.GetSection(ChangeFeedConfiguration.ConfigurationSectionKey)
-                .GetValue($"{ChangeFeedConfiguration.AccountsKey}:Enabled", false);
-            this.notificationChannelChangeFeedEnabled = configuration.GetSection(ChangeFeedConfiguration.ConfigurationSectionKey)
-                .GetValue($"{ChangeFeedConfiguration.NotificationChannelVerifiedKey}:Enabled", false);
+            ChangeFeedOptions? changeFeedConfiguration = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>();
+            this.accountsChangeFeedEnabled = changeFeedConfiguration?.Accounts.Enabled ?? false;
+            this.notificationsChangeFeedEnabled = changeFeedConfiguration?.Notifications.Enabled ?? false;
         }
 
         /// <inheritdoc/>
@@ -287,10 +286,10 @@ namespace HealthGateway.GatewayApi.Services
             if (!string.IsNullOrWhiteSpace(requestedEmail))
             {
                 bool isEmailVerified = requestedEmail.Equals(jwtEmailAddress, StringComparison.OrdinalIgnoreCase);
-                await this.userEmailService.CreateUserEmailAsync(hdid, requestedEmail, isEmailVerified, !this.notificationChannelChangeFeedEnabled, ct);
+                await this.userEmailService.CreateUserEmailAsync(hdid, requestedEmail, isEmailVerified, !this.notificationsChangeFeedEnabled, ct);
                 userProfileModel.Email = requestedEmail;
                 userProfileModel.IsEmailVerified = isEmailVerified;
-                if (isEmailVerified && this.notificationChannelChangeFeedEnabled)
+                if (isEmailVerified && this.notificationsChangeFeedEnabled)
                 {
                     MessageEnvelope[] events =
                     {

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -53,7 +53,7 @@
         "Accounts": {
             "Enabled": true
         },
-        "NotificationChannelVerified": {
+        "Notifications": {
             "Enabled": true
         }
     }

--- a/Apps/GatewayApi/src/appsettings.hgdev.json
+++ b/Apps/GatewayApi/src/appsettings.hgdev.json
@@ -36,5 +36,16 @@
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
+    "ChangeFeed": {
+        "Dependents": {
+            "Enabled": true
+        },
+        "Accounts": {
+            "Enabled": true
+        },
+        "Notifications": {
+            "Enabled": true
+        }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -121,7 +121,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 .Returns(new DbResult<UserProfile>());
             Mock<IMessageSender> mockMessageSender = new();
 
-            string changeFeedKey = $"{ChangeFeedConfiguration.ConfigurationSectionKey}:{ChangeFeedConfiguration.NotificationChannelVerifiedKey}:Enabled";
+            string changeFeedKey = $"{ChangeFeedOptions.ChangeFeed}:Notifications:Enabled";
             Dictionary<string, string?> configDict = new()
             {
                 { changeFeedKey, "true" },

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -278,7 +278,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 { "WebClient:MinPatientAge", "0" },
                 {
-                    $"{ChangeFeedConfiguration.ConfigurationSectionKey}:{ChangeFeedConfiguration.AccountsKey}:Enabled",
+                    $"{ChangeFeedOptions.ChangeFeed}:Accounts:Enabled",
                     "false"
                 },
             };
@@ -337,7 +337,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 { "WebClient:MinPatientAge", "0" },
                 {
-                    $"{ChangeFeedConfiguration.ConfigurationSectionKey}:{ChangeFeedConfiguration.AccountsKey}:Enabled",
+                    $"{ChangeFeedOptions.ChangeFeed}:Accounts:Enabled",
                     "true"
                 },
             };
@@ -393,7 +393,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 { "WebClient:MinPatientAge", "0" },
                 {
-                    $"{ChangeFeedConfiguration.ConfigurationSectionKey}:{ChangeFeedConfiguration.AccountsKey}:Enabled",
+                    $"{ChangeFeedOptions.ChangeFeed}:Accounts:Enabled",
                     "false"
                 },
             };

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -107,7 +107,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
 
-            string changeFeedKey = $"{ChangeFeedConfiguration.ConfigurationSectionKey}:{ChangeFeedConfiguration.NotificationChannelVerifiedKey}:Enabled";
+            string changeFeedKey = $"{ChangeFeedOptions.ChangeFeed}:Notifications:Enabled";
             Dictionary<string, string?> configDict = new()
             {
                 { changeFeedKey, "true" },

--- a/Apps/GatewayApi/test/unit/UnitTest.json
+++ b/Apps/GatewayApi/test/unit/UnitTest.json
@@ -39,7 +39,7 @@
         "Accounts": {
             "Enabled": true
         },
-        "NotificationChannelVerified": {
+        "Notifications": {
             "Enabled": true
         }
     }


### PR DESCRIPTION
# Implements [AB#16372](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16372)

## Description
1. Improve consistency in configuration consumption for change feed code.
2. Repurposed `ChangeFeedConfiguration` class to `ChangeFeedOptions` to house the parsed configuration structure
3. `ChangeFeedConfiguration` is now the individual feed configuration structure namely `{ Enabled: bool }`
4. Tests and consumption of the change feed configuration in code has been updated.


## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

![image](https://github.com/bcgov/healthgateway/assets/19548348/4c6a63ec-e56d-4f1e-a08f-2ed9047204d8)


## Notes
Events are still being recorded as expected:
![image](https://github.com/bcgov/healthgateway/assets/19548348/cf3bc8ce-c6d5-4980-b89a-71367a514a58)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
