### PR TITLE
Add count to admin dashboard & fix label bug AB#16484 AB#16485 AB#16518

### DIFF
--- a/Apps/Admin/Client/Api/IDashboardApi.cs
+++ b/Apps/Admin/Client/Api/IDashboardApi.cs
@@ -28,6 +28,13 @@ using Refit;
 public interface IDashboardApi
 {
     /// <summary>
+    /// Retrieves all-time counts.
+    /// </summary>
+    /// <returns>A model containing the all-time counts.</returns>
+    [Get("/AllTimeCounts")]
+    Task<AllTimeDashboardCounts> GetAllTimeCounts();
+
+    /// <summary>
     /// Retrieves the daily counts of user registrations.
     /// </summary>
     /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>

--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -144,7 +144,7 @@
                     ChartSeries="[GetAgeCountSeries()]"
                     XAxisLabels="@GetAgeLabels()"
                     Width="100%"
-                    Height="325" />
+                    Height="295" />
             }
             else
             {

--- a/Apps/Admin/Client/Pages/DashboardPage.razor
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor
@@ -53,6 +53,24 @@
             }
         </MudPaper>
     </MudItem>
+    <MudItem xs="12" lg="4">
+        <MudPaper Class="my-2 pa-4" Outlined="true">
+            @if (AllTimeCountsLoading)
+            {
+                <MudSkeleton />
+                <MudSkeleton data-testid="skeleton-closed-accounts" />
+            }
+            else
+            {
+                <MudText Align="Align.Center" Typo="Typo.subtitle1">
+                    Closed Accounts
+                </MudText>
+                <MudText Align="Align.Center" Typo="Typo.subtitle1" data-testid="total-closed-accounts">
+                    @FormatNumber(AllTimeCounts.ClosedAccounts)
+                </MudText>
+            }
+        </MudPaper>
+    </MudItem>
 </MudGrid>
 
 <MudText Class="mt-12" Typo="@Typo.h6">Platform & Demographics</MudText>

--- a/Apps/Admin/Client/Pages/DashboardPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor.cs
@@ -42,6 +42,8 @@ public partial class DashboardPage : FluxorComponent
     [Inject]
     private IState<DashboardState> DashboardState { get; set; } = default!;
 
+    private AllTimeDashboardCounts AllTimeCounts => this.DashboardState.Value.GetAllTimeCounts.Result ?? new();
+
     private IDictionary<DateOnly, int> UserRegistrationCounts => this.DashboardState.Value.GetDailyUserRegistrationCounts.Result ?? ImmutableDictionary<DateOnly, int>.Empty;
 
     private IDictionary<DateOnly, int> DailyDependentRegistrationCounts => this.DashboardState.Value.GetDailyDependentRegistrationCounts.Result ?? ImmutableDictionary<DateOnly, int>.Empty;
@@ -53,6 +55,8 @@ public partial class DashboardPage : FluxorComponent
     private AppLoginCounts AppLoginCounts => this.DashboardState.Value.GetAppLoginCounts.Result ?? new(0, 0);
 
     private IDictionary<int, int> AgeCounts => this.DashboardState.Value.AgeCounts;
+
+    private bool AllTimeCountsLoading => this.DashboardState.Value.GetAllTimeCounts.IsLoading;
 
     private bool DailyUserRegistrationCountsLoading => this.DashboardState.Value.GetDailyUserRegistrationCounts.IsLoading;
 
@@ -182,6 +186,7 @@ public partial class DashboardPage : FluxorComponent
     {
         base.OnInitialized();
         this.Dispatcher.Dispatch(new DashboardActions.ResetStateAction());
+        this.Dispatcher.Dispatch(new DashboardActions.GetAllTimeCountsAction());
         this.RetrieveDemographicsData();
         this.RetrieveUsageData();
     }

