### PR TITLE
Use appsettings for host instead of HttpContextAccessor for AB#16538

### DIFF
--- a/Apps/CommonData/src/Models/EmailTemplateConfig.cs
+++ b/Apps/CommonData/src/Models/EmailTemplateConfig.cs
@@ -1,0 +1,33 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Common.Data.Models
+{
+    /// <summary>
+    /// Model object representing email template configuration.
+    /// </summary>
+    public class EmailTemplateConfig
+    {
+        /// <summary>
+        /// The section key to use when binding this object.
+        /// </summary>
+        public const string ConfigurationSectionKey = "EmailTemplate";
+
+        /// <summary>
+        /// Gets the host.
+        /// </summary>
+        public string Host { get; init; } = string.Empty;
+    }
+}

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -56,5 +56,8 @@
         "Notifications": {
             "Enabled": true
         }
+    },
+    "EmailTemplate": {
+        "Host": "http://localhost:5002"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgdev.json
+++ b/Apps/GatewayApi/src/appsettings.hgdev.json
@@ -47,5 +47,8 @@
         "Notifications": {
             "Enabled": true
         }
+    },
+    "EmailTemplate": {
+        "Host": "https://dev.healthgateway.gov.bc.ca"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgmock.json
+++ b/Apps/GatewayApi/src/appsettings.hgmock.json
@@ -28,5 +28,8 @@
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
+    "EmailTemplate": {
+        "Host": "https://mock.healthgateway.gov.bc.ca"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgpoc.json
+++ b/Apps/GatewayApi/src/appsettings.hgpoc.json
@@ -28,5 +28,8 @@
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
+    },
+    "EmailTemplate": {
+        "Host": "https://dev.healthgateway.gov.bc.ca"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgtest.json
+++ b/Apps/GatewayApi/src/appsettings.hgtest.json
@@ -28,5 +28,8 @@
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-test.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-test.azure-api.net/healthgateway"
+    },
+    "EmailTemplate": {
+        "Host": "https://test.healthgateway.gov.bc.ca"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -125,5 +125,8 @@
         "GrantType": "urn:ietf:params:oauth:grant-type:token-exchange",
         "Scope": "healthdata.read webalert.read patient_profile account.read patientidentity.read file.read",
         "TokenCacheEnabled": true
+    },
+    "EmailTemplate": {
+      "Host": "https://www.healthgateway.gov.bc.ca"
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -35,7 +35,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
     using HealthGateway.Database.Wrapper;
     using HealthGateway.GatewayApi.Services;
     using HealthGateway.GatewayApiTests.Services.Test.Utils;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -64,7 +63,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         private Mock<IMessagingVerificationDelegate> messageVerificationDelegateMock = new MessagingVerificationDelegateMock();
         private Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
         private Mock<IEmailQueueService> emailQueueServiceMock = new();
-        private Mock<IHttpContextAccessor> httpContextAccessorMock = new();
         private Mock<IUserProfileDelegate> userProfileDelegateMock = new();
         private Mock<ICryptoDelegate> cryptoDelegateMock = new();
         private Mock<ILegalAgreementDelegate> legalAgreementDelegateMock = new LegalAgreementDelegateMock(
@@ -108,7 +106,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
                 this.legalAgreementDelegateMock.Object,
                 this.messageVerificationDelegateMock.Object,
                 this.cryptoDelegateMock.Object,
-                this.httpContextAccessorMock.Object,
                 this.configuration,
                 this.autoMapper,
                 this.authenticationDelegateMock.Object,
@@ -215,17 +212,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         }
 
         /// <summary>
-        /// Setup the <see cref="HttpContextAccessorMock"/> that will be used for by the UserProfileService.
-        /// </summary>
-        /// <param name="headerDictionary">Mocked headers for a request.</param>
-        /// <returns>UserProfileServiceMock.</returns>
-        public UserProfileServiceMock SetupHttpAccessorMockCustomHeaders(IHeaderDictionary headerDictionary)
-        {
-            this.httpContextAccessorMock = new HttpContextAccessorMock(headerDictionary);
-            return this;
-        }
-
-        /// <summary>
         /// Setup the <see cref="LegalAgreementDelegateMock"/> that will be used for by the UserProfileService.
         /// </summary>
         /// <param name="legalAgreement">The mocked legal agreement to be returned.</param>
@@ -310,8 +296,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         {
             this.messageSenderMock.Verify(
                 m => m.SendAsync(
-                    It.Is<IEnumerable<MessageEnvelope>>(
-                        envelopes => envelopes.First().Content is T),
+                    It.Is<IEnumerable<MessageEnvelope>>(envelopes => envelopes.First().Content is T),
                     CancellationToken.None));
             return this;
         }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -31,7 +31,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Wrapper;
     using HealthGateway.GatewayApi.Services;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -82,7 +81,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IEmailQueueService>().Object,
                 new Mock<INotificationSettingsService>().Object,
                 GetIConfigurationRoot(),
-                new Mock<IHttpContextAccessor>().Object,
                 new Mock<IMessageSender>().Object);
 
             RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey, CancellationToken.None);
