### PR TITLE
Trigger queries on Admin pages when hitting Enter key AB#16234

### DIFF
--- a/Apps/Admin/Client/Pages/AgentAccessPage.razor
+++ b/Apps/Admin/Client/Pages/AgentAccessPage.razor
@@ -15,19 +15,22 @@
     @ErrorMessage
 </HgBannerFeedback>
 
-<MudForm @ref="Form">
+<MudForm @ref="Form" id="query-controls">
     <div class="d-flex align-start">
         <HgTextField
             T="string"
             Label="Query"
             Required="@true"
+            Immediate="@true"
             Validation="@ValidateQueryParameter"
+            TopMargin="Breakpoint.None"
             @bind-Value="Query"
-            Class="flex-grow-1"
+            Class="flex-grow-1 query-input"
             data-testid="query-input" />
         <HgButton
-            TopMargin="Breakpoint.Always"
             EndIcon="fas fa-magnifying-glass"
+            TopMargin="Breakpoint.Always"
+            LeftMargin="Breakpoint.Always"
             OnClick="SearchAsync"
             data-testid="search-btn">
             Search

--- a/Apps/Admin/Client/Pages/AgentAccessPage.razor.cs
+++ b/Apps/Admin/Client/Pages/AgentAccessPage.razor.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using Fluxor;
 using Fluxor.Blazor.Web.Components;
 using HealthGateway.Admin.Client.Components.AgentAccess;
+using HealthGateway.Admin.Client.Services;
 using HealthGateway.Admin.Client.Store.AgentAccess;
 using HealthGateway.Admin.Client.Utils;
 using HealthGateway.Admin.Common.Models;
@@ -67,6 +68,9 @@ public partial class AgentAccessPage : FluxorComponent
     [Inject]
     private ISnackbar Snackbar { get; set; } = default!;
 
+    [Inject]
+    private IKeyInterceptorService KeyInterceptorService { get; set; } = default!;
+
     private string Query { get; set; } = string.Empty;
 
     [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Assigned in .razor file")]
@@ -99,6 +103,32 @@ public partial class AgentAccessPage : FluxorComponent
         this.ActionSubscriber.SubscribeToAction<AgentAccessActions.AddSuccessAction>(this, this.DisplayAddSuccessful);
         this.ActionSubscriber.SubscribeToAction<AgentAccessActions.UpdateSuccessAction>(this, this.DisplayUpdateSuccessful);
         this.ActionSubscriber.SubscribeToAction<AgentAccessActions.DeleteSuccessAction>(this, this.DisplayDeleteSuccessful);
+    }
+
+    /// <inheritdoc/>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            await this.KeyInterceptorService.RegisterOnKeyDownAsync(
+                "query-controls",
+                "query-input",
+                IKeyInterceptorService.EnterKey,
+                _ => this.SearchAsync());
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
+    }
+
+    /// <inheritdoc/>
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this.KeyInterceptorService.Dispose();
+        }
+
+        base.Dispose(disposing);
     }
 
     private void ResetState()

--- a/Apps/Admin/Client/Pages/DelegationPage.razor
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor
@@ -12,16 +12,17 @@
 <HgPageHeading>Delegation</HgPageHeading>
 <NavigationConfirmation Enabled="@AnyUnsavedDelegationChanges" />
 
-<MudForm @ref="Form">
+<MudForm @ref="Form" id="query-controls">
     <div class="d-flex align-start">
         <HgTextField
             T="string"
             Label="PHN"
             Required="@true"
+            Immediate="@true"
             Validation="@ValidateQueryParameter"
             Mask="@Mask.PhnMask"
             TopMargin="Breakpoint.None"
-            Class="flex-grow-1"
+            Class="flex-grow-1 query-input"
             @bind-Value="QueryParameter"
             data-testid="query-input" />
         <HgButton
@@ -31,7 +32,7 @@
             Loading="@Searching"
             TopMargin="Breakpoint.Always"
             LeftMargin="Breakpoint.Always"
-            OnClick="Search"
+            OnClick="SearchAsync"
             data-testid="search-button">
             Search
         </HgButton>

--- a/Apps/Admin/Client/Pages/DelegationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.Admin.Client.Pages
     using HealthGateway.Admin.Client.Components.AgentAudit;
     using HealthGateway.Admin.Client.Components.Delegation;
     using HealthGateway.Admin.Client.Models;
