### PR TITLE
Associate on redirect to sharing for AB#16187

### DIFF
--- a/Apps/GatewayApi/src/Controllers/DelegationController.cs
+++ b/Apps/GatewayApi/src/Controllers/DelegationController.cs
@@ -49,8 +49,8 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         /// <param name="hdid">The delegate's hdid.</param>
-        /// <param name="encryptedDelegationId">The encrypted delegation id.</param>
         /// <param name="ct">cancellation token.</param>
+        /// <param name="encryptedDelegationId">The encrypted delegation id.</param>
         /// <response code="200">The delegation is associated with the user.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">

--- a/Apps/WebClient/src/ClientApp/src/components/private/sharing/SharingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/sharing/SharingView.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed } from "vue";
+import { useRouter } from "vue-router";
 
 import BreadcrumbComponent from "@/components/common/BreadcrumbComponent.vue";
 import LoadingComponent from "@/components/common/LoadingComponent.vue";
@@ -8,6 +9,11 @@ import DelegationWizardDialog from "@/components/private/sharing/DelegationWizar
 import EmptySharingPageComponent from "@/components/private/sharing/EmptySharingPageComponent.vue";
 import BreadcrumbItem from "@/models/breadcrumbItem";
 import { useDelegationStore } from "@/stores/delegation";
+
+interface Props {
+    invite?: string;
+}
+const props = defineProps<Props>();
 
 const breadcrumbItems: BreadcrumbItem[] = [
     {
@@ -20,12 +26,18 @@ const breadcrumbItems: BreadcrumbItem[] = [
 
 const delegationStore = useDelegationStore();
 
+const router = useRouter();
+
 const delegationsAreLoading = computed(
     () => delegationStore.delegationsAreLoading
 );
 const hasDelegations = computed(() => delegationStore.delegations.length > 0);
 
 // TODO: call for invitations
+if (props.invite !== undefined) {
+    delegationStore.associateDelegation(props.invite);
+    router.replace({ query: {} });
+}
 </script>
 
 <template>

--- a/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
@@ -31,6 +31,7 @@ export const enum Action {
 }
 
 export const enum Actor {
+    Delegate = "Delegate",
     Guardian = "Guardian",
     User = "User",
 }
@@ -98,6 +99,7 @@ export const enum Type {
     Covid19ProofOfVaccination = "COVID-19 Proof of Vaccination",
     OrganDonorRegistration = "Organ Donor Registration",
     PublicCovid19ProofOfVaccination = "Public COVID-19 Proof of Vaccination",
+    AssociateDelegation = "Associate Delegation",
     Recall = "Recall",
     Result = "Result",
 }

--- a/Apps/WebClient/src/ClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/ClientApp/src/router/index.ts
@@ -340,6 +340,9 @@ const routes = [
         path: Path.Sharing,
         name: "Sharing",
         component: SharingView,
+        props: (route: RouteLocation) => ({
+            invite: route.query.invite,
+        }),
         meta: {
             validStates: [UserState.registered],
             requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -281,4 +281,6 @@ export interface IDelegationService {
         ownerHdid: string,
         delegation: CreateDelegationRequest
     ): Promise<string | undefined>;
+
+    associateDelegation(delegateHdid: string, inviteId: string): Promise<void>;
 }

--- a/Apps/WebClient/src/ClientApp/src/services/restDelegationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restDelegationService.ts
@@ -1,10 +1,18 @@
 import { ServiceCode } from "@/constants/serviceCodes";
+import { container } from "@/ioc/container";
+import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { ExternalConfiguration } from "@/models/configData";
 import { HttpError } from "@/models/errors";
 import { CreateDelegationRequest } from "@/models/sharing/createDelegationRequest";
+import { Action, Actor, Text, Type } from "@/plugins/extensions";
 import ErrorTranslator from "@/utility/errorTranslator";
 
-import { IDelegationService, IHttpDelegate, ILogger } from "./interfaces";
+import {
+    IDelegationService,
+    IHttpDelegate,
+    ILogger,
+    ITrackingService,
+} from "./interfaces";
 
 export class RestDelegationService implements IDelegationService {
     private readonly DELEGATE_BASE_URI: string = "Delegation";
@@ -20,6 +28,34 @@ export class RestDelegationService implements IDelegationService {
         this.logger = logger;
         this.http = http;
         this.baseUri = config.serviceEndpoints["GatewayApi"];
+    }
+    associateDelegation(delegateHdid: string, inviteId: string): Promise<void> {
+        const trackingService = container.get<ITrackingService>(
+            SERVICE_IDENTIFIER.TrackingService
+        );
+        trackingService.trackEvent({
+            action: Action.Submit,
+            actor: Actor.Delegate,
+            text: Text.Request,
+            type: Type.AssociateDelegation,
+        });
+        return this.http
+            .put<void>(
+                `${this.baseUri}${this.DELEGATE_BASE_URI}/${delegateHdid}/Associate?encryptedDelegationId=${inviteId}`,
+                null
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestDelegationService.associateDelegation()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            })
+            .then(() => {
+                this.logger.verbose(`associateDelegation success`);
+            });
     }
 
     public createDelegation(


### PR DESCRIPTION
# Implements [AB#16187](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16187)

## Description
1. Add Associate call to rest service
2. Add tracking on call to endpoint
3. display error accordingly.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
Existing invitation:
![image](https://github.com/bcgov/healthgateway/assets/19548348/e98596b3-13e6-46c1-afb4-7275c513a136)

Unassociated record:
![image](https://github.com/bcgov/healthgateway/assets/19548348/232fa67d-6b34-4f0a-a6e3-79e352392f9a)

Unauthed landing page:
![image](https://github.com/bcgov/healthgateway/assets/19548348/2a82cffb-f30b-4b6d-bb2a-c7eb5ea37bd4)

Post-redirect Associate call:
![image](https://github.com/bcgov/healthgateway/assets/19548348/2eab19e9-602e-47ac-8dbf-6e426a4214ac)

Reattempt to associate from different account (note the scrubbed URL):
![image](https://github.com/bcgov/healthgateway/assets/19548348/f6407c1f-1547-4399-97c0-bafd6d8a3776)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
