### PR TITLE
Add pervasive click handler to close for AB#16382

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/common/InfoTooltipComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/InfoTooltipComponent.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { onBeforeUnmount } from "vue";
 import { computed, ref } from "vue";
 
 interface Props {
@@ -22,7 +23,25 @@ const hasText = computed(() => !!props.text);
 function handleClick() {
     openedFromClick.value = !openedFromClick.value;
     openedFromHover.value = false;
+    if (openedFromClick.value) {
+        setTimeout(() => {
+            document.addEventListener("click", closeOnOutsideClick, {
+                once: true,
+            });
+        });
+    }
 }
+
+function closeOnOutsideClick() {
+    if (openedFromClick.value) {
+        openedFromClick.value = false;
+    }
+}
+
+onBeforeUnmount(() => {
+    // Remove click event if the event hasn't been triggered once.
+    document.removeEventListener("click", closeOnOutsideClick);
+});
 </script>
 
 <template>


### PR DESCRIPTION
# Fixes AB#16382

## Description
1. add a click handler to register the next click to close the tooltip.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes

https://github.com/bcgov/healthgateway/assets/19548348/43c03d4b-f4e1-47ae-a770-7f693c7e6773



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
