### PR TITLE
Retrieve recurring user count and app logins separately AB#16470

### DIFF
--- a/Apps/Admin/Client/Api/IDashboardApi.cs
+++ b/Apps/Admin/Client/Api/IDashboardApi.cs
@@ -19,56 +19,67 @@ namespace HealthGateway.Admin.Client.Api;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using HealthGateway.Admin.Common.Models;
 using Refit;
 
 /// <summary>
-/// API to fetch the Dashboard from the server.
+/// API to fetch dashboard data.
 /// </summary>
 public interface IDashboardApi
 {
     /// <summary>
-    /// Retrieves the count of registered users.
+    /// Retrieves the daily counts of user registrations.
     /// </summary>
-    /// <param name="timeOffset">The offset from the client browser to UTC.</param>
-    /// <returns>The count of registered users.</returns>
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+    /// <returns>The number of user registrations by date.</returns>
     [Get("/RegisteredCount")]
-    Task<IDictionary<DateTime, int>> GetRegisteredUserCountAsync(int timeOffset);
+    Task<IDictionary<DateOnly, int>> GetDailyUserRegistrationCountsAsync(int timeOffset);
 
     /// <summary>
-    /// Retrieves the count of logged in user in the last day.
+    /// Retrieves the daily counts of dependent registrations.
     /// </summary>
-    /// <param name="startDateLocal">The local start date to query.</param>
-    /// <param name="endDateLocal">The local end date to query.</param>
-    /// <param name="timeOffset">The offset from the client browser to UTC.</param>
-    /// <returns>The count of logged in users in the current day.</returns>
-    [Get("/LoggedInCount")]
-    Task<IDictionary<DateTime, int>> GetLoggedinUsersCountAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
-
-    /// <summary>
-    /// Retrieves the count of dependents.
-    /// </summary>
-    /// <param name="timeOffset">The offset from the client browser to UTC.</param>
-    /// <returns>The count of logged in users in the current day.</returns>
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+    /// <returns>The number of dependent registrations by date.</returns>
     [Get("/DependentCount")]
-    Task<IDictionary<DateTime, int>> GetDependentCountAsync(int timeOffset);
+    Task<IDictionary<DateOnly, int>> GetDailyDependentRegistrationCountsAsync(int timeOffset);
 
     /// <summary>
-    /// Retrieves user counts.
+    /// Retrieves the daily counts of unique user logins over a date range.
     /// </summary>
-    /// <param name="days">The number of unique days for evaluating a recurring user.</param>
     /// <param name="startDateLocal">The local start date to query.</param>
     /// <param name="endDateLocal">The local end date to query.</param>
-    /// <param name="timeOffset">The offset from the client browser to UTC.</param>
-    /// <returns>The counts of recurring users, mobile logins, and web logins.</returns>
-    [Get("/RecurringUserCounts")]
-    Task<IDictionary<string, int>> GetUserCountsAsync(int days, DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+    /// <returns>The number of unique user logins by date.</returns>
+    [Get("/LoggedInCount")]
+    Task<IDictionary<DateOnly, int>> GetDailyUniqueLoginCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+
+    /// <summary>
+    /// Retrieves a count of recurring users over a date range.
+    /// </summary>
+    /// <param name="days">Minimum number of days users must have logged in within the period to count as recurring.</param>
+    /// <param name="startDateLocal">The local start date to query.</param>
+    /// <param name="endDateLocal">The local end date to query.</param>
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+    /// <returns>A count of recurring users.</returns>
+    [Get("/RecurringUserCount")]
+    Task<int> GetRecurringUserCountAsync(int days, DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+
+    /// <summary>
+    /// Retrieves unique app login counts over a date range.
+    /// </summary>
+    /// <param name="startDateLocal">The local start date to query.</param>
+    /// <param name="endDateLocal">The local end date to query.</param>
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+    /// <returns>The login counts for Health Gateway applications.</returns>
+    [Get("/AppLoginCounts")]
+    Task<AppLoginCounts> GetAppLoginCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
 
     /// <summary>
     /// Retrieves the ratings summary.
     /// </summary>
     /// <param name="startDateLocal">The local start date to query.</param>
     /// <param name="endDateLocal">The local end date to query.</param>
-    /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
     /// <returns>A dictionary pairing the ratings with the counts.</returns>
     [Get("/Ratings/Summary")]
     Task<IDictionary<string, int>> GetRatingsSummaryAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
@@ -78,7 +89,7 @@ public interface IDashboardApi
     /// </summary>
     /// <param name="startDateLocal">The local start date to query.</param>
     /// <param name="endDateLocal">The local end date to query.</param>
-    /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
+    /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
     /// <returns>A dictionary mapping birth years to user counts.</returns>
     [Get("/YearOfBirthCounts")]
     Task<IDictionary<string, int>> GetYearOfBirthCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);

--- a/Apps/Admin/Client/Components/Dashboard/RatingSummary.razor.cs
+++ b/Apps/Admin/Client/Components/Dashboard/RatingSummary.razor.cs
@@ -33,7 +33,7 @@ public partial class RatingSummary : FluxorComponent
     [Inject]
     private IState<DashboardState> DashboardState { get; set; } = default!;
 
-    private IDictionary<string, int> RatingSummaryResult => this.DashboardState.Value.GetRatingSummary.Result ?? ImmutableDictionary<string, int>.Empty;
+    private IDictionary<string, int> RatingSummaryResult => this.DashboardState.Value.GetRatingsSummary.Result ?? ImmutableDictionary<string, int>.Empty;
 
     private IDictionary<int, int> Ratings => this.RatingSummaryResult.ToDictionary(r => Convert.ToInt32(r.Key, CultureInfo.InvariantCulture), r => r.Value);
 

--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -19,7 +19,7 @@
     <MudItem xs="12" lg="12">
         <MudPaper Class="my-2 pa-4 d-flex justify-end" Elevation="0">
             <HgButton
-                Loading="@(RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading || UserCountsLoading || RatingSummaryLoading || YearOfBirthCountsLoading)"
+                Loading="@(DailyUserRegistrationCountsLoading || DailyDependentRegistrationCountsLoading || DailyUniqueLoginCountsLoading || RecurringUserCountLoading || AppLoginCountsLoading || RatingsSummaryLoading || YearOfBirthCountsLoading)"
                 EndIcon="fas fa-arrow-rotate-right"
                 OnClick="RefreshData"
                 data-testid="refresh-btn">
@@ -29,7 +29,7 @@
     </MudItem>
 </MudGrid>
 
-@if (RegisteredUsersLoading || DependentsLoading)
+@if (DailyUserRegistrationCountsLoading || DailyDependentRegistrationCountsLoading)
 {
     <MudGrid>
         <MudItem xs="6" lg="6">
@@ -72,7 +72,7 @@ else
     </MudGrid>
 }
 
-@if (RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading || UserCountsLoading || YearOfBirthCountsLoading)
+@if (DailyUserRegistrationCountsLoading || DailyUniqueLoginCountsLoading || DailyDependentRegistrationCountsLoading || RecurringUserCountLoading || AppLoginCountsLoading || YearOfBirthCountsLoading)
 {
     <MudGrid Class="my-3">
         <MudItem xs="6" lg="3">
@@ -95,7 +95,7 @@ else
     </MudGrid>
 }
 
-@if (UserCountsLoading)
+@if (RecurringUserCountLoading || AppLoginCountsLoading)
 {
     <MudSkeleton Width="20%" />
     <MudGrid Class="my-3">
@@ -151,7 +151,7 @@ else
                     Mobile Logins
                 </MudText>
                 <MudText Align="Align.Center" Typo="Typo.subtitle1" data-testid="total-mobile-users">
-                    @MobileUserCount
+                    @AppLoginCounts.Mobile
                 </MudText>
             </MudPaper>
         </MudItem>
@@ -161,14 +161,14 @@ else
                     Web Logins
                 </MudText>
                 <MudText Align="Align.Center" Typo="Typo.subtitle1" data-testid="total-web-users">
-                    @WebUserCount
+                    @AppLoginCounts.Web
                 </MudText>
             </MudPaper>
         </MudItem>
     </MudGrid>
 }
 
-@if (RatingSummaryLoading)
+@if (RatingsSummaryLoading)
 {
     <MudSkeleton Width="20%" />
     <MudSkeleton data-testid="skeleton-rating-summary" SkeletonType="SkeletonType.Rectangle" Width="500px" Height="350px" />
@@ -213,7 +213,7 @@ else if (YearOfBirthCountsErrorMessage.Length == 0)
             Daily Data
         </MudText>
         <MudTable Class="mt-3"
-                  Loading="@(RegisteredUsersLoading || LoggedInUsersLoading || DependentsLoading)"
+                  Loading="@(DailyUserRegistrationCountsLoading || DailyUniqueLoginCountsLoading || DailyDependentRegistrationCountsLoading)"
                   Items="@TableData"
                   AllowUnsorted="false"
                   HorizontalScrollbar="true"
@@ -223,32 +223,32 @@ else if (YearOfBirthCountsErrorMessage.Length == 0)
                   data-testid="daily-data-table">
             <HeaderContent>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.DailyDateTime)"
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.Date)"
                                        InitialDirection="@SortDirection.Descending">
                         Date
                     </MudTableSortLabel>
                 </MudTh>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalRegisteredUsers)">
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.UserRegistrations)">
                         Registered
                     </MudTableSortLabel>
                 </MudTh>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalLoggedInUsers)">
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.UniqueLogins)">
                         Logged In
                     </MudTableSortLabel>
                 </MudTh>
                 <MudTh>
