### PR TITLE
Add wait on query to complete before attempting to edit for AB#16566

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/agentaccess.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/agentaccess.cy.js
@@ -68,6 +68,7 @@ describe("Provision", () => {
     });
 
     it("Edit User", () => {
+        cy.intercept("GET", `**/AgentAccess/?query=${user}`).as("getUser");
         cy.get("[data-testid=query-input]").clear().type(user);
         cy.get("[data-testid=search-btn]").click();
         cy.get("[data-testid^=agent-table-username-]")
@@ -75,30 +76,35 @@ describe("Provision", () => {
             .parents(".mud-table-row")
             .get("[data-testid^=agent-table-edit-btn]")
             .click();
-        cy.get("[data-testid=provision-dialog-modal-text]").should(
-            "be.visible"
-        );
-        cy.get("[data-testid=roles-select]").click();
-        cy.get("[data-testid=role]").contains("AdminAnalyst").click();
-        cy.get("[data-testid=save-btn]").parent().parent().click(0, 0);
-        cy.get("[data-testid=save-btn]").click();
-        cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
+        cy.wait("@getUser").then(() => {
+            cy.get("[data-testid=provision-dialog-modal-text]").should(
+                "be.visible"
+            );
+            cy.get("[data-testid=roles-select]").click();
+            cy.get("[data-testid=role]").contains("AdminAnalyst").click();
+            cy.get("[data-testid=save-btn]").parent().parent().click(0, 0);
+            cy.get("[data-testid=save-btn]").click();
+            cy.get("[data-testid=provision-dialog-modal-text]").should(
+                "not.exist"
+            );
 
-        cy.log("Validate user edit.");
-        const rowSelector = "[data-testid=agent-table] tbody tr.mud-table-row";
-        cy.get(rowSelector)
-            .first()
-            .within(() => {
-                cy.get("[data-testid^=agent-table-username-]").contains(
-                    user.toLowerCase()
-                );
-                cy.get(
-                    "[data-testid^=agent-table-identity-provider-]"
-                ).contains("IDIR");
-                cy.get("[data-testid^=agent-table-roles-]").contains(
-                    "AdminAnalyst, AdminUser"
-                );
-            });
+            cy.log("Validate user edit.");
+            const rowSelector =
+                "[data-testid=agent-table] tbody tr.mud-table-row";
+            cy.get(rowSelector)
+                .first()
+                .within(() => {
+                    cy.get("[data-testid^=agent-table-username-]").contains(
+                        user.toLowerCase()
+                    );
+                    cy.get(
+                        "[data-testid^=agent-table-identity-provider-]"
+                    ).contains("IDIR");
+                    cy.get("[data-testid^=agent-table-roles-]").contains(
+                        "AdminAnalyst, AdminUser"
+                    );
+                });
+        });
     });
 
     it("Delete User", () => {

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/agentaccess.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/agentaccess.cy.js
@@ -3,6 +3,7 @@ import { removeUserIfExists } from "../../utilities/kcUtilities";
 const username = Cypress.env("idir_username");
 const password = Cypress.env("idir_password");
 const user = "FncTstUser1";
+const timeout = 45000;
 
 describe("Provision", () => {
     beforeEach(() => {
@@ -76,35 +77,31 @@ describe("Provision", () => {
             .parents(".mud-table-row")
             .get("[data-testid^=agent-table-edit-btn]")
             .click();
-        cy.wait("@getUser").then(() => {
-            cy.get("[data-testid=provision-dialog-modal-text]").should(
-                "be.visible"
-            );
-            cy.get("[data-testid=roles-select]").click();
-            cy.get("[data-testid=role]").contains("AdminAnalyst").click();
-            cy.get("[data-testid=save-btn]").parent().parent().click(0, 0);
-            cy.get("[data-testid=save-btn]").click();
-            cy.get("[data-testid=provision-dialog-modal-text]").should(
-                "not.exist"
-            );
+        cy.wait("@getUser", { timeout });
+        cy.get("[data-testid=provision-dialog-modal-text]").should(
+            "be.visible"
+        );
+        cy.get("[data-testid=roles-select]").click();
+        cy.get("[data-testid=role]").contains("AdminAnalyst").click();
+        cy.get("[data-testid=save-btn]").parent().parent().click(0, 0);
+        cy.get("[data-testid=save-btn]").click();
+        cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
 
-            cy.log("Validate user edit.");
-            const rowSelector =
-                "[data-testid=agent-table] tbody tr.mud-table-row";
-            cy.get(rowSelector)
-                .first()
-                .within(() => {
-                    cy.get("[data-testid^=agent-table-username-]").contains(
-                        user.toLowerCase()
-                    );
-                    cy.get(
-                        "[data-testid^=agent-table-identity-provider-]"
-                    ).contains("IDIR");
-                    cy.get("[data-testid^=agent-table-roles-]").contains(
-                        "AdminAnalyst, AdminUser"
-                    );
-                });
-        });
+        cy.log("Validate user edit.");
+        const rowSelector = "[data-testid=agent-table] tbody tr.mud-table-row";
+        cy.get(rowSelector)
+            .first()
+            .within(() => {
+                cy.get("[data-testid^=agent-table-username-]").contains(
+                    user.toLowerCase()
+                );
+                cy.get(
+                    "[data-testid^=agent-table-identity-provider-]"
+                ).contains("IDIR");
+                cy.get("[data-testid^=agent-table-roles-]").contains(
+                    "AdminAnalyst, AdminUser"
+                );
+            });
     });
 
     it("Delete User", () => {


### PR DESCRIPTION
# Fixes [AB#16566](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16566)

## Description

Ensure query completes before attempting to edit user.

<img width="1119" alt="Screenshot 2023-12-05 at 4 33 36 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/62c81f09-e9bf-4474-9e7d-f402e9db4565">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
