### PR TITLE
Fix issues on Admin patient details page AB#16494

### DIFF
--- a/Apps/Admin/Client/Components/Details/AccountTab.razor
+++ b/Apps/Admin/Client/Components/Details/AccountTab.razor
@@ -6,32 +6,34 @@
     <MudText Class="mb-4 mt-6" Typo="Typo.h6">
         Account Details
     </MudText>
-    @if (CanViewHdid)
-    {
-        <MudGrid Spacing="2">
+    <MudGrid Spacing="2">
+        @if (CanViewHdid)
+        {
             <MudItem xs="12">
                 <HgField Label="HDID" Value="@Patient.Hdid" data-testid="patient-hdid" />
             </MudItem>
-        </MudGrid>
-    }
-    @if (IsDefaultPatientStatus)
-    {
-        <MudGrid Spacing="2">
+        }
+
+        @if (IsDefaultPatientStatus)
+        {
             <MudItem xs="12" lg="6">
                 <HgField Label="Account Created" Value="@ProfileCreatedDateTime.ToString()" data-testid="profile-created-datetime" />
             </MudItem>
             <MudItem xs="12" lg="6">
                 <HgField Label="Last Login" Value="@ProfileLastLoginDateTime.ToString()" data-testid="profile-last-login-datetime" />
             </MudItem>
-        </MudGrid>
-    }
-    else
-    {
-        <MudText data-testid="no-hg-profile" Class="mt-6">
-            No Health Gateway Profile
-        </MudText>
-    }
+        }
+        else
+        {
+            <MudItem xs="12">
+                <MudText data-testid="no-hg-profile">
+                    No Health Gateway Profile
+                </MudText>
+            </MudItem>
+        }
+    </MudGrid>
 }
+
 @if (CanViewMessagingVerifications && IsDefaultPatientStatus)
 {
     <MessageVerificationTable Data="@MessagingVerifications" IsLoading="@PatientSupportDetailsLoading" />

--- a/Apps/Admin/Client/Components/Details/AccountTab.razor
+++ b/Apps/Admin/Client/Components/Details/AccountTab.razor
@@ -7,7 +7,7 @@
         Account Details
     </MudText>
     <MudGrid Spacing="2">
-        @if (CanViewHdid)
+        @if (CanViewHdid && !string.IsNullOrWhiteSpace(Patient.Hdid))
         {
             <MudItem xs="12">
                 <HgField Label="HDID" Value="@Patient.Hdid" data-testid="patient-hdid" />

--- a/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor
+++ b/Apps/Admin/Client/Components/Support/DatasetAccessSection.razor
@@ -5,7 +5,7 @@
     Dataset Access
 </MudText>
 
-<MudGrid Spacing="2" Class="mt-2">
+<MudGrid Spacing="2">
     <MudItem xs="12">
         <MudPaper>
             <MudProgressLinear

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.Admin.Client.Pages
 
         private bool CanViewManageProfile => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
 
-        private bool CanViewNotes => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
+        private bool CanViewNotes => this.UserHasRole(Roles.Admin);
 
         private AuthenticationState? AuthenticationState { get; set; }
 

--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -119,7 +119,7 @@ namespace HealthGateway.Admin.Server.Controllers
                     QueryParameter = queryString,
                     IncludeMessagingVerifications = userIsAdmin || userIsReviewer,
                     IncludeBlockedDataSources = userIsAdmin || userIsReviewer,
-                    IncludeAgentActions = userIsAdmin || userIsReviewer,
+                    IncludeAgentActions = userIsAdmin,
                     IncludeDependents = userIsAdmin || userIsReviewer,
                     IncludeCovidDetails = userIsAdmin || userIsSupport,
                     RefreshVaccineDetails = refreshVaccineDetails,

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details.cy.js
@@ -586,6 +586,7 @@ describe("Patient details page as reviewer", () => {
         performSearch("HDID", hdid);
 
         selectPatientTab("Manage");
+        validateTabDoesNotExist("Notes");
 
         cy.get(`[data-testid*="block-access-switch-"]`).each(($el) => {
             // follow the mud tag structure to find the mud-readonly class


### PR DESCRIPTION
# Fixes [AB#16494](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16494)

## Description

- restricts notes tab to admin users
- standardizes element spacing on patient details tabs
- hides HDID field on patient details account tab when empty
- updates functional test to verify reviewer cannot access notes tab
- restricts agent actions data to admin users

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![localhost-2023-11-21-111650](https://github.com/bcgov/healthgateway/assets/16570293/ff8dd3b6-f47c-4939-b1ed-e406afa76eff)
![localhost-2023-11-21-111712](https://github.com/bcgov/healthgateway/assets/16570293/0c9514c0-242c-4452-8d9c-2970b1af5e8c)
![localhost-2023-11-21-111727](https://github.com/bcgov/healthgateway/assets/16570293/0f0f31a0-ea64-44b4-ad21-2244ae781724)
![localhost-2023-11-21-111951](https://github.com/bcgov/healthgateway/assets/16570293/8d3d5ac1-94c8-4164-a4fd-ef40d895703b)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
