### PR TITLE
Hide pcrtest manual only components for AB#16338

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/public/pcr-test-kit-registration/PcrTestKitRegistrationForm.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/public/pcr-test-kit-registration/PcrTestKitRegistrationForm.vue
@@ -455,7 +455,11 @@ if (!props.serialNumber) {
                         />
                     </v-col>
                 </v-row>
-                <v-row align="center" no-gutters>
+                <v-row
+                    v-if="dataSource === PcrDataSource.Manual"
+                    align="center"
+                    no-gutters
+                >
                     <v-col cols="auto">
                         <v-checkbox
                             v-model="noPhn"
@@ -524,6 +528,7 @@ if (!props.serialNumber) {
                 <v-row>
                     <v-col>
                         <HgDatePickerComponent
+                            v-if="dataSource === PcrDataSource.Manual"
                             v-model="v$.dob.$model"
                             label="Date of Birth"
                             data-testid="dob-input"


### PR DESCRIPTION
# Fixes [AB#16338](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16338)

## Description
1. Hide Birth date and no PHN checkbox when authenticated.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/ee935619-fe82-4c17-9122-1cd2280d3e94)

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