-                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.TotalDependents)">
+                    <MudTableSortLabel SortBy="new Func<DailyDataRow, object>(x => x.DependentRegistrations)">
                         Dependents
                     </MudTableSortLabel>
                 </MudTh>
             </HeaderContent>
             <RowTemplate>
-                <MudTd data-testid="daily-data-date" DataLabel="Date">@context.DailyDateTime.ToString("yyyy-MM-dd")</MudTd>
-                <MudTd data-testid="daily-data-total-registered-users" DataLabel="Registered">@context.TotalRegisteredUsers</MudTd>
-                <MudTd data-testid="daily-data-total-logged-in-users" DataLabel="Logged In">@context.TotalLoggedInUsers</MudTd>
-                <MudTd data-testid="daily-data-dependents" DataLabel="Dependents">@context.TotalDependents</MudTd>
+                <MudTd data-testid="daily-data-date" DataLabel="Date">@context.Date.ToString("yyyy-MM-dd")</MudTd>
+                <MudTd data-testid="daily-data-total-registered-users" DataLabel="Registered">@context.UserRegistrations</MudTd>
+                <MudTd data-testid="daily-data-total-logged-in-users" DataLabel="Logged In">@context.UniqueLogins</MudTd>
+                <MudTd data-testid="daily-data-dependents" DataLabel="Dependents">@context.DependentRegistrations</MudTd>
             </RowTemplate>
             <PagerContent>
                 <MudTablePager PageSizeOptions="new[]{10, 25, 50, 100, 200}" />

--- a/Apps/Admin/Client/Store/BaseRequestState.cs
+++ b/Apps/Admin/Client/Store/BaseRequestState.cs
@@ -37,7 +37,6 @@ public record BaseRequestState
 /// </summary>
 /// <typeparam name="TModel">The type of the model returned by the request.</typeparam>
 public record BaseRequestState<TModel> : BaseRequestState