+    using HealthGateway.Admin.Client.Services;
     using HealthGateway.Admin.Client.Store.Delegation;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.Utils;
@@ -67,6 +68,9 @@ namespace HealthGateway.Admin.Client.Pages
         [Inject]
         private NavigationManager NavigationManager { get; set; } = default!;
 
+        [Inject]
+        private IKeyInterceptorService KeyInterceptorService { get; set; } = default!;
+
         private MudForm Form { get; set; } = default!;
 
         private string QueryParameter { get; set; } = string.Empty;
@@ -102,6 +106,32 @@ namespace HealthGateway.Admin.Client.Pages
             }
         }
 
+        /// <inheritdoc/>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                await this.KeyInterceptorService.RegisterOnKeyDownAsync(
+                    "query-controls",
+                    "query-input",
+                    IKeyInterceptorService.EnterKey,
+                    _ => this.SearchAsync());
+            }
+
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.KeyInterceptorService.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
         /// <summary>
         /// Resets the component to its initial state.
         /// </summary>
@@ -110,7 +140,7 @@ namespace HealthGateway.Admin.Client.Pages
             this.Dispatcher.Dispatch(new DelegationActions.ResetStateAction());
         }
 
-        private async Task Search()
+        private async Task SearchAsync()
         {
             await this.Form.Validate().ConfigureAwait(true);
             if (this.Form.IsValid)

--- a/Apps/Admin/Client/Pages/SupportPage.razor
+++ b/Apps/Admin/Client/Pages/SupportPage.razor
@@ -21,7 +21,7 @@
     @PatientSupportState.Value.Error?.Message
 </HgBannerFeedback>
 
-<MudForm @ref="Form">
+<MudForm @ref="Form" id="query-controls">
     <MudGrid Spacing="0">
         <MudItem xs="12" sm="3">
             <HgSelect
@@ -47,12 +47,13 @@
                         T="string"
                         Label="@FormattingUtility.FormatPatientQueryType(PatientQueryType.Phn)"
                         Required="@true"
+                        Immediate="@true"
                         Validation="@ValidateQueryParameter"
                         Mask="@Mask.PhnMask"
                         @bind-Value="QueryParameter"
                         TopMargin="Breakpoint.None"
                         LeftMargin="Breakpoint.Sm"
-                        Class="flex-grow-1"
+                        Class="flex-grow-1 query-input"
                         data-testid="query-input" />
                 }
                 else
@@ -61,11 +62,12 @@
                         T="string"
                         Label="@FormattingUtility.FormatPatientQueryType(SelectedQueryType)"
                         Required="@true"
+                        Immediate="@true"
                         Validation="@ValidateQueryParameter"
                         @bind-Value="QueryParameter"
                         TopMargin="Breakpoint.None"
                         LeftMargin="Breakpoint.Sm"
-                        Class="flex-grow-1"
+                        Class="flex-grow-1 query-input"
                         data-testid="query-input" />
                 }
                 <HgButton

--- a/Apps/Admin/Client/Pages/SupportPage.razor.cs
+++ b/Apps/Admin/Client/Pages/SupportPage.razor.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Admin.Client.Pages
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
     using HealthGateway.Admin.Client.Authorization;
+    using HealthGateway.Admin.Client.Services;
     using HealthGateway.Admin.Client.Store.PatientSupport;
     using HealthGateway.Admin.Client.Utils;
     using HealthGateway.Admin.Common.Constants;
@@ -58,6 +59,9 @@ namespace HealthGateway.Admin.Client.Pages
 
         [Inject]
         private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
+
+        [Inject]
+        private IKeyInterceptorService KeyInterceptorService { get; set; } = default!;
 
         [Inject]
         private IJSRuntime JsRuntime { get; set; } = default!;
@@ -134,6 +138,32 @@ namespace HealthGateway.Admin.Client.Pages
             await this.RepopulateQueryAndResults();
             this.AuthenticationState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
             this.ActionSubscriber.SubscribeToAction<PatientSupportActions.LoadSuccessAction>(this, this.CheckForSingleResult);
+        }
+
+        /// <inheritdoc/>
+        protected override async Task OnAfterRenderAsync(bool firstRender)
+        {
+            if (firstRender)
+            {
+                await this.KeyInterceptorService.RegisterOnKeyDownAsync(
+                    "query-controls",
+                    "query-input",
+                    IKeyInterceptorService.EnterKey,
+                    _ => this.SearchAsync());
+            }
+
+            await base.OnAfterRenderAsync(firstRender);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.KeyInterceptorService.Dispose();
+            }
+
+            base.Dispose(disposing);
         }
 
         private bool UserHasRole(string role)

