### PR TITLE
Swap year of birth chart for age chart AB#16483

### DIFF
--- a/Apps/Admin/Client/Api/IDashboardApi.cs
+++ b/Apps/Admin/Client/Api/IDashboardApi.cs
@@ -85,12 +85,12 @@ public interface IDashboardApi
     Task<IDictionary<string, int>> GetRatingsSummaryAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
 
     /// <summary>
-    /// Retrieves year of birth counts for users that have logged in between two dates.
+    /// Retrieves age counts for users that have logged in between two dates.
     /// </summary>
     /// <param name="startDateLocal">The local start date to query.</param>
     /// <param name="endDateLocal">The local end date to query.</param>
     /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
-    /// <returns>A dictionary mapping birth years to user counts.</returns>
-    [Get("/YearOfBirthCounts")]
-    Task<IDictionary<string, int>> GetYearOfBirthCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
+    /// <returns>A dictionary mapping ages to user counts.</returns>
+    [Get("/AgeCounts")]
+    Task<IDictionary<int, int>> GetAgeCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset);
 }

--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -112,19 +112,19 @@
         </MudPaper>
     </MudItem>
     <MudItem xs="12" lg="6">
-        @if (YearOfBirthCountsLoading)
+        @if (AgeCountsLoading)
         {
-            <MudSkeleton data-testid="skeleton-year-of-birth-chart" SkeletonType="SkeletonType.Rectangle" Width="100%" Height="325px" />
+            <MudSkeleton data-testid="skeleton-age-chart" SkeletonType="SkeletonType.Rectangle" Width="100%" Height="325px" />
         }
-        else if (YearOfBirthCountsErrorMessage.Length == 0)
+        else if (AgeCountsErrorMessage.Length == 0)
         {
-            @if (YearOfBirthCounts.Any())
+            @if (AgeCounts.Any())
             {
                 <MudChart
-                    data-testid="year-of-birth-chart"
+                    data-testid="age-chart"
                     ChartType="ChartType.Bar"
-                    ChartSeries="[GetYearOfBirthCountSeries()]"
-                    XAxisLabels="@GetYearOfBirthLabels()"
+                    ChartSeries="[GetAgeCountSeries()]"
+                    XAxisLabels="@GetAgeLabels()"
                     Width="100%"
                     Height="325" />
             }

--- a/Apps/Admin/Client/Pages/DashboardPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor.cs
@@ -52,7 +52,7 @@ public partial class DashboardPage : FluxorComponent
 
     private AppLoginCounts AppLoginCounts => this.DashboardState.Value.GetAppLoginCounts.Result ?? new(0, 0);
 
-    private IDictionary<string, int> YearOfBirthCounts => this.DashboardState.Value.YearOfBirthCounts;
+    private IDictionary<int, int> AgeCounts => this.DashboardState.Value.AgeCounts;
 
     private bool DailyUserRegistrationCountsLoading => this.DashboardState.Value.GetDailyUserRegistrationCounts.IsLoading;
 
@@ -66,7 +66,7 @@ public partial class DashboardPage : FluxorComponent
 
     private bool RatingsSummaryLoading => this.DashboardState.Value.GetRatingsSummary.IsLoading;
 
-    private bool YearOfBirthCountsLoading => this.DashboardState.Value.GetYearOfBirthCounts.IsLoading;
+    private bool AgeCountsLoading => this.DashboardState.Value.GetAgeCounts.IsLoading;
 
     private MudDateRangePicker DemographicsDateRangePicker { get; set; } = default!;
 
@@ -90,7 +90,7 @@ public partial class DashboardPage : FluxorComponent
 
     private string RatingSummaryErrorMessage => this.DashboardState.Value.GetRatingsSummary.Error?.Message ?? string.Empty;
 
-    private string YearOfBirthCountsErrorMessage => this.DashboardState.Value.GetYearOfBirthCounts.Error?.Message ?? string.Empty;
+    private string AgeCountsErrorMessage => this.DashboardState.Value.GetAgeCounts.Error?.Message ?? string.Empty;
 
     private IEnumerable<string> ErrorMessages => StringManipulator.ExcludeBlanks(
     [
@@ -100,7 +100,7 @@ public partial class DashboardPage : FluxorComponent
         this.RecurringUsersErrorMessage,
         this.AppLoginCountsErrorMessage,
         this.RatingSummaryErrorMessage,
-        this.YearOfBirthCountsErrorMessage,
+        this.AgeCountsErrorMessage,
     ]);
 
     private DateRange? DemographicsDateRange
@@ -197,7 +197,7 @@ public partial class DashboardPage : FluxorComponent
         DateOnly endDate = DateOnly.FromDateTime(this.DemographicsDateRangeEnd);
         this.Dispatcher.Dispatch(new DashboardActions.GetAppLoginCountsAction { StartDateLocal = startDate, EndDateLocal = endDate, TimeOffset = this.TimeOffset });
         this.Dispatcher.Dispatch(new DashboardActions.GetRatingsSummaryAction { StartDateLocal = startDate, EndDateLocal = endDate, TimeOffset = this.TimeOffset });
-        this.Dispatcher.Dispatch(new DashboardActions.GetYearOfBirthCountsAction { StartDateLocal = startDate, EndDateLocal = endDate, TimeOffset = this.TimeOffset });
+        this.Dispatcher.Dispatch(new DashboardActions.GetAgeCountsAction { StartDateLocal = startDate, EndDateLocal = endDate, TimeOffset = this.TimeOffset });
     }
 
     private void RetrieveUsageData()