-    where TModel : class
 {
     /// <summary>
     /// Gets the result.

--- a/Apps/Admin/Client/Store/Dashboard/DashboardActions.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardActions.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Admin.Client.Store.Dashboard;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using HealthGateway.Admin.Common.Models;
 
 /// <summary>
 /// Static class that implements all actions for the feature.
@@ -27,30 +28,51 @@ using System.Diagnostics.CodeAnalysis;
 public static class DashboardActions
 {
     /// <summary>
-    /// The action representing the initiation of a retrieval of registered users.
+    /// The action representing the initiation of a retrieval of daily user registration counts.
     /// </summary>
-    public record GetRegisteredUsersAction
+    public record GetDailyUserRegistrationCountsAction
     {
         /// <summary>
-        /// Gets the offset from the client browser to UTC.
+        /// Gets the local timezone offset from UTC in minutes.
         /// </summary>
         public required int TimeOffset { get; init; }
     }
 
     /// <summary>
-    /// The action representing a successful retrieval of registered users.
+    /// The action representing a successful retrieval of daily user registration counts.
     /// </summary>
-    public record GetRegisteredUsersSuccessAction : BaseSuccessAction<IDictionary<DateTime, int>>;
+    public record GetDailyUserRegistrationCountsSuccessAction : BaseSuccessAction<IDictionary<DateOnly, int>>;
 
     /// <summary>
-    /// The action representing a failed retrieval of registered users.
+    /// The action representing a failed retrieval of daily user registration counts.
     /// </summary>
-    public record GetRegisteredUsersFailureAction : BaseFailureAction;
+    public record GetDailyUserRegistrationCountsFailureAction : BaseFailureAction;
 
     /// <summary>
-    /// The action representing the initiation of a retrieval of logged in users.
+    /// The action representing the initiation of a retrieval of daily dependent registration counts.
     /// </summary>
-    public record GetLoggedInUsersAction
+    public record GetDailyDependentRegistrationCountsAction
+    {
+        /// <summary>
+        /// Gets the local timezone offset from UTC in minutes.
+        /// </summary>
+        public required int TimeOffset { get; init; }
+    }
+
+    /// <summary>
+    /// The action representing a successful retrieval of daily dependent registration counts.
+    /// </summary>
+    public record GetDailyDependentRegistrationCountsSuccessAction : BaseSuccessAction<IDictionary<DateOnly, int>>;
+
+    /// <summary>
+    /// The action representing a failed retrieval of daily dependent registration counts.
+    /// </summary>
+    public record GetDailyDependentRegistrationCountsFailureAction : BaseFailureAction;
+
+    /// <summary>
+    /// The action representing the initiation of a retrieval of daily unique login counts.
+    /// </summary>
+    public record GetDailyUniqueLoginCountsAction
     {
         /// <summary>
         /// Gets the local start date to query.
@@ -63,49 +85,28 @@ public static class DashboardActions
         public required DateOnly EndDateLocal { get; init; }
 
         /// <summary>
-        /// Gets the offset from the client browser to UTC.
+        /// Gets the local timezone offset from UTC in minutes.
         /// </summary>
         public required int TimeOffset { get; init; }
     }
 
     /// <summary>
-    /// The action representing a successful retrieval of logged in users.
+    /// The action representing a successful retrieval of daily unique login counts.
     /// </summary>
-    public record GetLoggedInUsersSuccessAction : BaseSuccessAction<IDictionary<DateTime, int>>;
+    public record GetDailyUniqueLoginCountsSuccessAction : BaseSuccessAction<IDictionary<DateOnly, int>>;
 
     /// <summary>
-    /// The action representing a failed retrieval of logged in users.
+    /// The action representing a failed retrieval of daily unique login counts.
     /// </summary>
-    public record GetLoggedInUsersFailureAction : BaseFailureAction;
+    public record GetDailyUniqueLoginCountsFailureAction : BaseFailureAction;
 
     /// <summary>
-    /// The action representing the initiation of a retrieval of dependents.
+    /// The action representing the initiation of a retrieval of a recurring user count.
     /// </summary>
-    public record GetDependentsAction
+    public record GetRecurringUserCountAction
     {
         /// <summary>
-        /// Gets the offset from the client browser to UTC.
-        /// </summary>
-        public required int TimeOffset { get; init; }
-    }
-
-    /// <summary>
-    /// The action representing a successful retrieval of dependents.
-    /// </summary>
-    public record GetDependentsSuccessAction : BaseSuccessAction<IDictionary<DateTime, int>>;
-
-    /// <summary>
-    /// The action representing a failed retrieval of dependents.
-    /// </summary>
-    public record GetDependentsFailureAction : BaseFailureAction;
-
-    /// <summary>
-    /// The action representing the initiation of a retrieval of user counts.
-    /// </summary>
-    public record GetUserCountsAction
-    {
-        /// <summary>
-        /// Gets the minimum number of unique days logged in required to qualify as a recurring user.
+        /// Gets the minimum number of days users must have logged in within the period to count as recurring.
         /// </summary>
         public required int Days { get; init; }
 
@@ -120,25 +121,25 @@ public static class DashboardActions
         public required DateOnly EndDateLocal { get; init; }
 
         /// <summary>
-        /// Gets the offset from the client browser to UTC.
+        /// Gets the local timezone offset from UTC in minutes.
         /// </summary>
         public required int TimeOffset { get; init; }
     }
 
     /// <summary>
-    /// The action representing a successful retrieval of user counts.
+    /// The action representing a successful retrieval of a recurring user count.
     /// </summary>
-    public record GetUserCountsSuccessAction : BaseSuccessAction<IDictionary<string, int>>;
+    public record GetRecurringUserCountSuccessAction : BaseSuccessAction<int>;
 
     /// <summary>
-    /// The action representing a failed retrieval of user counts.
+    /// The action representing a failed retrieval of a recurring user count.
     /// </summary>
-    public record GetUserCountsFailureAction : BaseFailureAction;
+    public record GetRecurringUserCountFailureAction : BaseFailureAction;
 
     /// <summary>
-    /// The action representing the initiation of a retrieval of a ratings summary.
+    /// The action representing the initiation of a retrieval of app login counts.
     /// </summary>
-    public record GetRatingSummaryAction
+    public record GetAppLoginCountsAction
     {
         /// <summary>
         /// Gets the local start date to query.
@@ -151,7 +152,38 @@ public static class DashboardActions
         public required DateOnly EndDateLocal { get; init; }
 
         /// <summary>
-        /// Gets the offset from the client browser to UTC.
+        /// Gets the local timezone offset from UTC in minutes.
+        /// </summary>
+        public required int TimeOffset { get; init; }
+    }
+
+    /// <summary>
+    /// The action representing a successful retrieval of app login counts.
+    /// </summary>
+    public record GetAppLoginCountsSuccessAction : BaseSuccessAction<AppLoginCounts>;
+
+    /// <summary>
+    /// The action representing a failed retrieval of app login counts.
+    /// </summary>
+    public record GetAppLoginCountsFailureAction : BaseFailureAction;
+
+    /// <summary>
+    /// The action representing the initiation of a retrieval of a ratings summary.
+    /// </summary>
+    public record GetRatingsSummaryAction
+    {
+        /// <summary>
+        /// Gets the local start date to query.
+        /// </summary>
+        public required DateOnly StartDateLocal { get; init; }
+
+        /// <summary>
+        /// Gets the local end date to query.
+        /// </summary>
+        public required DateOnly EndDateLocal { get; init; }
+
+        /// <summary>
+        /// Gets the local timezone offset from UTC in minutes.
         /// </summary>
         public required int TimeOffset { get; init; }
     }
@@ -159,12 +191,12 @@ public static class DashboardActions
     /// <summary>
     /// The action representing a successful retrieval of a ratings summary.
     /// </summary>
-    public record GetRatingSummarySuccessAction : BaseSuccessAction<IDictionary<string, int>>;
+    public record GetRatingsSummarySuccessAction : BaseSuccessAction<IDictionary<string, int>>;
 
     /// <summary>
     /// The action representing a failed retrieval of a ratings summary.
     /// </summary>
-    public record GetRatingSummaryFailureAction : BaseFailureAction;
+    public record GetRatingsSummaryFailureAction : BaseFailureAction;
 
     /// <summary>
     /// The action representing the initiation of a retrieval of year of birth counts.
@@ -182,7 +214,7 @@ public static class DashboardActions
         public required DateOnly EndDateLocal { get; init; }
 
         /// <summary>
-        /// Gets the offset from the client browser to UTC.
+        /// Gets the local timezone offset from UTC in minutes.
         /// </summary>
         public required int TimeOffset { get; init; }
     }

--- a/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using Fluxor;
 using HealthGateway.Admin.Client.Api;
 using HealthGateway.Admin.Client.Utils;
+using HealthGateway.Admin.Common.Models;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
@@ -42,96 +43,115 @@ public class DashboardEffects
     private IDashboardApi DashboardApi { get; set; }
 
     [EffectMethod]
-    public async Task HandleGetRegisteredUsersAction(DashboardActions.GetRegisteredUsersAction action, IDispatcher dispatcher)
+    public async Task HandleGetDailyUserRegistrationCountsAction(DashboardActions.GetDailyUserRegistrationCountsAction action, IDispatcher dispatcher)
     {
-        this.Logger.LogInformation("Retrieving registered users");
+        this.Logger.LogInformation("Retrieving daily user registration counts");
         try
         {
-            IDictionary<DateTime, int> response = await this.DashboardApi.GetRegisteredUserCountAsync(action.TimeOffset).ConfigureAwait(true);
-            this.Logger.LogInformation("Registered users retrieved successfully!");
-            dispatcher.Dispatch(new DashboardActions.GetRegisteredUsersSuccessAction { Data = response });
+            IDictionary<DateOnly, int> response = await this.DashboardApi.GetDailyUserRegistrationCountsAsync(action.TimeOffset).ConfigureAwait(true);
+            this.Logger.LogInformation("Daily user registration counts retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetDailyUserRegistrationCountsSuccessAction { Data = response });
         }
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            this.Logger.LogError("Error retrieving registered users, reason: {ErrorMessage}", error.Message);
-            dispatcher.Dispatch(new DashboardActions.GetRegisteredUsersFailureAction { Error = error });
+            this.Logger.LogError("Error retrieving daily user registration counts, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetDailyUserRegistrationCountsFailureAction { Error = error });
         }
     }
 
     [EffectMethod]
-    public async Task HandleGetLoggedInUsersAction(DashboardActions.GetLoggedInUsersAction action, IDispatcher dispatcher)
+    public async Task HandleGetDailyDependentRegistrationCountsAction(DashboardActions.GetDailyDependentRegistrationCountsAction action, IDispatcher dispatcher)
     {
-        this.Logger.LogInformation("Retrieving logged in users");
+        this.Logger.LogInformation("Retrieving daily dependent registration counts");
 
         try
         {
-            IDictionary<DateTime, int> response = await this.DashboardApi.GetLoggedinUsersCountAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
-            this.Logger.LogInformation("Logged in users retrieved successfully!");
-            dispatcher.Dispatch(new DashboardActions.GetLoggedInUsersSuccessAction { Data = response });
+            IDictionary<DateOnly, int> response = await this.DashboardApi.GetDailyDependentRegistrationCountsAsync(action.TimeOffset).ConfigureAwait(true);
+            this.Logger.LogInformation("Daily dependent registration counts retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetDailyDependentRegistrationCountsSuccessAction { Data = response });
         }
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            this.Logger.LogError("Error retrieving logged in users, reason: {ErrorMessage}", error.Message);
-            dispatcher.Dispatch(new DashboardActions.GetLoggedInUsersFailureAction { Error = error });
+            this.Logger.LogError("Error retrieving daily dependent registration counts, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetDailyDependentRegistrationCountsFailureAction { Error = error });
         }
     }
 
     [EffectMethod]
-    public async Task HandleGetDependentsAction(DashboardActions.GetDependentsAction action, IDispatcher dispatcher)
+    public async Task HandleGetDailyUniqueLoginCountsAction(DashboardActions.GetDailyUniqueLoginCountsAction action, IDispatcher dispatcher)
     {
-        this.Logger.LogInformation("Retrieving dependents");
+        this.Logger.LogInformation("Retrieving daily unique login counts");
 
         try
         {
-            IDictionary<DateTime, int> response = await this.DashboardApi.GetDependentCountAsync(action.TimeOffset).ConfigureAwait(true);
-            this.Logger.LogInformation("Dependents retrieved successfully!");
-            dispatcher.Dispatch(new DashboardActions.GetDependentsSuccessAction { Data = response });
+            IDictionary<DateOnly, int> response = await this.DashboardApi.GetDailyUniqueLoginCountsAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
+            this.Logger.LogInformation("Daily unique login counts retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetDailyUniqueLoginCountsSuccessAction { Data = response });
         }
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            this.Logger.LogError("Error retrieving dependents, reason: {ErrorMessage}", error.Message);
-            dispatcher.Dispatch(new DashboardActions.GetDependentsFailureAction { Error = error });
+            this.Logger.LogError("Error retrieving daily unique login counts, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetDailyUniqueLoginCountsFailureAction { Error = error });
         }
     }
 
     [EffectMethod]
-    public async Task HandleGetUserCountsAction(DashboardActions.GetUserCountsAction action, IDispatcher dispatcher)
+    public async Task HandleGetRecurringUserCountAction(DashboardActions.GetRecurringUserCountAction action, IDispatcher dispatcher)
     {
-        this.Logger.LogInformation("Retrieving user counts");
+        this.Logger.LogInformation("Retrieving recurring user count");
 
         try
         {
-            IDictionary<string, int> response = await this.DashboardApi.GetUserCountsAsync(action.Days, action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
-            this.Logger.LogInformation("User counts retrieved successfully!");
-            dispatcher.Dispatch(new DashboardActions.GetUserCountsSuccessAction { Data = response });
+            int response = await this.DashboardApi.GetRecurringUserCountAsync(action.Days, action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
+            this.Logger.LogInformation("Recurring user count retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetRecurringUserCountSuccessAction { Data = response });
         }
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            this.Logger.LogError("Error retrieving user counts, reason: {ErrorMessage}", error.Message);
-            dispatcher.Dispatch(new DashboardActions.GetUserCountsFailureAction { Error = error });
+            this.Logger.LogError("Error retrieving recurring user count, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetRecurringUserCountFailureAction { Error = error });
         }
     }
 
     [EffectMethod]
-    public async Task HandleGetRatingSummaryAction(DashboardActions.GetRatingSummaryAction action, IDispatcher dispatcher)
+    public async Task HandleGetAppLoginCountsAction(DashboardActions.GetAppLoginCountsAction action, IDispatcher dispatcher)
     {
-        this.Logger.LogInformation("Retrieving rating summary");
+        this.Logger.LogInformation("Retrieving app login counts");
+
+        try
+        {
+            AppLoginCounts response = await this.DashboardApi.GetAppLoginCountsAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
+            this.Logger.LogInformation("App login counts retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetAppLoginCountsSuccessAction { Data = response });
+        }
+        catch (ApiException ex)
+        {
+            RequestError error = StoreUtility.FormatRequestError(ex);
+            this.Logger.LogError("Error retrieving recurring app login counts, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetAppLoginCountsFailureAction { Error = error });
+        }
+    }
+
+    [EffectMethod]
+    public async Task HandleGetRatingsSummaryAction(DashboardActions.GetRatingsSummaryAction action, IDispatcher dispatcher)
+    {
+        this.Logger.LogInformation("Retrieving ratings summary");
 
         try
         {
             IDictionary<string, int> response = await this.DashboardApi.GetRatingsSummaryAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
-            this.Logger.LogInformation("Rating summary retrieved successfully!");
-            dispatcher.Dispatch(new DashboardActions.GetRatingSummarySuccessAction { Data = response });
+            this.Logger.LogInformation("Ratings summary retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetRatingsSummarySuccessAction { Data = response });
         }
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            this.Logger.LogError("Error retrieving rating summary, reason: {ErrorMessage}", error.Message);
-            dispatcher.Dispatch(new DashboardActions.GetRatingSummaryFailureAction { Error = error });
+            this.Logger.LogError("Error retrieving ratings summary, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetRatingsSummaryFailureAction { Error = error });
         }
     }
 
@@ -143,7 +163,7 @@ public class DashboardEffects
         try
         {
             IDictionary<string, int> response = await this.DashboardApi.GetYearOfBirthCountsAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
-            this.Logger.LogInformation("Year of birth counts retrieved successfully!");
+            this.Logger.LogInformation("Year of birth counts retrieved successfully");
             dispatcher.Dispatch(new DashboardActions.GetYearOfBirthCountsSuccessAction { Data = response });
         }
         catch (ApiException ex)

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -24,21 +24,21 @@ using Fluxor;
 #pragma warning disable CS1591, SA1600
 public static class DashboardReducers
 {
-    [ReducerMethod(typeof(DashboardActions.GetRegisteredUsersAction))]
+    [ReducerMethod(typeof(DashboardActions.GetDailyUserRegistrationCountsAction))]
     public static DashboardState ReduceGetRegisteredUsersAction(DashboardState state)
     {
         return state with
         {
-            GetRegisteredUsers = state.GetRegisteredUsers with { IsLoading = true },
+            GetDailyUserRegistrationCounts = state.GetDailyUserRegistrationCounts with { IsLoading = true },
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetRegisteredUsersSuccessAction(DashboardState state, DashboardActions.GetRegisteredUsersSuccessAction action)
+    public static DashboardState ReduceGetDailyUserRegistrationCountsSuccessAction(DashboardState state, DashboardActions.GetDailyUserRegistrationCountsSuccessAction action)
     {
         return state with
         {
-            GetRegisteredUsers = state.GetRegisteredUsers with
+            GetDailyUserRegistrationCounts = state.GetDailyUserRegistrationCounts with
             {
                 Result = action.Data,
                 IsLoading = false,
@@ -48,11 +48,11 @@ public static class DashboardReducers
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetRegisteredUsersFailureAction(DashboardState state, DashboardActions.GetRegisteredUsersFailureAction action)
+    public static DashboardState ReduceGetDailyUserRegistrationCountsFailureAction(DashboardState state, DashboardActions.GetDailyUserRegistrationCountsFailureAction action)
     {
         return state with
         {
-            GetRegisteredUsers = state.GetRegisteredUsers with
+            GetDailyUserRegistrationCounts = state.GetDailyUserRegistrationCounts with
             {
                 Result = null,
                 IsLoading = false,
@@ -61,21 +61,21 @@ public static class DashboardReducers
         };
     }
 
-    [ReducerMethod(typeof(DashboardActions.GetLoggedInUsersAction))]
-    public static DashboardState ReduceGetLoggedInUsersAction(DashboardState state)
+    [ReducerMethod(typeof(DashboardActions.GetDailyUniqueLoginCountsAction))]
+    public static DashboardState ReduceGetDailyUniqueLoginCountsAction(DashboardState state)
     {
         return state with
         {
-            GetLoggedInUsers = state.GetLoggedInUsers with { IsLoading = true },
+            GetDailyUniqueLoginCounts = state.GetDailyUniqueLoginCounts with { IsLoading = true },
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetLoggedInUsersSuccessAction(DashboardState state, DashboardActions.GetLoggedInUsersSuccessAction action)
+    public static DashboardState ReduceGetDailyUniqueLoginCountsSuccessAction(DashboardState state, DashboardActions.GetDailyUniqueLoginCountsSuccessAction action)
     {
         return state with
         {
-            GetLoggedInUsers = state.GetLoggedInUsers with
+            GetDailyUniqueLoginCounts = state.GetDailyUniqueLoginCounts with
             {
                 Result = action.Data,
                 IsLoading = false,
@@ -85,11 +85,11 @@ public static class DashboardReducers
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetLoggedInUserFailureAction(DashboardState state, DashboardActions.GetLoggedInUsersFailureAction action)
+    public static DashboardState GetDailyUniqueLoginCountsFailureAction(DashboardState state, DashboardActions.GetDailyUniqueLoginCountsFailureAction action)
     {
         return state with
         {
-            GetLoggedInUsers = state.GetLoggedInUsers with
+            GetDailyUniqueLoginCounts = state.GetDailyUniqueLoginCounts with
             {
                 Result = null,
                 IsLoading = false,
@@ -98,21 +98,21 @@ public static class DashboardReducers
         };
     }
 
-    [ReducerMethod(typeof(DashboardActions.GetDependentsAction))]
-    public static DashboardState ReduceGetDependentsAction(DashboardState state)
+    [ReducerMethod(typeof(DashboardActions.GetDailyDependentRegistrationCountsAction))]
+    public static DashboardState ReduceGetDailyDependentRegistrationCountsAction(DashboardState state)
     {
         return state with
         {
-            GetDependents = state.GetDependents with { IsLoading = true },
+            GetDailyDependentRegistrationCounts = state.GetDailyDependentRegistrationCounts with { IsLoading = true },
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReducGeteDependentsSuccessAction(DashboardState state, DashboardActions.GetDependentsSuccessAction action)
+    public static DashboardState ReduceGetDailyDependentRegistrationCountsSuccessAction(DashboardState state, DashboardActions.GetDailyDependentRegistrationCountsSuccessAction action)
     {
         return state with
         {
-            GetDependents = state.GetDependents with
+            GetDailyDependentRegistrationCounts = state.GetDailyDependentRegistrationCounts with
             {
                 Result = action.Data,
                 IsLoading = false,
@@ -122,11 +122,11 @@ public static class DashboardReducers
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetDependentsFailureAction(DashboardState state, DashboardActions.GetDependentsFailureAction action)
+    public static DashboardState ReduceGetDailyDependentRegistrationCountsFailureAction(DashboardState state, DashboardActions.GetDailyDependentRegistrationCountsFailureAction action)
     {
         return state with
         {
-            GetDependents = state.GetDependents with
+            GetDailyDependentRegistrationCounts = state.GetDailyDependentRegistrationCounts with
             {
                 Result = null,
                 IsLoading = false,
@@ -135,21 +135,21 @@ public static class DashboardReducers
         };
     }
 
-    [ReducerMethod(typeof(DashboardActions.GetUserCountsAction))]
-    public static DashboardState ReduceGetUserCountsAction(DashboardState state)
+    [ReducerMethod(typeof(DashboardActions.GetRecurringUserCountAction))]
+    public static DashboardState ReduceGetRecurringUserCountAction(DashboardState state)
     {
         return state with
         {
-            GetUserCounts = state.GetUserCounts with { IsLoading = true },
+            GetRecurringUserCount = state.GetRecurringUserCount with { IsLoading = true },
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetUserCountsSuccessAction(DashboardState state, DashboardActions.GetUserCountsSuccessAction action)
+    public static DashboardState ReduceGetRecurringUserCountSuccessAction(DashboardState state, DashboardActions.GetRecurringUserCountSuccessAction action)
     {
         return state with
         {
-            GetUserCounts = state.GetUserCounts with
+            GetRecurringUserCount = state.GetRecurringUserCount with
             {
                 Result = action.Data,
                 IsLoading = false,
@@ -159,11 +159,11 @@ public static class DashboardReducers
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetUserCountsFailureAction(DashboardState state, DashboardActions.GetUserCountsFailureAction action)
+    public static DashboardState ReduceGetRecurringUserCountFailureAction(DashboardState state, DashboardActions.GetRecurringUserCountFailureAction action)
     {
         return state with
         {
-            GetUserCounts = state.GetUserCounts with
+            GetRecurringUserCount = state.GetRecurringUserCount with
             {
                 Result = null,
                 IsLoading = false,
@@ -172,21 +172,21 @@ public static class DashboardReducers
         };
     }
 
-    [ReducerMethod(typeof(DashboardActions.GetRatingSummaryAction))]
-    public static DashboardState ReduceGetRatingSummaryAction(DashboardState state)
+    [ReducerMethod(typeof(DashboardActions.GetAppLoginCountsAction))]
+    public static DashboardState ReduceGetAppLoginCountsAction(DashboardState state)
     {
         return state with
         {
-            GetRatingSummary = state.GetRatingSummary with { IsLoading = true },
+            GetAppLoginCounts = state.GetAppLoginCounts with { IsLoading = true },
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetRatingSummarySuccessAction(DashboardState state, DashboardActions.GetRatingSummarySuccessAction action)
+    public static DashboardState ReduceGetAppLoginCountsSuccessAction(DashboardState state, DashboardActions.GetAppLoginCountsSuccessAction action)
     {
         return state with
         {
-            GetRatingSummary = state.GetRatingSummary with
+            GetAppLoginCounts = state.GetAppLoginCounts with
             {
                 Result = action.Data,
                 IsLoading = false,
@@ -196,11 +196,48 @@ public static class DashboardReducers
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetRatingSummaryFailureAction(DashboardState state, DashboardActions.GetRatingSummaryFailureAction action)
+    public static DashboardState ReduceGetAppLoginCountsFailureAction(DashboardState state, DashboardActions.GetAppLoginCountsFailureAction action)
     {
         return state with
         {
-            GetRatingSummary = state.GetRatingSummary with
+            GetAppLoginCounts = state.GetAppLoginCounts with
+            {
+                Result = null,
+                IsLoading = false,
+                Error = action.Error,
+            },
+        };
+    }
+
+    [ReducerMethod(typeof(DashboardActions.GetRatingsSummaryAction))]
+    public static DashboardState ReduceGetRatingsSummaryAction(DashboardState state)
+    {
+        return state with
+        {
+            GetRatingsSummary = state.GetRatingsSummary with { IsLoading = true },
+        };
+    }
+
+    [ReducerMethod]
+    public static DashboardState ReduceGetRatingsSummarySuccessAction(DashboardState state, DashboardActions.GetRatingsSummarySuccessAction action)
+    {
+        return state with
+        {
+            GetRatingsSummary = state.GetRatingsSummary with
+            {
+                Result = action.Data,
+                IsLoading = false,
+                Error = null,
+            },
+        };
+    }
+
+    [ReducerMethod]
+    public static DashboardState ReduceGetRatingsSummaryFailureAction(DashboardState state, DashboardActions.GetRatingsSummaryFailureAction action)
+    {
+        return state with
+        {
+            GetRatingsSummary = state.GetRatingsSummary with
             {
                 Result = null,
                 IsLoading = false,
@@ -269,11 +306,12 @@ public static class DashboardReducers
     {
         return state with
         {
-            GetRegisteredUsers = new(),
-            GetLoggedInUsers = new(),
-            GetDependents = new(),
-            GetUserCounts = new(),
-            GetRatingSummary = new(),
+            GetDailyUserRegistrationCounts = new(),
+            GetDailyUniqueLoginCounts = new(),
+            GetDailyDependentRegistrationCounts = new(),
+            GetRecurringUserCount = new(),
+            GetAppLoginCounts = new(),
+            GetRatingsSummary = new(),
             GetYearOfBirthCounts = new(),
             YearOfBirthCounts = ImmutableDictionary<string, int>.Empty,
         };

--- a/Apps/Admin/Client/Store/Dashboard/DashboardState.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardState.cs
@@ -20,6 +20,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using Fluxor;
+using HealthGateway.Admin.Common.Models;
 
 /// <summary>
 /// The state for the feature.
@@ -29,29 +30,34 @@ using Fluxor;
 public record DashboardState
 {
     /// <summary>
-    /// Gets the request state for retrieving registered users.
+    /// Gets the request state for retrieving daily counts of user registrations.
     /// </summary>
-    public BaseRequestState<IDictionary<DateTime, int>> GetRegisteredUsers { get; init; } = new();
+    public BaseRequestState<IDictionary<DateOnly, int>> GetDailyUserRegistrationCounts { get; init; } = new();
 
     /// <summary>
-    /// Gets the request state for retrieving logged in users.
+    /// Gets the request state for retrieving daily counts of dependent registrations.
     /// </summary>
-    public BaseRequestState<IDictionary<DateTime, int>> GetLoggedInUsers { get; init; } = new();
+    public BaseRequestState<IDictionary<DateOnly, int>> GetDailyDependentRegistrationCounts { get; init; } = new();
 
     /// <summary>
-    /// Gets the request state for retrieving dependents.
+    /// Gets the request state for retrieving daily counts of unique user logins.
     /// </summary>
-    public BaseRequestState<IDictionary<DateTime, int>> GetDependents { get; init; } = new();
+    public BaseRequestState<IDictionary<DateOnly, int>> GetDailyUniqueLoginCounts { get; init; } = new();
 
     /// <summary>
-    /// Gets the request state for retrieving user counts.
+    /// Gets the request state for retrieving a recurring user count.
     /// </summary>
-    public BaseRequestState<IDictionary<string, int>> GetUserCounts { get; init; } = new();
+    public BaseRequestState<int?> GetRecurringUserCount { get; init; } = new();
 
     /// <summary>
-    /// Gets the request state for retrieving a rating summary.
+    /// Gets the request state for retrieving app login counts.
     /// </summary>
-    public BaseRequestState<IDictionary<string, int>> GetRatingSummary { get; init; } = new();
+    public BaseRequestState<AppLoginCounts> GetAppLoginCounts { get; init; } = new();
+
+    /// <summary>
+    /// Gets the request state for retrieving a ratings summary.
+    /// </summary>
+    public BaseRequestState<IDictionary<string, int>> GetRatingsSummary { get; init; } = new();
 
     /// <summary>
     /// Gets the request state for retrieving year of birth counts.

--- a/Apps/Admin/Common/Models/AppLoginCounts.cs
+++ b/Apps/Admin/Common/Models/AppLoginCounts.cs
@@ -1,4 +1,4 @@
-// -------------------------------------------------------------------------
+﻿// -------------------------------------------------------------------------
 //  Copyright © 2019 Province of British Columbia
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,24 +13,12 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.Data.Constants
+namespace HealthGateway.Admin.Common.Models
 {
-    using System.Text.Json.Serialization;
-
     /// <summary>
-    /// Represents the type of login client used.
+    /// Model containing login counts for Health Gateway applications.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
-    public enum UserLoginClientType
-    {
-        /// <summary>
-        /// Login from Health Gateway web app.
-        /// </summary>
-        Web,
-
-        /// <summary>
-        /// Login from Health Gateway mobile app.
-        /// </summary>
-        Mobile,
-    }
+    /// <param name="Web">Number of Health Gateway web app logins.</param>
+    /// <param name="Mobile">Number of Health Gateway mobile app logins.</param>
+    public record AppLoginCounts(int Web, int Mobile);
 }

--- a/Apps/Admin/Server/Controllers/DashboardController.cs
+++ b/Apps/Admin/Server/Controllers/DashboardController.cs
@@ -19,13 +19,14 @@ namespace HealthGateway.Admin.Server.Controllers
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Mvc;
 
     /// <summary>
-    /// Web API to handle user feedback review.
+    /// Web API for the Admin dashboard.
     /// </summary>
     [ApiController]
     [ApiVersion("1.0")]
@@ -46,11 +47,12 @@ namespace HealthGateway.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Retrieves the count of registered users.
+        /// Retrieves the daily counts of user registrations.
         /// </summary>
-        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
-        /// <returns>The count of registered users.</returns>
-        /// <response code="200">Returns the count of registered users.</response>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of user registrations by date.</returns>
+        /// <response code="200">Returns the number of user registrations by date.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
         /// The client does not have access rights to the content; that is, it is unauthorized, so the server
@@ -58,37 +60,21 @@ namespace HealthGateway.Admin.Server.Controllers
         /// </response>
         [HttpGet]
         [Route("RegisteredCount")]
-        public IActionResult GetRegisteredUserCount(int timeOffset)
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IDictionary<DateOnly, int>> GetDailyUserRegistrationCounts([FromQuery] int timeOffset, CancellationToken ct)
         {
-            return new JsonResult(this.dashboardService.GetDailyRegisteredUsersCount(timeOffset));
+            return await this.dashboardService.GetDailyUserRegistrationCountsAsync(timeOffset, ct);
         }
 
         /// <summary>
-        /// Retrieves the count of logged in user in the last day.
+        /// Retrieves the daily counts of dependent registrations.
         /// </summary>
-        /// <param name="startDateLocal">The starting date to get the user counts in the client's Local time.</param>
-        /// <param name="endDateLocal">The ending date for the query in the client's local time.</param>
-        /// <param name="timeOffset">The current timezone offset from the client browser to UTC in minutes.</param>
-        /// <returns>The count of logged in users in the current day.</returns>
-        /// <response code="200">Returns the list of user feedbacks.</response>
-        /// <response code="401">The client must authenticate itself to get the requested response.</response>
-        /// <response code="403">
-        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
-        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
-        /// </response>
-        [HttpGet]
-        [Route("LoggedInCount")]
-        public IActionResult GetLoggedInUsersCount(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset)
-        {
-            return new JsonResult(this.dashboardService.GetDailyLoggedInUsersCount(startDateLocal, endDateLocal, timeOffset));
-        }
-
-        /// <summary>
-        /// Retrieves the count of dependents.
-        /// </summary>
-        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
-        /// <returns>The count of logged in users in the current day.</returns>
-        /// <response code="200">Returns the list of user feedbacks.</response>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of dependent registrations by date.</returns>
+        /// <response code="200">Returns the number of dependent registrations by date.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
         /// The client does not have access rights to the content; that is, it is unauthorized, so the server
@@ -96,38 +82,107 @@ namespace HealthGateway.Admin.Server.Controllers
         /// </response>
         [HttpGet]
         [Route("DependentCount")]
-        public IActionResult GetDependentCount(int timeOffset)
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IDictionary<DateOnly, int>> GetDailyDependentRegistrationCounts([FromQuery] int timeOffset, CancellationToken ct)
         {
-            return new JsonResult(this.dashboardService.GetDailyDependentCount(timeOffset));
+            return await this.dashboardService.GetDailyDependentRegistrationCountsAsync(timeOffset, ct);
         }
 
         /// <summary>
-        /// Retrieves recurring user counts.
+        /// Retrieves the daily counts of unique user logins over a date range.
         /// </summary>
-        /// <param name="days">The number of unique days for evaluating a user.</param>
-        /// <param name="startDateLocal">The starting date to get the user counts in the client's Local time.</param>
-        /// <param name="endDateLocal">The ending date for the query in the client's local time.</param>
-        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
-        /// <returns>The recurrent user counts.</returns>
-        /// <response code="200">Returns the list of user feedbacks.</response>
+        /// <param name="startDateLocal">The local start date to query.</param>
+        /// <param name="endDateLocal">The local end date to query.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of unique user logins by date.</returns>
+        /// <response code="200">Returns the number of unique user logins by date.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
         /// The client does not have access rights to the content; that is, it is unauthorized, so the server
         /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
         /// </response>
         [HttpGet]
-        [Route("RecurringUserCounts")]
-        public IActionResult GetRecurringUserCounts(int days, DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset)
+        [Route("LoggedInCount")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IDictionary<DateOnly, int>> GetDailyUniqueLoginCounts(
+            [FromQuery] DateOnly startDateLocal,
+            [FromQuery] DateOnly endDateLocal,
+            [FromQuery] int timeOffset,
+            CancellationToken ct)
         {
-            return new JsonResult(this.dashboardService.GetRecurrentUserCounts(days, startDateLocal, endDateLocal, timeOffset));
+            return await this.dashboardService.GetDailyUniqueLoginCountsAsync(startDateLocal, endDateLocal, timeOffset, ct);
+        }
+
+        /// <summary>
+        /// Retrieves a count of recurring users over a date range.
+        /// </summary>
+        /// <param name="days">Minimum number of days users must have logged in within the period to count as recurring.</param>
+        /// <param name="startDateLocal">The local start date to query.</param>
+        /// <param name="endDateLocal">The local end date to query.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A count of recurring users.</returns>
+        /// <response code="200">Returns a count of recurring users.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        [Route("RecurringUserCount")]
+        public async Task<int> GetRecurringUserCount(
+            [FromQuery] int days,
+            [FromQuery] DateOnly startDateLocal,
+            [FromQuery] DateOnly endDateLocal,
+            [FromQuery] int timeOffset,
+            CancellationToken ct)
+        {
+            return await this.dashboardService.GetRecurringUserCountAsync(days, startDateLocal, endDateLocal, timeOffset, ct);
+        }
+
+        /// <summary>
+        /// Retrieves unique app login counts over a date range.
+        /// </summary>
+        /// <param name="startDateLocal">The local start date to query.</param>
+        /// <param name="endDateLocal">The local end date to query.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The login counts for Health Gateway applications.</returns>
+        /// <response code="200">Returns the login counts for Health Gateway applications.</response>
+        /// <response code="401">The client must authenticate itself to get the requested resource.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        [Route("AppLoginCounts")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<AppLoginCounts> GetAppLoginCounts(
+            [FromQuery] DateOnly startDateLocal,
+            [FromQuery] DateOnly endDateLocal,
+            [FromQuery] int timeOffset,
+            CancellationToken ct)
+        {
+            return await this.dashboardService.GetAppLoginCountsAsync(startDateLocal, endDateLocal, timeOffset, ct);
         }
 
         /// <summary>
         /// Retrieves the ratings summary.
         /// </summary>
-        /// <param name="startDateLocal">The starting date to calculate the summary in the client's Local time.</param>
-        /// <param name="endDateLocal">The ending date for the query in the client's local time.</param>
-        /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
+        /// <param name="startDateLocal">The local start date to query.</param>
+        /// <param name="endDateLocal">The local end date to query.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dictionary pairing the ratings with the counts.</returns>
         /// <response code="200">Returns the ratings summary.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -137,19 +192,26 @@ namespace HealthGateway.Admin.Server.Controllers
         /// </response>
         [HttpGet]
         [Route("Ratings/Summary")]
-        public IActionResult GetRatingsSummary([FromQuery] DateOnly startDateLocal, [FromQuery] DateOnly endDateLocal, [FromQuery] int timeOffset)
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<IDictionary<string, int>> GetRatingsSummary(
+            [FromQuery] DateOnly startDateLocal,
+            [FromQuery] DateOnly endDateLocal,
+            [FromQuery] int timeOffset,
+            CancellationToken ct)
         {
-            return new JsonResult(this.dashboardService.GetRatingSummary(startDateLocal, endDateLocal, timeOffset));
+            return await this.dashboardService.GetRatingsSummaryAsync(startDateLocal, endDateLocal, timeOffset, ct);
         }
 
         /// <summary>
         /// Retrieves year of birth counts for users that have logged in between two dates.
         /// </summary>
-        /// <returns>A dictionary mapping birth years to user counts.</returns>
-        /// <param name="startDateLocal">The starting date to get the birth counts in the client's Local time.</param>
-        /// <param name="endDateLocal">The ending date for the query in the client's local time.</param>
+        /// <param name="startDateLocal">The local start date to query.</param>
+        /// <param name="endDateLocal">The local end date to query.</param>
         /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A dictionary mapping birth years to user counts.</returns>
         /// <response code="200">Returns a dictionary mapping birth years to user counts.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -161,7 +223,11 @@ namespace HealthGateway.Admin.Server.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IDictionary<string, int>> GetYearOfBirthCounts([FromQuery] DateOnly startDateLocal, [FromQuery] DateOnly endDateLocal, [FromQuery] int timeOffset, CancellationToken ct)
+        public async Task<IDictionary<string, int>> GetYearOfBirthCounts(
+            [FromQuery] DateOnly startDateLocal,
+            [FromQuery] DateOnly endDateLocal,
+            [FromQuery] int timeOffset,
+            CancellationToken ct)
         {
             return await this.dashboardService.GetYearOfBirthCountsAsync(startDateLocal, endDateLocal, timeOffset, ct);
         }

--- a/Apps/Admin/Server/Services/IDashboardService.cs
+++ b/Apps/Admin/Server/Services/IDashboardService.cs
@@ -19,60 +19,76 @@ namespace HealthGateway.Admin.Server.Services
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Admin.Common.Models;
 
     /// <summary>
-    /// Service that provides functionality to the admin dashboard.
+    /// Service that provides functionality for the Admin dashboard.
     /// </summary>
     public interface IDashboardService
     {
         /// <summary>
-        /// Retrieves the daily count of registered users.
+        /// Retrieves the daily counts of user registrations.
         /// </summary>
-        /// <param name="timeOffset">The time offset from the client browser to UTC.</param>
-        /// <returns>The count of user profiles that accepted the terms of service.</returns>
-        IDictionary<DateTime, int> GetDailyRegisteredUsersCount(int timeOffset);
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of user registrations by date.</returns>
+        Task<IDictionary<DateOnly, int>> GetDailyUserRegistrationCountsAsync(int timeOffset, CancellationToken ct = default);
 
         /// <summary>
-        /// Retrieves the daily count of logged in users in the current day.
+        /// Retrieves the daily counts of dependent registrations.
+        /// </summary>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of dependent registrations by date.</returns>
+        Task<IDictionary<DateOnly, int>> GetDailyDependentRegistrationCountsAsync(int timeOffset, CancellationToken ct = default);
+
+        /// <summary>
+        /// Retrieves the daily counts of unique user logins over a date range.
         /// </summary>
         /// <param name="startDateLocal">The local start date to query.</param>
         /// <param name="endDateLocal">The local end date to query.</param>
-        /// <param name="timeOffset">The time offset from the client browser to UTC.</param>
-        /// <returns>The count of logged in user.</returns>
-        IDictionary<DateTime, int> GetDailyLoggedInUsersCount(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of unique user logins by date.</returns>
+        Task<IDictionary<DateOnly, int>> GetDailyUniqueLoginCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct = default);
 
         /// <summary>
-        /// Retrieves the count of dependents.
+        /// Retrieves a count of recurring users over a date range.
         /// </summary>
-        /// <param name="timeOffset">The time offset from the client browser to UTC.</param>
-        /// <returns>The count of dependents.</returns>
-        IDictionary<DateTime, int> GetDailyDependentCount(int timeOffset);
-
-        /// <summary>
-        /// Retrieves the recurring user counts.
-        /// </summary>
-        /// <param name="dayCount">The number of unique days for evaluating a user.</param>
+        /// <param name="dayCount">Minimum number of days users must have logged in within the period to count as recurring.</param>
         /// <param name="startDateLocal">The local start date to query.</param>
         /// <param name="endDateLocal">The local end date to query.</param>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
-        /// <returns>The counts for recurrent users.</returns>
-        IDictionary<string, int> GetRecurrentUserCounts(int dayCount, DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A count of recurring users.</returns>
+        Task<int> GetRecurringUserCountAsync(int dayCount, DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct = default);
 
         /// <summary>
-        /// Retrieves the ratings summary.
+        /// Retrieves unique app login counts over a date range.
         /// </summary>
         /// <param name="startDateLocal">The local start date to query.</param>
         /// <param name="endDateLocal">The local end date to query.</param>
-        /// <param name="timeOffset">The offset from the client browser to UTC.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The login counts for Health Gateway applications.</returns>
+        Task<AppLoginCounts> GetAppLoginCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct = default);
+
+        /// <summary>
+        /// Retrieves app ratings over a date range.
+        /// </summary>
+        /// <param name="startDateLocal">The local start date to query.</param>
+        /// <param name="endDateLocal">The local end date to query.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dictionary pairing the ratings with the counts.</returns>
-        IDictionary<string, int> GetRatingSummary(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+        Task<IDictionary<string, int>> GetRatingsSummaryAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves year of birth counts for users that have logged in between two dates.
         /// </summary>
         /// <param name="startDateLocal">The local start date to query.</param>
         /// <param name="endDateLocal">The local end date to query.</param>
-        /// <param name="timeOffset">The clients offset to get to UTC.</param>
+        /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dictionary mapping birth years to user counts.</returns>
         Task<IDictionary<string, int>> GetYearOfBirthCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct);

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/dashboard.cy.js
@@ -12,8 +12,9 @@ function getPastDate(daysAgo) {
     // resetting the hours to 0 will fix this, since the day boundary hasn't been crossed
     date.setUTCHours(0);
 
-    cy.log(`"${daysAgo} days ago" was ${date.toISOString()}`);
-    return date.toISOString();
+    const dateString = date.toISOString().substring(0, 10);
+    cy.log(`"${daysAgo} days ago" was ${dateString}`);
+    return dateString;
 }
 
 describe("Dashboard", () => {
@@ -51,11 +52,14 @@ describe("Dashboard", () => {
         });
 
         // matches [data-testid=total-unique-users]
-        cy.intercept("GET", "**/Dashboard/RecurringUserCounts?days=3*", {
+        cy.intercept("GET", "**/Dashboard/RecurringUserCount?days=3*", {
+            body: 2,
+        });
+
+        cy.intercept("GET", "**/Dashboard/AppLoginCounts*", {
             body: {
                 Mobile: 1,
                 Web: 4,
-                RecurringUserCount: 2,
             },
         });
 
@@ -95,24 +99,16 @@ describe("Dashboard", () => {
             });
 
         cy.log("Change value in unique days input field.");
-        cy.intercept("GET", "**/Dashboard/RecurringUserCounts?days=5*", {
-            body: {
-                Mobile: 0,
-                Web: 0,
-                RecurringUserCount: 0,
-            },
+        cy.intercept("GET", "**/Dashboard/RecurringUserCount?days=5*", {
+            body: 0,
         });
         cy.log("Updating unique days input value.");
         cy.get("[data-testid=unique-days-input]").clear().type(5);
         cy.get("[data-testid=total-unique-users]").click();
         cy.get("[data-testid=total-unique-users]").contains(0);
 
-        cy.intercept("GET", "**/Dashboard/RecurringUserCounts?days=2*", {
-            body: {
-                Mobile: 0,
-                Web: 0,
-                RecurringUserCount: 3,
-            },
+        cy.intercept("GET", "**/Dashboard/RecurringUserCount?days=2*", {
+            body: 3,
         });
         cy.log("Updating unique days input value.");
         cy.get("[data-testid=unique-days-input]").clear().type(2);
@@ -149,11 +145,14 @@ describe("Dashboard", () => {
             fixture: "DashboardService/summary-refresh.json",
         });
 
-        cy.intercept("GET", "**/Dashboard/RecurringUserCounts?days=2*", {
+        cy.intercept("GET", "**/Dashboard/RecurringUserCount?days=2*", {
+            body: 10,
+        });
+
+        cy.intercept("GET", "**/Dashboard/AppLoginCounts*", {
             body: {
                 Mobile: 0,
                 Web: 0,
-                RecurringUserCount: 10,
             },
         });
 

--- a/Apps/Database/src/Delegates/DbProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbProfileDelegate.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.Database.Delegates
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
@@ -238,55 +239,55 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public IDictionary<DateTime, int> GetDailyRegisteredUsersCount(TimeSpan offset)
+        public async Task<IDictionary<DateOnly, int>> GetDailyUserRegistrationCountsAsync(TimeSpan offset, CancellationToken ct = default)
         {
-            Dictionary<DateTime, int> dateCount = this.dbContext.UserProfile
+            return await this.dbContext.UserProfile
                 .Select(x => new { x.HdId, createdDate = x.CreatedDateTime.AddMinutes(offset.TotalMinutes).Date })
                 .GroupBy(x => x.createdDate)
                 .Select(x => new { createdDate = x.Key, count = x.Count() })
                 .OrderBy(x => x.createdDate)
-                .ToDictionary(x => x.createdDate, x => x.count);
-
-            return dateCount;
+                .ToDictionaryAsync(x => DateOnly.FromDateTime(x.createdDate), x => x.count, ct);
         }
 
         /// <inheritdoc/>
-        public IDictionary<DateTime, int> GetLoggedInUsersCount(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset)
+        public async Task<IDictionary<DateOnly, int>> GetDailyUniqueLoginCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default)
         {
             TimeSpan offset = startDateTimeOffset.Offset;
             var userProfileQuery = this.dbContext.UserProfile
                 .Where(u => u.LastLoginDateTime >= startDateTimeOffset.UtcDateTime && u.LastLoginDateTime <= endDateTimeOffset.UtcDateTime)
-                .Select(u => new
-                {
-                    u.HdId,
-                    u.LastLoginDateTime,
-                });
+                .Select(
+                    u => new
+                    {
+                        u.HdId,
+                        u.LastLoginDateTime,
+                    });
 
             var userProfileHistoryQuery = this.dbContext.UserProfileHistory
                 .Where(u => u.LastLoginDateTime >= startDateTimeOffset.UtcDateTime && u.LastLoginDateTime <= endDateTimeOffset.UtcDateTime)
-                .Select(u => new
-                {
-                    u.HdId,
-                    u.LastLoginDateTime,
-                });
+                .Select(
+                    u => new
+                    {
+                        u.HdId,
+                        u.LastLoginDateTime,
+                    });
 
             var unionQuery = userProfileQuery
                 .Union(userProfileHistoryQuery);
 
-            Dictionary<DateTime, int> loggedInUsers = unionQuery
-                .GroupBy(t => new
-                {
-                    LastLoginDate = t.LastLoginDateTime.AddMinutes(offset.TotalMinutes).Date,
-                })
-                .Select(g => new
-                {
-                    g.Key.LastLoginDate,
-                    Count = g.Select(t => t.HdId).Distinct().Count(),
-                })
+            return await unionQuery
+                .GroupBy(
+                    t => new
+                    {
+                        LastLoginDate = t.LastLoginDateTime.AddMinutes(offset.TotalMinutes).Date,
+                    })
+                .Select(
+                    g => new
+                    {
+                        g.Key.LastLoginDate,
+                        Count = g.Select(t => t.HdId).Distinct().Count(),
+                    })
                 .OrderBy(r => r.LastLoginDate)
-                .ToDictionary(x => x.LastLoginDate, x => x.Count);
-
-            return loggedInUsers;
+                .ToDictionaryAsync(x => DateOnly.FromDateTime(x.LastLoginDate), x => x.Count, ct);
         }
 
         /// <inheritdoc/>
@@ -301,11 +302,11 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public int GetRecurrentUserCount(int dayCount, DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset)
+        public async Task<int> GetRecurringUserCountAsync(int dayCount, DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default)
         {
             this.logger.LogTrace("Retrieving recurring user count for {DayCount} days between {StartDate} and {EndDate}...", dayCount, startDateTimeOffset, endDateTimeOffset);
 
-            int recurrentCount = this.dbContext.UserProfile
+            return await this.dbContext.UserProfile
                 .Select(x => new { x.HdId, x.LastLoginDateTime })
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime }))
@@ -314,29 +315,26 @@ namespace HealthGateway.Database.Delegates
                 .Distinct()
                 .GroupBy(x => x.HdId)
                 .Select(x => new { HdId = x.Key, count = x.Count() })
-                .Count(x => x.count >= dayCount);
-
-            return recurrentCount;
+                .CountAsync(x => x.count >= dayCount, ct);
         }
 
         /// <inheritdoc/>
-        public IDictionary<string, int> GetLastLoginClientCounts(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset)
+        public async Task<IDictionary<UserLoginClientType, int>> GetLoginClientCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default)
         {
-            Dictionary<string, int> loginClientCounts = this.dbContext.UserProfile
+            return await this.dbContext.UserProfile
                 .Select(x => new { x.HdId, x.LastLoginClientCode, x.LastLoginDateTime })
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginClientCode, x.LastLoginDateTime }))
-                .Where(x =>
-                    x.LastLoginClientCode != null &&
-                    x.LastLoginDateTime >= startDateTimeOffset.UtcDateTime &&
-                    x.LastLoginDateTime <= endDateTimeOffset.UtcDateTime)
+                .Where(
+                    x =>
+                        x.LastLoginClientCode != null &&
+                        x.LastLoginDateTime >= startDateTimeOffset.UtcDateTime &&
+                        x.LastLoginDateTime <= endDateTimeOffset.UtcDateTime)
                 .Select(x => new { x.HdId, x.LastLoginClientCode })
                 .Distinct()
                 .GroupBy(x => x.LastLoginClientCode)
                 .Select(x => new { lastLoginClientCode = x.Key, count = x.Count() })
-                .ToDictionary(x => x.lastLoginClientCode.ToString()!, x => x.count);
-
-            return loginClientCounts;
+                .ToDictionaryAsync(x => x.lastLoginClientCode!.Value, x => x.count, ct);
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/DbRatingDelegate.cs
+++ b/Apps/Database/src/Delegates/DbRatingDelegate.cs
@@ -20,6 +20,8 @@ namespace HealthGateway.Database.Delegates
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
@@ -80,14 +82,14 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public IDictionary<string, int> GetSummary(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset)
+        public async Task<IDictionary<string, int>> GetRatingsSummaryAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default)
         {
             this.logger.LogTrace("Retrieving the ratings summary between {StartDate} and {EndDate}...", startDateTimeOffset, endDateTimeOffset);
-            return this.dbContext.Rating
+            return await this.dbContext.Rating
                 .Where(r => r.CreatedDateTime >= startDateTimeOffset.UtcDateTime && r.CreatedDateTime <= endDateTimeOffset.UtcDateTime && !r.Skip)
                 .GroupBy(x => x.RatingValue)
                 .Select(r => new { Value = r.Key, Count = r.Count() })
-                .ToDictionary(r => r.Value.ToString(CultureInfo.CurrentCulture), r => r.Count);
+                .ToDictionaryAsync(r => r.Value.ToString(CultureInfo.CurrentCulture), r => r.Count, ct);
         }
     }
 }

--- a/Apps/Database/src/Delegates/IRatingDelegate.cs
+++ b/Apps/Database/src/Delegates/IRatingDelegate.cs
@@ -17,6 +17,8 @@ namespace HealthGateway.Database.Delegates
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
 
@@ -45,7 +47,8 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="startDateTimeOffset">The start datetime offset to query.</param>
         /// <param name="endDateTimeOffset">The end datetime offset to query.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dictionary pairing the ratings with the counts.</returns>
-        IDictionary<string, int> GetSummary(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset);
+        Task<IDictionary<string, int>> GetRatingsSummaryAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default);
     }
 }

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.Database.Delegates
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -59,11 +60,12 @@ namespace HealthGateway.Database.Delegates
         DbResult<IEnumerable<ResourceDelegate>> Get(DateTime fromDate, DateTime? toDate, int page, int pageSize);
 
         /// <summary>
-        /// Gets the count of dependents from the database.
+        /// Retrieves the daily counts of dependent registrations.
         /// </summary>
-        /// <param name="offset">The clients offset to get to UTC.</param>
-        /// <returns>Total number of dependents.</returns>
-        IDictionary<DateTime, int> GetDailyDependentCount(TimeSpan offset);
+        /// <param name="offset">The local timezone offset from UTC in minutes.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of dependent registrations by date.</returns>
+        Task<IDictionary<DateOnly, int>> GetDailyDependentRegistrationCountsAsync(TimeSpan offset, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the total number of delegates associated with each specified dependent from the database.

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Models;
@@ -108,22 +109,24 @@ namespace HealthGateway.Database.Delegates
         DbResult<List<UserProfile>> GetClosedProfiles(DateTime filterDateTime, int page = 0, int pageSize = 500);
 
         /// <summary>
-        /// Returns the daily count of registered users from the database.
+        /// Retrieves the daily counts of user registrations.
         /// </summary>
         /// <param name="offset">The clients offset to get to UTC.</param>
-        /// <returns>The count of user profiles that accepted the terms of service.</returns>
-        IDictionary<DateTime, int> GetDailyRegisteredUsersCount(TimeSpan offset);
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The daily counts of user registrations by date.</returns>
+        Task<IDictionary<DateOnly, int>> GetDailyUserRegistrationCountsAsync(TimeSpan offset, CancellationToken ct = default);
 
         /// <summary>
-        /// Returns the daily count of logged in users with the given offset .
+        /// Retrieves the daily counts of unique user logins over a date range.
         /// </summary>
         /// <param name="startDateTimeOffset">The start datetime offset to query.</param>
         /// <param name="endDateTimeOffset">The end datetime offset to query.</param>
-        /// <returns>The daily count of logged in users.</returns>
-        IDictionary<DateTime, int> GetLoggedInUsersCount(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset);
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of unique user logins by date.</returns>
+        Task<IDictionary<DateOnly, int>> GetDailyUniqueLoginCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default);
 
         /// <summary>
-        /// Returns the list of all UserProfiles sorted by CreatedDateTime in assending order.
+        /// Returns the list of all UserProfiles sorted by CreatedDateTime in ascending order.
         /// </summary>
         /// <param name="page">The page to request.</param>
         /// <param name="pageSize">The amount of records to retrieve in 1 request.</param>
@@ -131,21 +134,23 @@ namespace HealthGateway.Database.Delegates
         DbResult<IEnumerable<UserProfile>> GetAll(int page, int pageSize);
 
         /// <summary>
-        /// Retrieves the count recurring users.
+        /// Retrieves a count of recurring users over a date range.
         /// </summary>
-        /// <param name="dayCount">The number of unique days for evaluating a user.</param>
+        /// <param name="dayCount">Minimum number of days users must have logged in within the period to count as recurring.</param>
         /// <param name="startDateTimeOffset">The start datetime offset to query.</param>
         /// <param name="endDateTimeOffset">The end datetime offset to query.</param>
-        /// <returns>The count of recurrent users.</returns>
-        int GetRecurrentUserCount(int dayCount, DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset);
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A count of recurring users.</returns>
+        Task<int> GetRecurringUserCountAsync(int dayCount, DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default);
 
         /// <summary>
-        /// Returns the list of login client counts over a date range.
+        /// Retrieves unique login counts over a date range grouped by client type.
         /// </summary>
         /// <param name="startDateTimeOffset">The start datetime offset to query.</param>
         /// <param name="endDateTimeOffset">The end datetime offset to query.</param>
-        /// <returns>The counts of login clients for date range.</returns>
-        IDictionary<string, int> GetLastLoginClientCounts(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset);
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A dictionary containing login counts grouped by client type.</returns>
+        Task<IDictionary<UserLoginClientType, int>> GetLoginClientCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct = default);
 
         /// <summary>
         /// Returns the list of UserProfileHistory for a particular hdid and x number of records to return.


### PR DESCRIPTION
# Implements [AB#16470](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16470)

## Description

Refactors Admin Dashboard:

- splits /RecurringUserCounts into 2 separate endpoints, /RecurringUserCount and /AppLoginCounts
- modernizes all Dashboard controller actions, introducing async all the way down to the DB delegates
- replaces DateTime with DateOnly for daily counts
- renames actions to match behaviour and standardizes documentation
  - RegisteredUserCount => DailyUserRegistrationCounts
  - DependentCount => DailyDependentRegistrationCounts
  - LoggedinUsers => DailyUniqueLoginCounts

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