--- a/Apps/Admin/Client/Program.cs
+++ b/Apps/Admin/Client/Program.cs
@@ -101,6 +101,7 @@ namespace HealthGateway.Admin.Client
             builder.Services.AddBlazoredLocalStorage();
 
             builder.Services.AddSingleton<IDateConversionService, DateConversionService>();
+            builder.Services.AddTransient<IKeyInterceptorService, KeyInterceptorService>();
 
             app[0] = builder.Build();
             await app[0].RunAsync().ConfigureAwait(true);

--- a/Apps/Admin/Client/Services/IKeyInterceptorService.cs
+++ b/Apps/Admin/Client/Services/IKeyInterceptorService.cs
@@ -1,0 +1,43 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Services
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Components.Web;
+
+    /// <summary>
+    /// Injectable service to simplify key interceptor subscriptions.
+    /// </summary>
+    public interface IKeyInterceptorService : IDisposable
+    {
+        /// <summary>
+        /// Value for the enter key used by the key property in the JavaScript KeyboardEvent.
+        /// </summary>
+        const string EnterKey = "Enter";
+
+        /// <summary>
+        /// Registers an event handler to monitor keypresses when specific elements are focused and perform a callback action when
+        /// a particular key is pressed.
+        /// </summary>
+        /// <param name="ancestorId">HTML ID matching ancestor element.</param>
+        /// <param name="targetClass">HTML class matching target element(s) to monitor.</param>
+        /// <param name="key">Name of key to monitor, matching JavaScript KeyboardEvent.key values.</param>
+        /// <param name="callback">Action to perform when Enter key is pressed.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task RegisterOnKeyDownAsync(string ancestorId, string targetClass, string key, Func<KeyboardEventArgs, Task> callback);
+    }
+}

--- a/Apps/Admin/Client/Services/KeyInterceptorService.cs
+++ b/Apps/Admin/Client/Services/KeyInterceptorService.cs
@@ -1,0 +1,88 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Client.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Components.Web;
+    using MudBlazor.Services;
+
+    /// <inheritdoc/>
+    public class KeyInterceptorService : IKeyInterceptorService
+    {
+        private readonly IList<IKeyInterceptor> keyInterceptors = new List<IKeyInterceptor>();
+        private bool isDisposed;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyInterceptorService"/> class.
+        /// </summary>
+        /// <param name="keyInterceptorFactory">Injected key interceptor factory.</param>
+        public KeyInterceptorService(IKeyInterceptorFactory keyInterceptorFactory)
+        {
+            this.KeyInterceptorFactory = keyInterceptorFactory;
+        }
+
+        private IKeyInterceptorFactory KeyInterceptorFactory { get; }
+
+        /// <inheritdoc/>
+        public async Task RegisterOnKeyDownAsync(string ancestorId, string targetClass, string key, Func<KeyboardEventArgs, Task> callback)
+        {
+            IKeyInterceptor keyInterceptor = this.KeyInterceptorFactory.Create();
+
+            await keyInterceptor.Connect(
+                ancestorId,
+                new()
+                {
+                    TargetClass = targetClass,
+                    Keys = new List<KeyOptions> { new() { Key = key, PreventDown = "key+none", SubscribeDown = true } },
+                });
+
+            keyInterceptor.KeyDown += async args => await callback(args);
+
+            this.keyInterceptors.Add(keyInterceptor);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Releases the unmanaged resources used by this class and optionally disposes of the managed resources.
+        /// </summary>
+        /// <param name="disposing">
+        /// If true, releases both managed and unmanaged resources. If false, releases only unmanaged
+        /// resources.
+        /// </param>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing || this.isDisposed)
+            {
+                return;
+            }
+
+            this.isDisposed = true;
+
+            for (int i = this.keyInterceptors.Count - 1; i >= 0; i--)
+            {
+                this.keyInterceptors[i].Dispose();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Implements [AB#16234](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16234) ([AB#16383](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16383))

## Description

- introduces IKeyInterceptorService to simplify key interceptor subscriptions
- updates Support, Delegation, and Provisioning pages to listen for Enter keypresses on query input fields
  - sets Immediate prop to true on input fields so values are validated and updated without waiting for focus to leave the element
- tidies up margins around query controls on Provisioning page

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