@@ -210,18 +210,18 @@ public partial class DashboardPage : FluxorComponent
         this.Dispatcher.Dispatch(new DashboardActions.GetRecurringUserCountAction { Days = this.UniqueDays, StartDateLocal = startDate, EndDateLocal = endDate, TimeOffset = this.TimeOffset });
     }
 
-    private ChartSeries GetYearOfBirthCountSeries()
+    private ChartSeries GetAgeCountSeries()
     {
         return new ChartSeries
         {
-            Name = "Count of Unique Users",
-            Data = this.YearOfBirthCounts.Select(kvp => (double)kvp.Value).ToArray(),
+            Name = "User Age Demographics",
+            Data = this.AgeCounts.Select(kvp => (double)kvp.Value).ToArray(),
         };
     }
 
-    private string[] GetYearOfBirthLabels()
+    private string[] GetAgeLabels()
     {
-        return this.YearOfBirthCounts.Select((kvp, i) => i % 10 == 0 ? kvp.Key : string.Empty).ToArray();
+        return this.AgeCounts.Select((kvp, i) => i % 10 == 0 ? kvp.Key.ToString(CultureInfo.InvariantCulture) : string.Empty).ToArray();
     }
 
     private sealed record DailyDataRow

--- a/Apps/Admin/Client/Store/Dashboard/DashboardActions.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardActions.cs
@@ -199,9 +199,9 @@ public static class DashboardActions
     public record GetRatingsSummaryFailureAction : BaseFailureAction;
 
     /// <summary>
-    /// The action representing the initiation of a retrieval of year of birth counts.
+    /// The action representing the initiation of a retrieval of age counts.
     /// </summary>
-    public record GetYearOfBirthCountsAction
+    public record GetAgeCountsAction
     {
         /// <summary>
         /// Gets the local start date to query.
@@ -220,14 +220,14 @@ public static class DashboardActions
     }
 
     /// <summary>
-    /// The action representing a successful retrieval of year of birth counts.
+    /// The action representing a successful retrieval of age counts.
     /// </summary>
-    public record GetYearOfBirthCountsSuccessAction : BaseSuccessAction<IDictionary<string, int>>;
+    public record GetAgeCountsSuccessAction : BaseSuccessAction<IDictionary<int, int>>;
 
     /// <summary>
-    /// The action representing a failed retrieval of year of birth counts.
+    /// The action representing a failed retrieval of age counts.
     /// </summary>
-    public record GetYearOfBirthCountsFailureAction : BaseFailureAction;
+    public record GetAgeCountsFailureAction : BaseFailureAction;
 
     /// <summary>
     /// The action that clears the state.

--- a/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
@@ -142,21 +142,21 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
     }
 
     [EffectMethod]
