### PR TITLE
Remove JobScheduler link from Admin nav menu AB#16359 

### DIFF
--- a/Apps/Admin/Client/Components/Site/NavMenu.razor
+++ b/Apps/Admin/Client/Components/Site/NavMenu.razor
@@ -23,12 +23,6 @@
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer},{Roles.Analyst}")">
         <MudNavLink Href="dashboard" Icon="fas fa-gauge">Dashboard</MudNavLink>
     </AuthorizeView>
-    @if (JobSchedulerUrl.Length > 0)
-    {
-        <AuthorizeView Roles="@Roles.Admin">
-            <MudNavLink Href="@JobSchedulerUrl" Icon="fas fa-business-time">Job Scheduler</MudNavLink>
-        </AuthorizeView>
-    }
     <AuthorizeView Roles="@($"{Roles.Admin},{Roles.Reviewer}")">
         <MudNavLink Href="communications" Icon="fas fa-satellite-dish">Communications</MudNavLink>
     </AuthorizeView>

--- a/Apps/Admin/Client/Components/Site/NavMenu.razor.cs
+++ b/Apps/Admin/Client/Components/Site/NavMenu.razor.cs
@@ -27,8 +27,4 @@ public partial class NavMenu : FluxorComponent
 {
     [Inject]
     private IState<ConfigurationState> ConfigurationState { get; set; } = default!;
-
-    private string JobSchedulerUrl => this.ConfigurationState.Value.Result?.ServiceEndpoints.ContainsKey("JobScheduler") == true
-        ? this.ConfigurationState.Value.Result.ServiceEndpoints["JobScheduler"].ToString()
-        : string.Empty;
 }

--- a/Apps/Admin/Common/Models/ExternalConfiguration.cs
+++ b/Apps/Admin/Common/Models/ExternalConfiguration.cs
@@ -41,11 +41,5 @@ namespace HealthGateway.Admin.Common.Models
         /// Gets or sets the OpenIdConnect configuration.
         /// </summary>
         public OpenIdConnectConfiguration OpenIdConnect { get; set; } = new();
-
-        /// <summary>
-        /// Gets or sets the Service Endpoints.
-        /// </summary>
-        [SuppressMessage("Usage", "CA2227:Collection properties should be read only", Justification = "Team decision")]
-        public Dictionary<string, Uri> ServiceEndpoints { get; set; } = new();
     }
 }

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -34,9 +34,6 @@
     "Features": {
         "Showcase": true
     },
-    "ServiceEndpoints": {
-        "JobScheduler": "http://localhost:5005/"
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -34,9 +34,6 @@
     "Features": {
         "Showcase": true
     },
-    "ServiceEndpoints": {
-        "JobScheduler": "https://dev.healthgateway.gov.bc.ca/admin/jobscheduler"
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },

--- a/Apps/Admin/Server/appsettings.hgmock.json
+++ b/Apps/Admin/Server/appsettings.hgmock.json
@@ -27,9 +27,6 @@
     "Features": {
         "Showcase": true
     },
-    "ServiceEndpoints": {
-        "JobScheduler": "https://mock.healthgateway.gov.bc.ca/admin/jobscheduler"
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },

--- a/Apps/Admin/Server/appsettings.hgtest.json
+++ b/Apps/Admin/Server/appsettings.hgtest.json
@@ -24,9 +24,6 @@
         "TokenUri": "https://test.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold/protocol/openid-connect/token",
         "BaseUrl": "https://test.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
-    "ServiceEndpoints": {
-        "JobScheduler": "https://test.healthgateway.gov.bc.ca/admin/jobscheduler"
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-test.azurewebsites.net"
     },

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -104,9 +104,6 @@
         "Showcase": false,
         "UserInfo": true
     },
-    "ServiceEndpoints": {
-        "JobScheduler": "https://www.healthgateway.gov.bc.ca/admin/jobscheduler"
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-prod.azurewebsites.net",
         "FetchSize": "25",
@@ -161,8 +158,6 @@
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",
-        "IgnorePathPrefixes": [
-            "/health"
-        ]
+        "IgnorePathPrefixes": ["/health"]
     }
 }


### PR DESCRIPTION
# Implements [AB#16359](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16359) ([AB#16384](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16384))

## Description

- removes JobScheduler link from Admin nav menu [AB#16384](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16384)
  - removes associated appsetting value which is no longer needed

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/ad986a7e-1293-4b50-97c9-0e5428dd32d5)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
