### PR TITLE
Add AdminUser permissions to COVID for AB#16407

### DIFF
--- a/Apps/Admin/Client/Components/Details/ProfileTab.razor.cs
+++ b/Apps/Admin/Client/Components/Details/ProfileTab.razor.cs
@@ -68,7 +68,7 @@ namespace HealthGateway.Admin.Client.Components.Details
         private IEnumerable<PreviousAssessmentDetails> AssessmentDetails =>
             this.AssessmentInfo?.PreviousAssessmentDetailsList?.OrderByDescending(a => a.DateTimeOfAssessment) ?? Enumerable.Empty<PreviousAssessmentDetails>();
 
-        private bool CanViewCovidDetails => this.UserHasRole(Roles.Support);
+        private bool CanViewCovidDetails => this.UserHasRole(Roles.Support) || this.UserHasRole(Roles.Admin);
 
         private bool ImmunizationsAreBlocked => this.VaccineDetails?.Blocked ?? false;
 

--- a/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor
+++ b/Apps/Admin/Client/Pages/Covid19TreatmentAssessmentPage.razor
@@ -1,6 +1,6 @@
 @page "/covid-19-treatment-assessment"
 @layout MainLayout
-@attribute [Authorize(Roles = $"{Roles.Support}")]
+@attribute [Authorize(Roles = $"{Roles.Support},{Roles.Admin}")]
 @using HealthGateway.Admin.Client.Store.PatientDetails
 @using HealthGateway.Admin.Client.Store.PatientSupport
 @using HealthGateway.Admin.Common.Constants

--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -121,7 +121,7 @@ namespace HealthGateway.Admin.Server.Controllers
                     IncludeBlockedDataSources = userIsAdmin || userIsReviewer,
                     IncludeAgentActions = userIsAdmin || userIsReviewer,
                     IncludeDependents = userIsAdmin || userIsReviewer,
-                    IncludeCovidDetails = userIsSupport,
+                    IncludeCovidDetails = userIsAdmin || userIsSupport,
                     RefreshVaccineDetails = refreshVaccineDetails,
                 },
                 ct);
@@ -199,7 +199,7 @@ namespace HealthGateway.Admin.Server.Controllers
         [HttpPost]
         [Produces("application/json")]
         [Route("CovidAssessment")]