-    public async Task HandleGetYearOfBirthCountsAction(DashboardActions.GetYearOfBirthCountsAction action, IDispatcher dispatcher)
+    public async Task HandleGetAgeCountsAction(DashboardActions.GetAgeCountsAction action, IDispatcher dispatcher)
     {
-        logger.LogInformation("Retrieving year of birth counts");
+        logger.LogInformation("Retrieving age counts");
 
         try
         {
-            IDictionary<string, int> response = await dashboardApi.GetYearOfBirthCountsAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
-            logger.LogInformation("Year of birth counts retrieved successfully");
-            dispatcher.Dispatch(new DashboardActions.GetYearOfBirthCountsSuccessAction { Data = response });
+            IDictionary<int, int> response = await dashboardApi.GetAgeCountsAsync(action.StartDateLocal, action.EndDateLocal, action.TimeOffset).ConfigureAwait(true);
+            logger.LogInformation("Age counts retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetAgeCountsSuccessAction { Data = response });
         }
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving year of birth counts, reason: {ErrorMessage}", error.Message);
-            dispatcher.Dispatch(new DashboardActions.GetYearOfBirthCountsFailureAction { Error = error });
+            logger.LogError("Error retrieving age counts, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetAgeCountsFailureAction { Error = error });
         }
     }
 }

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Client.Store.Dashboard;
 
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Globalization;
 using System.Linq;
 using Fluxor;
 
@@ -245,58 +244,54 @@ public static class DashboardReducers
         };
     }
 
-    [ReducerMethod(typeof(DashboardActions.GetYearOfBirthCountsAction))]
-    public static DashboardState ReduceGetYearOfBirthCountsAction(DashboardState state)
+    [ReducerMethod(typeof(DashboardActions.GetAgeCountsAction))]
+    public static DashboardState ReduceGetAgeCountsAction(DashboardState state)
     {
         return state with
         {
-            GetYearOfBirthCounts = state.GetYearOfBirthCounts with { IsLoading = true },
+            GetAgeCounts = state.GetAgeCounts with { IsLoading = true },
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetYearOfBirthCountsSuccessAction(DashboardState state, DashboardActions.GetYearOfBirthCountsSuccessAction action)
+    public static DashboardState ReduceGetAgeCountsSuccessAction(DashboardState state, DashboardActions.GetAgeCountsSuccessAction action)
     {
-        List<string> years = action.Data.Keys.Order().ToList();
-        Dictionary<string, int> yearOfBirthCounts = new(action.Data);
+        IList<int> ages = [..action.Data.Keys.Order()];
+        Dictionary<int, int> ageCounts = new(action.Data);
 
-        // add empty entries for years that are not populated
-        if (years.Count > 0 && int.TryParse(years[0], out int firstYear) && int.TryParse(years[^1], out int lastYear))
+        // add empty entries for ages that are not populated
+        if (ages.Count > 0)
         {
-            for (int year = firstYear; year <= lastYear; year++)
+            for (int year = ages[0]; year <= ages[^1]; year++)
             {
-                string yearString = year.ToString(CultureInfo.InvariantCulture);
-                if (!yearOfBirthCounts.ContainsKey(yearString))
-                {
-                    yearOfBirthCounts[yearString] = 0;
-                }
+                ageCounts.TryAdd(year, 0);
             }
         }
 
         return state with
         {
-            GetYearOfBirthCounts = state.GetYearOfBirthCounts with
+            GetAgeCounts = state.GetAgeCounts with
             {
                 Result = action.Data,
                 IsLoading = false,
                 Error = null,
             },
-            YearOfBirthCounts = yearOfBirthCounts.ToImmutableSortedDictionary(),
+            AgeCounts = ageCounts.ToImmutableSortedDictionary(),
         };
     }
 
     [ReducerMethod]
-    public static DashboardState ReduceGetYearOfBirthCountsFailureAction(DashboardState state, DashboardActions.GetYearOfBirthCountsFailureAction action)
+    public static DashboardState ReduceGetAgeCountsFailureAction(DashboardState state, DashboardActions.GetAgeCountsFailureAction action)
     {
         return state with
         {
-            GetYearOfBirthCounts = state.GetYearOfBirthCounts with
+            GetAgeCounts = state.GetAgeCounts with
             {
                 Result = null,
                 IsLoading = false,
                 Error = action.Error,
             },
-            YearOfBirthCounts = ImmutableDictionary<string, int>.Empty,
+            AgeCounts = ImmutableDictionary<int, int>.Empty,
         };
     }
 
@@ -311,8 +306,8 @@ public static class DashboardReducers
             GetRecurringUserCount = new(),
             GetAppLoginCounts = new(),
             GetRatingsSummary = new(),
-            GetYearOfBirthCounts = new(),
-            YearOfBirthCounts = ImmutableDictionary<string, int>.Empty,
+            GetAgeCounts = new(),
+            AgeCounts = ImmutableDictionary<int, int>.Empty,
         };
     }
 }

--- a/Apps/Admin/Client/Store/Dashboard/DashboardState.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardState.cs
@@ -60,12 +60,12 @@ public record DashboardState
     public BaseRequestState<IDictionary<string, int>> GetRatingsSummary { get; init; } = new();
 
     /// <summary>
