### PR TITLE
Update warning handling and resolve .NET 8 issues AB#16491

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,9 @@ indent_size = 2
 # S101: Types should be named in PascalCase
 dotnet_diagnostic.s101.severity = none
 
+# S2094: Remove this empty record, write its code or make it an "interface"
+dotnet_diagnostic.s2094.severity = none
+
 # CA1000: Do not declare static members on generic types
 dotnet_diagnostic.ca1000.severity = warning
 
@@ -291,6 +294,15 @@ dotnet_diagnostic.ca1828.severity = warning
 
 # CA1829: Use Length/Count property instead of Count() when available
 dotnet_diagnostic.ca1829.severity = warning
+
+# CA1848: For improved performance, use the LoggerMessage delegates
+dotnet_diagnostic.ca1848.severity = suggestion
+
+# CA1859: Use concrete types when possible for improved performance
+dotnet_diagnostic.ca1859.severity = suggestion
+
+# CA1863: Cache a 'CompositeFormat' for repeated use in this formatting operation	
+dotnet_diagnostic.ca1863.severity = suggestion
 
 # CA2000: Dispose objects before losing scope
 dotnet_diagnostic.ca2000.severity = warning
@@ -673,6 +685,9 @@ dotnet_diagnostic.s1135.severity = warning
 # SA1000: Keywords should be spaced correctly
 dotnet_diagnostic.sa1000.severity = error
 
+# SA1010: Opening square brackets should not be preceded by a space
+dotnet_diagnostic.sa1010.severity = none
+
 # SA1206: Declaration keywords should follow order
 # disabled due to StyleCop not recognizing 'required' modifier
 dotnet_diagnostic.sa1206.severity = none
@@ -805,10 +820,16 @@ dotnet_diagnostic.SA1629.severity = none
 # IDE0058: Remove unnecessary expression value
 dotnet_diagnostic.IDE0058.severity = none
 
-[**/{test/unit,Tests}/**/*Tests.cs]
+[**/{test,Tests}/**/*Tests.cs]
 
 # CA1506: Avoid excessive class coupling
 dotnet_diagnostic.ca1506.severity = none
+
+# CA1859: Use concrete types when possible for improved performance
+dotnet_diagnostic.ca1859.severity = none
+
+# CA1869: Cache and reuse 'JsonSerializerOptions' instances
+dotnet_diagnostic.ca1869.severity = none
 
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.cs1591.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -801,6 +801,7 @@ resharper_web_config_wrong_module_highlighting = warning
 
 # SA1629: Documentation text should end with a period
 dotnet_diagnostic.SA1629.severity = none
+
 # IDE0058: Remove unnecessary expression value
 dotnet_diagnostic.IDE0058.severity = none
 
