### PR TITLE
Refactor patient support details parameters AB#16376

### DIFF
--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.Admin.Server.Controllers
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Common.Models.CovidSupport;
+    using HealthGateway.Admin.Server.Models;
     using HealthGateway.Admin.Server.Services;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
@@ -107,20 +108,23 @@ namespace HealthGateway.Admin.Server.Controllers
             CancellationToken ct)
         {
             ClaimsPrincipal user = this.HttpContext.User;
-            bool includeEverything = user.IsInRole("AdminUser") || user.IsInRole("AdminReviewer");
-            bool includeCovidDetails = user.IsInRole("SupportUser");
+            bool userIsAdmin = user.IsInRole("AdminUser");
+            bool userIsReviewer = user.IsInRole("AdminReviewer");
+            bool userIsSupport = user.IsInRole("SupportUser");
 
             return await this.supportService.GetPatientSupportDetailsAsync(
-                    queryType,
-                    queryString,
-                    includeEverything,
-                    includeEverything,
-                    includeEverything,
-                    includeEverything,
-                    includeCovidDetails,
-                    refreshVaccineDetails,
-                    ct)
-                .ConfigureAwait(true);
+                new PatientSupportDetailsQuery
+                {
+                    QueryType = queryType,
+                    QueryParameter = queryString,
+                    IncludeMessagingVerifications = userIsAdmin || userIsReviewer,
+                    IncludeBlockedDataSources = userIsAdmin || userIsReviewer,
+                    IncludeAgentActions = userIsAdmin || userIsReviewer,
+                    IncludeDependents = userIsAdmin || userIsReviewer,
+                    IncludeCovidDetails = userIsSupport,
+                    RefreshVaccineDetails = refreshVaccineDetails,
+                },
+                ct);
         }
 
         /// <summary>