-    /// Gets the request state for retrieving year of birth counts.
+    /// Gets the request state for retrieving age counts.
     /// </summary>
-    public BaseRequestState<IDictionary<string, int>> GetYearOfBirthCounts { get; init; } = new();
+    public BaseRequestState<IDictionary<int, int>> GetAgeCounts { get; init; } = new();
 
     /// <summary>
-    /// Gets year of birth counts associated with the most recent query.
+    /// Gets age counts associated with the most recent query.
     /// </summary>
-    public IDictionary<string, int> YearOfBirthCounts { get; init; } = ImmutableDictionary<string, int>.Empty;
+    public IDictionary<int, int> AgeCounts { get; init; } = ImmutableDictionary<int, int>.Empty;
 }

--- a/Apps/Admin/Server/Controllers/DashboardController.cs
+++ b/Apps/Admin/Server/Controllers/DashboardController.cs
@@ -195,13 +195,13 @@ namespace HealthGateway.Admin.Server.Controllers
         }
 
         /// <summary>
-        /// Retrieves year of birth counts for users that have logged in between two dates.
+        /// Retrieves age counts for users that have logged in between two dates.
         /// </summary>
         /// <param name="startDateLocal">The local start date to query.</param>
         /// <param name="endDateLocal">The local end date to query.</param>
         /// <param name="timeOffset">The current timezone offset from the client browser to UTC.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A dictionary mapping birth years to user counts.</returns>
+        /// <returns>A dictionary mapping ages to user counts.</returns>
         /// <response code="200">Returns a dictionary mapping birth years to user counts.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -209,17 +209,17 @@ namespace HealthGateway.Admin.Server.Controllers
         /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
         /// </response>
         [HttpGet]
-        [Route("YearOfBirthCounts")]
+        [Route("AgeCounts")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IDictionary<string, int>> GetYearOfBirthCounts(
+        public async Task<IDictionary<int, int>> GetAgeCounts(
             [FromQuery] DateOnly startDateLocal,
             [FromQuery] DateOnly endDateLocal,
             [FromQuery] int timeOffset,
             CancellationToken ct)
         {
-            return await dashboardService.GetYearOfBirthCountsAsync(startDateLocal, endDateLocal, timeOffset, ct);
+            return await dashboardService.GetAgeCountsAsync(startDateLocal, endDateLocal, timeOffset, ct);
         }
     }
 }

--- a/Apps/Admin/Server/Mappers/UserFeedbackCsvMap.cs
+++ b/Apps/Admin/Server/Mappers/UserFeedbackCsvMap.cs
@@ -70,31 +70,21 @@ namespace HealthGateway.Admin.Server.Mappers
             this.Map(m => m.UserProfile!.YearOfBirth).Convert(userProfile => GetAgeCohort(userProfile.Value.UserProfile?.YearOfBirth)).Name("Age Cohort").Index(3);
         }
 
-        private static string GetAgeCohort(string? yearOfBirth)
+        private static string GetAgeCohort(int? yearOfBirth)
         {
-            int yob = int.Parse(yearOfBirth ?? "0", CultureInfo.InvariantCulture);
-
-            switch (yob)
+            yearOfBirth ??= 0;
+            return yearOfBirth switch
             {
-                case 0:
-                    return "0";
-                case <= 1927:
-                    return "1";
-                case <= 1945:
-                    return "2";
-                case <= 1954:
-                    return "3";
-                case <= 1964:
-                    return "4";
-                case <= 1980:
-                    return "5";
-                case <= 1996:
-                    return "6";
-                case <= 2012:
-                    return "7";
-                default:
-                    return "8";
-            }
+                0 => "0",
+                <= 1927 => "1",
+                <= 1945 => "2",
+                <= 1954 => "3",
+                <= 1964 => "4",
+                <= 1980 => "5",
+                <= 1996 => "6",
+                <= 2012 => "7",
+                _ => "8",
+            };
         }
     }
 }

--- a/Apps/Admin/Server/Services/CsvExportService.cs
+++ b/Apps/Admin/Server/Services/CsvExportService.cs
@@ -105,7 +105,7 @@ namespace HealthGateway.Admin.Server.Services
             DateTimeOffset startDateOffset = new(startDateLocal.ToDateTime(TimeOnly.MinValue), offsetSpan);
             DateTimeOffset endDateOffset = new(endDateLocal.ToDateTime(TimeOnly.MaxValue), offsetSpan);
 