@@ -134,15 +132,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IEmailQueueService>().Object,
                 new Mock<INotificationSettingsService>().Object,
                 GetIConfigurationRoot(configDict),
-                new Mock<IHttpContextAccessor>().Object,
                 mockMessageSender.Object);
 
             RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey, CancellationToken.None);
 
             mockMessageSender.Verify(
                 m => m.SendAsync(
-                    It.Is<IEnumerable<MessageEnvelope>>(
-                        envelopes => envelopes.First().Content is NotificationChannelVerifiedEvent),
+                    It.Is<IEnumerable<MessageEnvelope>>(envelopes => envelopes.First().Content is NotificationChannelVerifiedEvent),
                     CancellationToken.None));
 
             Assert.True(actual.ResultStatus == ResultType.Success);
@@ -182,7 +178,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IEmailQueueService>().Object,
                 new Mock<INotificationSettingsService>().Object,
                 GetIConfigurationRoot(),
-                new Mock<IHttpContextAccessor>().Object,
                 new Mock<IMessageSender>().Object);
 
             RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey, CancellationToken.None);
@@ -228,7 +223,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IEmailQueueService>().Object,
                 new Mock<INotificationSettingsService>().Object,
                 GetIConfigurationRoot(),
-                new Mock<IHttpContextAccessor>().Object,
                 new Mock<IMessageSender>().Object);
 
             RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey);
@@ -260,7 +254,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IEmailQueueService>().Object,
                 new Mock<INotificationSettingsService>().Object,
                 GetIConfigurationRoot(),
-                new Mock<IHttpContextAccessor>().Object,
                 new Mock<IMessageSender>().Object);
 
             RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey);
@@ -293,7 +286,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IEmailQueueService>().Object,
                 new Mock<INotificationSettingsService>().Object,
                 GetIConfigurationRoot(),
-                new Mock<IHttpContextAccessor>().Object,
                 new Mock<IMessageSender>().Object);
 
             RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -640,7 +640,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { "referer", "http://localhost/" },
             };
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
-                .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
                 .SetupEmailQueueServiceMock(false)
                 .SetupPatientRepository(this.hdid, dataSources);
@@ -681,7 +680,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
-                .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
                 .SetupEmailQueueServiceMock(false);
 
@@ -721,7 +719,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
-                .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
                 .SetupEmailQueueServiceMock(false);
 
@@ -768,7 +765,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
-                .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
                 .SetupEmailQueueServiceMock(false)
                 .SetupPatientRepository(this.hdid, dataSources);
@@ -810,7 +806,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
-                .SetupHttpAccessorMockCustomHeaders(headerDictionary)
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult)
                 .SetupEmailQueueServiceMock(false);
 


### PR DESCRIPTION
# Fixes [AB#16538](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16538)

## Description

Use appsettings to store host instead of retrieving from HttpContextAccessor.

**Unit Tests:**

<img width="1253" alt="Screenshot 2023-11-28 at 1 18 47 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/2fc23e96-dafe-454e-ba7d-0225c8807e3d">


**Emails:**

<img width="1554" alt="Screenshot 2023-11-28 at 1 17 14 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/4eca3d9e-0829-4b40-ba5f-0d05b506bd6c">

<img width="1832" alt="Screenshot 2023-11-28 at 1 05 34 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/ded0201f-1fd2-444b-8666-c7aa7d3b0a16">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