--- a/Apps/Admin/Client/Store/Dashboard/DashboardActions.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardActions.cs
@@ -28,6 +28,21 @@ using HealthGateway.Admin.Common.Models;
 public static class DashboardActions
 {
     /// <summary>
+    /// The action representing the initiation of a retrieval of all-time counts.
+    /// </summary>
+    public record GetAllTimeCountsAction;
+
+    /// <summary>
+    /// The action representing a successful retrieval of all-time counts.
+    /// </summary>
+    public record GetAllTimeCountsSuccessAction : BaseSuccessAction<AllTimeDashboardCounts>;
+
+    /// <summary>
+    /// The action representing a failed retrieval of all-time counts.
+    /// </summary>
+    public record GetAllTimeCountsFailureAction : BaseFailureAction;
+
+    /// <summary>
     /// The action representing the initiation of a retrieval of daily user registration counts.
     /// </summary>
     public record GetDailyUserRegistrationCountsAction

--- a/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
@@ -28,6 +28,24 @@ using Refit;
 
 public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi dashboardApi)
 {
+    [EffectMethod(typeof(DashboardActions.GetAllTimeCountsAction))]
+    public async Task HandleGetAllTimeCountsAction(IDispatcher dispatcher)
+    {
+        logger.LogInformation("Retrieving all-time counts");
+        try
+        {
+            AllTimeDashboardCounts response = await dashboardApi.GetAllTimeCounts().ConfigureAwait(true);
+            logger.LogInformation("All-time counts retrieved successfully");
+            dispatcher.Dispatch(new DashboardActions.GetAllTimeCountsSuccessAction { Data = response });
+        }
+        catch (ApiException ex)
+        {
+            RequestError error = StoreUtility.FormatRequestError(ex);
+            logger.LogError("Error retrieving all-time counts, reason: {ErrorMessage}", error.Message);
+            dispatcher.Dispatch(new DashboardActions.GetAllTimeCountsFailureAction { Error = error });
+        }
+    }
+
     [EffectMethod]
     public async Task HandleGetDailyUserRegistrationCountsAction(DashboardActions.GetDailyUserRegistrationCountsAction action, IDispatcher dispatcher)
     {

--- a/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardReducers.cs
@@ -22,6 +22,43 @@ using Fluxor;
 
 public static class DashboardReducers
 {
+    [ReducerMethod(typeof(DashboardActions.GetAllTimeCountsAction))]
+    public static DashboardState ReduceGetAllTimeCountsAction(DashboardState state)
+    {
+        return state with
+        {
+            GetAllTimeCounts = state.GetAllTimeCounts with { IsLoading = true },
+        };
+    }
+
+    [ReducerMethod]
+    public static DashboardState ReduceGetAllTimeCountsSuccessAction(DashboardState state, DashboardActions.GetAllTimeCountsSuccessAction action)
+    {
+        return state with
+        {
+            GetAllTimeCounts = state.GetAllTimeCounts with
+            {
+                Result = action.Data,
+                IsLoading = false,
+                Error = null,
+            },
+        };
+    }
+
+    [ReducerMethod]
+    public static DashboardState ReduceGetAllTimeCountsFailureAction(DashboardState state, DashboardActions.GetAllTimeCountsFailureAction action)
+    {
+        return state with
+        {
+            GetAllTimeCounts = state.GetAllTimeCounts with
+            {
+                Result = null,
+                IsLoading = false,
+                Error = action.Error,
+            },
+        };
+    }
+
     [ReducerMethod(typeof(DashboardActions.GetDailyUserRegistrationCountsAction))]
     public static DashboardState ReduceGetRegisteredUsersAction(DashboardState state)
     {
@@ -300,6 +337,7 @@ public static class DashboardReducers
     {
         return state with
         {
+            GetAllTimeCounts = new(),
             GetDailyUserRegistrationCounts = new(),
             GetDailyUniqueLoginCounts = new(),
             GetDailyDependentRegistrationCounts = new(),

--- a/Apps/Admin/Client/Store/Dashboard/DashboardState.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardState.cs
@@ -30,6 +30,11 @@ using HealthGateway.Admin.Common.Models;
 public record DashboardState
 {
     /// <summary>
+    /// Gets the request state for retrieving all-time counts.
+    /// </summary>
+    public BaseRequestState<AllTimeDashboardCounts> GetAllTimeCounts { get; init; } = new();
+
+    /// <summary>
     /// Gets the request state for retrieving daily counts of user registrations.
     /// </summary>
     public BaseRequestState<IDictionary<DateOnly, int>> GetDailyUserRegistrationCounts { get; init; } = new();

--- a/Apps/Admin/Common/Models/AllTimeDashboardCounts.cs
+++ b/Apps/Admin/Common/Models/AllTimeDashboardCounts.cs
@@ -1,0 +1,26 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Common.Models
+{
+    /// <summary>
+    /// Model containing all-time counts for the admin dashboard.
+    /// </summary>
+    public record AllTimeDashboardCounts
+    {
+        /// <summary>Gets the number of closed Health Gateway accounts.</summary>
+        public int ClosedAccounts { get; init; }
+    }
+}

--- a/Apps/Admin/Server/Controllers/DashboardController.cs
+++ b/Apps/Admin/Server/Controllers/DashboardController.cs
@@ -37,6 +37,27 @@ namespace HealthGateway.Admin.Server.Controllers
     public class DashboardController(IDashboardService dashboardService)
     {
         /// <summary>
+        /// Retrieves all-time counts.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A model containing the all-time counts.</returns>
+        /// <response code="200">Returns a model containing the all-time counts.</response>
+        /// <response code="401">The client must authenticate itself to get the requested response.</response>
+        /// <response code="403">
+        /// The client does not have access rights to the content; that is, it is unauthorized, so the server
+        /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
+        /// </response>
+        [HttpGet]
+        [Route("AllTimeCounts")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
+        public async Task<AllTimeDashboardCounts> GetAllTimeCounts(CancellationToken ct)
+        {
+            return await dashboardService.GetAllTimeCountsAsync(ct);
+        }
+
+        /// <summary>
         /// Retrieves the daily counts of user registrations.
         /// </summary>
         /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>

--- a/Apps/Admin/Server/Services/DashboardService.cs
+++ b/Apps/Admin/Server/Services/DashboardService.cs
@@ -34,6 +34,13 @@ namespace HealthGateway.Admin.Server.Services
         IRatingDelegate ratingDelegate) : IDashboardService
     {
         /// <inheritdoc/>
+        public async Task<AllTimeDashboardCounts> GetAllTimeCountsAsync(CancellationToken ct = default)
+        {
+            int closedUserProfileCount = await userProfileDelegate.GetClosedUserProfileCount(ct);
+            return new() { ClosedAccounts = closedUserProfileCount };
+        }
+
+        /// <inheritdoc/>
         public async Task<IDictionary<DateOnly, int>> GetDailyUserRegistrationCountsAsync(int timeOffset, CancellationToken ct = default)
         {
             TimeSpan ts = new(0, timeOffset, 0);

--- a/Apps/Admin/Server/Services/IDashboardService.cs
+++ b/Apps/Admin/Server/Services/IDashboardService.cs
@@ -27,6 +27,13 @@ namespace HealthGateway.Admin.Server.Services
     public interface IDashboardService
     {
         /// <summary>
+        /// Retrieves all-time counts.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A model containing the all-time counts.</returns>
+        Task<AllTimeDashboardCounts> GetAllTimeCountsAsync(CancellationToken ct = default);
+
+        /// <summary>
         /// Retrieves the daily counts of user registrations.
         /// </summary>
         /// <param name="timeOffset">The local timezone offset from UTC in minutes.</param>

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard.cy.js
@@ -11,6 +11,7 @@ describe("Dashboard", () => {
         cy.log("Dashboard test started.");
         cy.get("[data-testid=total-registered-users]").contains(8);
         cy.get("[data-testid=total-dependents]").contains(6);
+        cy.get("[data-testid=total-closed-accounts]").contains(1);
         cy.get("[data-testid=recurring-user-count]").contains(2);
         cy.get("[data-testid=total-mobile-users]").contains(3);
         cy.get("[data-testid=total-web-users]").contains(4);

--- a/Apps/Database/src/Delegates/DbProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbProfileDelegate.cs
@@ -350,6 +350,14 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
+        public async Task<int> GetClosedUserProfileCount(CancellationToken ct)
+        {
+            return await this.dbContext.UserProfileHistory
+                .Where(h => h.Operation == "DELETE" && !this.dbContext.UserProfile.Any(p => p.HdId == h.HdId))
+                .CountAsync(ct);
+        }
+
+        /// <inheritdoc/>
         public async Task<IDictionary<int, int>> GetLoggedInUserYearOfBirthCountsAsync(DateTimeOffset startDateTimeOffset, DateTimeOffset endDateTimeOffset, CancellationToken ct)
         {
             Dictionary<int, int> yobCounts = await this.dbContext.UserProfile

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -161,6 +161,13 @@ namespace HealthGateway.Database.Delegates
         DbResult<IEnumerable<UserProfileHistory>> GetUserProfileHistories(string hdid, int limit);
 
         /// <summary>
+        /// Retrieves the number of user profiles that have been closed and not re-opened.
+        /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The number of user profiles that have been closed and not re-opened</returns>
+        Task<int> GetClosedUserProfileCount(CancellationToken ct);
+
+        /// <summary>
         /// Returns the list of logged in user year of birth counts over a date range.
         /// </summary>
         /// <param name="startDateTimeOffset">The start datetime offset to query.</param>

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -571,6 +571,46 @@ VALUES (
 	'Web'
 );
 
+INSERT INTO gateway."UserProfileHistory"(
+    "UserProfileHistoryId",
+    "CreatedBy",
+    "CreatedDateTime",
+    "UpdatedBy",
+    "UpdatedDateTime",
+    "UserProfileId",
+    "AcceptedTermsOfService",
+    "Email",
+    "ClosedDateTime",
+    "IdentityManagementId",
+    "LastLoginDateTime",
+    "Operation",
+    "OperationDateTime",
+    "EncryptionKey",
+    "SMSNumber",
+    "TermsOfServiceId",
+    "YearOfBirth",
+    "LastLoginClientCode")
+VALUES (
+    'd139c62d-c899-43fb-84f2-45c654ca3270',
+    'System',
+    '2023-09-29 19:11:01.637456 +00:00',
+    'System',
+    '2023-10-04 19:40:02.282833 +00:00',
+    'UF3PZJUD45R7GJFWEVZ6USVANSIRGXOZK7JZI2XBYTG5P4CBAUAA',
+    null,
+    null,
+    '2023-10-31 19:40:02.282237 +00:00',
+    'b5a687c7-2915-4d3f-bb14-a3cf0504a2b2',
+    '2023-10-31 19:39:28.000000 +00:00',
+    'DELETE',
+    '2023-12-01 19:41:29.067450 +00:00',
+    'CwqU7+gCkL3jMWWcUpq80Oh42QejXOwI+Ov0tmsVWBI=',
+    null,
+    '2fab66e7-37c9-4b03-ba25-e8fad604dc7f',
+    '1994',
+    'Web'
+);
+
 INSERT INTO gateway."Rating"(
 	"RatingId", 
 	"CreatedBy", 


### PR DESCRIPTION
# Implements [AB#16484](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16484) and [AB#16485](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16485) and Fixes [AB#16518](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16518)

## Description

- adds closed profile count to admin dashboard [AB#16484](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16484)
- updates functional test to check closed profile count [AB#16485](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16485)
- prevents labels being cut off on age demographic chart [AB#16518](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16518)

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![localhost-2023-12-04-141445](https://github.com/bcgov/healthgateway/assets/16570293/0628e0e2-8332-4ca5-be36-c9fbbc082b49)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