-            IDictionary<string, int> yobCounts = await userProfileDelegate.GetLoggedInUserYearOfBirthCountsAsync(startDateOffset, endDateOffset, ct);
+            IDictionary<int, int> yobCounts = await userProfileDelegate.GetLoggedInUserYearOfBirthCountsAsync(startDateOffset, endDateOffset, ct);
 
             MemoryStream stream = new();
             await using StreamWriter writer = new(stream, leaveOpen: true);

--- a/Apps/Admin/Server/Services/DashboardService.cs
+++ b/Apps/Admin/Server/Services/DashboardService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Common.Models;
@@ -83,11 +84,13 @@ namespace HealthGateway.Admin.Server.Services
         }
 
         /// <inheritdoc/>
-        public async Task<IDictionary<string, int>> GetYearOfBirthCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct)
+        public async Task<IDictionary<int, int>> GetAgeCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct)
         {
             DateTimeOffset startDate = GetStartDateTimeOffset(startDateLocal, timeOffset);
             DateTimeOffset endDate = GetEndDateTimeOffset(endDateLocal, timeOffset);
-            return await userProfileDelegate.GetLoggedInUserYearOfBirthCountsAsync(startDate, endDate, ct);
+            IDictionary<int, int> yearOfBirthCounts = await userProfileDelegate.GetLoggedInUserYearOfBirthCountsAsync(startDate, endDate, ct);
+            int currentYear = DateTime.Today.Year;
+            return new SortedDictionary<int, int>(yearOfBirthCounts.ToDictionary(kvp => currentYear - kvp.Key, kvp => kvp.Value));
         }
 
         private static DateTimeOffset GetStartDateTimeOffset(DateOnly startDateLocal, int timeOffset)

--- a/Apps/Admin/Server/Services/IDashboardService.cs
+++ b/Apps/Admin/Server/Services/IDashboardService.cs
@@ -84,13 +84,13 @@ namespace HealthGateway.Admin.Server.Services
         Task<IDictionary<string, int>> GetRatingsSummaryAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct = default);
 
         /// <summary>
-        /// Retrieves year of birth counts for users that have logged in between two dates.
+        /// Retrieves age counts for users that have logged in between two dates.
         /// </summary>
         /// <param name="startDateLocal">The local start date to query.</param>
         /// <param name="endDateLocal">The local end date to query.</param>
         /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A dictionary mapping birth years to user counts.</returns>
-        Task<IDictionary<string, int>> GetYearOfBirthCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct);
+        /// <returns>A dictionary mapping ages to user counts.</returns>
+        Task<IDictionary<int, int>> GetAgeCountsAsync(DateOnly startDateLocal, DateOnly endDateLocal, int timeOffset, CancellationToken ct);
     }
 }

--- a/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
@@ -60,7 +60,7 @@ namespace HealthGateway.Admin.Tests.Services
         [Fact]
         public async Task ShouldGetYearOfBirthCounts()
         {
-            Dictionary<string, int> getResult = new();
+            Dictionary<int, int> getResult = new();
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
             profileDelegateMock.Setup(s => s.GetLoggedInUserYearOfBirthCountsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>())).ReturnsAsync(getResult);

--- a/Apps/CommonData/src/Models/UserProfile.cs
+++ b/Apps/CommonData/src/Models/UserProfile.cs
@@ -87,7 +87,7 @@ namespace HealthGateway.Common.Data.Models
         /// Gets or sets the user's year of birth.
         /// </summary>
         [MaxLength(4)]
-        public string? YearOfBirth { get; set; }
+        public int? YearOfBirth { get; set; }
 
         /// <summary>
         /// Gets or sets the user's last login client.

--- a/Apps/Database/src/Context/GatewayDbContext.cs
+++ b/Apps/Database/src/Context/GatewayDbContext.cs
@@ -357,6 +357,11 @@ namespace HealthGateway.Database.Context
             modelBuilder.Entity<UserProfile>()
                 .HasIndex(p => p.LastLoginDateTime);
 
+            modelBuilder
+                .Entity<UserProfile>()
+                .Property(e => e.YearOfBirth)
+                .HasConversion<string>();
+
             // Create Foreign keys for User Profile
             modelBuilder.Entity<UserProfile>()
                 .HasOne<UserLoginClientTypeCode>()