@@ -808,3 +809,17 @@ dotnet_diagnostic.IDE0058.severity = none
 
 # CA1506: Avoid excessive class coupling
 dotnet_diagnostic.ca1506.severity = none
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.cs1591.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.sa1600.severity = none
+
+[**/Store/**/*{Effects,Reducers}.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.cs1591.severity = none
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.sa1600.severity = none

--- a/Apps/Admin/Client/Authorization/RolesClaimsPrincipalFactory.cs
+++ b/Apps/Admin/Client/Authorization/RolesClaimsPrincipalFactory.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.Admin.Client.Authorization
 
             ClaimsIdentity identity = (ClaimsIdentity)user.Identity;
             List<Claim> roleClaims = identity.FindAll(claim => claim.Type == "roles").ToList();
-            if (!roleClaims.Any())
+            if (roleClaims.Count == 0)
             {
                 return user;
             }

--- a/Apps/Admin/Client/Components/Dashboard/RatingSummary.razor.cs
+++ b/Apps/Admin/Client/Components/Dashboard/RatingSummary.razor.cs
@@ -35,7 +35,7 @@ public partial class RatingSummary : FluxorComponent
 
     private IDictionary<string, int> RatingSummaryResult => this.DashboardState.Value.GetRatingSummary.Result ?? ImmutableDictionary<string, int>.Empty;
 
-    private IDictionary<int, int> Ratings => this.RatingSummaryResult.ToDictionary(r => Convert.ToInt32(r.Key, CultureInfo.InvariantCulture), r => r.Value);
+    private Dictionary<int, int> Ratings => this.RatingSummaryResult.ToDictionary(r => Convert.ToInt32(r.Key, CultureInfo.InvariantCulture), r => r.Value);
 
     private int TotalRatings => this.RatingSummaryResult.Select(r => r.Value).Sum();
 
@@ -52,7 +52,7 @@ public partial class RatingSummary : FluxorComponent
     {
         get
         {
-            List<(int? Count, int Percentage)> details = new();
+            List<(int? Count, int Percentage)> details = [];
             for (int stars = 1; stars <= 5; stars++)
             {
                 int percentage = 0;

--- a/Apps/Admin/Client/Services/KeyInterceptorService.cs
+++ b/Apps/Admin/Client/Services/KeyInterceptorService.cs
@@ -24,7 +24,7 @@ namespace HealthGateway.Admin.Client.Services
     /// <inheritdoc/>
     public class KeyInterceptorService : IKeyInterceptorService
     {
-        private readonly IList<IKeyInterceptor> keyInterceptors = new List<IKeyInterceptor>();
+        private readonly List<IKeyInterceptor> keyInterceptors = [];
         private bool isDisposed;
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace HealthGateway.Admin.Client.Services
                 new()
                 {
                     TargetClass = targetClass,
-                    Keys = new List<KeyOptions> { new() { Key = key, PreventDown = "key+none", SubscribeDown = true } },
+                    Keys = [new() { Key = key, PreventDown = "key+none", SubscribeDown = true }],
                 });
 
             keyInterceptor.KeyDown += async args => await callback(args);

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
@@ -27,7 +27,6 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
     using Microsoft.Extensions.Logging;
     using Refit;
 
-#pragma warning disable CS1591, SA1600
     public class AdminReportEffects
     {
         public AdminReportEffects(ILogger<AdminReportEffects> logger, IAdminReportApi adminReportApi)

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportReducers.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportReducers.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
 {
     using Fluxor;
 
-#pragma warning disable CS1591, SA1600
     public static class AdminReportReducers
     {
         [ReducerMethod(typeof(AdminReportActions.ResetStateAction))]

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportState.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportState.cs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-
 namespace HealthGateway.Admin.Client.Store.AdminReport
 {
     using System.Collections.Generic;

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
@@ -13,13 +13,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-
-#pragma warning disable CS1591
 namespace HealthGateway.Admin.Client.Store.AgentAccess;
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -31,7 +28,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Accessed only by Fluxor")]
 public class AgentAccessEffects
 {
     public AgentAccessEffects(ILogger<AgentAccessEffects> logger, IAgentAccessApi api)

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessReducers.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessReducers.cs
@@ -13,20 +13,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-#pragma warning disable CS1591
 namespace HealthGateway.Admin.Client.Store.AgentAccess;
 
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using Fluxor;
 using HealthGateway.Admin.Common.Models;
 
 /// <summary>
 /// The set of reducers for the feature.
 /// </summary>
-[SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Accessed only by Fluxor")]
 public static class AgentAccessReducers
 {
     [ReducerMethod(typeof(AgentAccessActions.SearchAction))]

--- a/Apps/Admin/Client/Store/Analytics/AnalyticsEffects.cs
+++ b/Apps/Admin/Client/Store/Analytics/AnalyticsEffects.cs
@@ -22,7 +22,6 @@ using HealthGateway.Admin.Client.Api;
 using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 
-#pragma warning disable CS1591, SA1600
 public class AnalyticsEffects
 {
     public AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi analyticsApi)

--- a/Apps/Admin/Client/Store/Analytics/AnalyticsReducers.cs
+++ b/Apps/Admin/Client/Store/Analytics/AnalyticsReducers.cs
@@ -17,8 +17,6 @@ namespace HealthGateway.Admin.Client.Store.Analytics;
 
 using Fluxor;
 
-#pragma warning disable CS1591, SA1600
-
 public static class AnalyticsReducers
 {
     [ReducerMethod(typeof(AnalyticsActions.LoadUserProfilesAction))]

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
@@ -30,7 +30,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-#pragma warning disable CS1591, SA1600
 public class BroadcastsEffects
 {
     public BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi api)

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsReducers.cs
@@ -23,7 +23,6 @@ using Fluxor;
 using HealthGateway.Admin.Client.Models;
 using HealthGateway.Common.Data.Models;
 
-#pragma warning disable CS1591, SA1600
 public static class BroadcastsReducers
 {
     [ReducerMethod(typeof(BroadcastsActions.LoadAction))]

--- a/Apps/Admin/Client/Store/Communications/CommunicationsEffects.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsEffects.cs
@@ -30,7 +30,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-#pragma warning disable CS1591, SA1600
 public class CommunicationsEffects
 {
     public CommunicationsEffects(ILogger<CommunicationsEffects> logger, ICommunicationsApi api)

--- a/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsReducers.cs
@@ -21,7 +21,6 @@ using Fluxor;
 using HealthGateway.Admin.Client.Models;
 using HealthGateway.Admin.Common.Models;
 
-#pragma warning disable CS1591, SA1600
 public static class CommunicationsReducers
 {
     [ReducerMethod(typeof(CommunicationsActions.LoadAction))]

--- a/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
+++ b/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
@@ -24,7 +24,6 @@ namespace HealthGateway.Admin.Client.Store.Configuration
     using Microsoft.Extensions.Logging;
     using Refit;
 
-#pragma warning disable CS1591, SA1600
     public class ConfigurationEffects
     {
         public ConfigurationEffects(ILogger<ConfigurationEffects> logger, IConfigurationApi configApi)

--- a/Apps/Admin/Client/Store/Configuration/ConfigurationReducers.cs
+++ b/Apps/Admin/Client/Store/Configuration/ConfigurationReducers.cs
@@ -17,8 +17,6 @@ namespace HealthGateway.Admin.Client.Store.Configuration
 {
     using Fluxor;
 
-#pragma warning disable CS1591, SA1600
-
     public static class ConfigurationReducers
     {
         [ReducerMethod(typeof(ConfigurationActions.LoadAction))]

--- a/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
@@ -26,7 +26,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-#pragma warning disable CS1591, SA1600
 public class DashboardEffects
 {
     public DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi dashboardApi)

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -221,7 +221,7 @@ public static class DashboardReducers
     public static DashboardState ReduceGetYearOfBirthCountsSuccessAction(DashboardState state, DashboardActions.GetYearOfBirthCountsSuccessAction action)
     {
         List<string> years = action.Data.Keys.Order().ToList();
-        IDictionary<string, int> yearOfBirthCounts = new Dictionary<string, int>(action.Data);
+        Dictionary<string, int> yearOfBirthCounts = new Dictionary<string, int>(action.Data);
 
         // add empty entries for years that are not populated
         if (years.Count > 0 && int.TryParse(years[0], out int firstYear) && int.TryParse(years[^1], out int lastYear))

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -21,7 +21,6 @@ using System.Globalization;
 using System.Linq;
 using Fluxor;
 
-#pragma warning disable CS1591, SA1600
 public static class DashboardReducers
 {
     [ReducerMethod(typeof(DashboardActions.GetRegisteredUsersAction))]

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -221,7 +221,7 @@ public static class DashboardReducers
     public static DashboardState ReduceGetYearOfBirthCountsSuccessAction(DashboardState state, DashboardActions.GetYearOfBirthCountsSuccessAction action)
     {
         List<string> years = action.Data.Keys.Order().ToList();
-        Dictionary<string, int> yearOfBirthCounts = new Dictionary<string, int>(action.Data);
+        Dictionary<string, int> yearOfBirthCounts = new(action.Data);
 
         // add empty entries for years that are not populated
         if (years.Count > 0 && int.TryParse(years[0], out int firstYear) && int.TryParse(years[^1], out int lastYear))

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -32,7 +32,6 @@ namespace HealthGateway.Admin.Client.Store.Delegation
     using Microsoft.Extensions.Logging;
     using Refit;
 
-#pragma warning disable CS1591, SA1600
     public class DelegationEffects
     {
         public DelegationEffects(IDelegationApi api, IMapper autoMapper, IState<DelegationState> delegationState, ILogger<DelegationEffects> logger)

--- a/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationReducers.cs
@@ -22,7 +22,6 @@ namespace HealthGateway.Admin.Client.Store.Delegation
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
 
-#pragma warning disable CS1591, SA1600
     public static class DelegationReducers
     {
         [ReducerMethod(typeof(DelegationActions.SearchAction))]

--- a/Apps/Admin/Client/Store/PatientDetails/PatientDetailsEffects.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientDetailsEffects.cs
@@ -27,7 +27,6 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
     using Microsoft.Extensions.Logging;
     using Refit;
 
-#pragma warning disable CS1591, SA1600
     public class PatientDetailsEffects
     {
         public PatientDetailsEffects(ILogger<PatientDetailsEffects> logger, ISupportApi supportApi)

--- a/Apps/Admin/Client/Store/PatientDetails/PatientDetailsReducers.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientDetailsReducers.cs
@@ -18,7 +18,6 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
     using System.Collections.Immutable;
     using Fluxor;
 
-#pragma warning disable CS1591, SA1600
     public static class PatientDetailsReducers
     {
         [ReducerMethod(typeof(PatientDetailsActions.LoadAction))]

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportEffects.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportEffects.cs
@@ -28,7 +28,6 @@ namespace HealthGateway.Admin.Client.Store.PatientSupport
     using Microsoft.Extensions.Logging;
     using Refit;
 
-#pragma warning disable CS1591, SA1600
     public class PatientSupportEffects
     {
         public PatientSupportEffects(ILogger<PatientSupportEffects> logger, ISupportApi supportApi)

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportReducers.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportReducers.cs
@@ -18,8 +18,6 @@ namespace HealthGateway.Admin.Client.Store.PatientSupport
     using System.Collections.Immutable;
     using Fluxor;
 
-#pragma warning disable CS1591, SA1600
-
     public static class PatientSupportReducers
     {
         [ReducerMethod(typeof(PatientSupportActions.LoadAction))]

--- a/Apps/Admin/Client/Store/Tag/TagEffects.cs
+++ b/Apps/Admin/Client/Store/Tag/TagEffects.cs
@@ -29,7 +29,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-#pragma warning disable CS1591, SA1600
 public class TagEffects
 {
     public TagEffects(ILogger<TagEffects> logger, ITagApi api)

--- a/Apps/Admin/Client/Store/Tag/TagReducers.cs
+++ b/Apps/Admin/Client/Store/Tag/TagReducers.cs
@@ -21,7 +21,6 @@ using System.Collections.Immutable;
 using Fluxor;
 using HealthGateway.Admin.Common.Models;
 
-#pragma warning disable CS1591, SA1600
 public static class TagReducers
 {
     [ReducerMethod(typeof(TagActions.LoadAction))]

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackEffects.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackEffects.cs
@@ -30,7 +30,6 @@ using HealthGateway.Common.Data.ViewModels;
 using Microsoft.Extensions.Logging;
 using Refit;
 
-#pragma warning disable CS1591, SA1600
 public class UserFeedbackEffects
 {
     public UserFeedbackEffects(ILogger<UserFeedbackEffects> logger, IUserFeedbackApi api, IMapper autoMapper)

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackReducers.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackReducers.cs
@@ -23,7 +23,6 @@ using Fluxor;
 using HealthGateway.Admin.Client.Models;
 using HealthGateway.Admin.Common.Models;
 
-#pragma warning disable CS1591, SA1600
 public static class UserFeedbackReducers
 {
     [ReducerMethod(typeof(UserFeedbackActions.LoadAction))]

--- a/Apps/Admin/Client/Store/VaccineCard/VaccineCardEffects.cs
+++ b/Apps/Admin/Client/Store/VaccineCard/VaccineCardEffects.cs
@@ -27,7 +27,6 @@ namespace HealthGateway.Admin.Client.Store.VaccineCard
     using Microsoft.Extensions.Logging;
     using Refit;
 
-#pragma warning disable CS1591, SA1600
     public class VaccineCardEffects
     {
         public VaccineCardEffects(ILogger<VaccineCardEffects> logger, ISupportApi supportApi)

--- a/Apps/Admin/Client/Store/VaccineCard/VaccineCardReducers.cs
+++ b/Apps/Admin/Client/Store/VaccineCard/VaccineCardReducers.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Client.Store.VaccineCard
 {
     using Fluxor;
 
-#pragma warning disable CS1591, SA1600
     public static class VaccineCardReducers
     {
         [ReducerMethod(typeof(VaccineCardActions.ResetStateAction))]

--- a/Apps/Admin/Server/Services/AgentAccessService.cs
+++ b/Apps/Admin/Server/Services/AgentAccessService.cs
@@ -129,7 +129,7 @@ namespace HealthGateway.Admin.Server.Services
             JwtModel jwtModel = this.authDelegate.AuthenticateAsSystem(this.tokenUri, this.tokenRequest);
             List<UserRepresentation> users = await this.keycloakAdminApi.GetUsersSearchAsync(searchString, firstRecord, resultLimit.GetValueOrDefault(), jwtModel.AccessToken).ConfigureAwait(true);
 
-            List<AdminAgent> adminAgents = new();
+            List<AdminAgent> adminAgents = [];
             foreach (UserRepresentation user in users)
             {
                 string[] splitString = user.Username.Split('@');
@@ -182,12 +182,12 @@ namespace HealthGateway.Admin.Server.Services
                 .Where(r => userRoles.TrueForAll(userRole => userRole.Id != r.Id))
                 .ToList();
 
-            if (rolesToDelete.Any())
+            if (rolesToDelete.Count > 0)
             {
                 await this.keycloakAdminApi.DeleteUserRolesAsync(agent.Id, rolesToDelete, jwtModel.AccessToken).ConfigureAwait(true);
             }
 
-            if (rolesToAdd.Any())
+            if (rolesToAdd.Count > 0)
             {
                 await this.keycloakAdminApi.AddUserRolesAsync(agent.Id, rolesToAdd, jwtModel.AccessToken).ConfigureAwait(true);
             }

--- a/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+    using Npgsql;
 
     /// <summary>
     /// Provides ASP.Net Services related to Authentication and Authorization services.
@@ -41,11 +42,15 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
             bool isSensitiveDataLoggingEnabled = section.GetValue("Enabled", false);
             logger.LogDebug("Sensitive Data Logging is enabled: {IsSensitiveDataLoggingEnabled}", isSensitiveDataLoggingEnabled);
 
+            NpgsqlDataSourceBuilder dataSourceBuilder = new(configuration.GetConnectionString("GatewayConnection"));
+            dataSourceBuilder.EnableDynamicJsonMappings();
+            NpgsqlDataSource dataSource = dataSourceBuilder.Build();
+
             services.AddDbContextPool<GatewayDbContext>(
                 options =>
                 {
                     options.UseNpgsql(
-                        configuration.GetConnectionString("GatewayConnection"),
+                        dataSource,
                         x => x.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
                     if (isSensitiveDataLoggingEnabled)
                     {

--- a/Apps/Common/test/unit/CacheProviders/DistributedCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/DistributedCacheProviderTests.cs
@@ -144,14 +144,13 @@ namespace HealthGateway.CommonTests.CacheProviders
         /// A <see cref="Task"/> representing the asynchronous unit test.
         /// </returns>
         [Fact]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Team decision")]
         public async Task AddItemAsyncToCacheExpired()
         {
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
             await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(100));
-            Thread.Sleep(101);
+            await Task.Delay(101);
 
             Assert.Null(await this.cacheProvider.GetItemAsync<string>(key));
         }

--- a/Apps/Common/test/unit/CacheProviders/MemoryCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/MemoryCacheProviderTests.cs
@@ -143,14 +143,13 @@ namespace HealthGateway.CommonTests.CacheProviders
         /// A <see cref="Task"/> representing the asynchronous unit test.
         /// </returns>
         [Fact]
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Team decision")]
         public async Task AddItemAsyncToCacheExpired()
         {
             string key = $"key_{GenerateRandomString()}";
             string value = $"value_{GenerateRandomString()}";
 
             await this.cacheProvider.AddItemAsync(key, value, TimeSpan.FromMilliseconds(100));
-            Thread.Sleep(101);
+            await Task.Delay(101);
 
             Assert.Null(await this.cacheProvider.GetItemAsync<string>(key));
         }

--- a/Apps/CommonData/src/Utils/AddressUtility.cs
+++ b/Apps/CommonData/src/Utils/AddressUtility.cs
@@ -44,7 +44,7 @@ namespace HealthGateway.Common.Data.Utils
         public static readonly IEnumerable<CountryCode> CountryCodes = Enum.GetValues<CountryCode>()[1..];
 
         [SuppressMessage("ReSharper", "StringLiteralTypo", Justification = "Country names don't require spellchecking")]
-        private static readonly Dictionary<string, CountryCode> CountryAliases = new Dictionary<string, CountryCode>
+        private static readonly Dictionary<string, CountryCode> CountryAliases = new()
         {
             ["Admiralty Islands (included in Papua New Guinea)"] = CountryCode.PG,
             ["Aegean Islands (included in Greece)"] = CountryCode.GR,

--- a/Apps/Directory.Build.props
+++ b/Apps/Directory.Build.props
@@ -6,7 +6,7 @@
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
         <WarningLevel>4</WarningLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <NoWarn>CA1859, CA1860, CA1863, CA1869, CA1848, S2094</NoWarn>
+        <NoWarn>CS8974</NoWarn>
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis" Version="4.7.0" ExcludeAssets="All"/>

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -42,6 +42,12 @@ namespace HealthGateway.JobScheduler.Listeners
         private const string Channel = "BannerChange";
         private const int SleepDuration = 10000;
 
+        private static readonly JsonSerializerOptions EventSerializerOptions = new()
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new DateTimeConverter(), new JsonStringEnumConverter() },
+        };
+
         private readonly ILogger<BannerListener> logger;
         private readonly IServiceProvider services;
 
@@ -118,13 +124,7 @@ namespace HealthGateway.JobScheduler.Listeners
         private void ReceiveEvent(object sender, NpgsqlNotificationEventArgs e)
         {
             this.logger.LogDebug("Banner Event received on channel {Channel}", Channel);
-            JsonSerializerOptions options = new()
-            {
-                PropertyNameCaseInsensitive = true,
-            };
-            options.Converters.Add(new DateTimeConverter());
-            options.Converters.Add(new JsonStringEnumConverter());
-            BannerChangeEvent? changeEvent = JsonSerializer.Deserialize<BannerChangeEvent>(e.Payload, options);
+            BannerChangeEvent? changeEvent = JsonSerializer.Deserialize<BannerChangeEvent>(e.Payload, EventSerializerOptions);
             using IServiceScope scope = this.services.CreateScope();
             ICommunicationService cs = scope.ServiceProvider.GetRequiredService<ICommunicationService>();
             this.logger.LogInformation("Banner Event received and being processed");

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -42,9 +42,6 @@ namespace HealthGateway.PatientTests.Services
     using PatientDataQuery = HealthGateway.Patient.Services.PatientDataQuery;
     using PatientFileQuery = HealthGateway.PatientDataAccess.PatientFileQuery;
 
-    // Disable documentation for tests.
-#pragma warning disable SA1600
-#pragma warning disable CS1591
     public class PatientDataServiceTests
     {
         private readonly Guid pid = Guid.NewGuid();
@@ -312,6 +309,4 @@ namespace HealthGateway.PatientTests.Services
             return personalAccountService;
         }
     }
-#pragma warning restore CS1591
-#pragma warning restore SA1600
 }

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -251,7 +251,6 @@ namespace PatientDataAccessTests
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1859:Use concrete types when possible for improved performance", Justification = "Team decision")]
         private static IPatientDataRepository CreateSut(IPatientApi api)
         {
             IMapper? mapper = new MapperConfiguration(cfg => cfg.AddMaps(typeof(Mappings))).CreateMapper();

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -29,9 +29,6 @@ namespace PatientDataAccessTests
     using OrganDonorRegistration = HealthGateway.PatientDataAccess.Api.OrganDonorRegistration;
     using OrganDonorRegistrationStatus = HealthGateway.PatientDataAccess.Api.OrganDonorRegistrationStatus;
 
-    // Disable documentation for tests.
-#pragma warning disable SA1600
-
     public class PatientDataRepositoryTests
     {
         private readonly Guid pid = Guid.NewGuid();
@@ -262,6 +259,4 @@ namespace PatientDataAccessTests
             return new PatientDataRepository(api, mapper);
         }
     }
-
-#pragma warning restore SA1600
 }


### PR DESCRIPTION
# Implements [AB#16491](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16491)

## Description

- suppresses "missing documentation" warnings for tests and Fluxor files
- moves warning suppressions into .editorconfig
- opts in to serializing arbitrary types in jsonb columns
  - this was required to support our usage of jsonb columns
  - this happened automatically before but [now requires opting in](https://www.npgsql.org/efcore/release-notes/8.0.html#json-poco-and-other-dynamic-features-now-require-an-explicit-opt-in) because it's a part of npgsql that is currently incompatible with the new Native AOT functionality introduced in .NET 8
    - EF Core is also incompatible with the Native AOT functionality, so we'd be unable to use it regardless

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
