### PR TITLE
Expand email validation for AB#16520

### DIFF
--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -33,6 +33,7 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.Common.Models.Events;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Delegates;
+    using HealthGateway.GatewayApi.Validations;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -198,6 +199,17 @@ namespace HealthGateway.GatewayApi.Services
                 throw new ProblemDetailsException(
                     ExceptionUtility.CreateProblemDetails(
                         $"User profile not found for hdid {hdid}",
+                        HttpStatusCode.BadRequest,
+                        nameof(UserSmsService)));
+            }
+
+            bool result = string.IsNullOrWhiteSpace(emailAddress)
+                          || (await new OptionalEmailAddressValidator().ValidateAsync(emailAddress, ct))?.IsValid == true;
+            if (!result)
+            {
+                throw new ProblemDetailsException(
+                    ExceptionUtility.CreateProblemDetails(
+                        $"Invalid email address {emailAddress}",
                         HttpStatusCode.BadRequest,
                         nameof(UserSmsService)));
             }

--- a/Apps/GatewayApi/src/Validations/OptionalEmailAddressValidator.cs
+++ b/Apps/GatewayApi/src/Validations/OptionalEmailAddressValidator.cs
@@ -1,0 +1,49 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Validations
+{
+    using System.Net.Mail;
+    using FluentValidation;
+
+    /// <summary>
+    /// Class encapsulating validation for email addresses.
+    /// </summary>
+    public class OptionalEmailAddressValidator : AbstractValidator<string>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OptionalEmailAddressValidator"/> class.
+        /// </summary>
+        public OptionalEmailAddressValidator()
+        {
+            this.RuleFor(emailAddress => emailAddress)
+                .Must(
+                    address =>
+                    {
+                        try
+                        {
+                            MailAddress addr = new(address);
+                            return addr.Address == address;
+                        }
+#pragma warning disable CA1031 // Do not catch general exception types
+                        catch
+                        {
+                            return false;
+                        }
+                    })
+                .When(emailAddress => !string.IsNullOrEmpty(emailAddress));
+        }
+    }
+}

--- a/Apps/GatewayApi/test/unit/Validations/OptionalEmailAddressValidatorTests.cs
+++ b/Apps/GatewayApi/test/unit/Validations/OptionalEmailAddressValidatorTests.cs
@@ -1,0 +1,38 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApiTests.Validations
+{
+    using FluentValidation.Results;
+    using HealthGateway.GatewayApi.Validations;
+    using Xunit;
+
+    /// <summary>
+    /// <see cref="OptionalEmailAddressValidatorTests"/> unit tests.
+    /// </summary>
+    public class OptionalEmailAddressValidatorTests
+    {
+        [Theory]
+        [InlineData("test]invalid@test.com", false)]
+        [InlineData("noStructure", false)]
+        [InlineData("test.valid.complex{something}@test.com", true)]
+        [InlineData("", true)]
+        public async void ShouldValidate(string? email, bool expected)
+        {
+            ValidationResult? result = await new OptionalEmailAddressValidator().ValidateAsync(email);
+            Assert.Equal(expected, result.IsValid);
+        }
+    }
+}

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
 import useVuelidate from "@vuelidate/core";
-import {
-    email as emailValidator,
-    helpers,
-    not,
-    sameAs,
-} from "@vuelidate/validators";
+import { helpers, not, sameAs } from "@vuelidate/validators";
 import { computed, ref, watch } from "vue";
 
 import DisplayFieldComponent from "@/components/common/DisplayFieldComponent.vue";
@@ -13,6 +8,7 @@ import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
 import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { Loader } from "@/constants/loader";
+import ValidationRegEx from "@/constants/validationRegEx";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { isTooManyRequestsError } from "@/models/errors";
@@ -48,11 +44,19 @@ const validations = computed(() => ({
             "New email must be different from the previous one",
             not(sameAs(email))
         ),
-        email: helpers.withMessage("Valid email is required", emailValidator),
+        email: helpers.withMessage("Valid email is required", validateEmail),
     },
 }));
 
 const v$ = useVuelidate(validations, { inputValue });
+
+function validateEmail(emailAddress: string): boolean {
+    return (
+        !emailAddress ||
+        emailAddress.length == 0 ||
+        ValidationRegEx.Email.test(emailAddress)
+    );
+}
 
 function makeEmailEditable(): void {
     isEmailEditable.value = true;

--- a/Apps/WebClient/src/ClientApp/src/components/private/registration/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/registration/RegistrationView.vue
@@ -93,7 +93,7 @@ const validations = computed(() => ({
     },
     email: {
         required: requiredIf(isEmailChecked),
-        email: emailValidator,
+        email: helpers.withMessage("Invalid email", validateEmail),
     },
     emailConfirmation: {
         required: requiredIf(isEmailChecked),
@@ -132,6 +132,10 @@ const v$ = useVuelidate(validations, {
     emailConfirmation,
     accepted,
 });
+
+function validateEmail(emailAddress: string): boolean {
+    return ValidationRegEx.Email.test(emailAddress);
+}
 
 function loadUserData(): void {
     if (userStore.oidcUserInfo === undefined) {

--- a/Apps/WebClient/src/ClientApp/src/components/private/registration/RegistrationView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/registration/RegistrationView.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
 import { useVuelidate } from "@vuelidate/core";
-import {
-    email as emailValidator,
-    helpers,
-    requiredIf,
-    sameAs,
-} from "@vuelidate/validators";
+import { helpers, requiredIf, sameAs } from "@vuelidate/validators";
 import { vMaska } from "maska";
 import { computed, Ref, ref } from "vue";
 import { useRouter } from "vue-router";
@@ -101,7 +96,7 @@ const validations = computed(() => ({
             "Both email addresses must match",
             sameAs(email)
         ),
-        email: emailValidator,
+        email: helpers.withMessage("Invalid email", validateEmail),
     },
     accepted: { isChecked: sameAs(true) },
 }));

--- a/Apps/WebClient/src/ClientApp/src/constants/validationRegEx.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/validationRegEx.ts
@@ -1,3 +1,5 @@
 ﻿export default abstract class ValidationRegEx {
     public static PhoneNumberMasked = /^\D?(\d{3})\D?\D?(\d{3})\D?(\d{4})$/;
+    public static Email =
+        /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 }


### PR DESCRIPTION
# Fixes [AB#16520](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16520)

## Description

1. Replace vuelidate's email validator with custom regex.
2. Add the new validation to registration and user profile email update.

## Testing

- [X] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

Unit Tests
![image](https://github.com/bcgov/healthgateway/assets/19548348/d9ae6d5f-22dc-4e2b-ac1b-ce2a104749fb)

Functional Tests
![image](https://github.com/bcgov/healthgateway/assets/19548348/da3ae04c-3ae7-4dfb-a2b9-34275c5b6d7b)

## UI Changes
![image](https://github.com/bcgov/healthgateway/assets/19548348/02aa7afa-3273-4293-b6e7-19536ba91962)


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