--- a/Apps/Admin/Server/Models/PatientSupportDetailsQuery.cs
+++ b/Apps/Admin/Server/Models/PatientSupportDetailsQuery.cs
@@ -1,0 +1,65 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Server.Models
+{
+    using HealthGateway.Admin.Common.Constants;
+
+    /// <summary>
+    /// Query to retrieve patient support details.
+    /// </summary>
+    public record PatientSupportDetailsQuery
+    {
+        /// <summary>
+        /// Gets the type of query.
+        /// </summary>
+        public ClientRegistryType QueryType { get; init; }
+
+        /// <summary>
+        /// Gets the query parameter.
+        /// </summary>
+        public string QueryParameter { get; init; } = string.Empty;
+
+        /// <summary>
+        /// Gets a value indicating whether messaging verifications should be included in the result.
+        /// </summary>
+        public bool IncludeMessagingVerifications { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether blocked data sources should be included in the result.
+        /// </summary>
+        public bool IncludeBlockedDataSources { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether agent actions should be included in the result.
+        /// </summary>
+        public bool IncludeAgentActions { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether dependents should be included in the result.
+        /// </summary>
+        public bool IncludeDependents { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether COVID-19 details should be included in the result.
+        /// </summary>
+        public bool IncludeCovidDetails { get; init; }
+
+        /// <summary>
+        /// Gets a value indicating whether the query should force cached vaccine validation details data to be refreshed.
+        /// </summary>
+        public bool RefreshVaccineDetails { get; init; }
+    }
+}

--- a/Apps/Admin/Server/Services/ISupportService.cs
+++ b/Apps/Admin/Server/Services/ISupportService.cs
@@ -18,8 +18,8 @@ namespace HealthGateway.Admin.Server.Services
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Server.Models;
     using HealthGateway.Common.Data.Constants;
 
     /// <summary>
@@ -28,33 +28,13 @@ namespace HealthGateway.Admin.Server.Services
     public interface ISupportService
     {
         /// <summary>
-        /// Retrieves patient support details, which includes messaging verifications, agent changes, blocked data sources and
-        /// covid details
-        /// matching the query.
+        /// Retrieves patient support details, which may include messaging verifications, agent actions, blocked data sources,
+        /// dependents, and COVID-19 details.
         /// </summary>
-        /// <param name="queryType">The type of query to be performed when searching for patient support details.</param>
-        /// <param name="queryString">The string value associated with the query type when searching for patient support details.</param>
-        /// <param name="includeMessagingVerifications">A value indicating whether messaging verifications should be returned.</param>
-        /// <param name="includeBlockedDataSources">A value indicating whether blocked data sources should be returned.</param>
-        /// <param name="includeAgentActions">A value indicating whether agent actions should be returned.</param>
-        /// <param name="includeDependents">A value indicating whether dependents should be returned.</param>
-        /// <param name="includeCovidDetails">A value indicating whether covid details should be returned.</param>
-        /// <param name="refreshVaccineDetails">
-        /// Whether the call should force cached vaccine validation details data to be
-        /// refreshed.
-        /// </param>
+        /// <param name="query">Query model.</param>
         /// <param name="ct">A cancellation token.</param>
-        /// <returns>A patient support details matching the query.</returns>
-        Task<PatientSupportDetails> GetPatientSupportDetailsAsync(
-            ClientRegistryType queryType,
-            string queryString,
-            bool includeMessagingVerifications,
-            bool includeBlockedDataSources,
-            bool includeAgentActions,
-            bool includeDependents,
-            bool includeCovidDetails,
-            bool refreshVaccineDetails,
-            CancellationToken ct = default);
+        /// <returns>Patient support details matching the query.</returns>
+        Task<PatientSupportDetails> GetPatientSupportDetailsAsync(PatientSupportDetailsQuery query, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves the collection of patients that match the query.

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -155,14 +155,17 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             PatientSupportDetails actualResult =
                 await supportService.GetPatientSupportDetailsAsync(
-                    queryType,
-                    queryType == ClientRegistryType.Hdid ? Hdid : Phn,
-                    includeMessagingVerifications,
-                    includeBlockedDataSources,
-                    includeAgentActions,
-                    includeDependents,
-                    includeCovidDetails,
-                    false);
+                    new()
+                    {
+                        QueryType = queryType,
+                        QueryParameter = queryType == ClientRegistryType.Hdid ? Hdid : Phn,
+                        IncludeMessagingVerifications = includeMessagingVerifications,
+                        IncludeBlockedDataSources = includeBlockedDataSources,
+                        IncludeAgentActions = includeAgentActions,
+                        IncludeDependents = includeDependents,
+                        IncludeCovidDetails = includeCovidDetails,
+                        RefreshVaccineDetails = false,
+                    });
 
             // Assert
             Assert.Equal(expectedMessagingVerificationCount, actualResult.MessagingVerifications?.Count());
@@ -204,14 +207,17 @@ namespace HealthGateway.Admin.Tests.Services
             async Task Actual()
             {
                 await supportService.GetPatientSupportDetailsAsync(
-                    queryType,
-                    queryType == ClientRegistryType.Hdid ? Hdid : Phn,
-                    true,
-                    true,
-                    true,
-                    true,
-                    true,
-                    false);
+                    new()
+                    {
+                        QueryType = queryType,
+                        QueryParameter = queryType == ClientRegistryType.Hdid ? Hdid : Phn,
+                        IncludeMessagingVerifications = true,
+                        IncludeBlockedDataSources = true,
+                        IncludeAgentActions = true,
+                        IncludeDependents = true,
+                        IncludeCovidDetails = true,
+                        RefreshVaccineDetails = false,
+                    });
             }
 
             // Verify
@@ -247,7 +253,18 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await supportService.GetPatientSupportDetailsAsync(ClientRegistryType.Phn, Phn, false, false, false, false, true, false);
+                await supportService.GetPatientSupportDetailsAsync(
+                    new()
+                    {
+                        QueryType = ClientRegistryType.Phn,
+                        QueryParameter = Phn,
+                        IncludeMessagingVerifications = false,
+                        IncludeBlockedDataSources = false,
+                        IncludeAgentActions = false,
+                        IncludeDependents = false,
+                        IncludeCovidDetails = true,
+                        RefreshVaccineDetails = false,
+                    });
             }
 
             // Verify
@@ -281,7 +298,18 @@ namespace HealthGateway.Admin.Tests.Services
             // Act
             async Task Actual()
             {
-                await supportService.GetPatientSupportDetailsAsync(ClientRegistryType.Hdid, Hdid, true, true, true, false, true, false);
+                await supportService.GetPatientSupportDetailsAsync(
+                    new()
+                    {
+                        QueryType = ClientRegistryType.Hdid,
+                        QueryParameter = Hdid,
+                        IncludeMessagingVerifications = true,
+                        IncludeBlockedDataSources = true,
+                        IncludeAgentActions = true,
+                        IncludeDependents = false,
+                        IncludeCovidDetails = true,
+                        RefreshVaccineDetails = false,
+                    });
             }
 
             // Verify


### PR DESCRIPTION
# Implements [AB#16376](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16376)

## Description

Introduces query model to take the place of 8 separate parameters for ISupportService.GetPatientSupportDetailsAsync.

Using named properties improves the clarity of what additional data is being requested.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