@@ -364,6 +369,11 @@ namespace HealthGateway.Database.Context
                 .HasPrincipalKey(k => k.UserLoginClientCode)
                 .HasForeignKey(k => k.LastLoginClientCode)
                 .OnDelete(DeleteBehavior.Restrict);
+
+            modelBuilder
+                .Entity<UserProfileHistory>()
+                .Property(e => e.YearOfBirth)
+                .HasConversion<string>();
 
             // Create Foreign keys for User Profile History
             modelBuilder.Entity<UserProfileHistory>()

--- a/Apps/Database/src/Delegates/DbProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbProfileDelegate.cs
@@ -350,9 +350,9 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IDictionary<string, int>> GetLoggedInUserYearOfBirthCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct)
+        public async Task<IDictionary<int, int>> GetLoggedInUserYearOfBirthCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct)
         {
-            Dictionary<string, int> yobCount = await this.dbContext.UserProfile
+            Dictionary<int, int> yobCounts = await this.dbContext.UserProfile
                 .Select(x => new { x.HdId, x.LastLoginDateTime, x.YearOfBirth })
                 .Concat(
                     this.dbContext.UserProfileHistory.Select(x => new { x.HdId, x.LastLoginDateTime, x.YearOfBirth }))
@@ -361,9 +361,9 @@ namespace HealthGateway.Database.Delegates
                 .Distinct()
                 .GroupBy(x => x.YearOfBirth)
                 .Select(x => new { yearOfBirth = x.Key, count = x.Count() })
-                .ToDictionaryAsync(x => x.yearOfBirth!, x => x.count, ct);
+                .ToDictionaryAsync(x => x.yearOfBirth!.Value, x => x.count, ct);
 
-            return new SortedDictionary<string, int>(yobCount);
+            return new SortedDictionary<int, int>(yobCounts);
         }
     }
 }

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -167,6 +167,6 @@ namespace HealthGateway.Database.Delegates
         /// <param name="endDateTimeOffset">The end datetime offset to query.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The counts of logged in users by year of birth.</returns>
-        Task<IDictionary<string, int>> GetLoggedInUserYearOfBirthCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct);
+        Task<IDictionary<int, int>> GetLoggedInUserYearOfBirthCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct);
     }
 }

--- a/Apps/Database/src/Models/UserProfileHistory.cs
+++ b/Apps/Database/src/Models/UserProfileHistory.cs
@@ -86,7 +86,7 @@ namespace HealthGateway.Database.Models
         /// Gets or sets the user's year of birth.
         /// </summary>
         [MaxLength(4)]
-        public string? YearOfBirth { get; set; }
+        public int? YearOfBirth { get; set; }
 
         /// <summary>
         /// Gets or sets the user's last login client.

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -173,7 +173,7 @@ namespace HealthGateway.GatewayApi.Services
                 // Update user year of birth.
                 RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid).ConfigureAwait(true);
                 DateTime? birthDate = patientResult.ResourcePayload?.Birthdate;
-                userProfileDbResult.Payload.YearOfBirth = birthDate?.Year.ToString(CultureInfo.InvariantCulture);
+                userProfileDbResult.Payload.YearOfBirth = birthDate?.Year;
 
                 this.userProfileDelegate.Update(userProfileDbResult.Payload);
                 this.logger.LogDebug("Finished updating user last login and year of birth... {Hdid}", hdid);
@@ -250,7 +250,7 @@ namespace HealthGateway.GatewayApi.Services
                 UpdatedBy = hdid,
                 LastLoginDateTime = jwtAuthTime,
                 EncryptionKey = this.cryptoDelegate.GenerateKey(),
-                YearOfBirth = birthDate?.Year.ToString(CultureInfo.InvariantCulture),
+                YearOfBirth = birthDate?.Year,
                 LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType(),
             };
             DbResult<UserProfile> insertResult = await this.userProfileDelegate.InsertUserProfileAsync(newProfile, !this.accountsChangeFeedEnabled, ct);


### PR DESCRIPTION
# Implements [AB#16483](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16483)

## Description

- updates type of `YearOfBirth` from `string` to `int?` in `UserProfile` and `UserProfileHistory` models
  - the underlying type in the database remains unchanged
  - conversion is provided by `HasConversion<string>()` in `GatewayDbContext`
- updates dashboard service to return age counts instead of year of birth counts
  - the analytics export service still returns year of birth counts
- updates naming and documentation relating to year of birth counts for the dashboard

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/3787b7cb-36de-4ad8-8fca-2d8ecb55ff01)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