-        [Authorize(Roles = "SupportUser")]
+        [Authorize(Roles = "SupportUser,AdminUser")]
         public async Task<CovidAssessmentResponse> SubmitCovidAssessment([FromBody] CovidAssessmentRequest request)
         {
             return await this.covidSupportService.SubmitCovidAssessmentAsync(request).ConfigureAwait(true);

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
@@ -1,5 +1,5 @@
 import { performSearch } from "../../utilities/supportUtilities";
-import { getTableRows } from "../../utilities/sharedUtilities";
+import { getTableRows, selectTab } from "../../utilities/sharedUtilities";
 
 const hdid = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 const hdidPatientDeceased =
@@ -15,10 +15,8 @@ const auditReasonInput = "Test block reason";
 const auditReasonFeedback =
     "Response status code does not indicate success: 400 (Bad Request).";
 
-function selectTab(tabText) {
-    cy.get("[data-testid=patient-details-tabs]")
-        .contains(".mud-tab", tabText)
-        .click();
+function selectPatientTab(tabText) {
+    selectTab("[data-testid=patient-details-tabs]", tabText);
 }
 
 describe("Patient details as admin", () => {
@@ -96,7 +94,7 @@ describe("Patient details as admin", () => {
     it("Verify patient details", () => {
         performSearch("PHN", phn);
 
-        selectTab("Profile");
+        selectPatientTab("Profile");
 
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
@@ -104,7 +102,7 @@ describe("Patient details as admin", () => {
         cy.get("[data-testid=patient-physical-address]").should("be.visible");
         cy.get("[data-testid=patient-mailing-address]").should("be.visible");
 
-        selectTab("Account");
+        selectPatientTab("Account");
 
         cy.get("[data-testid=patient-hdid]")
             .should("be.visible")
@@ -122,7 +120,7 @@ describe("Patient details as admin", () => {
     it("Verify patient deceased", () => {
         performSearch("PHN", phnPatientDeceased);
 
-        selectTab("Profile");
+        selectPatientTab("Profile");
 
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
@@ -130,7 +128,7 @@ describe("Patient details as admin", () => {
         cy.get("[data-testid=patient-physical-address]").should("be.visible");
         cy.get("[data-testid=patient-mailing-address]").should("be.visible");
 
-        selectTab("Account");
+        selectPatientTab("Account");
 
         cy.get("[data-testid=patient-hdid]")
             .should("be.visible")
@@ -150,7 +148,7 @@ describe("Patient details as admin", () => {
     it("Verify patient not a user", () => {
         performSearch("PHN", phnPatientNotUser);
 
-        selectTab("Profile");
+        selectPatientTab("Profile");
 
         cy.get("[data-testid=patient-name]").should("be.visible");
         cy.get("[data-testid=patient-dob]").should("be.visible");
@@ -158,7 +156,7 @@ describe("Patient details as admin", () => {
         cy.get("[data-testid=patient-physical-address]").should("be.visible");
         cy.get("[data-testid=patient-mailing-address]").should("be.visible");
 
-        selectTab("Account");
+        selectPatientTab("Account");
 
         cy.get("[data-testid=patient-hdid]")
             .should("be.visible")
@@ -179,13 +177,13 @@ describe("Patient details as admin", () => {
     it("Verify block access modal handles 400 error", () => {
         performSearch("PHN", phn);
 
-        selectTab("Account");
+        selectPatientTab("Account");
 
         cy.get("[data-testid=patient-hdid]")
             .should("be.visible")
             .contains(hdid);
 
-        selectTab("Manage");
+        selectPatientTab("Manage");
 
         cy.get("[data-testid=block-access-loader]").should("not.be.visible");
 

--- a/Apps/Admin/Tests/Functional/cypress/utilities/sharedUtilities.js
+++ b/Apps/Admin/Tests/Functional/cypress/utilities/sharedUtilities.js
@@ -28,3 +28,7 @@ export function getTodayPlusDaysDate(days) {
     cy.log(`Today plus ${days} => ${dateString}`);
     return dateString;
 }
+
+export function selectTab(tabsSelector, tabText) {
+    cy.get(tabsSelector).contains(".mud-tab", tabText).click();
+}

--- a/Apps/Admin/Tests/Functional/cypress/utilities/supportUtilities.js
+++ b/Apps/Admin/Tests/Functional/cypress/utilities/supportUtilities.js
@@ -1,9 +1,7 @@
-import { getTableRows } from "./sharedUtilities";
+import { getTableRows, selectTab } from "./sharedUtilities";
 
-function selectTab(tabText) {
-    cy.get("[data-testid=patient-details-tabs]")
-        .contains(".mud-tab", tabText)
-        .click();
+function selectPatientTab(tabText) {
+    selectTab("[data-testid=patient-details-tabs]", tabText);
 }
 
 export function performSearch(queryType, queryString) {
@@ -33,7 +31,7 @@ export function verifySingleSupportResult(expectedHdid, expectedPhn) {
         .should("be.visible")
         .contains(expectedPhn);
     if (expectedHdid) {
-        selectTab("Account");
+        selectPatientTab("Account");
         cy.get("[data-testid=patient-hdid]")
             .should("be.visible")
             .contains(expectedHdid);


### PR DESCRIPTION
# Implements [AB#16407](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16407)

## Description
1. Allow "AdminUser" to access COVID support data.
2. Display COVID support controls for "AdminUser" role.

## Testing

- [ ] Unit Tests Updated
- [X] Functional Tests Updated
- [ ] Not Required

Similar to previous conversation related to the assessment submission not working, this has been reported to Tyler at PHSA.

![image](https://github.com/bcgov/healthgateway/assets/19548348/0925ace2-273a-4e33-8e1e-983b1733c31e)

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/52eb80dc-cb67-49a5-84e7-04e15d4a3365)



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
