### PR TITLE
Make GatewayApi async

### DIFF
--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -241,7 +241,7 @@ namespace HealthGateway.Admin.Server.Services
                 : patient?.Hdid;
             UserProfile? profile = hdid == null
                 ? null
-                : await userProfileDelegate.GetUserProfileAsync(hdid);
+                : await userProfileDelegate.GetUserProfileAsync(hdid, ct);
 
             if (patient == null && profile == null)
             {

--- a/Apps/Admin/Server/Services/UserFeedbackService.cs
+++ b/Apps/Admin/Server/Services/UserFeedbackService.cs
@@ -97,7 +97,7 @@ namespace HealthGateway.Admin.Server.Services
             DbResult<UserFeedback> userFeedbackResult = await feedbackDelegate.GetUserFeedbackWithFeedbackTagsAsync(feedback.Id, ct);
             if (userFeedbackResult.Status == DbStatusCode.Read)
             {
-                string email = await this.GetUserEmail(userFeedbackResult.Payload.UserProfileId);
+                string email = await this.GetUserEmail(userFeedbackResult.Payload.UserProfileId, ct);
                 result.ResourcePayload = UserFeedbackMapUtils.ToUiModel(userFeedbackResult.Payload, email, autoMapper);
                 result.ResultStatus = ResultType.Success;
             }
@@ -200,7 +200,7 @@ namespace HealthGateway.Admin.Server.Services
 
                 if (savedUserFeedbackResult.Status == DbStatusCode.Updated)
                 {
-                    string email = await this.GetUserEmail(userFeedback.UserProfileId);
+                    string email = await this.GetUserEmail(userFeedback.UserProfileId, ct);
                     result.ResourcePayload = UserFeedbackMapUtils.ToUiModel(userFeedback, email, autoMapper);
                     result.ResultStatus = ResultType.Success;
                 }
@@ -223,12 +223,12 @@ namespace HealthGateway.Admin.Server.Services
             return result;
         }
 
-        private async Task<string> GetUserEmail(string? hdid)
+        private async Task<string> GetUserEmail(string? hdid, CancellationToken ct)
         {
             string email = string.Empty;
             if (hdid != null)
             {
-                UserProfile? userProfile = await userProfileDelegate.GetUserProfileAsync(hdid);
+                UserProfile? userProfile = await userProfileDelegate.GetUserProfileAsync(hdid, ct);
                 if (userProfile != null)
                 {
                     email = userProfile.Email ?? string.Empty;

--- a/Apps/Admin/Server/Services/UserFeedbackService.cs
+++ b/Apps/Admin/Server/Services/UserFeedbackService.cs
@@ -92,12 +92,12 @@ namespace HealthGateway.Admin.Server.Services
                 ResultStatus = ResultType.Error,
             };
 
-            feedbackDelegate.UpdateUserFeedback(autoMapper.Map<UserFeedback>(feedback));
+            await feedbackDelegate.UpdateUserFeedbackAsync(autoMapper.Map<UserFeedback>(feedback), ct);
 
             DbResult<UserFeedback> userFeedbackResult = await feedbackDelegate.GetUserFeedbackWithFeedbackTagsAsync(feedback.Id, ct);
             if (userFeedbackResult.Status == DbStatusCode.Read)
             {
-                string email = await this.GetUserEmail(userFeedbackResult.Payload.UserProfileId, ct);
+                string email = await this.GetUserEmailAsync(userFeedbackResult.Payload.UserProfileId, ct);
                 result.ResourcePayload = UserFeedbackMapUtils.ToUiModel(userFeedbackResult.Payload, email, autoMapper);
                 result.ResultStatus = ResultType.Success;
             }
@@ -196,11 +196,11 @@ namespace HealthGateway.Admin.Server.Services
                         userFeedbackTag.UserFeedbackId);
                 }
 
-                DbResult<UserFeedback> savedUserFeedbackResult = feedbackDelegate.UpdateUserFeedbackWithTagAssociations(userFeedback);
+                DbResult<UserFeedback> savedUserFeedbackResult = await feedbackDelegate.UpdateUserFeedbackWithTagAssociationsAsync(userFeedback, ct);
 
                 if (savedUserFeedbackResult.Status == DbStatusCode.Updated)
                 {
-                    string email = await this.GetUserEmail(userFeedback.UserProfileId, ct);
+                    string email = await this.GetUserEmailAsync(userFeedback.UserProfileId, ct);
                     result.ResourcePayload = UserFeedbackMapUtils.ToUiModel(userFeedback, email, autoMapper);
                     result.ResultStatus = ResultType.Success;
                 }
@@ -223,7 +223,7 @@ namespace HealthGateway.Admin.Server.Services
             return result;
         }
 
-        private async Task<string> GetUserEmail(string? hdid, CancellationToken ct)
+        private async Task<string> GetUserEmailAsync(string? hdid, CancellationToken ct)
         {
             string email = string.Empty;
             if (hdid != null)

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -931,7 +931,7 @@ namespace HealthGateway.Admin.Tests.Services
         private static Mock<IUserProfileDelegate> GetUserProfileDelegateMock(UserProfile? profile = null, IList<UserProfile>? profiles = null)
         {
             Mock<IUserProfileDelegate> mock = new();
-            mock.Setup(u => u.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(profile);
+            mock.Setup(u => u.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(profile);
             mock.Setup(u => u.GetUserProfilesAsync(It.IsAny<UserQueryType>(), It.IsAny<string>())).ReturnsAsync(profiles ?? []);
             return mock;
         }

--- a/Apps/Common/src/Api/ICDogsApi.cs
+++ b/Apps/Common/src/Api/ICDogsApi.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.Api
 {
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Models.CDogs;
     using Refit;
@@ -29,8 +30,9 @@ namespace HealthGateway.Common.Api
         /// Generates a document.
         /// </summary>
         /// <param name="request">Model containing an inline template and set of substitution variables.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>HttpResponseMessage containing the raw binary-encoded PDF that was generated.</returns>
         [Post("/api/v2/template/render")]
-        Task<HttpResponseMessage> GenerateDocumentAsync([Body] CDogsRequestModel request);
+        Task<HttpResponseMessage> GenerateDocumentAsync([Body] CDogsRequestModel request, CancellationToken ct = default);
     }
 }

--- a/Apps/Common/src/Api/IPersonalAccountsApi.cs
+++ b/Apps/Common/src/Api/IPersonalAccountsApi.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Api
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Models.PHSA;
     using Refit;
@@ -28,9 +29,10 @@ namespace HealthGateway.Common.Api
         /// Retrieves the Personal Account by HDID.
         /// </summary>
         /// <param name="hdid">The HDID to lookup.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The Personal Account matching the id.</returns>
         [Get("/personal-accounts/hdid/{hdid}")]
-        Task<PersonalAccount> AccountLookupByHdidAsync(string hdid);
+        Task<PersonalAccount> AccountLookupByHdidAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves the Personal Account by PID.

--- a/Apps/Common/src/Constants/ErrorMessages.cs
+++ b/Apps/Common/src/Constants/ErrorMessages.cs
@@ -134,5 +134,20 @@ namespace HealthGateway.Common.Constants
         /// Error message to return when unable to get vaccine status.
         /// </summary>
         public const string CannotGetVaccineStatus = "Error retrieving vaccine status information.";
+
+        /// <summary>
+        /// Error message to return when email template not found in database.
+        /// </summary>
+        public const string EmailTemplateNotFound = "Email Template not found in database.";
+
+        /// <summary>
+        /// Error message to return when user profile not found in database.
+        /// </summary>
+        public const string UserProfileNotFound = "User Profile not found in database.";
+
+        /// <summary>
+        /// Error message to return when legal agreement not found in database.
+        /// </summary>
+        public const string LegalAgreementNotFound = "Legal Agreement not found in database.";
     }
 }

--- a/Apps/Common/src/Constants/ErrorMessages.cs
+++ b/Apps/Common/src/Constants/ErrorMessages.cs
@@ -116,6 +116,11 @@ namespace HealthGateway.Common.Constants
         public const string VaccinationStatusUnknown = "Vaccination status is unknown.";
 
         /// <summary>
+        /// Error message to return when delegate user profile not found.
+        /// </summary>
+        public const string DelegateUserProfileNotFound = "Delegate user profile not found.";
+
+        /// <summary>
         /// Error message to return when unable to get vaccine proof.
         /// </summary>
         public const string CannotGetVaccineProof = "Unable to obtain Vaccine Proof.";

--- a/Apps/Common/src/Delegates/CDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/CDogsDelegate.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Common.Delegates
     using System;
     using System.Diagnostics;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.Data.Constants;
@@ -51,7 +52,7 @@ namespace HealthGateway.Common.Delegates
         private static ActivitySource Source { get; } = new(nameof(CDogsDelegate));
 
         /// <inheritdoc/>
-        public async Task<RequestResult<ReportModel>> GenerateReportAsync(CDogsRequestModel request)
+        public async Task<RequestResult<ReportModel>> GenerateReportAsync(CDogsRequestModel request, CancellationToken ct = default)
         {
             using (Source.StartActivity())
             {
@@ -62,8 +63,8 @@ namespace HealthGateway.Common.Delegates
 
                 try
                 {
-                    HttpResponseMessage response = await this.cdogsApi.GenerateDocumentAsync(request).ConfigureAwait(true);
-                    byte[] payload = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(true);
+                    HttpResponseMessage response = await this.cdogsApi.GenerateDocumentAsync(request, ct);
+                    byte[] payload = await response.Content.ReadAsByteArrayAsync(ct);
                     this.logger.LogTrace("CDogs Response status code: {ResponseStatusCode}", response.StatusCode);
 
                     if (response.IsSuccessStatusCode)

--- a/Apps/Common/src/Delegates/ICDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/ICDogsDelegate.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Common.Delegates
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
@@ -29,7 +30,8 @@ namespace HealthGateway.Common.Delegates
         /// Generates a report based on the request model provided.
         /// </summary>
         /// <param name="request">The CDOGS request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The report data.</returns>
-        Task<RequestResult<ReportModel>> GenerateReportAsync(CDogsRequestModel request);
+        Task<RequestResult<ReportModel>> GenerateReportAsync(CDogsRequestModel request, CancellationToken ct = default);
     }
 }

--- a/Apps/Common/src/Services/ICommunicationService.cs
+++ b/Apps/Common/src/Services/ICommunicationService.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Services
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models;
@@ -30,8 +32,9 @@ namespace HealthGateway.Common.Services
         /// Only Banner, In-App, and Mobile values are supported.
         /// </summary>
         /// <param name="communicationType">The type of communication to retrieve.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The active communication wrapped in a RequestResult.</returns>
-        RequestResult<Communication?> GetActiveCommunication(CommunicationType communicationType);
+        Task<RequestResult<Communication?>> GetActiveCommunicationAsync(CommunicationType communicationType, CancellationToken ct = default);
 
         /// <summary>
         /// Processes a change event from the DB for communications.

--- a/Apps/Common/src/Services/IEmailQueueService.cs
+++ b/Apps/Common/src/Services/IEmailQueueService.cs
@@ -17,6 +17,8 @@ namespace HealthGateway.Common.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Models;
 
@@ -48,6 +50,19 @@ namespace HealthGateway.Common.Services
         void QueueNewEmail(string toEmail, string templateName, Dictionary<string, string> keyValues, bool shouldCommit = true);
 
         /// <summary>
+        /// Queues a new email based on a template name.
+        /// Template will be looked up in the DB.
+        /// A new email will be added to the database.
+        /// </summary>
+        /// <param name="toEmail">The To email address.</param>
+        /// <param name="templateName">The template to search the database for.</param>
+        /// <param name="keyValues">A dictionary of key/value pairs for replacement.</param>
+        /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task QueueNewEmailAsync(string toEmail, string templateName, Dictionary<string, string> keyValues, bool shouldCommit = true, CancellationToken ct = default);
+
+        /// <summary>
         /// Queues an email using a resolved template.
         /// A new email will be added to the database.
         /// </summary>
@@ -58,12 +73,34 @@ namespace HealthGateway.Common.Services
         void QueueNewEmail(string toEmail, EmailTemplate emailTemplate, Dictionary<string, string> keyValues, bool shouldCommit = true);
 
         /// <summary>
+        /// Queues an email using a resolved template.
+        /// A new email will be added to the database.
+        /// </summary>
+        /// <param name="toEmail">The To email address.</param>
+        /// <param name="emailTemplate">The resolved Email Template.</param>
+        /// <param name="keyValues">A dictionary of key/value pairs for replacement.</param>
+        /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task QueueNewEmailAsync(string toEmail, EmailTemplate emailTemplate, Dictionary<string, string> keyValues, bool shouldCommit = true, CancellationToken ct = default);
+
+        /// <summary>
         /// Queues an email using a populated Email object.
         /// A new email will be added to the database.
         /// </summary>
         /// <param name="email">The populated email to save.</param>
         /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
         void QueueNewEmail(Email email, bool shouldCommit = true);
+
+        /// <summary>
+        /// Queues an email using a populated Email object.
+        /// A new email will be added to the database.
+        /// </summary>
+        /// <param name="email">The populated email to save.</param>
+        /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
+        Task QueueNewEmailAsync(Email email, bool shouldCommit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Clones an existing email and queues it for send.
@@ -78,6 +115,14 @@ namespace HealthGateway.Common.Services
         /// <param name="templateName">The name of the template.</param>
         /// <returns>The populated Email template or null if not found.</returns>
         EmailTemplate GetEmailTemplate(string templateName);
+
+        /// <summary>
+        /// Looks up an Email Template in the database.
+        /// </summary>
+        /// <param name="templateName">The name of the template.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The populated Email template or null if not found.</returns>
+        Task<EmailTemplate?> GetEmailTemplateAsync(string templateName, CancellationToken ct = default);
 
         /// <summary>
         /// Given an Email template it will swap the dictionary key/values in the Subject and Body.

--- a/Apps/Common/src/Services/INotificationSettingsService.cs
+++ b/Apps/Common/src/Services/INotificationSettingsService.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Services
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Models;
 
     /// <summary>
@@ -28,5 +30,14 @@ namespace HealthGateway.Common.Services
         /// </summary>
         /// <param name="notificationSettings">The Notification Settings Request object.</param>
         void QueueNotificationSettings(NotificationSettingsRequest notificationSettings);
+
+        /// <summary>
+        /// Queues pushing the Notification Settings to PHSA using our batch system.
+        /// Will use access_token acquired from system account authenication.
+        /// </summary>
+        /// <param name="notificationSettings">The Notification Settings Request object.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task QueueNotificationSettingsAsync(NotificationSettingsRequest notificationSettings, CancellationToken ct = default);
     }
 }

--- a/Apps/Common/src/Services/INotificationSettingsService.cs
+++ b/Apps/Common/src/Services/INotificationSettingsService.cs
@@ -26,14 +26,14 @@ namespace HealthGateway.Common.Services
     {
         /// <summary>
         /// Queues pushing the Notification Settings to PHSA using our batch system.
-        /// Will use access_token acquired from system account authenication.
+        /// Will use access_token acquired from system account authentication.
         /// </summary>
         /// <param name="notificationSettings">The Notification Settings Request object.</param>
         void QueueNotificationSettings(NotificationSettingsRequest notificationSettings);
 
         /// <summary>
         /// Queues pushing the Notification Settings to PHSA using our batch system.
-        /// Will use access_token acquired from system account authenication.
+        /// Will use access_token acquired from system account authentication.
         /// </summary>
         /// <param name="notificationSettings">The Notification Settings Request object.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>

--- a/Apps/Common/src/Services/IPersonalAccountsService.cs
+++ b/Apps/Common/src/Services/IPersonalAccountsService.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.Services
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
@@ -28,8 +29,9 @@ namespace HealthGateway.Common.Services
         /// Gets personal account information from PHSA using the supplied HDID.
         /// </summary>
         /// <param name="hdid">The HDID to look up.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The personal account model.</returns>
-        Task<PersonalAccount> GetPatientAccountAsync(string hdid);
+        Task<PersonalAccount> GetPatientAccountAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets personal account information from PHSA using the supplied HDID.

--- a/Apps/Common/src/Services/PersonalAccountsService.cs
+++ b/Apps/Common/src/Services/PersonalAccountsService.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Common.Services
     using System;
     using System.Diagnostics;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.CacheProviders;
@@ -68,7 +69,7 @@ namespace HealthGateway.Common.Services
         private static ActivitySource Source { get; } = new(nameof(PersonalAccountsService));
 
         /// <inheritdoc/>
-        public async Task<PersonalAccount> GetPatientAccountAsync(string hdid)
+        public async Task<PersonalAccount> GetPatientAccountAsync(string hdid, CancellationToken ct = default)
         {
             PersonalAccount? account = this.GetFromCache(hdid);
             if (account is not null)
@@ -76,7 +77,7 @@ namespace HealthGateway.Common.Services
                 return account;
             }
 
-            account = await this.personalAccountsApi.AccountLookupByHdidAsync(hdid).ConfigureAwait(true);
+            account = await this.personalAccountsApi.AccountLookupByHdidAsync(hdid, ct);
             this.PutCache(hdid, account);
             return account;
         }

--- a/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.CommonTests.Delegates
     using System.Net.Http;
     using System.Text;
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Api;
@@ -67,7 +68,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             Mock<ILogger<CDogsDelegate>> mockLogger = new();
             Mock<ICDogsApi> mockCdogsApi = new();
-            mockCdogsApi.Setup(s => s.GenerateDocumentAsync(It.IsAny<CDogsRequestModel>())).ReturnsAsync(httpResponseMessage);
+            mockCdogsApi.Setup(s => s.GenerateDocumentAsync(It.IsAny<CDogsRequestModel>(), It.IsAny<CancellationToken>())).ReturnsAsync(httpResponseMessage);
 
             ICDogsDelegate cdogsDelegate = new CDogsDelegate(mockLogger.Object, mockCdogsApi.Object);
 
@@ -101,7 +102,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             Mock<ILogger<CDogsDelegate>> mockLogger = new();
             Mock<ICDogsApi> mockCdogsApi = new();
-            mockCdogsApi.Setup(s => s.GenerateDocumentAsync(It.IsAny<CDogsRequestModel>())).ReturnsAsync(httpResponseMessage);
+            mockCdogsApi.Setup(s => s.GenerateDocumentAsync(It.IsAny<CDogsRequestModel>(), It.IsAny<CancellationToken>())).ReturnsAsync(httpResponseMessage);
 
             ICDogsDelegate cdogsDelegate = new CDogsDelegate(mockLogger.Object, mockCdogsApi.Object);
 
@@ -129,7 +130,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             Mock<ILogger<CDogsDelegate>> mockLogger = new();
             Mock<ICDogsApi> mockCdogsApi = new();
-            mockCdogsApi.Setup(s => s.GenerateDocumentAsync(It.IsAny<CDogsRequestModel>())).ThrowsAsync(new InvalidOperationException());
+            mockCdogsApi.Setup(s => s.GenerateDocumentAsync(It.IsAny<CDogsRequestModel>(), It.IsAny<CancellationToken>())).ThrowsAsync(new InvalidOperationException());
             ICDogsDelegate cdogsDelegate = new CDogsDelegate(mockLogger.Object, mockCdogsApi.Object);
 
             CDogsRequestModel request = GetRequestModel();

--- a/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.CommonTests.Services
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Api;
     using HealthGateway.Common.CacheProviders;
@@ -137,11 +138,12 @@ namespace HealthGateway.CommonTests.Services
             Mock<IPersonalAccountsApi> personalAccountsApiMock = new();
             if (!throwException)
             {
-                personalAccountsApiMock.Setup(p => p.AccountLookupByHdidAsync(It.IsAny<string>())).ReturnsAsync(content);
+                personalAccountsApiMock.Setup(p => p.AccountLookupByHdidAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(content);
             }
             else
             {
-                personalAccountsApiMock.Setup(p => p.AccountLookupByHdidAsync(It.IsAny<string>())).ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
+                personalAccountsApiMock.Setup(p => p.AccountLookupByHdidAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
             }
 
             return new PersonalAccountsService(

--- a/Apps/Database/src/Delegates/DbCommentDelegate.cs
+++ b/Apps/Database/src/Delegates/DbCommentDelegate.cs
@@ -50,20 +50,20 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IList<Comment>> GetByParentEntry(string hdId, string parentEntryId)
+        public async Task<DbResult<IList<Comment>>> GetByParentEntryAsync(string hdId, string parentEntryId, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting Comments for user {HdId} and entry id {ParentEntryId}...", hdId, parentEntryId);
             DbResult<IList<Comment>> result = new();
-            result.Payload = this.dbContext.Comment
+            result.Payload = await this.dbContext.Comment
                 .Where(p => p.UserProfileId == hdId && p.ParentEntryId == parentEntryId)
                 .OrderBy(o => o.CreatedDateTime)
-                .ToList();
+                .ToListAsync(ct);
             result.Status = DbStatusCode.Read;
             return result;
         }
 
         /// <inheritdoc/>
-        public DbResult<Comment> Add(Comment comment, bool commit = true)
+        public async Task<DbResult<Comment>> AddAsync(Comment comment, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Adding Note to DB...");
             DbResult<Comment> result = new()
@@ -71,12 +71,12 @@ namespace HealthGateway.Database.Delegates
                 Payload = comment,
                 Status = DbStatusCode.Deferred,
             };
-            this.dbContext.Comment.Add(comment);
+            await this.dbContext.Comment.AddAsync(comment, ct);
             if (commit)
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Created;
                 }
                 catch (DbUpdateException e)
@@ -92,7 +92,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<Comment> Update(Comment comment, bool commit = true)
+        public async Task<DbResult<Comment>> UpdateAsync(Comment comment, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating Comment in DB...");
             DbResult<Comment> result = new()
@@ -106,7 +106,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Updated;
                 }
                 catch (DbUpdateConcurrencyException e)
@@ -121,7 +121,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<Comment> Delete(Comment comment, bool commit = true)
+        public async Task<DbResult<Comment>> DeleteAsync(Comment comment, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Deleting Comment from DB...");
             DbResult<Comment> result = new()
@@ -134,7 +134,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Deleted;
                 }
                 catch (DbUpdateConcurrencyException e)
@@ -149,14 +149,14 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IEnumerable<Comment>> GetAll(string hdId)
+        public async Task<DbResult<IEnumerable<Comment>>> GetAllAsync(string hdId, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting Comments for user {HdId}...", hdId);
             DbResult<IEnumerable<Comment>> result = new();
-            result.Payload = this.dbContext.Comment
+            result.Payload = await this.dbContext.Comment
                 .Where(p => p.UserProfileId == hdId)
                 .OrderBy(o => o.CreatedDateTime)
-                .ToList();
+                .ToListAsync(ct);
             result.Status = DbStatusCode.Read;
             return result;
         }

--- a/Apps/Database/src/Delegates/DbEmailDelegate.cs
+++ b/Apps/Database/src/Delegates/DbEmailDelegate.cs
@@ -19,6 +19,8 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Constants;
@@ -94,6 +96,20 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
+        public async Task<Guid> InsertEmailAsync(Email email, bool shouldCommit = true, CancellationToken ct = default)
+        {
+            this.logger.LogTrace("Inserting email to DB..");
+            await this.dbContext.AddAsync(email, ct);
+            if (shouldCommit)
+            {
+                await this.dbContext.SaveChangesAsync(ct);
+            }
+
+            this.logger.LogDebug("Finished inserting email to DB. {Email}", email.Id);
+            return email.Id;
+        }
+
+        /// <inheritdoc/>
         public void UpdateEmail(Email email)
         {
             this.logger.LogTrace("Updating email {Email} in DB... ", email.Id);
@@ -112,6 +128,15 @@ namespace HealthGateway.Database.Delegates
             this.logger.LogDebug("Finished getting email {TemplateName} template from DB", templateName);
 
             return retVal;
+        }
+
+        /// <inheritdoc/>
+        public async Task<EmailTemplate?> GetEmailTemplateAsync(string templateName, CancellationToken ct)
+        {
+            this.logger.LogTrace("Getting email template {TemplateName} from DB... ", templateName);
+            return await this.dbContext
+                .EmailTemplate
+                .FirstOrDefaultAsync(p => p.Name == templateName, ct);
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/DbFeedbackDelegate.cs
+++ b/Apps/Database/src/Delegates/DbFeedbackDelegate.cs
@@ -70,7 +70,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public void UpdateUserFeedback(UserFeedback feedback)
+        public async Task UpdateUserFeedbackAsync(UserFeedback feedback, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating the user feedback in DB...");
             this.dbContext.Update(feedback);
@@ -78,16 +78,16 @@ namespace HealthGateway.Database.Delegates
             // Disallow updates to UserProfileId
             this.dbContext.Entry(feedback).Property(p => p.UserProfileId).IsModified = false;
 
-            this.dbContext.SaveChanges();
+            await this.dbContext.SaveChangesAsync(ct);
 
             // Reload the entry after saving to retrieve the actual UserProfileId value
-            this.dbContext.Entry(feedback).Reload();
+            await this.dbContext.Entry(feedback).ReloadAsync(ct);
 
             this.logger.LogDebug("Finished updating feedback in DB...");
         }
 
         /// <inheritdoc/>
-        public DbResult<UserFeedback> UpdateUserFeedbackWithTagAssociations(UserFeedback feedback)
+        public async Task<DbResult<UserFeedback>> UpdateUserFeedbackWithTagAssociationsAsync(UserFeedback feedback, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating the user feedback id {UserFeedbackId} with {NumberOfAssociations} admin tag association in DB", feedback.Id, feedback.Tags.Count);
             this.dbContext.Update(feedback);
@@ -95,7 +95,7 @@ namespace HealthGateway.Database.Delegates
 
             try
             {
-                this.dbContext.SaveChanges();
+                await this.dbContext.SaveChangesAsync(ct);
                 result.Status = DbStatusCode.Updated;
                 result.Payload = feedback;
             }

--- a/Apps/Database/src/Delegates/DbFeedbackDelegate.cs
+++ b/Apps/Database/src/Delegates/DbFeedbackDelegate.cs
@@ -49,14 +49,14 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<UserFeedback> InsertUserFeedback(UserFeedback feedback)
+        public async Task<DbResult<UserFeedback>> InsertUserFeedbackAsync(UserFeedback feedback, CancellationToken ct = default)
         {
             this.logger.LogTrace("Inserting user feedback to DB...");
             DbResult<UserFeedback> result = new();
-            this.dbContext.Add(feedback);
+            await this.dbContext.AddAsync(feedback, ct);
             try
             {
-                this.dbContext.SaveChanges();
+                await this.dbContext.SaveChangesAsync(ct);
                 result.Status = DbStatusCode.Created;
             }
             catch (DbUpdateException e)

--- a/Apps/Database/src/Delegates/DbLegalAgreementDelegate.cs
+++ b/Apps/Database/src/Delegates/DbLegalAgreementDelegate.cs
@@ -18,11 +18,12 @@ namespace HealthGateway.Database.Delegates
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
-    using HealthGateway.Database.Wrapper;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
@@ -48,20 +49,14 @@ namespace HealthGateway.Database.Delegates
         /// <inheritdoc/>
         [SuppressMessage("Globalization", "CA1309:Use ordinal stringcomparison", Justification = "Ordinal doesn't work")]
         [SuppressMessage("Globalization", "CA1307:Specify StringComparison", Justification = "Ordinal doesn't work")]
-        public DbResult<LegalAgreement> GetActiveByAgreementType(LegalAgreementType agreementTypeCode)
+        public async Task<LegalAgreement?> GetActiveByAgreementTypeAsync(LegalAgreementType agreementTypeCode, CancellationToken ct = default)
         {
             this.logger.LogDebug("Getting active legal agreement by type {AgreementTypeCode}", agreementTypeCode);
-            LegalAgreement legalAgreement = this.dbContext.LegalAgreement
+            return await this.dbContext.LegalAgreement
                 .Where(la => la.EffectiveDate <= DateTime.UtcNow)
                 .Where(la => agreementTypeCode.Equals(la.LegalAgreementCode))
                 .OrderByDescending(la => la.EffectiveDate)
-                .First();
-
-            return new DbResult<LegalAgreement>
-            {
-                Payload = legalAgreement,
-                Status = DbStatusCode.Read,
-            };
+                .FirstOrDefaultAsync(ct);
         }
     }
 }

--- a/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
@@ -73,21 +73,6 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public MessagingVerification? GetLastByInviteKey(Guid inviteKey)
-        {
-            this.logger.LogTrace("Getting email message verification from DB... {InviteKey}", inviteKey);
-            MessagingVerification? retVal = this.dbContext
-                .MessagingVerification
-                .Include(email => email.Email)
-                .Where(p => p.InviteKey == inviteKey && p.VerificationType == MessagingVerificationType.Email)
-                .OrderByDescending(mv => mv.CreatedDateTime)
-                .FirstOrDefault();
-
-            this.logger.LogDebug("Finished getting email message verification from DB");
-            return retVal;
-        }
-
-        /// <inheritdoc/>
         public async Task<MessagingVerification?> GetLastByInviteKeyAsync(Guid inviteKey, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting email message verification from DB... {InviteKey}", inviteKey);
@@ -103,19 +88,6 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public IEnumerable<MessagingVerification> GetAllEmail()
-        {
-            this.logger.LogTrace("Getting all email message verifications from DB...");
-            IEnumerable<MessagingVerification> retVal = this.dbContext
-                .MessagingVerification
-                .Where(p => p.VerificationType == MessagingVerificationType.Email)
-                .ToList();
-
-            this.logger.LogDebug("Finished getting all email message verifications from DB");
-            return retVal;
-        }
-
-        /// <inheritdoc/>
         public async Task UpdateAsync(MessagingVerification messageVerification, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating email message verification in DB...");
@@ -126,26 +98,6 @@ namespace HealthGateway.Database.Delegates
             }
 
             this.logger.LogDebug("Finished updating email message verification {Id} in DB", messageVerification.Id);
-        }
-
-        /// <inheritdoc/>
-        public MessagingVerification? GetLastForUser(string hdid, string messagingVerificationType)
-        {
-            this.logger.LogTrace("Getting last messaging verification from DB for user... {HdId}", hdid);
-            MessagingVerification? retVal = this.dbContext
-                .MessagingVerification
-                .Include(email => email.Email)
-                .Where(p => p.UserProfileId == hdid && p.VerificationType == messagingVerificationType)
-                .OrderByDescending(p => p.UpdatedDateTime)
-                .FirstOrDefault();
-
-            if (retVal != null && retVal.Deleted)
-            {
-                return null;
-            }
-
-            this.logger.LogDebug("Finished getting messaging verification from DB");
-            return retVal;
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/DbNoteDelegate.cs
+++ b/Apps/Database/src/Delegates/DbNoteDelegate.cs
@@ -68,22 +68,22 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IList<Note>> GetNotes(string hdId, int offset = 0, int pageSize = 500)
+        public async Task<DbResult<IList<Note>>> GetNotesAsync(string hdId, int offset = 0, int pageSize = 500, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting Notes for {HdId}...", hdId);
             DbResult<IList<Note>> result = new();
-            result.Payload = this.dbContext.Note
+            result.Payload = await this.dbContext.Note
                 .Where(p => p.HdId == hdId)
                 .OrderBy(o => o.JournalDate)
                 .Skip(offset)
                 .Take(pageSize)
-                .ToList();
+                .ToListAsync(ct);
             result.Status = DbStatusCode.Read;
             return result;
         }
 
         /// <inheritdoc/>
-        public DbResult<Note> AddNote(Note note, bool commit = true)
+        public async Task<DbResult<Note>> AddNoteAsync(Note note, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Adding Note to DB...");
             DbResult<Note> result = new()
@@ -91,12 +91,12 @@ namespace HealthGateway.Database.Delegates
                 Payload = note,
                 Status = DbStatusCode.Deferred,
             };
-            this.dbContext.Note.Add(note);
+            await this.dbContext.Note.AddAsync(note, ct);
             if (commit)
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Created;
                 }
                 catch (DbUpdateException e)
@@ -112,7 +112,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<Note> UpdateNote(Note note, bool commit = true)
+        public async Task<DbResult<Note>> UpdateNoteAsync(Note note, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating Note request in DB...");
             DbResult<Note> result = new()
@@ -126,7 +126,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Updated;
                 }
                 catch (DbUpdateConcurrencyException e)
@@ -141,7 +141,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IEnumerable<Note>> BatchUpdate(IEnumerable<Note> notes, bool commit = true)
+        public async Task<DbResult<IEnumerable<Note>>> BatchUpdateAsync(IEnumerable<Note> notes, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating Note request in DB...");
             DbResult<IEnumerable<Note>> result = new()
@@ -154,7 +154,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Updated;
                 }
                 catch (DbUpdateConcurrencyException e)
@@ -169,7 +169,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<Note> DeleteNote(Note note, bool commit = true)
+        public async Task<DbResult<Note>> DeleteNoteAsync(Note note, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Deleting Note from DB...");
             DbResult<Note> result = new()
@@ -183,7 +183,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Deleted;
                 }
                 catch (DbUpdateConcurrencyException e)

--- a/Apps/Database/src/Delegates/DbNoteDelegate.cs
+++ b/Apps/Database/src/Delegates/DbNoteDelegate.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Database.Delegates
 {
-    using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
@@ -48,23 +47,6 @@ namespace HealthGateway.Database.Delegates
         {
             this.logger = logger;
             this.dbContext = dbContext;
-        }
-
-        /// <inheritdoc/>
-        public DbResult<Note> GetNote(Guid noteId, string hdid)
-        {
-            DbResult<Note> result = new()
-            {
-                Status = DbStatusCode.NotFound,
-            };
-            Note? note = this.dbContext.Note.Find(noteId, hdid);
-            if (note != null)
-            {
-                result.Payload = note;
-                result.Status = DbStatusCode.Read;
-            }
-
-            return result;
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/DbProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbProfileDelegate.cs
@@ -119,7 +119,7 @@ namespace HealthGateway.Database.Delegates
         public async Task<DbResult<UserProfile>> UpdateAsync(UserProfile profile, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating user profile in DB");
-            UserProfile? userProfile = await this.GetUserProfileAsync(profile.HdId);
+            UserProfile? userProfile = await this.GetUserProfileAsync(profile.HdId, ct);
             DbResult<UserProfile> result = new();
 
             if (userProfile != null)
@@ -220,9 +220,9 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<UserProfile?> GetUserProfileAsync(string hdid)
+        public async Task<UserProfile?> GetUserProfileAsync(string hdid, CancellationToken ct = default)
         {
-            return await this.dbContext.UserProfile.FindAsync(hdid);
+            return await this.dbContext.UserProfile.FindAsync(new object[] { hdid }, ct);
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/DbRatingDelegate.cs
+++ b/Apps/Database/src/Delegates/DbRatingDelegate.cs
@@ -50,14 +50,14 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<Rating> InsertRating(Rating rating)
+        public async Task<DbResult<Rating>> InsertRatingAsync(Rating rating, CancellationToken ct = default)
         {
             this.logger.LogTrace("Inserting rating to DB");
             DbResult<Rating> result = new();
-            this.dbContext.Add(rating);
+            await this.dbContext.AddAsync(rating, ct);
             try
             {
-                this.dbContext.SaveChanges();
+                await this.dbContext.SaveChangesAsync(ct);
                 result.Status = DbStatusCode.Created;
             }
             catch (DbUpdateException e)

--- a/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
@@ -115,20 +115,18 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IEnumerable<ResourceDelegate>> Get(DateTime fromDate, DateTime? toDate, int page, int pageSize)
+        public async Task<IList<ResourceDelegate>> GetAsync(DateTime fromDate, DateTime? toDate, int page, int pageSize, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting resource delegates from DB for date...{FromDate}", fromDate);
             toDate ??= DateTime.MaxValue;
 
-            DbResult<IEnumerable<ResourceDelegate>> result = DbDelegateHelper.GetPagedDbResult(
+            return await DbDelegateHelper.GetPagedDbResultAsync(
                 this.dbContext.ResourceDelegate
                     .Where(resourceDelegate => resourceDelegate.CreatedDateTime >= fromDate && resourceDelegate.CreatedDateTime <= toDate)
                     .OrderBy(resourceDelegate => resourceDelegate.CreatedDateTime),
                 page,
-                pageSize);
-
-            this.logger.LogTrace("Finished getting resource delegates from DB for date {FromDate}", fromDate);
-            return result;
+                pageSize,
+                ct);
         }
 
         /// <inheritdoc/>

--- a/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
@@ -102,6 +102,19 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
+        public async Task<IList<ResourceDelegate>> GetAsync(string delegateId, int page = 0, int pageSize = 500, CancellationToken ct = default)
+        {
+            this.logger.LogTrace("Getting resource delegates from DB... {DelegateId}", delegateId);
+            return await DbDelegateHelper.GetPagedDbResultAsync(
+                this.dbContext.ResourceDelegate
+                    .Where(resourceDelegate => resourceDelegate.ProfileHdid == delegateId)
+                    .OrderBy(resourceDelegate => resourceDelegate.CreatedDateTime),
+                page,
+                pageSize,
+                ct);
+        }
+
+        /// <inheritdoc/>
         public DbResult<IEnumerable<ResourceDelegate>> Get(DateTime fromDate, DateTime? toDate, int page, int pageSize)
         {
             this.logger.LogTrace("Getting resource delegates from DB for date...{FromDate}", fromDate);

--- a/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
@@ -165,7 +165,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<ResourceDelegate> Delete(ResourceDelegate resourceDelegate, bool commit)
+        public async Task<DbResult<ResourceDelegate>> DeleteAsync(ResourceDelegate resourceDelegate, bool commit, CancellationToken ct = default)
         {
             this.logger.LogTrace("Deleting resourceDelegate from DB...");
             DbResult<ResourceDelegate> result = new()
@@ -178,7 +178,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Deleted;
                 }
                 catch (DbUpdateConcurrencyException e)

--- a/Apps/Database/src/Delegates/DbUserPreferenceDelegate.cs
+++ b/Apps/Database/src/Delegates/DbUserPreferenceDelegate.cs
@@ -18,6 +18,8 @@ namespace HealthGateway.Database.Delegates
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
@@ -46,7 +48,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<UserPreference> CreateUserPreference(UserPreference userPreference, bool commit = true)
+        public async Task<DbResult<UserPreference>> CreateUserPreferenceAsync(UserPreference userPreference, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Creating new User Preference in DB...");
             DbResult<UserPreference> result = new()
@@ -54,13 +56,13 @@ namespace HealthGateway.Database.Delegates
                 Payload = userPreference,
                 Status = DbStatusCode.Deferred,
             };
-            this.dbContext.UserPreference.Add(userPreference);
+            await this.dbContext.UserPreference.AddAsync(userPreference, ct);
 
             if (commit)
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Created;
                 }
                 catch (DbUpdateConcurrencyException e)
@@ -80,7 +82,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<UserPreference> UpdateUserPreference(UserPreference userPreference, bool commit = true)
+        public async Task<DbResult<UserPreference>> UpdateUserPreferenceAsync(UserPreference userPreference, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating User Preference in DB...");
             DbResult<UserPreference> result = new()
@@ -95,7 +97,7 @@ namespace HealthGateway.Database.Delegates
             {
                 try
                 {
-                    this.dbContext.SaveChanges();
+                    await this.dbContext.SaveChangesAsync(ct);
                     result.Status = DbStatusCode.Updated;
                 }
                 catch (DbUpdateConcurrencyException e)
@@ -115,14 +117,11 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public DbResult<IEnumerable<UserPreference>> GetUserPreferences(string hdid)
+        public async Task<IEnumerable<UserPreference>> GetUserPreferencesAsync(string hdid, CancellationToken ct = default)
         {
-            DbResult<IEnumerable<UserPreference>> result = new();
-            result.Payload = this.dbContext.UserPreference
+            return await this.dbContext.UserPreference
                 .Where(p => p.HdId == hdid)
-                .ToList();
-            result.Status = DbStatusCode.Read;
-            return result;
+                .ToListAsync(ct);
         }
     }
 }

--- a/Apps/Database/src/Delegates/ICommentDelegate.cs
+++ b/Apps/Database/src/Delegates/ICommentDelegate.cs
@@ -31,39 +31,44 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="hdId">The users health identifier id.</param>
         /// <param name="parentEntryId">The parent entry id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>An IEnumerable of Comments wrapped in a DBResult.</returns>
-        DbResult<IList<Comment>> GetByParentEntry(string hdId, string parentEntryId);
+        Task<DbResult<IList<Comment>>> GetByParentEntryAsync(string hdId, string parentEntryId, CancellationToken ct = default);
 
         /// <summary>
         /// Add the given note.
         /// </summary>
         /// <param name="comment">The comment to be added to the database.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A comment wrapped in a DBResult.</returns>
-        DbResult<Comment> Add(Comment comment, bool commit = true);
+        Task<DbResult<Comment>> AddAsync(Comment comment, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Update the supplied note.
         /// </summary>
         /// <param name="comment">The comment to be updated in the database.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A comment wrapped in a DBResult.</returns>
-        DbResult<Comment> Update(Comment comment, bool commit = true);
+        Task<DbResult<Comment>> UpdateAsync(Comment comment, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Deletes the supplied note.
         /// </summary>
         /// <param name="comment">The comment to be deleted in the database.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A comment wrapped in a DBResult.</returns>
-        DbResult<Comment> Delete(Comment comment, bool commit = true);
+        Task<DbResult<Comment>> DeleteAsync(Comment comment, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a list of comments ordered by the created datetime for the given HdId.
         /// </summary>
         /// <param name="hdId">The users health identifier id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>An IEnumerable of Comments wrapped in a DBResult.</returns>
-        DbResult<IEnumerable<Comment>> GetAll(string hdId);
+        Task<DbResult<IEnumerable<Comment>>> GetAllAsync(string hdId, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a list of all the comments ordered by the CreatedDateTime in ascending order.

--- a/Apps/Database/src/Delegates/ICommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/ICommunicationDelegate.cs
@@ -31,24 +31,9 @@ namespace HealthGateway.Database.Delegates
         /// Gets the next oldest by effective date, non-expired communication banner by type.
         /// </summary>
         /// <param name="communicationType">The active communication type to retrieve.</param>
-        /// <returns>The Communication wrapped in a DBResult.</returns>
-        DbResult<Communication?> GetNext(CommunicationType communicationType);
-
-        /// <summary>
-        /// Gets the next oldest by effective date, non-expired communication banner by type.
-        /// </summary>
-        /// <param name="communicationType">The active communication type to retrieve.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The Communication wrapped in a DBResult.</returns>
         Task<Communication?> GetNextAsync(CommunicationType communicationType, CancellationToken ct = default);
-
-        /// <summary>
-        /// Add the given communication.
-        /// </summary>
-        /// <param name="communication">The communication to be added to the database.</param>
-        /// <param name="commit">if true the transaction is persisted immediately.</param>
-        /// <returns>The added communication wrapped in a DBResult.</returns>
-        DbResult<Communication> Add(Communication communication, bool commit = true);
 
         /// <summary>
         /// Add the given communication.
@@ -62,12 +47,6 @@ namespace HealthGateway.Database.Delegates
         /// <summary>
         /// Get a list of all past communications.
         /// </summary>
-        /// <returns>A list of all communications added, wrapped in a DBResult.</returns>
-        DbResult<IEnumerable<Communication>> GetAll();
-
-        /// <summary>
-        /// Get a list of all past communications.
-        /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of all communications added.</returns>
         Task<IList<Communication>> GetAllAsync(CancellationToken ct = default);
@@ -77,25 +56,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="communication">The communication to be updated in the database.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
-        /// <returns>The updated communication wrapped in a DBResult.</returns>
-        DbResult<Communication> Update(Communication communication, bool commit = true);
-
-        /// <summary>
-        /// Update the given communication.
-        /// </summary>
-        /// <param name="communication">The communication to be updated in the database.</param>
-        /// <param name="commit">if true the transaction is persisted immediately.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The updated communication wrapped in a DBResult.</returns>
         Task<DbResult<Communication>> UpdateAsync(Communication communication, bool commit = true, CancellationToken ct = default);
-
-        /// <summary>
-        /// Deletes the given communication from the database.
-        /// </summary>
-        /// <param name="communication">The communication to be deleted from the database.</param>
-        /// <param name="commit">if true the transaction is persisted immediately.</param>
-        /// <returns>A Communication wrapped in a DBResult.</returns>
-        DbResult<Communication> Delete(Communication communication, bool commit = true);
 
         /// <summary>
         /// Deletes the given communication from the database.

--- a/Apps/Database/src/Delegates/IEmailDelegate.cs
+++ b/Apps/Database/src/Delegates/IEmailDelegate.cs
@@ -17,6 +17,8 @@ namespace HealthGateway.Database.Delegates
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -58,6 +60,15 @@ namespace HealthGateway.Database.Delegates
         Guid InsertEmail(Email email, bool shouldCommit = true);
 
         /// <summary>
+        /// Inserts an email using a populated Email object.
+        /// </summary>
+        /// <param name="email">The populated email to save.</param>
+        /// <param name="shouldCommit">If true, the record will be written to the DB immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>Returns the guid of the saved email.</returns>
+        Task<Guid> InsertEmailAsync(Email email, bool shouldCommit = true, CancellationToken ct = default);
+
+        /// <summary>
         /// Updates an email using a populated Email object.
         /// </summary>
         /// <param name="email">The populated email to save.</param>
@@ -69,6 +80,14 @@ namespace HealthGateway.Database.Delegates
         /// <param name="templateName">The name of the template.</param>
         /// <returns>The populated Email template or null if not found.</returns>
         EmailTemplate GetEmailTemplate(string templateName);
+
+        /// <summary>
+        /// Looks up an Email Template in the database.
+        /// </summary>
+        /// <param name="templateName">The name of the template.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The populated Email template or null if not found.</returns>
+        Task<EmailTemplate?> GetEmailTemplateAsync(string templateName, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a list of emails ordered by the create datetime descending.

--- a/Apps/Database/src/Delegates/IFeedbackDelegate.cs
+++ b/Apps/Database/src/Delegates/IFeedbackDelegate.cs
@@ -41,7 +41,9 @@ namespace HealthGateway.Database.Delegates
         /// UpdatedDateTime will overridden by our framework.
         /// </summary>
         /// <param name="feedback">The feedback to update.</param>
-        void UpdateUserFeedback(UserFeedback feedback);
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        Task UpdateUserFeedbackAsync(UserFeedback feedback, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the UserFeedback object including user feedback tag associations in the DB.
@@ -49,8 +51,9 @@ namespace HealthGateway.Database.Delegates
         /// UpdatedDateTime will overridden by our framework.
         /// </summary>
         /// <param name="feedback">The feedback to update.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<UserFeedback> UpdateUserFeedbackWithTagAssociations(UserFeedback feedback);
+        Task<DbResult<UserFeedback>> UpdateUserFeedbackWithTagAssociationsAsync(UserFeedback feedback, CancellationToken ct = default);
 
         /// <summary>
         /// Fetches the UserFeedback from the database.

--- a/Apps/Database/src/Delegates/IFeedbackDelegate.cs
+++ b/Apps/Database/src/Delegates/IFeedbackDelegate.cs
@@ -31,8 +31,9 @@ namespace HealthGateway.Database.Delegates
         /// Creates a UserFeedback object in the database.
         /// </summary>
         /// <param name="feedback">The feedback to create.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<UserFeedback> InsertUserFeedback(UserFeedback feedback);
+        Task<DbResult<UserFeedback>> InsertUserFeedbackAsync(UserFeedback feedback, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the UserFeedback object in the DB.

--- a/Apps/Database/src/Delegates/ILegalAgreementDelegate.cs
+++ b/Apps/Database/src/Delegates/ILegalAgreementDelegate.cs
@@ -15,9 +15,10 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Database.Delegates
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Database.Wrapper;
 
     /// <summary>
     /// Operations to be performed in the DB for the TermsOfService.
@@ -28,7 +29,8 @@ namespace HealthGateway.Database.Delegates
         /// Fetches the last active Legal Agreement from the database of the specified agreement type.
         /// </summary>
         /// <param name="agreementTypeCode">The agreement type to filter the result.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<LegalAgreement> GetActiveByAgreementType(LegalAgreementType agreementTypeCode);
+        Task<LegalAgreement?> GetActiveByAgreementTypeAsync(LegalAgreementType agreementTypeCode, CancellationToken ct = default);
     }
 }

--- a/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
@@ -39,25 +39,9 @@ namespace HealthGateway.Database.Delegates
         /// Gets the last Email Message Verification by the Invite key.
         /// </summary>
         /// <param name="inviteKey">The users inviteKey as emailed.</param>
-        /// <returns>The message verification that was fetched.</returns>
-        MessagingVerification? GetLastByInviteKey(Guid inviteKey);
-
-        /// <summary>
-        /// Gets the last Email Message Verification by the Invite key.
-        /// </summary>
-        /// <param name="inviteKey">The users inviteKey as emailed.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The message verification that was fetched.</returns>
         Task<MessagingVerification?> GetLastByInviteKeyAsync(Guid inviteKey, CancellationToken ct = default);
-
-        /// <summary>
-        /// Gets the last Messaging Verification for the user base on type and users HDID.
-        /// Defaults to MessagingVerificationType.Email.
-        /// </summary>
-        /// <param name="hdid">The users hdid.</param>
-        /// <param name="messagingVerificationType">The type to query.</param>
-        /// <returns>The  message verification that was fetched.</returns>
-        MessagingVerification? GetLastForUser(string hdid, string messagingVerificationType);
 
         /// <summary>
         /// Gets the last Messaging Verification for the user base on type and users HDID.
@@ -77,12 +61,6 @@ namespace HealthGateway.Database.Delegates
         /// <param name="ct">A cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task UpdateAsync(MessagingVerification messageVerification, bool commit = true, CancellationToken ct = default);
-
-        /// <summary>
-        /// Gets all email message verifications from the database.
-        /// </summary>
-        /// <returns>A list of message verifications.</returns>
-        IEnumerable<MessagingVerification> GetAllEmail();
 
         /// <summary>
         /// Expire a MessagingVerification.

--- a/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
@@ -43,6 +43,14 @@ namespace HealthGateway.Database.Delegates
         MessagingVerification? GetLastByInviteKey(Guid inviteKey);
 
         /// <summary>
+        /// Gets the last Email Message Verification by the Invite key.
+        /// </summary>
+        /// <param name="inviteKey">The users inviteKey as emailed.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The message verification that was fetched.</returns>
+        Task<MessagingVerification?> GetLastByInviteKeyAsync(Guid inviteKey, CancellationToken ct = default);
+
+        /// <summary>
         /// Gets the last Messaging Verification for the user base on type and users HDID.
         /// Defaults to MessagingVerificationType.Email.
         /// </summary>
@@ -50,6 +58,16 @@ namespace HealthGateway.Database.Delegates
         /// <param name="messagingVerificationType">The type to query.</param>
         /// <returns>The  message verification that was fetched.</returns>
         MessagingVerification? GetLastForUser(string hdid, string messagingVerificationType);
+
+        /// <summary>
+        /// Gets the last Messaging Verification for the user base on type and users HDID.
+        /// Defaults to MessagingVerificationType.Email.
+        /// </summary>
+        /// <param name="hdid">The users hdid.</param>
+        /// <param name="messagingVerificationType">The type to query.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The  message verification that was fetched.</returns>
+        Task<MessagingVerification?> GetLastForUserAsync(string hdid, string messagingVerificationType, CancellationToken ct = default);
 
         /// <summary>
         /// Updates a MessagingVerification using a populated model object.

--- a/Apps/Database/src/Delegates/INoteDelegate.cs
+++ b/Apps/Database/src/Delegates/INoteDelegate.cs
@@ -41,40 +41,45 @@ namespace HealthGateway.Database.Delegates
         /// <param name="hdId">The users health identifier id.</param>
         /// <param name="offset">The starting offset for the query.</param>
         /// <param name="pageSize">The maximum amount of rows to return.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of Notes wrapped in a DBResult.</returns>
-        DbResult<IList<Note>> GetNotes(string hdId, int offset = 0, int pageSize = 500);
+        Task<DbResult<IList<Note>>> GetNotesAsync(string hdId, int offset = 0, int pageSize = 500, CancellationToken ct = default);
 
         /// <summary>
         /// Add the given note.
         /// </summary>
         /// <param name="note">The note to be added to the backend.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A Note wrapped in a DBResult.</returns>
-        DbResult<Note> AddNote(Note note, bool commit = true);
+        Task<DbResult<Note>> AddNoteAsync(Note note, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Update the supplied note.
         /// </summary>
         /// <param name="note">The note to be updated in the backend.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A Note wrapped in a DBResult.</returns>
-        DbResult<Note> UpdateNote(Note note, bool commit = true);
+        Task<DbResult<Note>> UpdateNoteAsync(Note note, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Update the list of suplied notes.
         /// </summary>
         /// <param name="notes">The notes to be updated in the backend.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A List of Notes wrapped in a DBResult.</returns>
-        DbResult<IEnumerable<Note>> BatchUpdate(IEnumerable<Note> notes, bool commit = true);
+        Task<DbResult<IEnumerable<Note>>> BatchUpdateAsync(IEnumerable<Note> notes, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Deletes the supplied note.
         /// </summary>
         /// <param name="note">The note to be deleted in the backend.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A Note wrapped in a DBResult.</returns>
-        DbResult<Note> DeleteNote(Note note, bool commit = true);
+        Task<DbResult<Note>> DeleteNoteAsync(Note note, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a list of all the notes ordered by the CreatedDateTime in ascending order.

--- a/Apps/Database/src/Delegates/INoteDelegate.cs
+++ b/Apps/Database/src/Delegates/INoteDelegate.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Database.Delegates
 {
-    using System;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -27,14 +26,6 @@ namespace HealthGateway.Database.Delegates
     /// </summary>
     public interface INoteDelegate
     {
-        /// <summary>
-        /// Gets a note from the DB using the noteId.
-        /// </summary>
-        /// <param name="noteId">The Note ID to retrieve.</param>
-        /// <param name="hdid">The user hdid.</param>
-        /// <returns>The note wrapped in a DBResult.</returns>
-        DbResult<Note> GetNote(Guid noteId, string hdid);
-
         /// <summary>
         /// Gets a list of notes ordered by the journal datetime for the given HdId.
         /// </summary>
@@ -64,7 +55,7 @@ namespace HealthGateway.Database.Delegates
         Task<DbResult<Note>> UpdateNoteAsync(Note note, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
-        /// Update the list of suplied notes.
+        /// Update the list of supplied notes.
         /// </summary>
         /// <param name="notes">The notes to be updated in the backend.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>

--- a/Apps/Database/src/Delegates/IRatingDelegate.cs
+++ b/Apps/Database/src/Delegates/IRatingDelegate.cs
@@ -31,8 +31,9 @@ namespace HealthGateway.Database.Delegates
         /// Creates a Rating object in the database.
         /// </summary>
         /// <param name="rating">The rating to create.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<Rating> InsertRating(Rating rating);
+        Task<DbResult<Rating>> InsertRatingAsync(Rating rating, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a paged list of Ratings from the database.

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -65,9 +65,10 @@ namespace HealthGateway.Database.Delegates
         /// <param name="toDate">The to date.</param>
         /// <param name="page">The page to start at.</param>
         /// <param name="pageSize">The amount of rows to fetch per call.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of resourceDelegates wrapped in a DBResult.</returns>
         [SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "Team decision")]
-        DbResult<IEnumerable<ResourceDelegate>> Get(DateTime fromDate, DateTime? toDate, int page, int pageSize);
+        Task<IList<ResourceDelegate>> GetAsync(DateTime fromDate, DateTime? toDate, int page, int pageSize, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves a count of all dependents.

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -100,8 +100,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="resourceDelegate">The model to be deleted.</param>
         /// <param name="commit">Indicates if the transaction should be persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return record and status.</returns>
-        DbResult<ResourceDelegate> Delete(ResourceDelegate resourceDelegate, bool commit);
+        Task<DbResult<ResourceDelegate>> DeleteAsync(ResourceDelegate resourceDelegate, bool commit, CancellationToken ct = default);
 
         /// <summary>
         /// Finds a Resource Delegate record in the database.

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -35,8 +35,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="resourceDelegate">The resource delegate to create.</param>
         /// <param name="commit">Indicates if the transaction should be persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return record and status.</returns>
-        DbResult<ResourceDelegate> Insert(ResourceDelegate resourceDelegate, bool commit);
+        Task<DbResult<ResourceDelegate>> InsertAsync(ResourceDelegate resourceDelegate, bool commit, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the list of Resource Delegate records for a specific delegate Id from the database.
@@ -90,8 +91,9 @@ namespace HealthGateway.Database.Delegates
         /// Gets the total number of delegates associated with each specified dependent from the database.
         /// </summary>
         /// <param name="dependentHdids">The HDIDs corresponding to the dependents whose total delegate counts should be retrieved.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dictionary that associates dependent HDIDs with their total number of delegates, wrapped in a DBResult.</returns>
-        Task<DbResult<Dictionary<string, int>>> GetTotalDelegateCountsAsync(IEnumerable<string> dependentHdids);
+        Task<DbResult<Dictionary<string, int>>> GetTotalDelegateCountsAsync(IEnumerable<string> dependentHdids, CancellationToken ct = default);
 
         /// <summary>
         /// Deletes a Resource Delegate record in the database.

--- a/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/IResourceDelegateDelegate.cs
@@ -49,6 +49,16 @@ namespace HealthGateway.Database.Delegates
         DbResult<IEnumerable<ResourceDelegate>> Get(string delegateId, int page = 0, int pageSize = 500);
 
         /// <summary>
+        /// Gets the list of Resource Delegate records for a specific delegate Id from the database.
+        /// </summary>
+        /// <param name="delegateId">The resource delegate to create.</param>
+        /// <param name="page">The page to start at.</param>
+        /// <param name="pageSize">The amount of rows to fetch per call.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A list of resourceDelegates wrapped in a DBResult.</returns>
+        Task<IList<ResourceDelegate>> GetAsync(string delegateId, int page = 0, int pageSize = 500, CancellationToken ct = default);
+
+        /// <summary>
         /// Gets the list of Resource Delegate records for a date range from the database.
         /// </summary>
         /// <param name="fromDate">The from date.</param>

--- a/Apps/Database/src/Delegates/IUserPreferenceDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserPreferenceDelegate.cs
@@ -16,6 +16,8 @@
 namespace HealthGateway.Database.Delegates
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
 
@@ -29,22 +31,25 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="userPreference">The preference to be created.</param>
         /// <param name="commit">Indicates whether it should commit to the database or defer.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<UserPreference> CreateUserPreference(UserPreference userPreference, bool commit = true);
+        Task<DbResult<UserPreference>> CreateUserPreferenceAsync(UserPreference userPreference, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Saves a UserPreference object in the database.
         /// </summary>
         /// <param name="userPreference">The preference to be saved.</param>
         /// <param name="commit">Indicates whether it should commit to the database or defer.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<UserPreference> UpdateUserPreference(UserPreference userPreference, bool commit = true);
+        Task<DbResult<UserPreference>> UpdateUserPreferenceAsync(UserPreference userPreference, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Fetches the UserPreference from the database.
         /// </summary>
         /// <param name="hdid">The unique user profile key to find.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<IEnumerable<UserPreference>> GetUserPreferences(string hdid);
+        Task<IEnumerable<UserPreference>> GetUserPreferencesAsync(string hdid, CancellationToken ct = default);
     }
 }

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -47,30 +47,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="profile">The profile to update.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
-        /// <returns>A DB result which encapsulates the return object and status.</returns>
-        DbResult<UserProfile> Update(UserProfile profile, bool commit = true);
-
-        /// <summary>
-        /// Updates select attributes of the UserProfile object in the DB.
-        /// This method re-reads the UserProfile to ensure all other attributes are not overwritten.
-        /// Version must be set or a Concurrency exception will occur.
-        /// UpdatedDateTime will overridden by our framework.
-        /// </summary>
-        /// <param name="profile">The profile to update.</param>
-        /// <param name="commit">if true the transaction is persisted immediately.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
         Task<DbResult<UserProfile>> UpdateAsync(UserProfile profile, bool commit = true, CancellationToken ct = default);
-
-        /// <summary>
-        /// Updates the specified UserProfile object in the DB.
-        /// Version must be set or a Concurrency exception will occur.
-        /// UpdatedDateTime will overridden by our framework.
-        /// </summary>
-        /// <param name="profile">The profile to update.</param>
-        /// <param name="commit">if true the transaction is persisted immediately.</param>
-        /// <returns>A DB result which encapsulates the return object and status.</returns>
-        public DbResult<UserProfile> UpdateComplete(UserProfile profile, bool commit = true);
 
         /// <summary>
         /// Fetches the UserProfile from the database.

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -83,8 +83,9 @@ namespace HealthGateway.Database.Delegates
         /// Fetches a UserProfile from the database by HDID.
         /// </summary>
         /// <param name="hdid">The unique profile key to find.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The matching UserProfile, or null if not found.</returns>
-        Task<UserProfile?> GetUserProfileAsync(string hdid);
+        Task<UserProfile?> GetUserProfileAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Fetches UserProfiles from the database.

--- a/Apps/Database/src/Delegates/IUserProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileDelegate.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="profile">The profile to create.</param>
         /// <param name="commit">if true the transaction is persisted immediately.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
         Task<DbResult<UserProfile>> InsertUserProfileAsync(UserProfile profile, bool commit = true, CancellationToken ct = default);
 
@@ -49,6 +49,18 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">if true the transaction is persisted immediately.</param>
         /// <returns>A DB result which encapsulates the return object and status.</returns>
         DbResult<UserProfile> Update(UserProfile profile, bool commit = true);
+
+        /// <summary>
+        /// Updates select attributes of the UserProfile object in the DB.
+        /// This method re-reads the UserProfile to ensure all other attributes are not overwritten.
+        /// Version must be set or a Concurrency exception will occur.
+        /// UpdatedDateTime will overridden by our framework.
+        /// </summary>
+        /// <param name="profile">The profile to update.</param>
+        /// <param name="commit">if true the transaction is persisted immediately.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A DB result which encapsulates the return object and status.</returns>
+        Task<DbResult<UserProfile>> UpdateAsync(UserProfile profile, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the specified UserProfile object in the DB.
@@ -160,8 +172,9 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="hdid">The unique profile key to find.</param>
         /// <param name="limit">The number of rows to return.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of matching UserProfileHistory wrapped in a DBResult.</returns>
-        DbResult<IEnumerable<UserProfileHistory>> GetUserProfileHistories(string hdid, int limit);
+        Task<IList<UserProfileHistory>> GetUserProfileHistoryListAsync(string hdid, int limit, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves a count of user profiles.

--- a/Apps/GatewayApi/src/Api/IWebAlertApi.cs
+++ b/Apps/GatewayApi/src/Api/IWebAlertApi.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApi.Api
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.GatewayApi.Models.Phsa;
     using Refit;
@@ -30,25 +31,28 @@ namespace HealthGateway.GatewayApi.Api
         /// Retrieves all web alerts for a patient.
         /// </summary>
         /// <param name="pid">The patient's pid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The collection of web alerts for the specified patient.</returns>
         [Get("/personal-accounts/{pid}/web-alerts")]
-        Task<IList<PhsaWebAlert>> GetWebAlertsAsync(Guid pid);
+        Task<IList<PhsaWebAlert>> GetWebAlertsAsync(Guid pid, CancellationToken ct = default);
 
         /// <summary>
         /// Dismisses all web alerts for a patient.
         /// </summary>
         /// <param name="pid">The patient's pid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         [Delete("/personal-accounts/{pid}/web-alerts")]
-        Task DeleteWebAlertsAsync(Guid pid);
+        Task DeleteWebAlertsAsync(Guid pid, CancellationToken ct = default);
 
         /// <summary>
         /// Dismisses a web alert for a patient.
         /// </summary>
         /// <param name="pid">The patient's pid.</param>
         /// <param name="id">The ID of the web alert to be deleted.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A task representing the asynchronous operation.</returns>
         [Delete("/personal-accounts/{pid}/web-alerts/{id}")]
-        Task DeleteWebAlertAsync(Guid pid, Guid id);
+        Task DeleteWebAlertAsync(Guid pid, Guid id, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Controllers/CommentController.cs
+++ b/Apps/GatewayApi/src/Controllers/CommentController.cs
@@ -17,6 +17,8 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
@@ -51,6 +53,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The http status.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="comment">The Comment request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The comment record was saved.</response>
         /// <response code="400">The request is bad.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -61,7 +64,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPost]
         [Route("{hdid}/[controller]")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public ActionResult<RequestResult<UserComment>> Create(string hdid, [FromBody] UserComment? comment)
+        public async Task<ActionResult<RequestResult<UserComment>>> Create(string hdid, [FromBody] UserComment? comment, CancellationToken ct)
         {
             if (comment == null)
             {
@@ -71,7 +74,7 @@ namespace HealthGateway.GatewayApi.Controllers
             comment.UserProfileId = hdid;
             comment.CreatedBy = hdid;
             comment.UpdatedBy = hdid;
-            return this.commentService.Add(comment);
+            return await this.commentService.AddAsync(comment, ct);
         }
 
         /// <summary>
@@ -80,6 +83,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The updated Comment wrapped in a RequestResult.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="comment">The Comment to be updated.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The comment was saved.</response>
         /// <response code="400">The request is bad.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -90,7 +94,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPut]
         [Route("{hdid}/[controller]")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public ActionResult<RequestResult<UserComment>> Update(string hdid, [FromBody] UserComment? comment)
+        public async Task<ActionResult<RequestResult<UserComment>>> Update(string hdid, [FromBody] UserComment? comment, CancellationToken ct)
         {
             if (comment == null)
             {
@@ -103,7 +107,7 @@ namespace HealthGateway.GatewayApi.Controllers
             }
 
             comment.UpdatedBy = hdid;
-            return this.commentService.Update(comment);
+            return await this.commentService.UpdateAsync(comment, ct);
         }
 
         /// <summary>
@@ -112,6 +116,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The deleted UserComment wrapped in a RequestResult.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="comment">The comment to be deleted.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The note was deleted.</response>
         /// <response code="400">The request is bad.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -122,14 +127,14 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpDelete]
         [Route("{hdid}/[controller]")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public ActionResult<RequestResult<UserComment>> Delete(string hdid, [FromBody] UserComment comment)
+        public async Task<ActionResult<RequestResult<UserComment>>> Delete(string hdid, [FromBody] UserComment comment, CancellationToken ct)
         {
             if (comment.UserProfileId != hdid)
             {
                 return new ForbidResult();
             }
 
-            return this.commentService.Delete(comment);
+            return await this.commentService.DeleteAsync(comment, ct);
         }
 
         /// <summary>
@@ -137,6 +142,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="parentEntryId">The parent entry id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The list of comments wrapped in a request result.</returns>
         /// <response code="200">Returns the list of comments.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -147,15 +153,16 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Route("{hdid}/[controller]/Entry")]
         [Authorize(Policy = UserProfilePolicy.Read)]
-        public RequestResult<IEnumerable<UserComment>> GetAllForEntry(string hdid, [FromQuery] string parentEntryId)
+        public async Task<RequestResult<IEnumerable<UserComment>>> GetAllForEntry(string hdid, [FromQuery] string parentEntryId, CancellationToken ct)
         {
-            return this.commentService.GetEntryComments(hdid, parentEntryId);
+            return await this.commentService.GetEntryCommentsAsync(hdid, parentEntryId, ct);
         }
 
         /// <summary>
         /// Gets all comments for the authorized user.
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The list of comments wrapped in a request result.</returns>
         /// <response code="200">Returns the list of comments.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -167,9 +174,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [Route("{hdid}/[controller]")]
         [Authorize(Policy = UserProfilePolicy.Read)]
         [ExcludeFromCodeCoverage]
-        public RequestResult<IDictionary<string, IEnumerable<UserComment>>> GetAll(string hdid)
+        public async Task<RequestResult<IDictionary<string, IEnumerable<UserComment>>>> GetAll(string hdid, CancellationToken ct)
         {
-            return this.commentService.GetProfileComments(hdid);
+            return await this.commentService.GetProfileCommentsAsync(hdid, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Controllers/CommunicationController.cs
+++ b/Apps/GatewayApi/src/Controllers/CommunicationController.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.Controllers
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Services;
@@ -44,13 +46,14 @@ namespace HealthGateway.GatewayApi.Controllers
         /// Gets the latest active communication.
         /// </summary>
         /// <param name="communicationType">The communication type to retrieve.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The active communication or null if not found.</returns>
         /// <response code="200">Returns the communication json.</response>
         [HttpGet]
         [Route("{communicationType}")]
-        public RequestResult<Communication?> Get(CommunicationType communicationType = CommunicationType.Banner)
+        public async Task<RequestResult<Communication?>> Get(CommunicationType communicationType = CommunicationType.Banner, CancellationToken ct = default)
         {
-            return this.communicationService.GetActiveCommunication(communicationType);
+            return await this.communicationService.GetActiveCommunicationAsync(communicationType, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Controllers/DependentController.cs
+++ b/Apps/GatewayApi/src/Controllers/DependentController.cs
@@ -64,6 +64,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The list of dependent model wrapped in a request result.</returns>
         /// <param name="hdid">The owner hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the list of dependents.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -73,9 +74,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Authorize(Policy = UserProfilePolicy.Read)]
         [Route("{hdid}/[controller]")]
-        public async Task<RequestResult<IEnumerable<DependentModel>>> GetAll(string hdid)
+        public async Task<RequestResult<IEnumerable<DependentModel>>> GetAll(string hdid, CancellationToken ct)
         {
-            return await this.dependentService.GetDependentsAsync(hdid);
+            return await this.dependentService.GetDependentsAsync(hdid, 0, 25, ct);
         }
 
         /// <summary>
@@ -83,7 +84,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The http status.</returns>
         /// <param name="addDependentRequest">The Register Dependent request model.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The Dependent record was saved.</response>
         /// <response code="400">The Dependent was already inserted.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -115,7 +116,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <param name="hdid">The Delegate hdid.</param>
         /// <param name="dependentHdid">The Dependent hdid.</param>
         /// <param name="dependent">The dependent model object to be deleted.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The Dependent record was deleted.</response>
         /// <response code="400">The request is invalid.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>

--- a/Apps/GatewayApi/src/Controllers/NoteController.cs
+++ b/Apps/GatewayApi/src/Controllers/NoteController.cs
@@ -16,6 +16,8 @@
 namespace HealthGateway.GatewayApi.Controllers
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Filters;
@@ -53,6 +55,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The http status.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="note">The patient note request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The note record was saved.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -62,12 +65,12 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPost]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public RequestResult<UserNote> CreateNote(string hdid, [FromBody] UserNote note)
+        public async Task<RequestResult<UserNote>> CreateNote(string hdid, [FromBody] UserNote note, CancellationToken ct)
         {
             note.HdId = hdid;
             note.CreatedBy = hdid;
             note.UpdatedBy = hdid;
-            return this.noteService.CreateNote(note);
+            return await this.noteService.CreateNoteAsync(note, ct);
         }
 
         /// <summary>
@@ -76,6 +79,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The updated Note wrapped in a RequestResult.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="note">The patient note.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The note was saved.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -85,10 +89,10 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPut]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public RequestResult<UserNote> UpdateNote(string hdid, [FromBody] UserNote note)
+        public async Task<RequestResult<UserNote>> UpdateNote(string hdid, [FromBody] UserNote note, CancellationToken ct)
         {
             note.UpdatedBy = hdid;
-            return this.noteService.UpdateNote(note);
+            return await this.noteService.UpdateNoteAsync(note, ct);
         }
 
         /// <summary>
@@ -96,6 +100,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The deleted Note wrapped in a RequestResult.</returns>
         /// <param name="note">The patient note.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The note was deleted.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -105,9 +110,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpDelete]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public RequestResult<UserNote> DeleteNote([FromBody] UserNote note)
+        public async Task<RequestResult<UserNote>> DeleteNote([FromBody] UserNote note, CancellationToken ct)
         {
-            return this.noteService.DeleteNote(note);
+            return await this.noteService.DeleteNoteAsync(note, ct);
         }
 
         /// <summary>
@@ -115,6 +120,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The list of notes model wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the list of notes.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -124,9 +130,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Read)]
-        public RequestResult<IEnumerable<UserNote>> GetAll(string hdid)
+        public async Task<RequestResult<IEnumerable<UserNote>>> GetAll(string hdid, CancellationToken ct)
         {
-            return this.noteService.GetNotes(hdid);
+            return await this.noteService.GetNotesAsync(hdid, 0, 500, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Controllers/NotificationController.cs
+++ b/Apps/GatewayApi/src/Controllers/NotificationController.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.GatewayApi.Models;
@@ -49,6 +50,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// Gets all notifications for a user.
         /// </summary>
         /// <param name="hdid">The HDID of the user.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The collection of notifications.</returns>
         /// <response code="200">Returns the collection of notifications.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -62,9 +64,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(IEnumerable<WebAlert>))]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> Get(string hdid)
+        public async Task<IActionResult> Get(string hdid, CancellationToken ct)
         {
-            IList<WebAlert> notifications = await this.webAlertService.GetWebAlertsAsync(hdid).ConfigureAwait(true);
+            IList<WebAlert> notifications = await this.webAlertService.GetWebAlertsAsync(hdid, ct);
             return this.Ok(notifications);
         }
 
@@ -73,6 +75,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>An empty result.</returns>
         /// <param name="hdid">The HDID of the user.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The notifications were dismissed.</response>
         /// <response code="401">The client must authenticate itself to perform the operation.</response>
         /// <response code="403">
@@ -85,9 +88,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> DismissAll(string hdid)
+        public async Task<IActionResult> DismissAll(string hdid, CancellationToken ct)
         {
-            await this.webAlertService.DismissWebAlertsAsync(hdid).ConfigureAwait(true);
+            await this.webAlertService.DismissWebAlertsAsync(hdid, ct);
             return this.Ok();
         }
 
@@ -97,6 +100,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>An empty result.</returns>
         /// <param name="hdid">The HDID of the user.</param>
         /// <param name="id">The ID of the notification to be dismissed.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The notification was dismissed.</response>
         /// <response code="401">The client must authenticate itself to perform the operation.</response>
         /// <response code="403">
@@ -109,9 +113,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        public async Task<IActionResult> Dismiss(string hdid, Guid id)
+        public async Task<IActionResult> Dismiss(string hdid, Guid id, CancellationToken ct)
         {
-            await this.webAlertService.DismissWebAlertAsync(hdid, id).ConfigureAwait(true);
+            await this.webAlertService.DismissWebAlertAsync(hdid, id, ct);
             return this.Ok();
         }
     }

--- a/Apps/GatewayApi/src/Controllers/PhsaController.cs
+++ b/Apps/GatewayApi/src/Controllers/PhsaController.cs
@@ -18,8 +18,10 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
+    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Services;
@@ -77,6 +79,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <param name="toDateUtc">The to date in Utc.</param>
         /// <param name="page">The page number. Defaults to 0.</param>
         /// <param name="pageSize">The page size. Max 5000.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the list of dependents.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -86,19 +89,21 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Authorize(Policy = SystemDelegatedPatientPolicy.Read)]
         [Route("dependents")]
-        public ActionResult<RequestResult<IEnumerable<GetDependentResponse>>> GetAll(
+        public async Task<ActionResult<RequestResult<IEnumerable<GetDependentResponse>>>> GetAll(
             [FromQuery] DateTime fromDateUtc,
             [FromQuery] DateTime? toDateUtc,
             [FromQuery] int page = 0,
-            [FromQuery] int pageSize = 5000)
+            [FromQuery] int pageSize = 5000,
+            CancellationToken ct = default)
         {
-            return this.dependentService.GetDependents(fromDateUtc, toDateUtc, page, pageSize);
+            return await this.dependentService.GetDependentsAsync(fromDateUtc, toDateUtc, page, pageSize, ct);
         }
 
         /// <summary>
         /// Gets a json of patient record.
         /// </summary>
         /// <param name="hdid">The patient hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient record.</returns>
         /// <response code="200">Returns the patient record.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -117,9 +122,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status502BadGateway)]
         [Route("patients/{hdid}")]
         [Authorize(Policy = SystemDelegatedPatientPolicy.Read)]
-        public async Task<ActionResult<PatientDetails>> GetPatient(string hdid)
+        public async Task<ActionResult<PatientDetails>> GetPatient(string hdid, CancellationToken ct)
         {
-            return await this.patientDetailsService.GetPatientAsync(hdid).ConfigureAwait(true);
+            return await this.patientDetailsService.GetPatientAsync(hdid, PatientIdentifierType.Hdid, false, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Controllers/ReportController.cs
+++ b/Apps/GatewayApi/src/Controllers/ReportController.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.Controllers
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
@@ -47,12 +49,13 @@ namespace HealthGateway.GatewayApi.Controllers
         /// Gets a report based on the request provided.
         /// </summary>
         /// <param name="reportRequest">The report request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The report data.</returns>
         /// <response code="200">Returns the report data.</response>
         [HttpPost]
-        public RequestResult<ReportModel> GenerateReport([FromBody] ReportRequestModel reportRequest)
+        public async Task<RequestResult<ReportModel>> GenerateReport([FromBody] ReportRequestModel reportRequest, CancellationToken ct)
         {
-            return this.reportService.GetReport(reportRequest);
+            return await this.reportService.GetReportAsync(reportRequest, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Controllers/UserFeedbackController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserFeedbackController.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.Controllers
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Database.Constants;
@@ -51,6 +53,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The http status.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="userFeedback">The user feedback model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The user feedback record was saved.</response>
         /// <response code="400">The user feedback object is invalid.</response>
         /// <response code="409">The user feedback was already inserted.</response>
@@ -62,7 +65,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPost]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public IActionResult CreateUserFeedback(string hdid, [FromBody] UserFeedback? userFeedback)
+        public async Task<IActionResult> CreateUserFeedback(string hdid, [FromBody] UserFeedback? userFeedback, CancellationToken ct = default)
         {
             if (userFeedback == null)
             {
@@ -72,7 +75,7 @@ namespace HealthGateway.GatewayApi.Controllers
             userFeedback.UserProfileId = hdid;
             userFeedback.CreatedBy = hdid;
             userFeedback.UpdatedBy = hdid;
-            DbResult<UserFeedback> result = this.userFeedbackService.CreateUserFeedback(userFeedback);
+            DbResult<UserFeedback> result = await this.userFeedbackService.CreateUserFeedbackAsync(userFeedback, ct);
             if (result.Status != DbStatusCode.Created)
             {
                 return new ConflictResult();
@@ -85,6 +88,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// Saves the rating model.
         /// </summary>
         /// <param name="rating">The rating to be saved.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The saved rating wrapped in a request result.</returns>
         /// <response code="200">Returns the saved rating json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
@@ -94,9 +98,9 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </response>
         [HttpPost]
         [Route("Rating")]
-        public RequestResult<Rating> CreateRating(Rating rating)
+        public async Task<RequestResult<Rating>> CreateRating(Rating rating, CancellationToken ct)
         {
-            return this.userFeedbackService.CreateRating(rating);
+            return await this.userFeedbackService.CreateRatingAsync(rating, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -75,7 +75,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The http status.</returns>
         /// <param name="hdid">The resource hdid.</param>
         /// <param name="createUserRequest">The user profile request model.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The user profile record was saved.</response>
         /// <response code="400">The user profile was already inserted.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -100,7 +100,7 @@ namespace HealthGateway.GatewayApi.Controllers
                 ClaimsPrincipal user = httpContext.User;
                 DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(user);
                 string? jwtEmailAddress = user.FindFirstValue(ClaimTypes.Email);
-                return await this.userProfileService.CreateUserProfile(createUserRequest, jwtAuthTime, jwtEmailAddress, ct);
+                return await this.userProfileService.CreateUserProfileAsync(createUserRequest, jwtAuthTime, jwtEmailAddress, ct);
             }
 
             return this.Unauthorized();
@@ -111,6 +111,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The user profile model wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the user profile json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -120,13 +121,13 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Read)]
-        public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid)
+        public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, CancellationToken ct)
         {
             ClaimsPrincipal? user = this.httpContextAccessor.HttpContext?.User;
             DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(user);
 
-            RequestResult<UserProfileModel> result = await this.userProfileService.GetUserProfile(hdid, jwtAuthTime).ConfigureAwait(true);
-            this.AddUserPreferences(result.ResourcePayload);
+            RequestResult<UserProfileModel> result = await this.userProfileService.GetUserProfileAsync(hdid, jwtAuthTime, ct);
+            await this.AddUserPreferences(result.ResourcePayload, ct);
 
             return result;
         }
@@ -136,6 +137,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>A boolean wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The request result is returned.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -145,9 +147,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Route("{hdid}/Validate")]
         [Authorize(Policy = UserProfilePolicy.Read)]
-        public async Task<RequestResult<bool>> Validate(string hdid)
+        public async Task<RequestResult<bool>> Validate(string hdid, CancellationToken ct)
         {
-            return await this.userProfileService.ValidateMinimumAge(hdid).ConfigureAwait(true);
+            return await this.userProfileService.ValidateMinimumAgeAsync(hdid, ct);
         }
 
         /// <summary>
@@ -155,6 +157,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The user profile model wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the user profile json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -165,12 +168,12 @@ namespace HealthGateway.GatewayApi.Controllers
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Write)]
         [ExcludeFromCodeCoverage]
-        public RequestResult<UserProfileModel> CloseUserProfile(string hdid)
+        public async Task<RequestResult<UserProfileModel>> CloseUserProfile(string hdid, CancellationToken ct)
         {
             // Retrieve the user identity id from the claims
             Guid userId = new(this.authenticationDelegate.FetchAuthenticatedUserId());
 
-            return this.userProfileService.CloseUserProfile(hdid, userId);
+            return await this.userProfileService.CloseUserProfileAsync(hdid, userId, ct);
         }
 
         /// <summary>
@@ -178,6 +181,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <returns>The user profile model wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the user profile json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -188,14 +192,15 @@ namespace HealthGateway.GatewayApi.Controllers
         [Route("{hdid}/recover")]
         [Authorize(Policy = UserProfilePolicy.Write)]
         [ExcludeFromCodeCoverage]
-        public RequestResult<UserProfileModel> RecoverUserProfile(string hdid)
+        public async Task<RequestResult<UserProfileModel>> RecoverUserProfile(string hdid, CancellationToken ct)
         {
-            return this.userProfileService.RecoverUserProfile(hdid);
+            return await this.userProfileService.RecoverUserProfileAsync(hdid, ct);
         }
 
         /// <summary>
         /// Gets the terms of service json.
         /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The terms of service model wrapped in a request result.</returns>
         /// <response code="200">Returns the terms of service json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
@@ -207,9 +212,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [Route("termsofservice")]
         [AllowAnonymous]
         [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 3600)]
-        public RequestResult<TermsOfServiceModel> GetLastTermsOfService()
+        public async Task<RequestResult<TermsOfServiceModel>> GetLastTermsOfService(CancellationToken ct)
         {
-            return this.userProfileService.GetActiveTermsOfService();
+            return await this.userProfileService.GetActiveTermsOfServiceAsync(ct);
         }
 
         /// <summary>
@@ -218,7 +223,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The an empty response.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="verificationKey">The email verification key.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The email was validated.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="404">The verification key was not found.</response>
@@ -247,7 +252,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>An empty response.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="validationCode">The sms validation code.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The sms was validated.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="404">The validation code was not found.</response>
@@ -276,7 +281,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="emailAddress">The new email.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>True if the action was successful.</returns>
         /// <response code="200">Returns true if the call was successful.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
@@ -297,7 +302,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="smsNumber">The new sms number.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>True if the action was successful.</returns>
         /// <response code="200">Returns true if the call was successful.</response>
         /// <response code="400">the client must ensure sms number is valid.</response>
@@ -320,6 +325,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The http status.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="userPreferenceModel">The user preference request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The user preference record was saved.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -329,7 +335,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPut]
         [Route("{hdid}/preference")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public ActionResult<RequestResult<UserPreferenceModel>> UpdateUserPreference(string hdid, [FromBody] UserPreferenceModel? userPreferenceModel)
+        public async Task<ActionResult<RequestResult<UserPreferenceModel>>> UpdateUserPreference(string hdid, [FromBody] UserPreferenceModel? userPreferenceModel, CancellationToken ct)
         {
             if (userPreferenceModel == null || string.IsNullOrEmpty(userPreferenceModel.Preference))
             {
@@ -342,7 +348,7 @@ namespace HealthGateway.GatewayApi.Controllers
             }
 
             userPreferenceModel.UpdatedBy = hdid;
-            return this.userProfileService.UpdateUserPreference(userPreferenceModel);
+            return await this.userProfileService.UpdateUserPreferenceAsync(userPreferenceModel, ct);
         }
 
         /// <summary>
@@ -351,6 +357,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The http status.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="userPreferenceModel">The user preference request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The comment record was saved.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -360,7 +367,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPost]
         [Route("{hdid}/preference")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public ActionResult<RequestResult<UserPreferenceModel>> CreateUserPreference(string hdid, [FromBody] UserPreferenceModel? userPreferenceModel)
+        public async Task<ActionResult<RequestResult<UserPreferenceModel>>> CreateUserPreference(string hdid, [FromBody] UserPreferenceModel? userPreferenceModel, CancellationToken ct)
         {
             if (userPreferenceModel == null)
             {
@@ -370,7 +377,7 @@ namespace HealthGateway.GatewayApi.Controllers
             userPreferenceModel.HdId = hdid;
             userPreferenceModel.CreatedBy = hdid;
             userPreferenceModel.UpdatedBy = hdid;
-            return this.userProfileService.CreateUserPreference(userPreferenceModel);
+            return await this.userProfileService.CreateUserPreferenceAsync(userPreferenceModel, ct);
         }
 
         /// <summary>
@@ -379,6 +386,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The user profile model wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="termsOfServiceId">The id of the terms of service to update for this user.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the user profile json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -388,10 +396,10 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpPut]
         [Route("{hdid}/acceptedterms")]
         [Authorize(Policy = UserProfilePolicy.Write)]
-        public RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, [FromBody] Guid termsOfServiceId)
+        public async Task<RequestResult<UserProfileModel>> UpdateAcceptedTerms(string hdid, [FromBody] Guid termsOfServiceId, CancellationToken ct)
         {
-            RequestResult<UserProfileModel> result = this.userProfileService.UpdateAcceptedTerms(hdid, termsOfServiceId);
-            this.AddUserPreferences(result.ResourcePayload);
+            RequestResult<UserProfileModel> result = await this.userProfileService.UpdateAcceptedTermsAsync(hdid, termsOfServiceId, ct);
+            await this.AddUserPreferences(result.ResourcePayload, ct);
 
             return result;
         }
@@ -400,21 +408,22 @@ namespace HealthGateway.GatewayApi.Controllers
         /// Test phone number validation required by the GatewayAPI and PHSA.
         /// </summary>
         /// <param name="phoneNumber">Phone number stripped of any masked characters.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>True if the submitted phone number conforms to the appropriate standards.</returns>
         /// <response code="200">Returns the result of the validation attempt.</response>
         [HttpGet]
         [Route("IsValidPhoneNumber/{phoneNumber}")]
         [Authorize]
-        public ActionResult<bool> IsValidPhoneNumber(string phoneNumber)
+        public async Task<ActionResult<bool>> IsValidPhoneNumber(string phoneNumber, CancellationToken ct)
         {
-            return this.userProfileService.IsPhoneNumberValid(phoneNumber);
+            return await this.userProfileService.IsPhoneNumberValid(phoneNumber, ct);
         }
 
-        private void AddUserPreferences(UserProfileModel? profile)
+        private async Task AddUserPreferences(UserProfileModel? profile, CancellationToken ct)
         {
             if (profile != null)
             {
-                RequestResult<Dictionary<string, UserPreferenceModel>> userPreferences = this.userProfileService.GetUserPreferences(profile.HdId);
+                RequestResult<Dictionary<string, UserPreferenceModel>> userPreferences = await this.userProfileService.GetUserPreferencesAsync(profile.HdId, ct);
                 if (userPreferences.ResourcePayload != null)
                 {
                     foreach (KeyValuePair<string, UserPreferenceModel> preference in userPreferences.ResourcePayload)

--- a/Apps/GatewayApi/src/Services/CommentService.cs
+++ b/Apps/GatewayApi/src/Services/CommentService.cs
@@ -17,6 +17,8 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using AutoMapper;
     using FluentValidation.Results;
     using HealthGateway.Common.Data.Models;
@@ -60,17 +62,17 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserComment> Add(UserComment userComment)
+        public async Task<RequestResult<UserComment>> AddAsync(UserComment userComment, CancellationToken ct = default)
         {
-            ValidationResult validationResult = new UserCommentValidator().Validate(userComment);
+            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment, ct);
 
             if (!validationResult.IsValid)
             {
                 return RequestResultFactory.Error<UserComment>(ErrorType.InvalidState, validationResult.Errors);
             }
 
-            UserProfile profile = this.profileDelegate.GetUserProfile(userComment.UserProfileId).Payload;
-            string? key = profile.EncryptionKey;
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId);
+            string? key = profile?.EncryptionKey;
             if (key == null)
             {
                 this.logger.LogError("User does not have a key: {UserProfileId}", userComment.UserProfileId);
@@ -89,10 +91,10 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<IEnumerable<UserComment>> GetEntryComments(string hdId, string parentEntryId)
+        public async Task<RequestResult<IEnumerable<UserComment>>> GetEntryCommentsAsync(string hdId, string parentEntryId, CancellationToken ct = default)
         {
-            UserProfile profile = this.profileDelegate.GetUserProfile(hdId).Payload;
-            string? key = profile.EncryptionKey;
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId);
+            string? key = profile?.EncryptionKey;
 
             // Check that the key has been set
             if (key == null)
@@ -116,10 +118,10 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<IDictionary<string, IEnumerable<UserComment>>> GetProfileComments(string hdId)
+        public async Task<RequestResult<IDictionary<string, IEnumerable<UserComment>>>> GetProfileCommentsAsync(string hdId, CancellationToken ct = default)
         {
-            UserProfile profile = this.profileDelegate.GetUserProfile(hdId).Payload;
-            string? key = profile.EncryptionKey;
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId);
+            string? key = profile?.EncryptionKey;
 
             // Check that the key has been set
             if (key == null)
@@ -145,17 +147,17 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserComment> Update(UserComment userComment)
+        public async Task<RequestResult<UserComment>> UpdateAsync(UserComment userComment, CancellationToken ct = default)
         {
-            ValidationResult validationResult = new UserCommentValidator().Validate(userComment);
+            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment);
 
             if (!validationResult.IsValid)
             {
                 return RequestResultFactory.Error<UserComment>(ErrorType.InvalidState, validationResult.Errors);
             }
 
-            UserProfile profile = this.profileDelegate.GetUserProfile(userComment.UserProfileId).Payload;
-            string? key = profile.EncryptionKey;
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId);
+            string? key = profile?.EncryptionKey;
             if (key == null)
             {
                 this.logger.LogError("User does not have a key: {UserProfileId}", userComment.UserProfileId);
@@ -174,17 +176,17 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserComment> Delete(UserComment userComment)
+        public async Task<RequestResult<UserComment>> DeleteAsync(UserComment userComment, CancellationToken ct = default)
         {
-            ValidationResult validationResult = new UserCommentValidator().Validate(userComment);
+            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment);
 
             if (!validationResult.IsValid)
             {
                 return RequestResultFactory.Error<UserComment>(ErrorType.InvalidState, validationResult.Errors);
             }
 
-            UserProfile profile = this.profileDelegate.GetUserProfile(userComment.UserProfileId).Payload;
-            string? key = profile.EncryptionKey;
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId);
+            string? key = profile?.EncryptionKey;
             if (key == null)
             {
                 this.logger.LogError("User does not have a key: {UserProfileId}", userComment.UserProfileId);

--- a/Apps/GatewayApi/src/Services/CommentService.cs
+++ b/Apps/GatewayApi/src/Services/CommentService.cs
@@ -71,7 +71,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.Error<UserComment>(ErrorType.InvalidState, validationResult.Errors);
             }
 
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId, ct);
             string? key = profile?.EncryptionKey;
             if (key == null)
             {
@@ -93,7 +93,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<IEnumerable<UserComment>>> GetEntryCommentsAsync(string hdId, string parentEntryId, CancellationToken ct = default)
         {
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId, ct);
             string? key = profile?.EncryptionKey;
 
             // Check that the key has been set
@@ -120,7 +120,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<IDictionary<string, IEnumerable<UserComment>>>> GetProfileCommentsAsync(string hdId, CancellationToken ct = default)
         {
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId, ct);
             string? key = profile?.EncryptionKey;
 
             // Check that the key has been set
@@ -156,7 +156,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.Error<UserComment>(ErrorType.InvalidState, validationResult.Errors);
             }
 
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId, ct);
             string? key = profile?.EncryptionKey;
             if (key == null)
             {
@@ -185,7 +185,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.Error<UserComment>(ErrorType.InvalidState, validationResult.Errors);
             }
 
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userComment.UserProfileId, ct);
             string? key = profile?.EncryptionKey;
             if (key == null)
             {

--- a/Apps/GatewayApi/src/Services/CommentService.cs
+++ b/Apps/GatewayApi/src/Services/CommentService.cs
@@ -80,7 +80,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             Comment comment = CommentMapUtils.ToDbModel(userComment, this.cryptoDelegate, key, this.autoMapper);
-            DbResult<Comment> dbResult = this.commentDelegate.Add(comment);
+            DbResult<Comment> dbResult = await this.commentDelegate.AddAsync(comment, ct: ct);
 
             if (dbResult.Status != DbStatusCode.Created)
             {
@@ -103,7 +103,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.ServiceError<IEnumerable<UserComment>>(ErrorType.InvalidState, ServiceType.Database, "Profile Key not set");
             }
 
-            DbResult<IList<Comment>> dbComments = this.commentDelegate.GetByParentEntry(hdId, parentEntryId);
+            DbResult<IList<Comment>> dbComments = await this.commentDelegate.GetByParentEntryAsync(hdId, parentEntryId, ct);
 
             if (dbComments.Status != DbStatusCode.Read)
             {
@@ -130,7 +130,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.ServiceError<IDictionary<string, IEnumerable<UserComment>>>(ErrorType.InvalidState, ServiceType.Database, "Profile Key not set");
             }
 
-            DbResult<IEnumerable<Comment>> dbComments = this.commentDelegate.GetAll(hdId);
+            DbResult<IEnumerable<Comment>> dbComments = await this.commentDelegate.GetAllAsync(hdId, ct);
             IEnumerable<UserComment> comments = dbComments.Payload.Select(c => CommentMapUtils.CreateFromDbModel(c, this.cryptoDelegate, key, this.autoMapper));
             IDictionary<string, IEnumerable<UserComment>> userCommentsByEntry = comments.GroupBy(x => x.ParentEntryId).ToDictionary(g => g.Key, g => g.AsEnumerable());
 
@@ -149,7 +149,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<UserComment>> UpdateAsync(UserComment userComment, CancellationToken ct = default)
         {
-            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment);
+            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment, ct);
 
             if (!validationResult.IsValid)
             {
@@ -165,7 +165,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             Comment comment = CommentMapUtils.ToDbModel(userComment, this.cryptoDelegate, key, this.autoMapper);
-            DbResult<Comment> dbResult = this.commentDelegate.Update(comment);
+            DbResult<Comment> dbResult = await this.commentDelegate.UpdateAsync(comment, ct: ct);
 
             if (dbResult.Status != DbStatusCode.Updated)
             {
@@ -178,7 +178,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<UserComment>> DeleteAsync(UserComment userComment, CancellationToken ct = default)
         {
-            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment);
+            ValidationResult validationResult = await new UserCommentValidator().ValidateAsync(userComment, ct);
 
             if (!validationResult.IsValid)
             {
@@ -194,7 +194,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             Comment comment = CommentMapUtils.ToDbModel(userComment, this.cryptoDelegate, key, this.autoMapper);
-            DbResult<Comment> dbResult = this.commentDelegate.Delete(comment);
+            DbResult<Comment> dbResult = await this.commentDelegate.DeleteAsync(comment, ct: ct);
 
             if (dbResult.Status != DbStatusCode.Deleted)
             {

--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -241,7 +241,7 @@ namespace HealthGateway.GatewayApi.Services
 
             // commit to the database if change feed is disabled; if change feed enabled, commit will happen when message sender is called
             // this is temporary and will be changed when we introduce a proper unit of work to manage transactionality.
-            DbResult<ResourceDelegate> dbDependent = this.resourceDelegateDelegate.Delete(resourceDelegate, !this.dependentsChangeFeedEnabled);
+            DbResult<ResourceDelegate> dbDependent = await this.resourceDelegateDelegate.DeleteAsync(resourceDelegate, !this.dependentsChangeFeedEnabled, ct);
             if (dbDependent.Status == DbStatusCode.Error)
             {
                 throw new ProblemDetailsException(ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", dbDependent.Message));

--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -207,21 +207,17 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<IEnumerable<GetDependentResponse>> GetDependents(DateTime fromDateUtc, DateTime? toDateUtc, int page, int pageSize)
+        public async Task<RequestResult<IEnumerable<GetDependentResponse>>> GetDependentsAsync(DateTime fromDateUtc, DateTime? toDateUtc, int page, int pageSize, CancellationToken ct = default)
         {
-            DbResult<IEnumerable<ResourceDelegate>> dbResourceDelegates = this.resourceDelegateDelegate.Get(
+            IList<ResourceDelegate> resourceDelegates = await this.resourceDelegateDelegate.GetAsync(
                 fromDateUtc,
                 toDateUtc,
                 page,
-                pageSize);
-
-            if (dbResourceDelegates.Status != DbStatusCode.Read)
-            {
-                return RequestResultFactory.ServiceError<IEnumerable<GetDependentResponse>>(ErrorType.CommunicationInternal, ServiceType.Database, dbResourceDelegates.Message);
-            }
+                pageSize,
+                ct);
 
             IEnumerable<GetDependentResponse> getDependentResponses =
-                dbResourceDelegates.Payload
+                resourceDelegates
                     .Select(
                         g => new GetDependentResponse
                         {

--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -337,7 +337,7 @@ namespace HealthGateway.GatewayApi.Services
 
         private async Task UpdateNotificationSettingsAsync(string dependentHdid, string delegateHdid, bool isDelete = false, CancellationToken ct = default)
         {
-            UserProfile? delegateUserProfile = await this.userProfileDelegate.GetUserProfileAsync(delegateHdid) ?? throw new ProblemDetailsException(
+            UserProfile? delegateUserProfile = await this.userProfileDelegate.GetUserProfileAsync(delegateHdid, ct) ?? throw new ProblemDetailsException(
                 ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", ErrorMessages.DelegateUserProfileNotFound));
 
             // Update the notification settings

--- a/Apps/GatewayApi/src/Services/ICommentService.cs
+++ b/Apps/GatewayApi/src/Services/ICommentService.cs
@@ -16,6 +16,8 @@
 namespace HealthGateway.GatewayApi.Services
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
 
@@ -28,37 +30,42 @@ namespace HealthGateway.GatewayApi.Services
         /// Adds a UserComment in the backend.
         /// </summary>
         /// <param name="userComment">The UserComment to be created.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A UserComment wrapped in a RequestResult.</returns>
-        RequestResult<UserComment> Add(UserComment userComment);
+        Task<RequestResult<UserComment>> AddAsync(UserComment userComment, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a list of UserComment for the given hdId and event id.
         /// </summary>
         /// <param name="hdId">The users HDID.</param>
         /// <param name="parentEntryId">The parent entry id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A List of UserComment wrapped in a RequestResult.</returns>
-        RequestResult<IEnumerable<UserComment>> GetEntryComments(string hdId, string parentEntryId);
+        Task<RequestResult<IEnumerable<UserComment>>> GetEntryCommentsAsync(string hdId, string parentEntryId, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a list of UserComment for the given hdId.
         /// </summary>
         /// <param name="hdId">The users HDID.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A List of UserComment wrapped in a RequestResult.</returns>
-        RequestResult<IDictionary<string, IEnumerable<UserComment>>> GetProfileComments(string hdId);
+        Task<RequestResult<IDictionary<string, IEnumerable<UserComment>>>> GetProfileCommentsAsync(string hdId, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the given UserComment in the backend.
         /// Any changes to HDID will be ignored.
         /// </summary>
         /// <param name="userComment">The UserComment to update.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The updated UserComment.</returns>
-        RequestResult<UserComment> Update(UserComment userComment);
+        Task<RequestResult<UserComment>> UpdateAsync(UserComment userComment, CancellationToken ct = default);
 
         /// <summary>
         /// Deletes the given UserComment from the backend.
         /// </summary>
         /// <param name="userComment">The Comment to be deleted.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The deleted Comment wrapped in a RequestResult.</returns>
-        RequestResult<UserComment> Delete(UserComment userComment);
+        Task<RequestResult<UserComment>> DeleteAsync(UserComment userComment, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IDependentService.cs
+++ b/Apps/GatewayApi/src/Services/IDependentService.cs
@@ -44,8 +44,9 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="toDateUtc">The to date time in Utc.</param>
         /// <param name="page">The page of data to fetch indexed from 0.</param>
         /// <param name="pageSize">The amount of records per page.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A List of dependents wrapped in a RequestResult.</returns>
-        RequestResult<IEnumerable<GetDependentResponse>> GetDependents(DateTime fromDateUtc, DateTime? toDateUtc, int page, int pageSize);
+        Task<RequestResult<IEnumerable<GetDependentResponse>>> GetDependentsAsync(DateTime fromDateUtc, DateTime? toDateUtc, int page, int pageSize, CancellationToken ct = default);
 
         /// <summary>
         /// Add a dependent to the given hdId of the delegate (parent or guardian).

--- a/Apps/GatewayApi/src/Services/IDependentService.cs
+++ b/Apps/GatewayApi/src/Services/IDependentService.cs
@@ -33,8 +33,9 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="hdid">The users HDID.</param>
         /// <param name="page">The page of data to fetch indexed from 0.</param>
         /// <param name="pageSize">The amount of records per page.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A List of dependents wrapped in a RequestResult.</returns>
-        Task<RequestResult<IEnumerable<DependentModel>>> GetDependentsAsync(string hdid, int page = 0, int pageSize = 25);
+        Task<RequestResult<IEnumerable<DependentModel>>> GetDependentsAsync(string hdid, int page = 0, int pageSize = 25, CancellationToken ct = default);
 
         /// <summary>
         /// Gets all the dependents for the given date range.
@@ -51,7 +52,7 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="delegateHdid">The HdId of the Delegate (parent or guardian).</param>
         /// <param name="addDependentRequest">The request to create a User Delegate model.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dependent model wrapped in a RequestResult.</returns>
         Task<RequestResult<DependentModel>> AddDependentAsync(string delegateHdid, AddDependentRequest addDependentRequest, CancellationToken ct = default);
 
@@ -59,7 +60,7 @@ namespace HealthGateway.GatewayApi.Services
         /// Removes a dependent delegate relation.
         /// </summary>
         /// <param name="dependent">The dependent model to be deleted.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A dependent model wrapped in a RequestResult.</returns>
         Task<RequestResult<DependentModel>> RemoveAsync(DependentModel dependent, CancellationToken ct = default);
     }

--- a/Apps/GatewayApi/src/Services/INoteService.cs
+++ b/Apps/GatewayApi/src/Services/INoteService.cs
@@ -16,6 +16,8 @@
 namespace HealthGateway.GatewayApi.Services
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
 
@@ -28,8 +30,9 @@ namespace HealthGateway.GatewayApi.Services
         /// Creates a note in the backend.
         /// </summary>
         /// <param name="userNote">The note to create.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A note wrapped in a RequestResult.</returns>
-        RequestResult<UserNote> CreateNote(UserNote userNote);
+        Task<RequestResult<UserNote>> CreateNoteAsync(UserNote userNote, CancellationToken ct = default);
 
         /// <summary>
         /// Gets all the notes for the given hdId.
@@ -37,22 +40,25 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="hdId">The users HDID.</param>
         /// <param name="page">The page of data to fetch indexed from 0.</param>
         /// <param name="pageSize">The amount of records per page.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A List of notes wrapped in a RequestResult.</returns>
-        RequestResult<IEnumerable<UserNote>> GetNotes(string hdId, int page = 0, int pageSize = 500);
+        Task<RequestResult<IEnumerable<UserNote>>> GetNotesAsync(string hdId, int page = 0, int pageSize = 500, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the given note in the backend.
         /// Any changes to HDID will be ignored.
         /// </summary>
         /// <param name="userNote">The note to update.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The updated Note.</returns>
-        RequestResult<UserNote> UpdateNote(UserNote userNote);
+        Task<RequestResult<UserNote>> UpdateNoteAsync(UserNote userNote, CancellationToken ct = default);
 
         /// <summary>
         /// Deletes the given note from the backend.
         /// </summary>
         /// <param name="userNote">The note to delete.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The deleted note wrapped in a RequestResult.</returns>
-        RequestResult<UserNote> DeleteNote(UserNote userNote);
+        Task<RequestResult<UserNote>> DeleteNoteAsync(UserNote userNote, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IReportService.cs
+++ b/Apps/GatewayApi/src/Services/IReportService.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.Services
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.GatewayApi.Models;
@@ -28,7 +30,8 @@ namespace HealthGateway.GatewayApi.Services
         /// Gets a report based on the request provided.
         /// </summary>
         /// <param name="reportRequest">The report request model.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The report data.</returns>
-        RequestResult<ReportModel> GetReport(ReportRequestModel reportRequest);
+        Task<RequestResult<ReportModel>> GetReportAsync(ReportRequestModel reportRequest, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IUserFeedbackService.cs
+++ b/Apps/GatewayApi/src/Services/IUserFeedbackService.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.Services
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -28,14 +30,16 @@ namespace HealthGateway.GatewayApi.Services
         /// Saves the user feedback to the database.
         /// </summary>
         /// <param name="userFeedback">The user feedback model to be saved.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user feedback.</returns>
-        DbResult<UserFeedback> CreateUserFeedback(UserFeedback userFeedback);
+        Task<DbResult<UserFeedback>> CreateUserFeedbackAsync(UserFeedback userFeedback, CancellationToken ct = default);
 
         /// <summary>
         /// Saves the rating to the database.
         /// </summary>
         /// <param name="rating">The rating model to be saved.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped rating.</returns>
-        RequestResult<Rating> CreateRating(Rating rating);
+        Task<RequestResult<Rating>> CreateRatingAsync(Rating rating, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IUserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileService.cs
@@ -32,8 +32,9 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
         /// <param name="jwtAuthTime">The date of last jwt authorization time.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user profile.</returns>
-        Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, DateTime jwtAuthTime);
+        Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default);
 
         /// <summary>
         /// Saves the user profile to the database.
@@ -41,72 +42,81 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="createProfileRequest">The request to create a user profile model.</param>
         /// <param name="jwtAuthTime">The date of last jwt authorization time.</param>
         /// <param name="jwtEmailAddress">The email address contained by the jwt.</param>
-        /// <param name="ct">A cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user profile.</returns>
-        Task<RequestResult<UserProfileModel>> CreateUserProfile(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default);
+        Task<RequestResult<UserProfileModel>> CreateUserProfileAsync(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default);
 
         /// <summary>
         /// Closed the user profile.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
         /// <param name="userId">The user id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user profile.</returns>
-        RequestResult<UserProfileModel> CloseUserProfile(string hdid, Guid userId);
+        Task<RequestResult<UserProfileModel>> CloseUserProfileAsync(string hdid, Guid userId, CancellationToken ct = default);
 
         /// <summary>
         /// Recovers the user profile.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user profile.</returns>
-        RequestResult<UserProfileModel> RecoverUserProfile(string hdid);
+        Task<RequestResult<UserProfileModel>> RecoverUserProfileAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the most recent active terms of service.
         /// </summary>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped terms of service.</returns>
-        RequestResult<TermsOfServiceModel> GetActiveTermsOfService();
+        Task<RequestResult<TermsOfServiceModel>> GetActiveTermsOfServiceAsync(CancellationToken ct = default);
 
         /// <summary>
         /// Updates a User Preference in the backend.
         /// </summary>
         /// <param name="userPreferenceModel">The user preference to update.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A userPreference wrapped in a RequestResult.</returns>
-        RequestResult<UserPreferenceModel> UpdateUserPreference(UserPreferenceModel userPreferenceModel);
+        Task<RequestResult<UserPreferenceModel>> UpdateUserPreferenceAsync(UserPreferenceModel userPreferenceModel, CancellationToken ct = default);
 
         /// <summary>
         /// Create a User Preference in the backend.
         /// </summary>
         /// <param name="userPreferenceModel">The user preference to create.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A userPreference wrapped in a RequestResult.</returns>
-        RequestResult<UserPreferenceModel> CreateUserPreference(UserPreferenceModel userPreferenceModel);
+        Task<RequestResult<UserPreferenceModel>> CreateUserPreferenceAsync(UserPreferenceModel userPreferenceModel, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the user preference model.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user reference.</returns>
-        RequestResult<Dictionary<string, UserPreferenceModel>> GetUserPreferences(string hdid);
+        Task<RequestResult<Dictionary<string, UserPreferenceModel>>> GetUserPreferencesAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a value indicating if the patient age is valid for registration.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A boolean result.</returns>
-        Task<RequestResult<bool>> ValidateMinimumAge(string hdid);
+        Task<RequestResult<bool>> ValidateMinimumAgeAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the user profile and sets the accepted terms of service to the supplied value.
         /// </summary>
         /// <param name="hdid">The users hdid.</param>
         /// <param name="termsOfServiceId">The terms of service id accepted.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A user profile model wrapped in a RequestResult.</returns>
-        RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, Guid termsOfServiceId);
+        Task<RequestResult<UserProfileModel>> UpdateAcceptedTermsAsync(string hdid, Guid termsOfServiceId, CancellationToken ct = default);
 
         /// <summary>
         /// Validates a phone number against the system wide accepted number validation logic.
         /// </summary>
         /// <param name="phoneNumber">This should be a phone number without a mask.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>True if the phone number is valid.</returns>
-        bool IsPhoneNumberValid(string phoneNumber);
+        Task<bool> IsPhoneNumberValid(string phoneNumber, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IWebAlertService.cs
+++ b/Apps/GatewayApi/src/Services/IWebAlertService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.GatewayApi.Models;
 
@@ -29,22 +30,25 @@ namespace HealthGateway.GatewayApi.Services
         /// Gets all web alerts for a user.
         /// </summary>
         /// <param name="hdid">The HDID of the user.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The list of web alerts for the user.</returns>
-        Task<IList<WebAlert>> GetWebAlertsAsync(string hdid);
+        Task<IList<WebAlert>> GetWebAlertsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Dismisses all web alert for a user.
         /// </summary>
         /// <param name="hdid">The HDID of the user.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task DismissWebAlertsAsync(string hdid);
+        Task DismissWebAlertsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Dismisses a web alert for a user.
         /// </summary>
         /// <param name="hdid">The HDID of the user.</param>
         /// <param name="webAlertId">The ID of the web alert to be dismissed.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task DismissWebAlertAsync(string hdid, Guid webAlertId);
+        Task DismissWebAlertAsync(string hdid, Guid webAlertId, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/NoteService.cs
+++ b/Apps/GatewayApi/src/Services/NoteService.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<UserNote>> CreateNoteAsync(UserNote userNote, CancellationToken ct = default)
         {
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userNote.HdId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userNote.HdId, ct);
             string? key = profile?.EncryptionKey;
             if (key == null)
             {
@@ -110,7 +110,7 @@ namespace HealthGateway.GatewayApi.Services
             int offset = page * pageSize;
             DbResult<IList<Note>> dbNotes = await this.noteDelegate.GetNotesAsync(hdId, offset, pageSize, ct);
 
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(hdId, ct);
             string? key = profile?.EncryptionKey;
 
             // If there is no key yet, generate one and store it in the profile. Only valid while not all profiles have a encryption key.
@@ -136,7 +136,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<UserNote>> UpdateNoteAsync(UserNote userNote, CancellationToken ct = default)
         {
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userNote.HdId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userNote.HdId, ct);
             string? key = profile?.EncryptionKey;
             if (key == null)
             {
@@ -158,7 +158,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<UserNote>> DeleteNoteAsync(UserNote userNote, CancellationToken ct = default)
         {
-            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userNote.HdId);
+            UserProfile? profile = await this.profileDelegate.GetUserProfileAsync(userNote.HdId, ct);
             string? key = profile?.EncryptionKey;
             if (key == null)
             {

--- a/Apps/GatewayApi/src/Services/ReportService.cs
+++ b/Apps/GatewayApi/src/Services/ReportService.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.GatewayApi.Services
     using System.Globalization;
     using System.IO;
     using System.Reflection;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.ViewModels;
@@ -45,7 +46,7 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<ReportModel> GetReport(ReportRequestModel reportRequest)
+        public async Task<RequestResult<ReportModel>> GetReportAsync(ReportRequestModel reportRequest, CancellationToken ct = default)
         {
             this.logger.LogTrace("New report request type: {Type} and template: {Template}", reportRequest.Type, reportRequest.Template);
 
@@ -66,7 +67,7 @@ namespace HealthGateway.GatewayApi.Services
                 },
             };
 
-            RequestResult<ReportModel> retVal = Task.Run(async () => await this.cdogsDelegate.GenerateReportAsync(cdogsRequest).ConfigureAwait(true)).Result;
+            RequestResult<ReportModel> retVal = await this.cdogsDelegate.GenerateReportAsync(cdogsRequest);
             this.logger.LogTrace("Finished generating report: {ReportFileName}", retVal.ResourcePayload?.FileName);
             return retVal;
         }

--- a/Apps/GatewayApi/src/Services/ReportService.cs
+++ b/Apps/GatewayApi/src/Services/ReportService.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.GatewayApi.Services
                 },
             };
 
-            RequestResult<ReportModel> retVal = await this.cdogsDelegate.GenerateReportAsync(cdogsRequest);
+            RequestResult<ReportModel> retVal = await this.cdogsDelegate.GenerateReportAsync(cdogsRequest, ct);
             this.logger.LogTrace("Finished generating report: {ReportFileName}", retVal.ResourcePayload?.FileName);
             return retVal;
         }

--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -90,7 +90,7 @@ namespace HealthGateway.GatewayApi.Services
         public async Task<RequestResult<bool>> ValidateEmailAsync(string hdid, Guid inviteKey, CancellationToken ct = default)
         {
             this.logger.LogTrace("Validating email... {InviteKey}", inviteKey);
-            MessagingVerification? matchingVerification = this.messageVerificationDelegate.GetLastByInviteKey(inviteKey);
+            MessagingVerification? matchingVerification = await this.messageVerificationDelegate.GetLastByInviteKeyAsync(inviteKey, ct);
             UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid);
             if (userProfile == null ||
                 matchingVerification == null ||
@@ -98,7 +98,7 @@ namespace HealthGateway.GatewayApi.Services
                 matchingVerification.Deleted)
             {
                 // Invalid Verification Attempt
-                MessagingVerification? lastEmailVerification = this.messageVerificationDelegate.GetLastForUser(hdid, MessagingVerificationType.Email);
+                MessagingVerification? lastEmailVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
                 if (lastEmailVerification is { Validated: false })
                 {
                     lastEmailVerification.VerificationAttempts++;
@@ -153,7 +153,7 @@ namespace HealthGateway.GatewayApi.Services
             matchingVerification.Validated = true;
             await this.messageVerificationDelegate.UpdateAsync(matchingVerification, !this.notificationsChangeFeedEnabled, ct);
             userProfile.Email = matchingVerification.Email!.To; // Gets the user email from the email sent.
-            this.profileDelegate.Update(userProfile, !this.notificationsChangeFeedEnabled);
+            await this.profileDelegate.UpdateAsync(userProfile, !this.notificationsChangeFeedEnabled, ct);
 
             if (this.notificationsChangeFeedEnabled)
             {
@@ -165,7 +165,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             // Update the notification settings
-            this.notificationSettingsService.QueueNotificationSettings(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber));
+            await this.notificationSettingsService.QueueNotificationSettingsAsync(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber), ct);
 
             this.logger.LogDebug("Email validated");
 
@@ -182,7 +182,7 @@ namespace HealthGateway.GatewayApi.Services
         public async Task<bool> CreateUserEmailAsync(string hdid, string emailAddress, bool isVerified, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Creating user email...");
-            await this.AddVerificationEmail(hdid, emailAddress, Guid.NewGuid(), isVerified, commit);
+            await this.AddVerificationEmailAsync(hdid, emailAddress, Guid.NewGuid(), isVerified, commit, ct);
             this.logger.LogDebug("Finished creating user email");
             return true;
         }
@@ -215,13 +215,13 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             this.logger.LogInformation("Removing email from user {Hdid}", hdid);
-            this.profileDelegate.Update(userProfile);
+            await this.profileDelegate.UpdateAsync(userProfile, ct: ct);
             userProfile.Email = null;
 
             // Update the notification settings
-            this.notificationSettingsService.QueueNotificationSettings(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber));
+            await this.notificationSettingsService.QueueNotificationSettingsAsync(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber), ct);
 
-            MessagingVerification? lastEmailVerification = this.messageVerificationDelegate.GetLastForUser(hdid, MessagingVerificationType.Email);
+            MessagingVerification? lastEmailVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
             if (lastEmailVerification != null)
             {
                 this.logger.LogInformation("Expiring old email validation for user {Hdid}", hdid);
@@ -235,17 +235,17 @@ namespace HealthGateway.GatewayApi.Services
                         && !string.IsNullOrEmpty(lastEmailVerification.Email.To)
                         && emailAddress.Equals(lastEmailVerification.Email.To, StringComparison.OrdinalIgnoreCase))
                     {
-                        await this.AddVerificationEmail(hdid, emailAddress, lastEmailVerification.InviteKey!.Value);
+                        await this.AddVerificationEmailAsync(hdid, emailAddress, lastEmailVerification.InviteKey!.Value, ct: ct);
                     }
                     else
                     {
-                        await this.AddVerificationEmail(hdid, emailAddress, Guid.NewGuid());
+                        await this.AddVerificationEmailAsync(hdid, emailAddress, Guid.NewGuid(), ct: ct);
                     }
                 }
             }
             else
             {
-                await this.AddVerificationEmail(hdid, emailAddress, Guid.NewGuid());
+                await this.AddVerificationEmailAsync(hdid, emailAddress, Guid.NewGuid(), ct: ct);
             }
 
             this.logger.LogDebug("Finished updating user email");
@@ -253,7 +253,7 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         [ExcludeFromCodeCoverage]
-        private async Task AddVerificationEmail(string hdid, string toEmail, Guid inviteKey, bool isVerified = false, bool commit = true)
+        private async Task AddVerificationEmailAsync(string hdid, string toEmail, Guid inviteKey, bool isVerified = false, bool commit = true, CancellationToken ct = default)
         {
             float verificationExpiryHours = (float)this.emailVerificationExpirySeconds / 3600;
 
@@ -276,13 +276,13 @@ namespace HealthGateway.GatewayApi.Services
             if (isVerified)
             {
                 messageVerification.Email.EmailStatusCode = EmailStatus.Processed;
-                await this.messageVerificationDelegate.InsertAsync(messageVerification, commit);
-                await this.ValidateEmailAsync(hdid, inviteKey);
+                await this.messageVerificationDelegate.InsertAsync(messageVerification, commit, ct);
+                await this.ValidateEmailAsync(hdid, inviteKey, ct);
             }
             else
             {
-                await this.messageVerificationDelegate.InsertAsync(messageVerification);
-                this.emailQueueService.QueueNewEmail(messageVerification.Email);
+                await this.messageVerificationDelegate.InsertAsync(messageVerification, ct: ct);
+                await this.emailQueueService.QueueNewEmailAsync(messageVerification.Email, ct: ct);
             }
         }
     }

--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -91,7 +91,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Validating email... {InviteKey}", inviteKey);
             MessagingVerification? matchingVerification = await this.messageVerificationDelegate.GetLastByInviteKeyAsync(inviteKey, ct);
-            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, ct);
             if (userProfile == null ||
                 matchingVerification == null ||
                 matchingVerification.UserProfileId != hdid ||
@@ -193,7 +193,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Updating user email...");
 
-            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, ct);
             if (userProfile == null)
             {
                 throw new ProblemDetailsException(

--- a/Apps/GatewayApi/src/Services/UserFeedbackService.cs
+++ b/Apps/GatewayApi/src/Services/UserFeedbackService.cs
@@ -66,7 +66,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Creating user feedback...");
             DbResult<UserFeedback> retVal = await this.feedbackDelegate.InsertUserFeedbackAsync(userFeedback, ct);
-            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(userFeedback.UserProfileId);
+            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(userFeedback.UserProfileId, ct);
             string? clientEmail = userProfile?.Email;
             if (!string.IsNullOrWhiteSpace(clientEmail))
             {

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading;
@@ -148,14 +147,13 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        [SuppressMessage("Performance", "CA1849:Call async methods when in an async method", Justification = "Requires refactoring")]
-        public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, DateTime jwtAuthTime)
+        public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting user profile... {Hdid}", hdid);
-            DbResult<UserProfile> userProfileDbResult = this.userProfileDelegate.GetUserProfile(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
             this.logger.LogDebug("Finished getting user profile...{Hdid}", hdid);
 
-            if (userProfileDbResult.Status == DbStatusCode.NotFound)
+            if (userProfile == null)
             {
                 return new RequestResult<UserProfileModel>
                 {
@@ -164,71 +162,72 @@ namespace HealthGateway.GatewayApi.Services
                 };
             }
 
-            DateTime previousLastLogin = userProfileDbResult.Payload.LastLoginDateTime;
+            DateTime previousLastLogin = userProfile.LastLoginDateTime;
             if (DateTime.Compare(previousLastLogin, jwtAuthTime) != 0)
             {
                 this.logger.LogTrace("Updating user last login and year of birth... {Hdid}", hdid);
-                userProfileDbResult.Payload.LastLoginDateTime = jwtAuthTime;
-                userProfileDbResult.Payload.LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType();
+                userProfile.LastLoginDateTime = jwtAuthTime;
+                userProfile.LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType();
 
                 // Update user year of birth.
-                RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid).ConfigureAwait(true);
+                RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
                 DateTime? birthDate = patientResult.ResourcePayload?.Birthdate;
-                userProfileDbResult.Payload.YearOfBirth = birthDate?.Year;
+                userProfile.YearOfBirth = birthDate?.Year;
 
-                this.userProfileDelegate.Update(userProfileDbResult.Payload);
+                DbResult<UserProfile> updateResult = await this.userProfileDelegate.UpdateAsync(userProfile, ct: ct);
+
+                if (updateResult.Status != DbStatusCode.Updated)
+                {
+                    this.logger.LogError("Error updating user profile... {Hdid}", updateResult.Payload.HdId);
+                    return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, updateResult.Message);
+                }
+
                 this.logger.LogDebug("Finished updating user last login and year of birth... {Hdid}", hdid);
             }
 
-            DbResult<IEnumerable<UserProfileHistory>> userProfileHistoryDbResult =
-                this.userProfileDelegate.GetUserProfileHistories(hdid, this.userProfileHistoryRecordLimit);
-            UserProfileModel userProfile = this.BuildUserProfileModel(userProfileDbResult.Payload, userProfileHistoryDbResult.Payload.ToArray());
+            IList<UserProfileHistory> userProfileHistoryList =
+                await this.userProfileDelegate.GetUserProfileHistoryListAsync(hdid, this.userProfileHistoryRecordLimit, ct);
+            UserProfileModel userProfileModel = await this.BuildUserProfileModelAsync(userProfile, [.. userProfileHistoryList], ct);
 
             // Populate most recent login date time
-            userProfile.LastLoginDateTimes.Add(userProfileDbResult.Payload.LastLoginDateTime);
-            foreach (UserProfileHistory userProfileHistory in userProfileHistoryDbResult.Payload)
+            userProfileModel.LastLoginDateTimes.Add(userProfile.LastLoginDateTime);
+            foreach (UserProfileHistory userProfileHistory in userProfileHistoryList)
             {
-                userProfile.LastLoginDateTimes.Add(userProfileHistory.LastLoginDateTime);
+                userProfileModel.LastLoginDateTimes.Add(userProfileHistory.LastLoginDateTime);
             }
 
-            if (!userProfile.IsEmailVerified)
+            if (!userProfileModel.IsEmailVerified)
             {
                 this.logger.LogTrace("Retrieving last email invite... {Hdid}", hdid);
                 MessagingVerification? emailInvite =
-                    this.messageVerificationDelegate.GetLastForUser(hdid, MessagingVerificationType.Email);
+                    await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
                 this.logger.LogDebug("Finished retrieving email invite... {Hdid}", hdid);
-                userProfile.Email = emailInvite?.Email?.To;
+                userProfileModel.Email = emailInvite?.Email?.To;
             }
 
-            if (!userProfile.IsSmsNumberVerified)
+            if (!userProfileModel.IsSmsNumberVerified)
             {
                 this.logger.LogTrace("Retrieving last sms invite... {Hdid}", hdid);
                 MessagingVerification? smsInvite =
-                    this.messageVerificationDelegate.GetLastForUser(hdid, MessagingVerificationType.Sms);
+                    await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Sms, ct);
                 this.logger.LogDebug("Finished retrieving sms invite... {Hdid}", hdid);
-                userProfile.SmsNumber = smsInvite?.SmsNumber;
+                userProfileModel.SmsNumber = smsInvite?.SmsNumber;
             }
 
             return new RequestResult<UserProfileModel>
             {
-                ResultStatus = userProfileDbResult.Status != DbStatusCode.Error ? ResultType.Success : ResultType.Error,
-                ResultError = userProfileDbResult.Status != DbStatusCode.Error
-                    ? null
-                    : new RequestResultError
-                    {
-                        ResultMessage = userProfileDbResult.Message,
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
-                    },
-                ResourcePayload = userProfile,
+                ResultStatus = ResultType.Success,
+                ResultError = null,
+                ResourcePayload = userProfileModel,
             };
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<UserProfileModel>> CreateUserProfile(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default)
+        public async Task<RequestResult<UserProfileModel>> CreateUserProfileAsync(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default)
         {
             this.logger.LogTrace("Creating user profile... {Hdid}", createProfileRequest.Profile.HdId);
 
-            RequestResult<UserProfileModel>? validationResult = await this.ValidateUserProfile(createProfileRequest).ConfigureAwait(true);
+            RequestResult<UserProfileModel>? validationResult = await this.ValidateUserProfileAsync(createProfileRequest, ct);
             if (validationResult != null)
             {
                 return validationResult;
@@ -236,7 +235,7 @@ namespace HealthGateway.GatewayApi.Services
 
             string hdid = createProfileRequest.Profile.HdId;
 
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
             DateTime? birthDate = patientResult.ResourcePayload?.Birthdate;
 
             // Create profile
@@ -276,7 +275,7 @@ namespace HealthGateway.GatewayApi.Services
             string? requestedSmsNumber = createProfileRequest.Profile.SmsNumber;
             string? requestedEmail = createProfileRequest.Profile.Email;
 
-            UserProfileModel userProfileModel = this.BuildUserProfileModel(dbModel);
+            UserProfileModel userProfileModel = await this.BuildUserProfileModelAsync(dbModel, ct: ct);
 
             NotificationSettingsRequest notificationRequest = new(dbModel, requestedEmail, requestedSmsNumber);
 
@@ -305,7 +304,7 @@ namespace HealthGateway.GatewayApi.Services
                 userProfileModel.SmsNumber = requestedSmsNumber;
             }
 
-            this.notificationSettingsService.QueueNotificationSettings(notificationRequest);
+            await this.notificationSettingsService.QueueNotificationSettingsAsync(notificationRequest, ct);
 
             this.logger.LogDebug("Finished creating user profile... {Hdid}", insertResult.Payload.HdId);
 
@@ -313,87 +312,72 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserProfileModel> CloseUserProfile(string hdid, Guid userId)
+        public async Task<RequestResult<UserProfileModel>> CloseUserProfileAsync(string hdid, Guid userId, CancellationToken ct = default)
         {
             this.logger.LogTrace("Closing user profile... {Hdid}", hdid);
 
-            DbResult<UserProfile> retrieveResult = this.userProfileDelegate.GetUserProfile(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
 
-            if (retrieveResult.Status != DbStatusCode.Read)
+            if (userProfile == null)
             {
-                return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, retrieveResult.Message);
+                return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, ErrorMessages.UserProfileNotFound);
             }
 
-            UserProfile profile = retrieveResult.Payload;
-            if (profile.ClosedDateTime != null)
+            if (userProfile.ClosedDateTime != null)
             {
                 this.logger.LogTrace("Finished. Profile already Closed");
-                return RequestResultFactory.Success(this.BuildUserProfileModel(profile));
+                return RequestResultFactory.Success(await this.BuildUserProfileModelAsync(userProfile, ct: ct));
             }
 
-            profile.ClosedDateTime = DateTime.UtcNow;
-            profile.IdentityManagementId = userId;
-            DbResult<UserProfile> updateResult = this.userProfileDelegate.Update(profile);
-            if (!string.IsNullOrWhiteSpace(profile.Email))
-            {
-                this.QueueEmail(profile.Email, EmailTemplateName.AccountClosedTemplate);
-            }
-
-            return RequestResultFactory.Success(this.BuildUserProfileModel(updateResult.Payload));
+            userProfile.ClosedDateTime = DateTime.UtcNow;
+            userProfile.IdentityManagementId = userId;
+            DbResult<UserProfile> updateResult = await this.userProfileDelegate.UpdateAsync(userProfile, ct: ct);
+            return await this.HandleUpdateUserProfileResult(updateResult, EmailTemplateName.AccountClosedTemplate, ct);
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserProfileModel> RecoverUserProfile(string hdid)
+        public async Task<RequestResult<UserProfileModel>> RecoverUserProfileAsync(string hdid, CancellationToken ct = default)
         {
             this.logger.LogTrace("Recovering user profile... {Hdid}", hdid);
 
-            DbResult<UserProfile> retrieveResult = this.userProfileDelegate.GetUserProfile(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
 
-            if (retrieveResult.Status != DbStatusCode.Read)
+            if (userProfile == null)
             {
-                return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, retrieveResult.Message);
+                return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, ErrorMessages.UserProfileNotFound);
             }
 
-            UserProfile profile = retrieveResult.Payload;
-            if (profile.ClosedDateTime == null)
+            if (userProfile.ClosedDateTime == null)
             {
                 this.logger.LogTrace("Finished. Profile already is active, recover not needed");
-                return RequestResultFactory.Success(this.BuildUserProfileModel(profile));
+                return RequestResultFactory.Success(await this.BuildUserProfileModelAsync(userProfile, ct: ct));
             }
 
             // Remove values set for deletion
-            profile.ClosedDateTime = null;
-            profile.IdentityManagementId = null;
-            DbResult<UserProfile> updateResult = this.userProfileDelegate.Update(profile);
-            if (!string.IsNullOrWhiteSpace(profile.Email))
-            {
-                this.QueueEmail(profile.Email, EmailTemplateName.AccountRecoveredTemplate);
-            }
-
-            return RequestResultFactory.Success(this.BuildUserProfileModel(updateResult.Payload));
+            userProfile.ClosedDateTime = null;
+            userProfile.IdentityManagementId = null;
+            DbResult<UserProfile> updateResult = await this.userProfileDelegate.UpdateAsync(userProfile, true, ct);
+            await this.HandleUpdateUserProfileResult(updateResult, EmailTemplateName.AccountRecoveredTemplate, ct);
+            return RequestResultFactory.Success(await this.BuildUserProfileModelAsync(updateResult.Payload, ct: ct));
         }
 
         /// <inheritdoc/>
-        public RequestResult<TermsOfServiceModel> GetActiveTermsOfService()
+        public async Task<RequestResult<TermsOfServiceModel>> GetActiveTermsOfServiceAsync(CancellationToken ct = default)
         {
-            DbResult<LegalAgreement> retVal = this.legalAgreementDelegate.GetActiveByAgreementType(LegalAgreementType.TermsOfService);
-
-            if (retVal.Status == DbStatusCode.Error)
-            {
-                return RequestResultFactory.ServiceError<TermsOfServiceModel>(ErrorType.CommunicationInternal, ServiceType.Database, retVal.Message);
-            }
-
-            return RequestResultFactory.Success(this.autoMapper.Map<TermsOfServiceModel>(retVal.Payload));
+            LegalAgreement? legalAgreement = await this.legalAgreementDelegate.GetActiveByAgreementTypeAsync(LegalAgreementType.TermsOfService, ct);
+            return legalAgreement == null
+                ? RequestResultFactory.ServiceError<TermsOfServiceModel>(ErrorType.CommunicationInternal, ServiceType.Database, ErrorMessages.LegalAgreementNotFound)
+                : RequestResultFactory.Success(this.autoMapper.Map<TermsOfServiceModel>(legalAgreement));
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserPreferenceModel> UpdateUserPreference(UserPreferenceModel userPreferenceModel)
+        public async Task<RequestResult<UserPreferenceModel>> UpdateUserPreferenceAsync(UserPreferenceModel userPreferenceModel, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating user preference... {Preference} for {Hdid}", userPreferenceModel.Preference, userPreferenceModel.HdId);
 
             UserPreference userPreference = this.autoMapper.Map<UserPreference>(userPreferenceModel);
 
-            DbResult<UserPreference> dbResult = this.userPreferenceDelegate.UpdateUserPreference(userPreference);
+            DbResult<UserPreference> dbResult = await this.userPreferenceDelegate.UpdateUserPreferenceAsync(userPreference, ct: ct);
 
             if (dbResult.Status != DbStatusCode.Updated)
             {
@@ -404,11 +388,11 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserPreferenceModel> CreateUserPreference(UserPreferenceModel userPreferenceModel)
+        public async Task<RequestResult<UserPreferenceModel>> CreateUserPreferenceAsync(UserPreferenceModel userPreferenceModel, CancellationToken ct = default)
         {
             this.logger.LogTrace("Creating user preference... {Preference} for {Hdid}", userPreferenceModel.Preference, userPreferenceModel.HdId);
             UserPreference userPreference = this.autoMapper.Map<UserPreference>(userPreferenceModel);
-            DbResult<UserPreference> dbResult = this.userPreferenceDelegate.CreateUserPreference(userPreference);
+            DbResult<UserPreference> dbResult = await this.userPreferenceDelegate.CreateUserPreferenceAsync(userPreference, ct: ct);
 
             if (dbResult.Status != DbStatusCode.Created)
             {
@@ -419,28 +403,22 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<Dictionary<string, UserPreferenceModel>> GetUserPreferences(string hdid)
+        public async Task<RequestResult<Dictionary<string, UserPreferenceModel>>> GetUserPreferencesAsync(string hdid, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting user preference... {Hdid}", hdid);
-            DbResult<IEnumerable<UserPreference>> dbResult = this.userPreferenceDelegate.GetUserPreferences(hdid);
-
-            if (dbResult.Status != DbStatusCode.Read)
-            {
-                return RequestResultFactory.ServiceError<Dictionary<string, UserPreferenceModel>>(ErrorType.CommunicationInternal, ServiceType.Database, dbResult.Message);
-            }
-
-            return RequestResultFactory.Success(this.autoMapper.Map<IEnumerable<UserPreferenceModel>>(dbResult.Payload).ToDictionary(x => x.Preference, x => x));
+            IEnumerable<UserPreference> userPreferences = await this.userPreferenceDelegate.GetUserPreferencesAsync(hdid, ct);
+            return RequestResultFactory.Success(this.autoMapper.Map<IEnumerable<UserPreferenceModel>>(userPreferences).ToDictionary(x => x.Preference, x => x));
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<bool>> ValidateMinimumAge(string hdid)
+        public async Task<RequestResult<bool>> ValidateMinimumAgeAsync(string hdid, CancellationToken ct = default)
         {
             if (this.minPatientAge == 0)
             {
                 return RequestResultFactory.Success(true);
             }
 
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
 
             if (patientResult.ResultStatus != ResultType.Success || patientResult.ResourcePayload == null)
             {
@@ -454,42 +432,42 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public RequestResult<UserProfileModel> UpdateAcceptedTerms(string hdid, Guid termsOfServiceId)
+        public async Task<RequestResult<UserProfileModel>> UpdateAcceptedTermsAsync(string hdid, Guid termsOfServiceId, CancellationToken ct = default)
         {
-            DbResult<UserProfile> profileResult = this.userProfileDelegate.GetUserProfile(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
 
-            if (profileResult.Status != DbStatusCode.Read)
+            if (userProfile == null)
             {
                 return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, "Unable to retrieve user profile");
             }
 
-            profileResult.Payload.TermsOfServiceId = termsOfServiceId;
-            profileResult = this.userProfileDelegate.Update(profileResult.Payload);
-            if (profileResult.Status != DbStatusCode.Updated)
+            userProfile.TermsOfServiceId = termsOfServiceId;
+            DbResult<UserProfile> result = await this.userProfileDelegate.UpdateAsync(userProfile, ct: ct);
+            if (result.Status != DbStatusCode.Updated)
             {
                 return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, "Unable to update the terms of service: DB Error");
             }
 
-            return RequestResultFactory.Success(this.BuildUserProfileModel(profileResult.Payload));
+            return RequestResultFactory.Success(await this.BuildUserProfileModelAsync(result.Payload, ct: ct));
         }
 
         /// <inheritdoc/>
-        public bool IsPhoneNumberValid(string phoneNumber)
+        public async Task<bool> IsPhoneNumberValid(string phoneNumber, CancellationToken ct = default)
         {
-            return UserProfileValidator.ValidateUserProfileSmsNumber(phoneNumber);
+            return await UserProfileValidator.ValidateUserProfileSmsNumberAsync(phoneNumber, ct);
         }
 
-        private void QueueEmail(string toEmail, string templateName)
+        private async Task QueueEmailAsync(string toEmail, string templateName, CancellationToken ct)
         {
             Dictionary<string, string> keyValues = new() { [EmailTemplateVariable.Host] = this.emailTemplateConfig.Host };
-            this.emailQueueService.QueueNewEmail(toEmail, templateName, keyValues);
+            await this.emailQueueService.QueueNewEmailAsync(toEmail, templateName, keyValues, ct: ct);
         }
 
-        private async Task<RequestResult<UserProfileModel>?> ValidateUserProfile(CreateUserRequest createProfileRequest)
+        private async Task<RequestResult<UserProfileModel>?> ValidateUserProfileAsync(CreateUserRequest createProfileRequest, CancellationToken ct)
         {
             // Validate registration age
             string hdid = createProfileRequest.Profile.HdId;
-            RequestResult<bool> isMinimumAgeResult = await this.ValidateMinimumAge(hdid).ConfigureAwait(true);
+            RequestResult<bool> isMinimumAgeResult = await this.ValidateMinimumAgeAsync(hdid, ct);
             if (isMinimumAgeResult.ResultStatus != ResultType.Success)
             {
                 return RequestResultFactory.Error<UserProfileModel>(isMinimumAgeResult.ResultError);
@@ -502,7 +480,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             // Validate UserProfile inputs
-            ValidationResult profileValidationResult = await new UserProfileValidator().ValidateAsync(createProfileRequest.Profile);
+            ValidationResult profileValidationResult = await new UserProfileValidator().ValidateAsync(createProfileRequest.Profile, ct);
             if (!profileValidationResult.IsValid)
             {
                 this.logger.LogWarning("Profile inputs have failed validation for {Hdid}", createProfileRequest.Profile.HdId);
@@ -512,16 +490,16 @@ namespace HealthGateway.GatewayApi.Services
             return null;
         }
 
-        private UserProfileModel BuildUserProfileModel(UserProfile userProfile, UserProfileHistory[]? profileHistoryCollection = null)
+        private async Task<UserProfileModel> BuildUserProfileModelAsync(UserProfile userProfile, UserProfileHistory[]? profileHistoryCollection = null, CancellationToken ct = default)
         {
-            Guid? termsOfServiceId = this.GetActiveTermsOfService().ResourcePayload?.Id;
+            Guid? termsOfServiceId = (await this.legalAgreementDelegate.GetActiveByAgreementTypeAsync(LegalAgreementType.TermsOfService, ct))?.Id;
             DateTime? latestTourChangeDateTime = this.GetLatestTourChangeDateTime();
             UserProfileModel userProfileModel = UserProfileMapUtils.CreateFromDbModel(userProfile, termsOfServiceId, this.autoMapper);
             userProfileModel.HasTourUpdated = profileHistoryCollection != null &&
                                               profileHistoryCollection.Length != 0 &&
                                               latestTourChangeDateTime != null &&
                                               profileHistoryCollection.Max(x => x.LastLoginDateTime) < latestTourChangeDateTime;
-            userProfileModel.BlockedDataSources = this.patientRepository.GetDataSources(userProfile.HdId).Result;
+            userProfileModel.BlockedDataSources = await this.patientRepository.GetDataSources(userProfile.HdId, ct);
             return userProfileModel;
         }
 
@@ -538,6 +516,21 @@ namespace HealthGateway.GatewayApi.Services
                     return applicationSetting?.Value != null ? DateTime.Parse(applicationSetting.Value, CultureInfo.InvariantCulture).ToUniversalTime() : null;
                 },
                 TimeSpan.FromMinutes(30));
+        }
+
+        private async Task<RequestResult<UserProfileModel>> HandleUpdateUserProfileResult(DbResult<UserProfile> result, string emailTemplateName, CancellationToken ct)
+        {
+            if (result.Status == DbStatusCode.Updated)
+            {
+                if (!string.IsNullOrWhiteSpace(result.Payload.Email))
+                {
+                    await this.QueueEmailAsync(result.Payload.Email, emailTemplateName, ct);
+                }
+
+                return RequestResultFactory.Success(await this.BuildUserProfileModelAsync(result.Payload, ct: ct));
+            }
+
+            return RequestResultFactory.ServiceError<UserProfileModel>(ErrorType.CommunicationInternal, ServiceType.Database, result.Message);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -150,7 +150,7 @@ namespace HealthGateway.GatewayApi.Services
         public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting user profile... {Hdid}", hdid);
-            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct);
             this.logger.LogDebug("Finished getting user profile...{Hdid}", hdid);
 
             if (userProfile == null)
@@ -316,7 +316,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Closing user profile... {Hdid}", hdid);
 
-            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct);
 
             if (userProfile == null)
             {
@@ -340,7 +340,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Recovering user profile... {Hdid}", hdid);
 
-            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct);
 
             if (userProfile == null)
             {
@@ -434,7 +434,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task<RequestResult<UserProfileModel>> UpdateAcceptedTermsAsync(string hdid, Guid termsOfServiceId, CancellationToken ct = default)
         {
-            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct);
 
             if (userProfile == null)
             {

--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -86,7 +86,7 @@ namespace HealthGateway.GatewayApi.Services
             RequestResult<bool> retVal = new() { ResourcePayload = false, ResultStatus = ResultType.Success };
             MessagingVerification? smsVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Sms, ct);
 
-            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, ct);
             if (userProfile != null &&
                 smsVerification is { Validated: false, Deleted: false, VerificationAttempts: < MaxVerificationAttempts } &&
                 smsVerification.UserProfileId == hdid &&
@@ -150,7 +150,7 @@ namespace HealthGateway.GatewayApi.Services
                         nameof(UserSmsService)));
             }
 
-            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid);
+            UserProfile? userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, ct);
             if (userProfile == null)
             {
                 throw new ProblemDetailsException(

--- a/Apps/GatewayApi/src/Services/WebAlertService.cs
+++ b/Apps/GatewayApi/src/Services/WebAlertService.cs
@@ -60,7 +60,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Retrieving web alerts from PHSA");
-            Guid pid = await this.GetPersonalAccountPidByHdid(hdid, ct) ?? throw new InvalidOperationException($"No pid found for hdid {hdid}");
+            Guid pid = await this.GetPersonalAccountPidByHdidAsync(hdid, ct) ?? throw new InvalidOperationException($"No pid found for hdid {hdid}");
 
             IList<PhsaWebAlert> phsaWebAlerts = await this.webAlertApi.GetWebAlertsAsync(pid, ct);
             IList<WebAlert> webAlerts = this.autoMapper.Map<IEnumerable<PhsaWebAlert>, IList<WebAlert>>(
@@ -75,7 +75,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Sending request to dismiss web alerts to PHSA");
-            Guid pid = await this.GetPersonalAccountPidByHdid(hdid, ct) ?? throw new InvalidOperationException($"No pid found for hdid {hdid}");
+            Guid pid = await this.GetPersonalAccountPidByHdidAsync(hdid, ct) ?? throw new InvalidOperationException($"No pid found for hdid {hdid}");
 
             await this.webAlertApi.DeleteWebAlertsAsync(pid, ct);
             this.logger.LogDebug("Finished sending request to dismiss web alerts to PHSA");
@@ -86,13 +86,13 @@ namespace HealthGateway.GatewayApi.Services
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Sending request to dismiss web alert to PHSA");
-            Guid pid = await this.GetPersonalAccountPidByHdid(hdid, ct) ?? throw new InvalidOperationException($"No pid found for hdid {hdid}");
+            Guid pid = await this.GetPersonalAccountPidByHdidAsync(hdid, ct) ?? throw new InvalidOperationException($"No pid found for hdid {hdid}");
 
             await this.webAlertApi.DeleteWebAlertAsync(pid, webAlertId, ct);
             this.logger.LogDebug("Finished sending request to dismiss web alert to PHSA");
         }
 
-        private async Task<Guid?> GetPersonalAccountPidByHdid(string hdid, CancellationToken ct)
+        private async Task<Guid?> GetPersonalAccountPidByHdidAsync(string hdid, CancellationToken ct)
         {
             return (await this.personalAccountsService.GetPatientAccountAsync(hdid, ct)).PatientIdentity.Pid;
         }

--- a/Apps/GatewayApi/src/Validations/UserProfileValidator.cs
+++ b/Apps/GatewayApi/src/Validations/UserProfileValidator.cs
@@ -15,6 +15,8 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.Validations
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using FluentValidation;
     using HealthGateway.Common.Data.Models;
 
@@ -36,14 +38,16 @@ namespace HealthGateway.GatewayApi.Validations
         /// Convenience method to test sms phone number in the userprofile context.
         /// </summary>
         /// <param name="phoneNumber">Phone number for sms notifications.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>True if UserProfileValidator rules for SmsNumber member pass.</returns>
-        public static bool ValidateUserProfileSmsNumber(string? phoneNumber)
+        public static async Task<bool> ValidateUserProfileSmsNumberAsync(string? phoneNumber, CancellationToken ct = default)
         {
             UserProfile tempProfile = new()
             {
                 SmsNumber = phoneNumber,
             };
-            return new UserProfileValidator().Validate(tempProfile).IsValid;
+            bool isValid = (await new UserProfileValidator().ValidateAsync(tempProfile, ct)).IsValid;
+            return isValid;
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/CommentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/CommentControllerTests.cs
@@ -17,6 +17,8 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -37,8 +39,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Successfully Create Comment - Happy Path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateComment()
+        public async Task ShouldCreateComment()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -50,19 +53,21 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Add(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.AddAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(expectedResult));
 
-            CommentController service = new(commentServiceMock.Object);
+            CommentController controller = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Create(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await controller.Create(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
             expectedResult.ShouldDeepEqual(actualResult.Value);
         }
 
         /// <summary>
         /// Create Comment - Bad Request Error scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateCommentWithBadRequestError()
+        public async Task ShouldCreateCommentWithBadRequestError()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -71,11 +76,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Add(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.AddAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
-            CommentController service = new(commentServiceMock.Object);
+            CommentController controller = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Create(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await controller.Create(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
@@ -83,8 +88,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Update Comment - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateComment()
+        public async Task ShouldUpdateComment()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -97,11 +103,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Update(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.UpdateAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
-            CommentController service = new(commentServiceMock.Object);
+            CommentController controller = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Update(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await controller.Update(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             RequestResult<UserComment>? actualRequestResult = actualResult.Value;
             Assert.True(actualRequestResult != null && actualRequestResult.ResultStatus == ResultType.Success);
@@ -111,8 +117,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Update Comment - ForbidResult Error scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateCommentWithForbidResultError()
+        public async Task ShouldUpdateCommentWithForbidResultError()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -124,11 +131,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Update(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.UpdateAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
             CommentController service = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Update(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await service.Update(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             Assert.IsType<ForbidResult>(actualResult.Result);
         }
@@ -136,8 +143,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Update Comment - BadRequest Error scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateCommentWithBadRequestError()
+        public async Task ShouldUpdateCommentWithBadRequestError()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -146,11 +154,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Update(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.UpdateAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
             CommentController service = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Update(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await service.Update(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
@@ -158,8 +166,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Delete Comment - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteComment()
+        public async Task ShouldDeleteComment()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -172,11 +181,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Delete(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.DeleteAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
             CommentController service = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Delete(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await service.Delete(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             RequestResult<UserComment>? actualRequestResult = actualResult.Value;
             Assert.NotNull(actualRequestResult);
@@ -187,8 +196,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Delete Comment - ForbidResult Error scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteCommentWithForbidResultError()
+        public async Task ShouldDeleteCommentWithForbidResultError()
         {
             RequestResult<UserComment> expectedResult = new()
             {
@@ -200,20 +210,21 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.Delete(expectedResult.ResourcePayload)).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.DeleteAsync(expectedResult.ResourcePayload, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
             CommentController service = new(commentServiceMock.Object);
 
-            ActionResult<RequestResult<UserComment>> actualResult = service.Delete(Hdid, expectedResult.ResourcePayload);
+            ActionResult<RequestResult<UserComment>> actualResult = await service.Delete(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             Assert.IsType<ForbidResult>(actualResult.Result);
         }
 
         /// <summary>
-        /// GetAllForEntry - Happy path scenario.
+        /// GetAllForEntryAsync - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetAllForEntry()
+        public async Task ShouldGetAllForEntry()
         {
             List<UserComment> mockedComments = new();
             for (int i = 0; i < 10; i++)
@@ -233,11 +244,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommentService> commentServiceMock = new();
-            commentServiceMock.Setup(s => s.GetEntryComments(It.IsAny<string>(), It.IsAny<string>())).Returns(expectedResult);
+            commentServiceMock.Setup(s => s.GetEntryCommentsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
-            CommentController service = new(commentServiceMock.Object);
+            CommentController controller = new(commentServiceMock.Object);
 
-            RequestResult<IEnumerable<UserComment>> actualResult = service.GetAllForEntry(Hdid, "parentEntryIdMock");
+            RequestResult<IEnumerable<UserComment>> actualResult = await controller.GetAllForEntry(Hdid, "parentEntryIdMock", It.IsAny<CancellationToken>());
 
             Assert.NotNull(actualResult);
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);

--- a/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
@@ -15,6 +15,8 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.GatewayApiTests.Controllers.Test
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -32,8 +34,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Successfully Create Comment - Happy Path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetCommunication()
+        public async Task ShouldGetCommunication()
         {
             RequestResult<Communication?> expectedResult = new()
             {
@@ -46,10 +49,10 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<ICommunicationService> communicationServiceMock = new();
-            communicationServiceMock.Setup(s => s.GetActiveCommunication(CommunicationType.Banner)).Returns(expectedResult);
+            communicationServiceMock.Setup(s => s.GetActiveCommunicationAsync(CommunicationType.Banner, It.IsAny<CancellationToken>())).Returns(Task.FromResult(expectedResult));
 
             CommunicationController controller = new(communicationServiceMock.Object);
-            RequestResult<Communication?> actualResult = controller.Get();
+            RequestResult<Communication?> actualResult = await controller.Get();
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
@@ -61,13 +61,13 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 ResourcePayload = expectedDependents,
                 ResultStatus = ResultType.Success,
             };
-            dependentServiceMock.Setup(s => s.GetDependentsAsync(this.hdid, It.IsAny<int>(), It.IsAny<int>())).ReturnsAsync(expectedResult);
+            dependentServiceMock.Setup(s => s.GetDependentsAsync(this.hdid, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             DependentController dependentController = new(
                 new Mock<ILogger<DependentController>>().Object,
                 dependentServiceMock.Object,
                 httpContextAccessorMock.Object);
-            RequestResult<IEnumerable<DependentModel>> actualResult = await dependentController.GetAll(this.hdid);
+            RequestResult<IEnumerable<DependentModel>> actualResult = await dependentController.GetAll(this.hdid, It.IsAny<CancellationToken>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/NoteControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/NoteControllerTests.cs
@@ -16,6 +16,8 @@
 namespace HealthGateway.GatewayApiTests.Controllers.Test
 {
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -35,8 +37,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateNote - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateNote()
+        public async Task ShouldCreateNote()
         {
             RequestResult<UserNote> expectedResult = new()
             {
@@ -50,11 +53,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<INoteService> noteServiceMock = new();
-            noteServiceMock.Setup(s => s.CreateNote(It.IsAny<UserNote>())).Returns(expectedResult);
+            noteServiceMock.Setup(s => s.CreateNoteAsync(It.IsAny<UserNote>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             NoteController controller = new(noteServiceMock.Object);
 
-            RequestResult<UserNote> actualResult = controller.CreateNote(Hdid, expectedResult.ResourcePayload);
+            RequestResult<UserNote> actualResult = await controller.CreateNote(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -62,8 +65,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// UpdateNote - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateNote()
+        public async Task ShouldUpdateNote()
         {
             RequestResult<UserNote> expectedResult = new()
             {
@@ -76,11 +80,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<INoteService> noteServiceMock = new();
-            noteServiceMock.Setup(s => s.UpdateNote(It.IsAny<UserNote>())).Returns(expectedResult);
+            noteServiceMock.Setup(s => s.UpdateNoteAsync(It.IsAny<UserNote>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             NoteController controller = new(noteServiceMock.Object);
 
-            RequestResult<UserNote> actualResult = controller.UpdateNote(Hdid, expectedResult.ResourcePayload);
+            RequestResult<UserNote> actualResult = await controller.UpdateNote(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -88,8 +92,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// DeleteNote - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteNote()
+        public async Task ShouldDeleteNote()
         {
             RequestResult<UserNote> expectedResult = new()
             {
@@ -102,11 +107,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<INoteService> noteServiceMock = new();
-            noteServiceMock.Setup(s => s.DeleteNote(It.IsAny<UserNote>())).Returns(expectedResult);
+            noteServiceMock.Setup(s => s.DeleteNoteAsync(It.IsAny<UserNote>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             NoteController controller = new(noteServiceMock.Object);
 
-            RequestResult<UserNote> actualResult = controller.DeleteNote(expectedResult.ResourcePayload);
+            RequestResult<UserNote> actualResult = await controller.DeleteNote(expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -114,8 +119,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// GetAll Notes - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetAll()
+        public async Task ShouldGetAll()
         {
             List<UserNote> mockedNotes = new();
             for (int i = 0; i < 10; i++)
@@ -135,11 +141,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<INoteService> noteServiceMock = new();
-            noteServiceMock.Setup(s => s.GetNotes(It.IsAny<string>(), 0, 500)).Returns(expectedResult);
+            noteServiceMock.Setup(s => s.GetNotesAsync(It.IsAny<string>(), 0, 500, It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             NoteController service = new(noteServiceMock.Object);
 
-            RequestResult<IEnumerable<UserNote>> actualResult = service.GetAll(Hdid);
+            RequestResult<IEnumerable<UserNote>> actualResult = await service.GetAll(Hdid, It.IsAny<CancellationToken>());
 
             Assert.NotNull(actualResult);
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);

--- a/Apps/GatewayApi/test/unit/Controllers.Test/ReportControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/ReportControllerTests.cs
@@ -15,6 +15,8 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.GatewayApiTests.Controllers.Test
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
@@ -33,8 +35,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Successfully Generate a Report - Happy Path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetReport()
+        public async Task ShouldGetReport()
         {
             ReportRequestModel request = new()
             {
@@ -53,10 +56,10 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<IReportService> reportServiceMock = new();
-            reportServiceMock.Setup(s => s.GetReport(request)).Returns(expectedResult);
+            reportServiceMock.Setup(s => s.GetReportAsync(request, It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             ReportController controller = new(reportServiceMock.Object);
-            RequestResult<ReportModel> actualResult = controller.GenerateReport(request);
+            RequestResult<ReportModel> actualResult = await controller.GenerateReport(request, It.IsAny<CancellationToken>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserFeedbackControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserFeedbackControllerTests.cs
@@ -15,6 +15,8 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.GatewayApiTests.Controllers.Test
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -37,8 +39,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateUserFeedback - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateUserFeedback()
+        public async Task ShouldCreateUserFeedback()
         {
             UserFeedback userFeedback = new()
             {
@@ -54,10 +57,10 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<IUserFeedbackService> userFeedbackServiceMock = new();
-            userFeedbackServiceMock.Setup(s => s.CreateUserFeedback(It.IsAny<UserFeedback>())).Returns(mockedDbResult);
+            userFeedbackServiceMock.Setup(s => s.CreateUserFeedbackAsync(It.IsAny<UserFeedback>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDbResult);
 
             UserFeedbackController controller = new(userFeedbackServiceMock.Object);
-            IActionResult actualResult = controller.CreateUserFeedback(Hdid, userFeedback);
+            IActionResult actualResult = await controller.CreateUserFeedback(Hdid, userFeedback);
 
             Assert.IsType<OkResult>(actualResult);
         }
@@ -65,8 +68,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateUserFeedback - ConflictResult Error scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateUserFeedbackWithConflictResultError()
+        public async Task ShouldCreateUserFeedbackWithConflictResultError()
         {
             UserFeedback userFeedback = new()
             {
@@ -82,10 +86,10 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<IUserFeedbackService> userFeedbackServiceMock = new();
-            userFeedbackServiceMock.Setup(s => s.CreateUserFeedback(It.IsAny<UserFeedback>())).Returns(mockedDbResult);
+            userFeedbackServiceMock.Setup(s => s.CreateUserFeedbackAsync(It.IsAny<UserFeedback>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDbResult);
 
             UserFeedbackController controller = new(userFeedbackServiceMock.Object);
-            IActionResult actualResult = controller.CreateUserFeedback(Hdid, userFeedback);
+            IActionResult actualResult = await controller.CreateUserFeedback(Hdid, userFeedback);
 
             Assert.IsType<ConflictResult>(actualResult);
         }
@@ -93,8 +97,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateUserFeedback - BadRequestResult Error scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateUserFeedbackWithBadRequestResultError()
+        public async Task ShouldCreateUserFeedbackWithBadRequestResultError()
         {
             DbResult<UserFeedback> mockedDbResult = new()
             {
@@ -102,11 +107,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<IUserFeedbackService> userFeedbackServiceMock = new();
-            userFeedbackServiceMock.Setup(s => s.CreateUserFeedback(It.IsAny<UserFeedback>())).Returns(mockedDbResult);
+            userFeedbackServiceMock.Setup(s => s.CreateUserFeedbackAsync(It.IsAny<UserFeedback>(), It.IsAny<CancellationToken>())).ReturnsAsync(mockedDbResult);
 
             UserFeedbackController controller = new(userFeedbackServiceMock.Object);
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-            IActionResult actualResult = controller.CreateUserFeedback(Hdid, null);
+            IActionResult actualResult = await controller.CreateUserFeedback(Hdid, null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             Assert.IsType<BadRequestResult>(actualResult);
@@ -115,8 +120,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateRating - Happy path scenario.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateRating()
+        public async Task ShouldCreateRating()
         {
             Rating rating = new()
             {
@@ -131,10 +137,10 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<IUserFeedbackService> userFeedbackServiceMock = new();
-            userFeedbackServiceMock.Setup(s => s.CreateRating(It.IsAny<Rating>())).Returns(expectedResult);
+            userFeedbackServiceMock.Setup(s => s.CreateRatingAsync(It.IsAny<Rating>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             UserFeedbackController controller = new(userFeedbackServiceMock.Object);
-            RequestResult<Rating> actualResult = controller.CreateRating(rating);
+            RequestResult<Rating> actualResult = await controller.CreateRating(rating, It.IsAny<CancellationToken>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -102,7 +102,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.CreateUserProfile(createUserRequest, It.IsAny<DateTime>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(expected);
+            userProfileServiceMock.Setup(s => s.CreateUserProfileAsync(createUserRequest, It.IsAny<DateTime>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(expected);
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSmsService> smsServiceMock = new();
 
@@ -144,7 +144,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.CreateUserProfile(createUserRequest, It.IsAny<DateTime>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(expected);
+            userProfileServiceMock.Setup(s => s.CreateUserProfileAsync(createUserRequest, It.IsAny<DateTime>(), It.IsAny<string>(), CancellationToken.None)).ReturnsAsync(expected);
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSmsService> smsServiceMock = new();
 
@@ -170,7 +170,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.ValidateMinimumAge(this.hdid)).ReturnsAsync(expected);
+            userProfileServiceMock.Setup(s => s.ValidateMinimumAgeAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(expected);
 
             UserProfileController controller = new(
                 userProfileServiceMock.Object,
@@ -179,7 +179,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<IUserSmsService>().Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            RequestResult<bool> actualResult = await controller.Validate(this.hdid);
+            RequestResult<bool> actualResult = await controller.Validate(this.hdid, It.IsAny<CancellationToken>());
 
             Assert.Equal(expected, actualResult);
         }
@@ -187,8 +187,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateUserPreference - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateUserPreference()
+        public async Task ShouldCreateUserPreference()
         {
             UserPreferenceModel userPref = new()
             {
@@ -197,7 +198,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 Value = "Body value",
             };
 
-            ActionResult<RequestResult<UserPreferenceModel>> actualResult = this.CreateUserPreference(userPref);
+            ActionResult<RequestResult<UserPreferenceModel>> actualResult = await this.CreateUserPreference(userPref);
 
             RequestResult<UserPreferenceModel>? reqResult = actualResult.Value;
             Assert.NotNull(reqResult);
@@ -210,10 +211,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// CreateUserPreference - Bad Request.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateUserPreferenceWithBadRequestResultError()
+        public async Task ShouldCreateUserPreferenceWithBadRequestResultError()
         {
-            ActionResult<RequestResult<UserPreferenceModel>> actualResult = this.CreateUserPreference(null);
+            ActionResult<RequestResult<UserPreferenceModel>> actualResult = await this.CreateUserPreference(null);
 
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
@@ -221,8 +223,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// UpdateUserPreference - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateUserPreference()
+        public async Task ShouldUpdateUserPreference()
         {
             UserPreferenceModel userPref = new()
             {
@@ -231,7 +234,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 Value = "Body value",
             };
 
-            ActionResult<RequestResult<UserPreferenceModel>> actualResult = this.UpdateUserPreference(userPref);
+            ActionResult<RequestResult<UserPreferenceModel>> actualResult = await this.UpdateUserPreference(userPref);
 
             RequestResult<UserPreferenceModel>? reqResult = actualResult.Value;
             Assert.NotNull(reqResult);
@@ -241,10 +244,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// UpdateUserPreference - Bad Request.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateUserPreferenceWithBadRequestResultError()
+        public async Task ShouldUpdateUserPreferenceWithBadRequestResultError()
         {
-            ActionResult<RequestResult<UserPreferenceModel>> actualResult = this.UpdateUserPreference(null);
+            ActionResult<RequestResult<UserPreferenceModel>> actualResult = await this.UpdateUserPreference(null);
 
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
@@ -252,8 +256,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// UpdateUserPreference - Bad Request (Empty Preference).
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateUserPreferenceWithEmptyPreferenceError()
+        public async Task ShouldUpdateUserPreferenceWithEmptyPreferenceError()
         {
             UserPreferenceModel userPref = new()
             {
@@ -264,7 +269,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 Value = "Body value",
             };
 
-            ActionResult<RequestResult<UserPreferenceModel>> actualResult = this.UpdateUserPreference(userPref);
+            ActionResult<RequestResult<UserPreferenceModel>> actualResult = await this.UpdateUserPreference(userPref);
 
             Assert.IsType<BadRequestResult>(actualResult.Result);
         }
@@ -272,8 +277,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// UpdateUserPreference - Forbidden Request.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateUserPreferenceWithForbidResultError()
+        public async Task ShouldUpdateUserPreferenceWithForbidResultError()
         {
             UserPreferenceModel userPref = new()
             {
@@ -282,7 +288,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 Value = "Body value",
             };
 
-            ActionResult<RequestResult<UserPreferenceModel>> actualResult = this.UpdateUserPreference(userPref);
+            ActionResult<RequestResult<UserPreferenceModel>> actualResult = await this.UpdateUserPreference(userPref);
 
             Assert.IsType<ForbidResult>(actualResult.Result);
         }
@@ -290,8 +296,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// GetLastTermsOfService - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetLastTermsOfService()
+        public async Task ShouldGetLastTermsOfService()
         {
             // Setup
             TermsOfServiceModel termsOfService = new()
@@ -307,7 +314,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.GetActiveTermsOfService()).Returns(expectedResult);
+            userProfileServiceMock.Setup(s => s.GetActiveTermsOfServiceAsync(It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
             Mock<IUserEmailService> emailServiceMock = new();
@@ -320,7 +327,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            RequestResult<TermsOfServiceModel> actualResult = service.GetLastTermsOfService();
+            RequestResult<TermsOfServiceModel> actualResult = await service.GetLastTermsOfService(It.IsAny<CancellationToken>());
             expectedResult.ShouldDeepEqual(actualResult);
         }
 
@@ -495,8 +502,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         /// <summary>
         /// Validates the controller update terms of service method.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateTerms()
+        public async Task ShouldUpdateTerms()
         {
             RequestResult<UserProfileModel> expected = new()
             {
@@ -504,7 +512,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             };
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.UpdateAcceptedTerms(this.hdid, It.IsAny<Guid>())).Returns(expected);
+            userProfileServiceMock.Setup(s => s.UpdateAcceptedTermsAsync(this.hdid, It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expected);
 
             UserProfileController controller = new(
                 userProfileServiceMock.Object,
@@ -513,7 +521,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<IUserSmsService>().Object,
                 new Mock<IAuthenticationDelegate>().Object);
 
-            RequestResult<UserProfileModel> actualResult = controller.UpdateAcceptedTerms(this.hdid, Guid.Empty);
+            RequestResult<UserProfileModel> actualResult = await controller.UpdateAcceptedTerms(this.hdid, Guid.Empty, It.IsAny<CancellationToken>());
             expected.ShouldDeepEqual(actualResult);
         }
 
@@ -583,24 +591,24 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.GetUserProfile(this.hdid, It.IsAny<DateTime>())).Returns(Task.FromResult(expected));
-            userProfileServiceMock.Setup(s => s.GetActiveTermsOfService()).Returns(new RequestResult<TermsOfServiceModel>());
-            userProfileServiceMock.Setup(s => s.GetUserPreferences(this.hdid))
-                .Returns(new RequestResult<Dictionary<string, UserPreferenceModel>> { ResourcePayload = userPreferencePayloadMock });
+            userProfileServiceMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+            userProfileServiceMock.Setup(s => s.GetActiveTermsOfServiceAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new RequestResult<TermsOfServiceModel>());
+            userProfileServiceMock.Setup(s => s.GetUserPreferencesAsync(this.hdid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new RequestResult<Dictionary<string, UserPreferenceModel>> { ResourcePayload = userPreferencePayloadMock });
 
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSmsService> smsServiceMock = new();
 
-            UserProfileController service = new(
+            UserProfileController controller = new(
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
-            return await service.GetUserProfile(this.hdid);
+            return await controller.GetUserProfile(this.hdid, It.IsAny<CancellationToken>());
         }
 
-        private ActionResult<RequestResult<UserPreferenceModel>> UpdateUserPreference(UserPreferenceModel? userPref)
+        private async Task<ActionResult<RequestResult<UserPreferenceModel>>> UpdateUserPreference(UserPreferenceModel? userPref)
         {
             // Setup
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
@@ -612,21 +620,21 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 ResultStatus = ResultType.Success,
             };
 
-            userProfileServiceMock.Setup(s => s.UpdateUserPreference(userPref)).Returns(requestResult);
+            userProfileServiceMock.Setup(s => s.UpdateUserPreferenceAsync(userPref, It.IsAny<CancellationToken>())).ReturnsAsync(requestResult);
 
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSmsService> smsServiceMock = new();
 
-            UserProfileController service = new(
+            UserProfileController controller = new(
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
-            return service.UpdateUserPreference(this.hdid, userPref);
+            return await controller.UpdateUserPreference(this.hdid, userPref, It.IsAny<CancellationToken>());
         }
 
-        private ActionResult<RequestResult<UserPreferenceModel>> CreateUserPreference(UserPreferenceModel? userPref)
+        private async Task<ActionResult<RequestResult<UserPreferenceModel>>> CreateUserPreference(UserPreferenceModel? userPref)
         {
             // Setup
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
@@ -638,18 +646,18 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 ResultStatus = ResultType.Success,
             };
 
-            userProfileServiceMock.Setup(s => s.CreateUserPreference(userPref)).Returns(requestResult);
+            userProfileServiceMock.Setup(s => s.CreateUserPreferenceAsync(userPref, It.IsAny<CancellationToken>())).ReturnsAsync(requestResult);
 
             Mock<IUserEmailService> emailServiceMock = new();
             Mock<IUserSmsService> smsServiceMock = new();
 
-            UserProfileController service = new(
+            UserProfileController controller = new(
                 userProfileServiceMock.Object,
                 httpContextAccessorMock.Object,
                 emailServiceMock.Object,
                 smsServiceMock.Object,
                 new Mock<IAuthenticationDelegate>().Object);
-            return service.CreateUserPreference(this.hdid, userPref);
+            return await controller.CreateUserPreference(this.hdid, userPref, It.IsAny<CancellationToken>());
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
@@ -167,14 +167,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldGetCommentsWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
+            UserProfile userProfile = new()
             {
-                Payload = new UserProfile
-                    { EncryptionKey = encryptionKey },
+                EncryptionKey = encryptionKey,
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             ICommentService service = new CommentService(
                 new Mock<ILogger<CommentService>>().Object,
@@ -196,14 +195,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldInsertCommentWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
+            UserProfile userProfile = new()
             {
-                Payload = new UserProfile
-                    { EncryptionKey = encryptionKey },
+                EncryptionKey = encryptionKey,
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             UserComment userComment = new()
             {
@@ -234,14 +232,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldUpdateCommentWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
+            UserProfile userProfile = new()
             {
-                Payload = new UserProfile
-                    { EncryptionKey = encryptionKey },
+                EncryptionKey = encryptionKey,
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             UserComment userComment = new()
             {
@@ -272,14 +269,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldDeleteCommentWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
+            UserProfile userProfile = new()
             {
-                Payload = new UserProfile
-                    { EncryptionKey = encryptionKey },
+                EncryptionKey = encryptionKey,
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             UserComment userComment = new()
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Threading.Tasks;
     using AutoMapper;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
@@ -48,10 +49,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetComments - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetComments()
+        public async Task ShouldGetComments()
         {
-            (RequestResult<IEnumerable<UserComment>> actualResult, List<UserComment> userCommentList) = this.ExecuteGetComments("abc");
+            (Task<RequestResult<IEnumerable<UserComment>>> task, List<UserComment> userCommentList) = this.ExecuteGetComments("abc");
+            RequestResult<IEnumerable<UserComment>> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             userCommentList.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -60,10 +63,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetComments - Database error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetCommentsWithDbError()
+        public async Task ShouldGetCommentsWithDbError()
         {
-            (RequestResult<IEnumerable<UserComment>> actualResult, _) = this.ExecuteGetComments("abc", DbStatusCode.Error);
+            (Task<RequestResult<IEnumerable<UserComment>>> task, _) = this.ExecuteGetComments("abc", DbStatusCode.Error);
+            RequestResult<IEnumerable<UserComment>> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.True(actualResult.ResultError?.ErrorCode.EndsWith("-CI-DB", StringComparison.InvariantCulture));
@@ -72,10 +77,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// InsertComment - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldInsertComment()
+        public async Task ShouldInsertComment()
         {
-            (RequestResult<UserComment> actualResult, UserComment createdRecord) = this.ExecuteInsertComment();
+            (Task<RequestResult<UserComment>> task, UserComment createdRecord) = this.ExecuteInsertComment();
+            RequestResult<UserComment> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             createdRecord.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -84,10 +91,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// InsertComment - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldInsertCommentWithDbError()
+        public async Task ShouldInsertCommentWithDbError()
         {
-            (RequestResult<UserComment> actualResult, _) = this.ExecuteInsertComment(DbStatusCode.Error);
+            (Task<RequestResult<UserComment>> task, _) = this.ExecuteInsertComment(DbStatusCode.Error);
+            RequestResult<UserComment> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -96,10 +105,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// UpdateComment - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateComment()
+        public async Task ShouldUpdateComment()
         {
-            (RequestResult<UserComment> actualResult, UserComment updatedRecord) = this.ExecuteUpdateComment();
+            (Task<RequestResult<UserComment>> task, UserComment updatedRecord) = this.ExecuteUpdateComment();
+            RequestResult<UserComment> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             updatedRecord.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -108,10 +119,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// UpdateComment - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateCommentWithDbError()
+        public async Task ShouldUpdateCommentWithDbError()
         {
-            (RequestResult<UserComment> actualResult, _) = this.ExecuteUpdateComment(DbStatusCode.Error);
+            (Task<RequestResult<UserComment>> task, _) = this.ExecuteUpdateComment(DbStatusCode.Error);
+            RequestResult<UserComment> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -120,10 +133,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// DeleteComment - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteComment()
+        public async Task ShouldDeleteComment()
         {
-            (RequestResult<UserComment> actualResult, UserComment deletedRecord) = this.ExecuteDeleteComment();
+            (Task<RequestResult<UserComment>> task, UserComment deletedRecord) = this.ExecuteDeleteComment();
+            RequestResult<UserComment> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             deletedRecord.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -132,10 +147,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// DeleteComment - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteCommentWithDbError()
+        public async Task ShouldDeleteCommentWithDbError()
         {
-            (RequestResult<UserComment> actualResult, _) = this.ExecuteDeleteComment(DbStatusCode.Error);
+            (Task<RequestResult<UserComment>> task, _) = this.ExecuteDeleteComment(DbStatusCode.Error);
+            RequestResult<UserComment> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -144,14 +161,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetComments - No Encryption key error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetCommentsWithNoKeyError()
+        public async Task ShouldGetCommentsWithNoKeyError()
         {
             string? encryptionKey = null;
             DbResult<UserProfile> profileDbResult = new()
             {
                 Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
+                    { EncryptionKey = encryptionKey },
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -164,7 +182,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<ICryptoDelegate>().Object,
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<IEnumerable<UserComment>> actualResult = service.GetEntryComments(this.hdid, this.parentEntryId);
+            RequestResult<IEnumerable<UserComment>> actualResult = await service.GetEntryCommentsAsync(this.hdid, this.parentEntryId);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -172,14 +190,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// InsertComment - No Encryption key error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldInsertCommentWithNoKeyError()
+        public async Task ShouldInsertCommentWithNoKeyError()
         {
             string? encryptionKey = null;
             DbResult<UserProfile> profileDbResult = new()
             {
                 Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
+                    { EncryptionKey = encryptionKey },
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -201,7 +220,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<ICryptoDelegate>().Object,
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<UserComment> actualResult = service.Add(userComment);
+            RequestResult<UserComment> actualResult = await service.AddAsync(userComment);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -209,14 +228,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// UpdateComment - No Encryption key error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateCommentWithNoKeyError()
+        public async Task ShouldUpdateCommentWithNoKeyError()
         {
             string? encryptionKey = null;
             DbResult<UserProfile> profileDbResult = new()
             {
                 Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
+                    { EncryptionKey = encryptionKey },
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -238,7 +258,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<ICryptoDelegate>().Object,
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<UserComment> actualResult = service.Update(userComment);
+            RequestResult<UserComment> actualResult = await service.UpdateAsync(userComment);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -246,14 +266,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// DeleteComment - No Encryption key error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteCommentWithNoKeyError()
+        public async Task ShouldDeleteCommentWithNoKeyError()
         {
             string? encryptionKey = null;
             DbResult<UserProfile> profileDbResult = new()
             {
                 Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
+                    { EncryptionKey = encryptionKey },
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -275,22 +296,19 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<ICryptoDelegate>().Object,
                 MapperUtil.InitializeAutoMapper());
 
-            RequestResult<UserComment> actualResult = service.Delete(userComment);
+            RequestResult<UserComment> actualResult = await service.DeleteAsync(userComment);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
 
-        private (RequestResult<UserComment> ActualResult, UserComment UserComment) ExecuteDeleteComment(DbStatusCode dBStatusCode = DbStatusCode.Deleted)
+        private (Task<RequestResult<UserComment>> ActualResult, UserComment UserComment) ExecuteDeleteComment(DbStatusCode dBStatusCode = DbStatusCode.Deleted)
         {
             string encryptionKey = "abc";
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -323,21 +341,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 cryptoDelegateMock.Object,
                 autoMapper);
 
-            RequestResult<UserComment> actualResult = service.Delete(userComment);
+            Task<RequestResult<UserComment>> actualResult = service.DeleteAsync(userComment);
             return (actualResult, userComment);
         }
 
-        private (RequestResult<UserComment> ActualResult, UserComment UserComment) ExecuteUpdateComment(DbStatusCode dBStatusCode = DbStatusCode.Updated)
+        private (Task<RequestResult<UserComment>> ActualResult, UserComment UserComment) ExecuteUpdateComment(DbStatusCode dBStatusCode = DbStatusCode.Updated)
         {
             string encryptionKey = "abc";
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -371,22 +386,19 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 cryptoDelegateMock.Object,
                 autoMapper);
 
-            RequestResult<UserComment> actualResult = service.Update(userComment);
+            Task<RequestResult<UserComment>> actualResult = service.UpdateAsync(userComment);
             return (actualResult, userComment);
         }
 
-        private (RequestResult<IEnumerable<UserComment>> ActualResult, List<UserComment> UserCommentList) ExecuteGetComments(
+        private (Task<RequestResult<IEnumerable<UserComment>>> ActualResult, List<UserComment> UserCommentList) ExecuteGetComments(
             string? encryptionKey = null,
             DbStatusCode dbResultStatus = DbStatusCode.Read)
         {
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -430,22 +442,19 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 cryptoDelegateMock.Object,
                 autoMapper);
 
-            RequestResult<IEnumerable<UserComment>> actualResult = service.GetEntryComments(this.hdid, this.parentEntryId);
+            Task<RequestResult<IEnumerable<UserComment>>> actualResult = service.GetEntryCommentsAsync(this.hdid, this.parentEntryId);
 
             return (actualResult, userCommentList);
         }
 
-        private (RequestResult<UserComment> ActualResult, UserComment UserComment) ExecuteInsertComment(DbStatusCode dBStatusCode = DbStatusCode.Created)
+        private (Task<RequestResult<UserComment>> ActualResult, UserComment UserComment) ExecuteInsertComment(DbStatusCode dBStatusCode = DbStatusCode.Created)
         {
             string encryptionKey = "abc";
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -478,7 +487,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 cryptoDelegateMock.Object,
                 autoMapper);
 
-            RequestResult<UserComment> actualResult = service.Add(userComment);
+            Task<RequestResult<UserComment>> actualResult = service.AddAsync(userComment);
             return (actualResult, userComment);
         }
     }

--- a/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
@@ -309,7 +309,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -353,7 +353,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -399,7 +399,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -455,7 +455,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);

--- a/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using AutoMapper;
     using DeepEqual.Syntax;
@@ -332,7 +333,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<ICommentDelegate> commentDelegateMock = new();
-            commentDelegateMock.Setup(s => s.Delete(It.Is<Comment>(x => x.Text == comment.Text), true)).Returns(deleteResult);
+            commentDelegateMock.Setup(s => s.DeleteAsync(It.Is<Comment>(x => x.Text == comment.Text), true, It.IsAny<CancellationToken>())).ReturnsAsync(deleteResult);
 
             ICommentService service = new CommentService(
                 new Mock<ILogger<CommentService>>().Object,
@@ -377,7 +378,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<ICommentDelegate> commentDelegateMock = new();
-            commentDelegateMock.Setup(s => s.Update(It.Is<Comment>(x => x.Text == comment.Text), true)).Returns(updateResult);
+            commentDelegateMock.Setup(s => s.UpdateAsync(It.Is<Comment>(x => x.Text == comment.Text), true, It.IsAny<CancellationToken>())).ReturnsAsync(updateResult);
 
             ICommentService service = new CommentService(
                 new Mock<ILogger<CommentService>>().Object,
@@ -433,7 +434,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<ICommentDelegate> commentDelegateMock = new();
-            commentDelegateMock.Setup(s => s.GetByParentEntry(this.hdid, this.parentEntryId)).Returns(commentsDbResult);
+            commentDelegateMock.Setup(s => s.GetByParentEntryAsync(this.hdid, this.parentEntryId, It.IsAny<CancellationToken>())).ReturnsAsync(commentsDbResult);
 
             ICommentService service = new CommentService(
                 new Mock<ILogger<CommentService>>().Object,
@@ -478,7 +479,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<ICommentDelegate> commentDelegateMock = new();
-            commentDelegateMock.Setup(s => s.Add(It.Is<Comment>(x => x.Text == comment.Text), true)).Returns(insertResult);
+            commentDelegateMock.Setup(s => s.AddAsync(It.Is<Comment>(x => x.Text == comment.Text), true, It.IsAny<CancellationToken>())).ReturnsAsync(insertResult);
 
             ICommentService service = new CommentService(
                 new Mock<ILogger<CommentService>>().Object,

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -357,8 +357,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 .ReturnsAsync(new[] { new ResourceDelegate { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId } });
 
             Mock<IUserProfileDelegate> mockUserProfileDelegate = new();
-            mockUserProfileDelegate.Setup(s => s.GetUserProfile(this.mockParentHdid))
-                .Returns(new DbResult<UserProfile> { Payload = new UserProfile() });
+            mockUserProfileDelegate.Setup(s => s.GetUserProfileAsync(this.mockParentHdid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new UserProfile());
             Mock<INotificationSettingsService> mockNotificationSettingsService = new();
             mockNotificationSettingsService.Setup(s => s.QueueNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<CancellationToken>()));
 

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -347,8 +347,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             DependentModel delegateModel = new() { OwnerId = this.mockHdId, DelegateId = this.mockParentHdid };
             Mock<IResourceDelegateDelegate> mockDependentDelegate = new();
-            mockDependentDelegate.Setup(s => s.Delete(It.Is<ResourceDelegate>(d => d.ResourceOwnerHdid == this.mockHdId && d.ProfileHdid == this.mockParentHdid), It.IsAny<bool>()))
-                .Returns(
+            mockDependentDelegate.Setup(
+                    s => s.DeleteAsync(It.Is<ResourceDelegate>(d => d.ResourceOwnerHdid == this.mockHdId && d.ProfileHdid == this.mockParentHdid), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
                     new DbResult<ResourceDelegate>
                     {
                         Status = DbStatusCode.Deleted,

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -70,7 +70,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             IDependentService service = this.SetupMockForGetDependents();
 
-            RequestResult<IEnumerable<DependentModel>> actualResult = await service.GetDependentsAsync(this.mockParentHdid);
+            RequestResult<IEnumerable<DependentModel>> actualResult = await service.GetDependentsAsync(this.mockParentHdid, 0, 25, It.IsAny<CancellationToken>());
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Equal(10, actualResult.TotalResultCount);
@@ -459,7 +459,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IResourceDelegateDelegate> mockDependentDelegate = new();
-            mockDependentDelegate.Setup(s => s.Get(this.mockParentHdid, It.IsAny<int>(), It.IsAny<int>())).Returns(mockResourceDelegateResult);
+            mockDependentDelegate.Setup(s => s.GetAsync(this.mockParentHdid, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(this.GenerateMockResourceDelegatesList().ToList());
             mockDependentDelegate.Setup(s => s.Get(this.fromDate, this.toDate, It.IsAny<int>(), It.IsAny<int>())).Returns(mockResourceDelegateResult);
             mockDependentDelegate.Setup(s => s.GetTotalDelegateCountsAsync(It.IsAny<IEnumerable<string>>())).ReturnsAsync(mockDelegateCountsResult);
 

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -559,7 +559,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             delegationDelegate.Setup(s => s.GetDependentAsync(this.mockHdId, true, CancellationToken.None)).ReturnsAsync(dependent);
 
             Mock<IUserProfileDelegate> mockUserProfileDelegate = new();
-            mockUserProfileDelegate.Setup(s => s.GetUserProfileAsync(this.mockParentHdid))
+            mockUserProfileDelegate.Setup(s => s.GetUserProfileAsync(this.mockParentHdid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new UserProfile());
 
             Mock<INotificationSettingsService> mockNotificationSettingsService = new();

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/EmailQueueServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/EmailQueueServiceMock.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.GatewayApiTests.Services.Test.Mock
 {
     using System.Collections.Generic;
+    using System.Threading;
     using HealthGateway.Common.Services;
     using Moq;
 
@@ -30,7 +31,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="shouldCommit">check if allowing to commit.</param>
         public EmailQueueServiceMock(bool shouldCommit)
         {
-            this.Setup(s => s.QueueNewEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), shouldCommit));
+            this.Setup(s => s.QueueNewEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), shouldCommit, It.IsAny<CancellationToken>()));
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/LegalAgreementDelegateMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/LegalAgreementDelegateMock.cs
@@ -15,10 +15,10 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.GatewayApiTests.Services.Test.Mock
 {
+    using System.Threading;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Delegates;
-    using HealthGateway.Database.Wrapper;
     using Moq;
 
     /// <summary>
@@ -32,10 +32,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="termsOfService">terms of service.</param>
         public LegalAgreementDelegateMock(LegalAgreement termsOfService)
         {
-            this.Setup(s => s.GetActiveByAgreementType(LegalAgreementType.TermsOfService))
-                .Returns(
-                    new DbResult<LegalAgreement>
-                        { Payload = termsOfService });
+            this.Setup(s => s.GetActiveByAgreementTypeAsync(LegalAgreementType.TermsOfService, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    termsOfService);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/MessagingVerificationDelegateMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/MessagingVerificationDelegateMock.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.GatewayApiTests.Services.Test.Mock
 {
     using System;
+    using System.Threading;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Database.Delegates;
     using Moq;
@@ -30,7 +31,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// </summary>
         public MessagingVerificationDelegateMock()
         {
-            this.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(new MessagingVerification());
+            this.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(new MessagingVerification());
         }
 
         /// <summary>
@@ -39,7 +40,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="messagingVerification">messaging verification.</param>
         public MessagingVerificationDelegateMock(MessagingVerification messagingVerification)
         {
-            this.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(messagingVerification);
+            this.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(messagingVerification);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/NotificationSettingsServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/NotificationSettingsServiceMock.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.GatewayApiTests.Services.Test.Mock
 {
+    using System.Threading;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
     using Moq;
@@ -29,7 +30,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// </summary>
         public NotificationSettingsServiceMock()
         {
-            this.Setup(s => s.QueueNotificationSettings(It.IsAny<NotificationSettingsRequest>()));
+            this.Setup(s => s.QueueNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<CancellationToken>()));
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserPreferenceDelegateMock.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.GatewayApiTests.Services.Test.Mock
 {
     using System.Collections.Generic;
+    using System.Threading;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
@@ -30,11 +31,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <summary>
         /// Initializes a new instance of the <see cref="UserPreferenceDelegateMock"/> class.
         /// </summary>
-        /// <param name="readResult">readResult.</param>
+        /// <param name="userPreferences">readResult.</param>
         /// <param name="hdid">hdid.</param>
-        public UserPreferenceDelegateMock(DbResult<IEnumerable<UserPreference>> readResult, string hdid)
+        public UserPreferenceDelegateMock(IEnumerable<UserPreference> userPreferences, string hdid)
         {
-            this.Setup(s => s.GetUserPreferences(hdid)).Returns(readResult);
+            this.Setup(s => s.GetUserPreferencesAsync(hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userPreferences);
         }
 
         /// <summary>
@@ -46,12 +47,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         {
             if (action == TestConstants.UpdateAction)
             {
-                this.Setup(s => s.UpdateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
+                this.Setup(s => s.UpdateUserPreferenceAsync(It.IsAny<UserPreference>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(readResult);
             }
 
             if (action == TestConstants.CreateAction)
             {
-                this.Setup(s => s.CreateUserPreference(It.IsAny<UserPreference>(), It.IsAny<bool>())).Returns(readResult);
+                this.Setup(s => s.CreateUserPreferenceAsync(It.IsAny<UserPreference>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(readResult);
             }
         }
     }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
@@ -45,7 +45,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
             int limit,
             DbResult<UserProfile> updatedUserProfileResult)
         {
-            this.Setup(s => s.GetUserProfileAsync(hdid)).ReturnsAsync(userProfileData.Payload);
+            this.Setup(s => s.GetUserProfileAsync(hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileData.Payload);
             this.Setup(s => s.UpdateAsync(userProfile, true, It.IsAny<CancellationToken>())).ReturnsAsync(updatedUserProfileResult);
             this.Setup(s => s.GetUserProfileHistoryListAsync(hdid, limit, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileHistoryList);
         }
@@ -71,7 +71,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="userProfileUpdateDbResult">Optional update result.</param>
         public UserProfileDelegateMock(string hdid, UserProfile userProfile, DbResult<UserProfile> userProfileDbResult, bool commit = true, DbResult<UserProfile>? userProfileUpdateDbResult = null)
         {
-            this.Setup(s => s.GetUserProfileAsync(hdid)).ReturnsAsync(userProfileDbResult.Payload);
+            this.Setup(s => s.GetUserProfileAsync(hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileDbResult.Payload);
             this.Setup(s => s.UpdateAsync(userProfile, commit, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileUpdateDbResult ?? userProfileDbResult);
         }
     }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileDelegateMock.cs
@@ -34,13 +34,20 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="userProfile">user profile.</param>
         /// <param name="userProfileData">user profile data.</param>
         /// <param name="hdid">hdid.</param>
-        /// <param name="userProfileHistoryData">user profile history.</param>
+        /// <param name="userProfileHistoryList">list of user profile history.</param>
         /// <param name="limit">limit.</param>
-        public UserProfileDelegateMock(UserProfile userProfile, DbResult<UserProfile> userProfileData, string hdid, DbResult<IEnumerable<UserProfileHistory>> userProfileHistoryData, int limit)
+        /// <param name="updatedUserProfileResult">updated user profile result.</param>
+        public UserProfileDelegateMock(
+            UserProfile userProfile,
+            DbResult<UserProfile> userProfileData,
+            string hdid,
+            IList<UserProfileHistory> userProfileHistoryList,
+            int limit,
+            DbResult<UserProfile> updatedUserProfileResult)
         {
-            this.Setup(s => s.GetUserProfile(hdid)).Returns(userProfileData);
-            this.Setup(s => s.Update(userProfile, true)).Returns(userProfileData);
-            this.Setup(s => s.GetUserProfileHistories(hdid, limit)).Returns(userProfileHistoryData);
+            this.Setup(s => s.GetUserProfileAsync(hdid)).ReturnsAsync(userProfileData.Payload);
+            this.Setup(s => s.UpdateAsync(userProfile, true, It.IsAny<CancellationToken>())).ReturnsAsync(updatedUserProfileResult);
+            this.Setup(s => s.GetUserProfileHistoryListAsync(hdid, limit, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileHistoryList);
         }
 
         /// <summary>
@@ -64,8 +71,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="userProfileUpdateDbResult">Optional update result.</param>
         public UserProfileDelegateMock(string hdid, UserProfile userProfile, DbResult<UserProfile> userProfileDbResult, bool commit = true, DbResult<UserProfile>? userProfileUpdateDbResult = null)
         {
-            this.Setup(s => s.GetUserProfile(hdid)).Returns(userProfileDbResult);
-            this.Setup(s => s.Update(userProfile, commit)).Returns(userProfileUpdateDbResult ?? userProfileDbResult);
+            this.Setup(s => s.GetUserProfileAsync(hdid)).ReturnsAsync(userProfileDbResult.Payload);
+            this.Setup(s => s.UpdateAsync(userProfile, commit, It.IsAny<CancellationToken>())).ReturnsAsync(userProfileUpdateDbResult ?? userProfileDbResult);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -185,18 +185,20 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="hdid">User profile hdid to be returned.</param>
         /// <param name="userProfileData">The mocked user profile linked with the hdid.</param>
         /// <param name="userProfileDbResult">The mocked result from teh database.</param>
-        /// <param name="userProfileHistoryDbResult">Mocked user profile history.</param>
+        /// <param name="userProfileHistoryList">Mocked user profile history.</param>
+        /// <param name="updatedUserProfileResult">Updated user profile result.</param>
         /// <param name="limitRecords">Limit the number of records, if empty with extract from config, fallback is 2.</param>
         /// <returns>UserProfileServiceMock.</returns>
         public UserProfileServiceMock SetupUserProfileDelegateMockGetUpdateAndHistory(
             string hdid,
             UserProfile userProfileData,
             DbResult<UserProfile> userProfileDbResult,
-            DbResult<IEnumerable<UserProfileHistory>> userProfileHistoryDbResult,
+            IList<UserProfileHistory> userProfileHistoryList,
+            DbResult<UserProfile>? updatedUserProfileResult,
             int? limitRecords = null)
         {
             int limit = limitRecords ?? this.configuration.GetSection(this.webClientConfigSection).GetValue(this.userProfileHistoryRecordLimitKey, 2);
-            this.userProfileDelegateMock = new UserProfileDelegateMock(userProfileData, userProfileDbResult, hdid, userProfileHistoryDbResult, limit);
+            this.userProfileDelegateMock = new UserProfileDelegateMock(userProfileData, userProfileDbResult, hdid, userProfileHistoryList, limit, updatedUserProfileResult);
             return this;
         }
 
@@ -239,7 +241,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="hdid">HDID of the user which owns the preference.</param>
         /// <param name="readResult">Mock preferences to be returned.</param>
         /// <returns>UserProfileServiceMock.</returns>
-        public UserProfileServiceMock SetupUserPreferenceDelegateMockReturnPreferences(string hdid, DbResult<IEnumerable<UserPreference>> readResult)
+        public UserProfileServiceMock SetupUserPreferenceDelegateMockReturnPreferences(string hdid, IEnumerable<UserPreference> readResult)
         {
             this.userPreferenceDelegateMock = new UserPreferenceDelegateMock(readResult, hdid);
             return this;

--- a/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
@@ -311,6 +311,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
             Mock<IUserProfileDelegate> profileDelegateMock = new();
             profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new DbResult<UserProfile>
+                        { Status = DbStatusCode.Deferred, Payload = userProfile });
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.GenerateKey()).Returns(() => "Y1FmVGpXblpxNHQ3dyF6JUMqRi1KYU5kUmdVa1hwMnM=");
@@ -358,6 +362,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<INoteDelegate> noteDelegateMock = new();
             noteDelegateMock.Setup(s => s.GetNotesAsync(this.hdid, 0, 500, It.IsAny<CancellationToken>())).ReturnsAsync(notesDbResult);
+            noteDelegateMock.Setup(s => s.BatchUpdateAsync(It.IsAny<IEnumerable<Note>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new DbResult<IEnumerable<Note>>
+                        { Status = DbStatusCode.Updated });
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(canAccessDataSource);

--- a/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
@@ -203,7 +203,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             UserNote userNote = new()
             {
@@ -310,7 +310,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             UserProfile userProfile = new()
                 { EncryptionKey = encryptionKey };
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
             profileDelegateMock.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new DbResult<UserProfile>
@@ -389,7 +389,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             UserProfile userProfile = new()
                 { EncryptionKey = encryptionKey };
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -433,7 +433,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -477,7 +477,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);

--- a/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
@@ -20,6 +20,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using System.Globalization;
     using System.Linq;
     using System.Threading;
+    using System.Threading.Tasks;
     using AutoMapper;
     using DeepEqual.Syntax;
     using HealthGateway.AccountDataAccess.Patient;
@@ -51,10 +52,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetNotes - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetNotes()
+        public async Task ShouldGetNotes()
         {
-            (RequestResult<IEnumerable<UserNote>> actualResult, List<UserNote> userNoteList) = this.ExecuteGetNotes("abc");
+            (Task<RequestResult<IEnumerable<UserNote>>> task, List<UserNote> userNoteList) = this.ExecuteGetNotes("abc");
+            RequestResult<IEnumerable<UserNote>> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             actualResult.ResourcePayload.ShouldDeepEqual(userNoteList);
@@ -63,10 +66,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetNotes - Blocked Access.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetNotesGivenBlockedAccess()
+        public async Task ShouldGetNotesGivenBlockedAccess()
         {
-            (RequestResult<IEnumerable<UserNote>> actualResult, _) = this.ExecuteGetNotes("abc", DbStatusCode.Error, false);
+            (Task<RequestResult<IEnumerable<UserNote>>> task, _) = this.ExecuteGetNotes("abc", DbStatusCode.Error, false);
+            RequestResult<IEnumerable<UserNote>> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Empty(actualResult.ResourcePayload);
@@ -75,10 +80,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetNotes - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetNotesWithDbError()
+        public async Task ShouldGetNotesWithDbError()
         {
-            (RequestResult<IEnumerable<UserNote>> actualResult, _) = this.ExecuteGetNotes("abc", DbStatusCode.Error);
+            (Task<RequestResult<IEnumerable<UserNote>>> task, _) = this.ExecuteGetNotes("abc", DbStatusCode.Error);
+            RequestResult<IEnumerable<UserNote>> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.True(actualResult.ResultError?.ErrorCode.EndsWith("-CI-DB", StringComparison.InvariantCulture));
@@ -87,10 +94,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// GetNotes - Happy Path with No Existing Encryption Key.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldGetNotesWithProfileKeyNotSet()
+        public async Task ShouldGetNotesWithProfileKeyNotSet()
         {
-            (RequestResult<IEnumerable<UserNote>> actualResult, List<UserNote> userNoteList) = this.ExecuteGetNotes();
+            (Task<RequestResult<IEnumerable<UserNote>>> task, List<UserNote> userNoteList) = this.ExecuteGetNotes();
+            RequestResult<IEnumerable<UserNote>> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             actualResult.ResourcePayload.ShouldDeepEqual(userNoteList);
@@ -99,11 +108,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// InsertNote - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldInsertNote()
+        public async Task ShouldInsertNote()
         {
-            (RequestResult<UserNote> actualResult, UserNote userNote) = this.ExecuteCreateNote();
+            (Task<RequestResult<UserNote>> task, UserNote userNote) = this.ExecuteCreateNote();
 
+            RequestResult<UserNote> actualResult = await task;
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Null(actualResult.ResultError);
             userNote.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -112,10 +123,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// InsertNote - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldInsertNoteWithDbError()
+        public async Task ShouldInsertNoteWithDbError()
         {
-            (RequestResult<UserNote> actualResult, _) = this.ExecuteCreateNote(DbStatusCode.Error);
+            (Task<RequestResult<UserNote>> task, _) = this.ExecuteCreateNote(DbStatusCode.Error);
+            RequestResult<UserNote> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
@@ -124,10 +137,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// UpdateNote - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateNote()
+        public async Task ShouldUpdateNote()
         {
-            (RequestResult<UserNote> actualResult, UserNote userNote) = this.ExecuteUpdateNote();
+            (Task<RequestResult<UserNote>> task, UserNote userNote) = this.ExecuteUpdateNote();
+            RequestResult<UserNote> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             userNote.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -136,10 +151,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// UpdateNote - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateNoteWithDbError()
+        public async Task ShouldUpdateNoteWithDbError()
         {
-            (RequestResult<UserNote> actualResult, _) = this.ExecuteUpdateNote(DbStatusCode.Error);
+            (Task<RequestResult<UserNote>> task, _) = this.ExecuteUpdateNote(DbStatusCode.Error);
+            RequestResult<UserNote> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.Equal(ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database), actualResult.ResultError?.ErrorCode);
@@ -148,10 +165,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// DeleteNote - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteNote()
+        public async Task ShouldDeleteNote()
         {
-            (RequestResult<UserNote> actualResult, UserNote userNote) = this.ExecuteDeleteNote();
+            (Task<RequestResult<UserNote>> task, UserNote userNote) = this.ExecuteDeleteNote();
+            RequestResult<UserNote> actualResult = await task;
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             Assert.Null(actualResult.ResultError);
@@ -161,10 +180,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// DeleteNote - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteNoteWithDbError()
+        public async Task ShouldDeleteNoteWithDbError()
         {
-            (RequestResult<UserNote> actualResult, _) = this.ExecuteDeleteNote(DbStatusCode.Error);
+            (Task<RequestResult<UserNote>> task, _) = this.ExecuteDeleteNote(DbStatusCode.Error);
+            RequestResult<UserNote> actualResult = await task;
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             Assert.NotNull(actualResult.ResultError);
@@ -173,18 +194,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// InsertNote - No Encryption Key Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldInsertNoteWithNoKeyError()
+        public async Task ShouldInsertNoteWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile? userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             UserNote userNote = new()
             {
@@ -202,7 +221,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IPatientRepository>().Object,
                 this.autoMapper);
 
-            RequestResult<UserNote> actualResult = service.CreateNote(userNote);
+            RequestResult<UserNote> actualResult = await service.CreateNoteAsync(userNote);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -210,14 +229,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// UpdateNote - No Encryption Key Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldUpdateNoteWithNoKeyError()
+        public async Task ShouldUpdateNoteWithNoKeyError()
         {
             string? encryptionKey = null;
             DbResult<UserProfile> profileDbResult = new()
             {
                 Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
+                    { EncryptionKey = encryptionKey },
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -239,7 +259,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IPatientRepository>().Object,
                 this.autoMapper);
 
-            RequestResult<UserNote> actualResult = service.UpdateNote(userNote);
+            RequestResult<UserNote> actualResult = await service.UpdateNoteAsync(userNote);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -247,14 +267,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// DeleteNote - No Encryption Key Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldDeleteNoteWithNoKeyError()
+        public async Task ShouldDeleteNoteWithNoKeyError()
         {
             string? encryptionKey = null;
             DbResult<UserProfile> profileDbResult = new()
             {
                 Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
+                    { EncryptionKey = encryptionKey },
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -276,23 +297,20 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IPatientRepository>().Object,
                 this.autoMapper);
 
-            RequestResult<UserNote> actualResult = service.DeleteNote(userNote);
+            RequestResult<UserNote> actualResult = await service.DeleteNoteAsync(userNote);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
 
-        private (RequestResult<IEnumerable<UserNote>> ActualResult, List<UserNote> ExpectedPayload) ExecuteGetNotes(
+        private (Task<RequestResult<IEnumerable<UserNote>>> ActualResult, List<UserNote> ExpectedPayload) ExecuteGetNotes(
             string? encryptionKey = null,
             DbStatusCode notesDbResultStatus = DbStatusCode.Read,
             bool canAccessDataSource = true)
         {
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile { EncryptionKey = encryptionKey },
-            };
-
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.GenerateKey()).Returns(() => "Y1FmVGpXblpxNHQ3dyF6JUMqRi1KYU5kUmdVa1hwMnM=");
@@ -339,7 +357,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<INoteDelegate> noteDelegateMock = new();
-            noteDelegateMock.Setup(s => s.GetNotes(this.hdid, 0, 500)).Returns(notesDbResult);
+            noteDelegateMock.Setup(s => s.GetNotesAsync(this.hdid, 0, 500, It.IsAny<CancellationToken>())).ReturnsAsync(notesDbResult);
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(canAccessDataSource);
@@ -352,22 +370,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 patientRepository.Object,
                 this.autoMapper);
 
-            RequestResult<IEnumerable<UserNote>> actualResult = service.GetNotes(this.hdid);
+            Task<RequestResult<IEnumerable<UserNote>>> actualResult = service.GetNotesAsync(this.hdid);
 
             return (actualResult, expectedPayload);
         }
 
-        private (RequestResult<UserNote> ActualResult, UserNote UserNote) ExecuteCreateNote(DbStatusCode dBStatusCode = DbStatusCode.Created)
+        private (Task<RequestResult<UserNote>> ActualResult, UserNote UserNote) ExecuteCreateNote(DbStatusCode dBStatusCode = DbStatusCode.Created)
         {
             string encryptionKey = "abc";
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
-
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -390,7 +404,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<INoteDelegate> noteDelegateMock = new();
-            noteDelegateMock.Setup(s => s.AddNote(It.Is<Note>(x => x.Text == note.Text), true)).Returns(insertResult);
+            noteDelegateMock.Setup(s => s.AddNoteAsync(It.Is<Note>(x => x.Text == note.Text), true, It.IsAny<CancellationToken>())).ReturnsAsync(insertResult);
 
             INoteService service = new NoteService(
                 new Mock<ILogger<NoteService>>().Object,
@@ -400,21 +414,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IPatientRepository>().Object,
                 this.autoMapper);
 
-            RequestResult<UserNote> actualResult = service.CreateNote(userNote);
+            Task<RequestResult<UserNote>> actualResult = service.CreateNoteAsync(userNote);
             return (actualResult, userNote);
         }
 
-        private (RequestResult<UserNote> ActualResult, UserNote UserNote) ExecuteUpdateNote(DbStatusCode dBStatusCode = DbStatusCode.Updated)
+        private (Task<RequestResult<UserNote>> ActualResult, UserNote UserNote) ExecuteUpdateNote(DbStatusCode dBStatusCode = DbStatusCode.Updated)
         {
             string encryptionKey = "abc";
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -437,7 +448,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<INoteDelegate> noteDelegateMock = new();
-            noteDelegateMock.Setup(s => s.UpdateNote(It.Is<Note>(x => x.Text == note.Text), true)).Returns(updateResult);
+            noteDelegateMock.Setup(s => s.UpdateNoteAsync(It.Is<Note>(x => x.Text == note.Text), true, It.IsAny<CancellationToken>())).ReturnsAsync(updateResult);
 
             INoteService service = new NoteService(
                 new Mock<ILogger<NoteService>>().Object,
@@ -447,21 +458,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IPatientRepository>().Object,
                 this.autoMapper);
 
-            RequestResult<UserNote> actualResult = service.UpdateNote(userNote);
+            Task<RequestResult<UserNote>> actualResult = service.UpdateNoteAsync(userNote);
             return (actualResult, userNote);
         }
 
-        private (RequestResult<UserNote> ActualResult, UserNote UserNote) ExecuteDeleteNote(DbStatusCode dBStatusCode = DbStatusCode.Deleted)
+        private (Task<RequestResult<UserNote>> ActualResult, UserNote UserNote) ExecuteDeleteNote(DbStatusCode dBStatusCode = DbStatusCode.Deleted)
         {
             string encryptionKey = "abc";
-            DbResult<UserProfile> profileDbResult = new()
-            {
-                Payload = new UserProfile
-                { EncryptionKey = encryptionKey },
-            };
+            UserProfile? userProfile = new()
+                { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid)).ReturnsAsync(userProfile);
 
             Mock<ICryptoDelegate> cryptoDelegateMock = new();
             cryptoDelegateMock.Setup(s => s.Encrypt(It.IsAny<string>(), It.IsAny<string>())).Returns((string key, string text) => text + key);
@@ -484,7 +492,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<INoteDelegate> noteDelegateMock = new();
-            noteDelegateMock.Setup(s => s.DeleteNote(It.Is<Note>(x => x.Text == note.Text), true)).Returns(deleteResult);
+            noteDelegateMock.Setup(s => s.DeleteNoteAsync(It.Is<Note>(x => x.Text == note.Text), true, It.IsAny<CancellationToken>())).ReturnsAsync(deleteResult);
 
             INoteService service = new NoteService(
                 new Mock<ILogger<NoteService>>().Object,
@@ -494,7 +502,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<IPatientRepository>().Object,
                 this.autoMapper);
 
-            RequestResult<UserNote> actualResult = service.DeleteNote(userNote);
+            Task<RequestResult<UserNote>> actualResult = service.DeleteNoteAsync(userNote);
             return (actualResult, userNote);
         }
     }

--- a/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
@@ -234,14 +234,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldUpdateNoteWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
+            UserProfile userProfile = new()
             {
-                Payload = new UserProfile
-                    { EncryptionKey = encryptionKey },
+                EncryptionKey = encryptionKey,
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             UserNote userNote = new()
             {
@@ -272,14 +271,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldDeleteNoteWithNoKeyError()
         {
             string? encryptionKey = null;
-            DbResult<UserProfile> profileDbResult = new()
+            UserProfile userProfile = new()
             {
-                Payload = new UserProfile
-                    { EncryptionKey = encryptionKey },
+                EncryptionKey = encryptionKey,
             };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
-            profileDelegateMock.Setup(s => s.GetUserProfile(this.hdid)).Returns(profileDbResult);
+            profileDelegateMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
 
             UserNote userNote = new()
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System.Text.Json;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
@@ -38,6 +39,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <param name="templateType">Report Template Type.</param>
         /// <param name="reportName">Report Name.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
         [InlineData(TemplateType.Medication, "HealthGatewayMedicationReport")]
         [InlineData(TemplateType.Notes, "HealthGatewayNotesReport")]
@@ -48,7 +50,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(TemplateType.Laboratory, "HealthGatewayLaboratoryReport")]
         [InlineData(TemplateType.DependentImmunization, "HealthGatewayDependentImmunizationReport")]
         [InlineData(TemplateType.HospitalVisit, "HealthGatewayHospitalVisitReport")]
-        public void ShouldGetReport(TemplateType templateType, string reportName)
+        public async Task ShouldGetReport(TemplateType templateType, string reportName)
         {
             RequestResult<ReportModel> expectedResult = new()
             {
@@ -72,7 +74,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IReportService service = new ReportService(
                 new Mock<ILogger<ReportService>>().Object,
                 cdogsDelegateMock.Object);
-            RequestResult<ReportModel> actualResult = service.GetReport(reportRequest);
+            RequestResult<ReportModel> actualResult = await service.GetReportAsync(reportRequest);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedResult.ShouldDeepEqual(actualResult);

--- a/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System.Text.Json;
+    using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
@@ -69,7 +70,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<ICDogsDelegate> cdogsDelegateMock = new();
-            cdogsDelegateMock.Setup(s => s.GenerateReportAsync(It.Is<CDogsRequestModel>(r => r.Options.ReportName == reportName))).ReturnsAsync(expectedResult);
+            cdogsDelegateMock.Setup(s => s.GenerateReportAsync(It.Is<CDogsRequestModel>(r => r.Options.ReportName == reportName), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             IReportService service = new ReportService(
                 new Mock<ILogger<ReportService>>().Object,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -64,15 +64,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(expectedResult);
-            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>()))
-                .Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DbResult<UserProfile>());
 
             IUserEmailService service = new UserEmailService(
                 new Mock<ILogger<UserEmailService>>().Object,
@@ -108,15 +108,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(expectedResult);
-            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>()))
-                .Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DbResult<UserProfile>());
             Mock<IMessageSender> mockMessageSender = new();
 
             string changeFeedKey = $"{ChangeFeedOptions.ChangeFeed}:Notifications:Enabled";
@@ -161,15 +161,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(expectedResult);
-            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>()))
-                .Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DbResult<UserProfile>());
 
             IUserEmailService service = new UserEmailService(
                 new Mock<ILogger<UserEmailService>>().Object,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -27,7 +27,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using HealthGateway.Common.Messaging;
     using HealthGateway.Common.Models.Events;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Wrapper;
     using HealthGateway.GatewayApi.Services;
@@ -207,12 +206,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
-            DbResult<UserProfile> userProfileMock = new()
-            {
-                Payload = new UserProfile(),
-                Status = DbStatusCode.Read,
-            };
-            userProfileDelegate.Setup(s => s.GetUserProfile(It.IsAny<string>())).Returns(userProfileMock);
+            UserProfile userProfile = new();
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
             userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>()))
                 .Returns(new DbResult<UserProfile>());
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -70,7 +70,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new DbResult<UserProfile>());
 
@@ -114,7 +114,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new DbResult<UserProfile>());
             Mock<IMessageSender> mockMessageSender = new();
@@ -167,7 +167,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new DbResult<UserProfile>());
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -201,15 +201,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(expectedResult);
-            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfile = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>()))
-                .Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DbResult<UserProfile>());
 
             IUserEmailService service = new UserEmailService(
                 new Mock<ILogger<UserEmailService>>().Object,
@@ -238,7 +238,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
 
@@ -269,9 +269,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKey(It.IsAny<Guid>())).Returns(expectedResult);
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastByInviteKeyAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedResult);
             Mock<IUserProfileDelegate> userProfileDelegate = new();
 
             IUserEmailService service = new UserEmailService(

--- a/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
@@ -16,6 +16,8 @@
 namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using Hangfire;
     using HealthGateway.Common.Data.Constants;
@@ -38,8 +40,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// CreateRating - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateRating()
+        public async Task ShouldCreateRating()
         {
             Rating expectedRating = new()
             {
@@ -54,7 +57,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IRatingDelegate> ratingDelegateMock = new();
-            ratingDelegateMock.Setup(s => s.InsertRating(It.Is<Rating>(r => r.RatingValue == expectedRating.RatingValue && r.Skip == expectedRating.Skip))).Returns(insertResult);
+            ratingDelegateMock.Setup(s => s.InsertRatingAsync(It.Is<Rating>(r => r.RatingValue == expectedRating.RatingValue && r.Skip == expectedRating.Skip), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(insertResult);
 
             Mock<IBackgroundJobClient> mockJobclient = new();
             Mock<IUserProfileDelegate> mockProfileDelegate = new();
@@ -66,7 +70,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 mockProfileDelegate.Object,
                 mockJobclient.Object);
 
-            RequestResult<Rating> actualResult = service.CreateRating(expectedRating);
+            RequestResult<Rating> actualResult = await service.CreateRatingAsync(expectedRating);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedRating.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -75,8 +79,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// CreateRating - Database Error.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateRatingWithError()
+        public async Task ShouldCreateRatingWithError()
         {
             Rating expectedRating = new()
             {
@@ -91,7 +96,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IRatingDelegate> ratingDelegateMock = new();
-            ratingDelegateMock.Setup(s => s.InsertRating(It.Is<Rating>(r => r.RatingValue == expectedRating.RatingValue && r.Skip == expectedRating.Skip))).Returns(insertResult);
+            ratingDelegateMock.Setup(s => s.InsertRatingAsync(It.Is<Rating>(r => r.RatingValue == expectedRating.RatingValue && r.Skip == expectedRating.Skip), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(insertResult);
 
             Mock<IBackgroundJobClient> mockJobclient = new();
             Mock<IUserProfileDelegate> mockProfileDelegate = new();
@@ -103,7 +109,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 mockProfileDelegate.Object,
                 mockJobclient.Object);
 
-            RequestResult<Rating> actualResult = service.CreateRating(expectedRating);
+            RequestResult<Rating> actualResult = await service.CreateRatingAsync(expectedRating);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -111,8 +117,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// CreateUserFeedBack - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public void ShouldCreateUserFeedback()
+        public async Task ShouldCreateUserFeedback()
         {
             UserFeedback expectedUserFeedback = new()
             {
@@ -142,11 +149,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IFeedbackDelegate> userFeedbackDelegateMock = new();
             userFeedbackDelegateMock.Setup(
-                    s => s.InsertUserFeedback(
+                    s => s.InsertUserFeedbackAsync(
                         It.Is<UserFeedback>(
                             r => r.Comment == expectedUserFeedback.Comment && r.Id == expectedUserFeedback.Id && r.UserProfileId == expectedUserFeedback.UserProfileId &&
-                                 r.IsSatisfied == expectedUserFeedback.IsSatisfied && r.IsReviewed == expectedUserFeedback.IsReviewed)))
-                .Returns(insertResult);
+                                 r.IsSatisfied == expectedUserFeedback.IsSatisfied && r.IsReviewed == expectedUserFeedback.IsReviewed),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(insertResult);
 
             Mock<IBackgroundJobClient> mockJobclient = new();
             Mock<IUserProfileDelegate> mockProfileDelegate = new();
@@ -159,7 +167,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 mockProfileDelegate.Object,
                 mockJobclient.Object);
 
-            DbResult<UserFeedback> actualResult = service.CreateUserFeedback(expectedUserFeedback);
+            DbResult<UserFeedback> actualResult = await service.CreateUserFeedbackAsync(expectedUserFeedback);
 
             Assert.Equal(DbStatusCode.Created, actualResult.Status);
             expectedUserFeedback.ShouldDeepEqual(actualResult.Payload);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
@@ -141,12 +141,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "mock@email.com",
             };
 
-            DbResult<UserProfile> profileResult = new()
-            {
-                Payload = profile,
-                Status = DbStatusCode.Read,
-            };
-
             Mock<IFeedbackDelegate> userFeedbackDelegateMock = new();
             userFeedbackDelegateMock.Setup(
                     s => s.InsertUserFeedbackAsync(
@@ -158,7 +152,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IBackgroundJobClient> mockJobclient = new();
             Mock<IUserProfileDelegate> mockProfileDelegate = new();
-            mockProfileDelegate.Setup(s => s.GetUserProfile(It.Is<string>(hdid => hdid == expectedUserFeedback.UserProfileId))).Returns(profileResult);
+            mockProfileDelegate.Setup(s => s.GetUserProfileAsync(It.Is<string>(hdid => hdid == expectedUserFeedback.UserProfileId), It.IsAny<CancellationToken>())).ReturnsAsync(profile);
 
             IUserFeedbackService service = new UserFeedbackService(
                 new Mock<ILogger<UserFeedbackService>>().Object,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -36,7 +36,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using HealthGateway.GatewayApiTests.Services.Test.Constants;
     using HealthGateway.GatewayApiTests.Services.Test.Mock;
     using HealthGateway.GatewayApiTests.Services.Test.Utils;
-    using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Configuration;
     using Moq;
     using Xunit;
@@ -122,14 +121,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Value = true.ToString(),
             };
 
-            List<UserPreference> userPreferences = new()
-                { dbUserPreference };
+            List<UserPreference> userPreferences = [dbUserPreference];
 
-            HashSet<DataSource> dataSources = new()
-            {
+            HashSet<DataSource> dataSources =
+            [
                 DataSource.Immunization,
                 DataSource.Medication,
-            };
+            ];
 
             UserProfileModel expected = UserProfileMapUtils.CreateFromDbModel(userProfile, Guid.Empty, MapperUtil.InitializeAutoMapper());
             UserProfileServiceMock mockService = new(GetIConfigurationRoot(null));
@@ -177,11 +175,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
-            HashSet<DataSource> dataSources = new()
-            {
+            HashSet<DataSource> dataSources =
+            [
                 DataSource.Immunization,
                 DataSource.Medication,
-            };
+            ];
 
             DbResult<UserProfile> readProfileDbResult = new()
             {
@@ -235,11 +233,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
-            HashSet<DataSource> dataSources = new()
-            {
+            HashSet<DataSource> dataSources =
+            [
                 DataSource.Immunization,
                 DataSource.Medication,
-            };
+            ];
 
             PatientModel patientModel = new()
             {
@@ -294,11 +292,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
-            HashSet<DataSource> dataSources = new()
-            {
+            HashSet<DataSource> dataSources =
+            [
                 DataSource.Immunization,
                 DataSource.Medication,
-            };
+            ];
 
             PatientModel patientModel = new()
             {
@@ -597,11 +595,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 TermsOfServiceId = this.termsOfServiceGuid,
             };
 
-            HashSet<DataSource> dataSources = new()
-            {
+            HashSet<DataSource> dataSources =
+            [
                 DataSource.Immunization,
                 DataSource.Medication,
-            };
+            ];
 
             DbResult<UserProfile> userProfileDbResult = new()
             {
@@ -615,10 +613,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Status = DbStatusCode.Updated,
             };
 
-            IHeaderDictionary headerDictionary = new HeaderDictionary
-            {
-                { "referer", "http://localhost/" },
-            };
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult, userProfileDbResultUpdate: userProfileUpdateDbResult)
                 .SetupEmailQueueServiceMock(false)
@@ -653,11 +647,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 Payload = userProfile,
                 Status = DbStatusCode.Read,
-            };
-
-            IHeaderDictionary headerDictionary = new HeaderDictionary
-            {
-                { "referer", "http://localhost/" },
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
@@ -701,11 +690,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Status = DbStatusCode.Updated,
             };
 
-            IHeaderDictionary headerDictionary = new HeaderDictionary
-            {
-                { "referer", "http://localhost/" },
-            };
-
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
                 .SetupUserProfileDelegateMockGetAndUpdate(this.hdid, userProfile, userProfileDbResult, userProfileDbResultUpdate: userProfileUpdateDbResult)
                 .SetupEmailQueueServiceMock(false);
@@ -736,21 +720,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = "unit.test@hgw.ca",
             };
 
-            HashSet<DataSource> dataSources = new()
-            {
+            HashSet<DataSource> dataSources =
+            [
                 DataSource.Immunization,
                 DataSource.Medication,
-            };
+            ];
 
             DbResult<UserProfile> userProfileDbResult = new()
             {
                 Payload = userProfile,
                 Status = DbStatusCode.Read,
-            };
-
-            IHeaderDictionary headerDictionary = new HeaderDictionary
-            {
-                { "referer", "http://localhost/" },
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))
@@ -788,11 +767,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 Payload = userProfile,
                 Status = DbStatusCode.Read,
-            };
-
-            IHeaderDictionary headerDictionary = new HeaderDictionary
-            {
-                { "referer", "http://localhost/" },
             };
 
             UserProfileServiceMock mockService = new UserProfileServiceMock(GetIConfigurationRoot(null))

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -153,13 +153,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
 
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile>());
 
             IUserSmsService service = new UserSmsService(
                 new Mock<ILogger<UserSmsService>>().Object,
@@ -191,12 +191,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile>());
 
             IUserSmsService service = new UserSmsService(
                 new Mock<ILogger<UserSmsService>>().Object,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -63,12 +63,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile>());
 
             IUserSmsService service = new UserSmsService(
                 new Mock<ILogger<UserSmsService>>().Object,
@@ -100,12 +100,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegate = new();
-            messagingVerificationDelegate.Setup(s => s.GetLastForUser(It.IsAny<string>(), It.IsAny<string>())).Returns(expectedResult);
+            messagingVerificationDelegate.Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedResult);
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
             userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
-            userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
+            userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile>());
 
             string changeFeedKey = $"{ChangeFeedOptions.ChangeFeed}:Notifications:Enabled";
             Dictionary<string, string?> configDict = new()

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile>());
 
             IUserSmsService service = new UserSmsService(
@@ -104,7 +104,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile>());
 
             string changeFeedKey = $"{ChangeFeedOptions.ChangeFeed}:Notifications:Enabled";
@@ -158,7 +158,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
 
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
 
             IUserSmsService service = new UserSmsService(
@@ -195,7 +195,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileDelegate> userProfileDelegate = new();
             UserProfile userProfileMock = new();
-            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>())).ReturnsAsync(userProfileMock);
+            userProfileDelegate.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfileMock);
             userProfileDelegate.Setup(s => s.Update(It.IsAny<UserProfile>(), It.IsAny<bool>())).Returns(new DbResult<UserProfile>());
 
             IUserSmsService service = new UserSmsService(

--- a/Apps/GatewayApi/test/unit/Services.Test/WebAlertServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/WebAlertServiceTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Models;
@@ -184,7 +185,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IPersonalAccountsService> mockPersonalAccountsService = new();
 
             PersonalAccount mockPersonalAccount = new() { Id = AccountId, PatientIdentity = new PatientIdentity { Pid = Pid } };
-            mockPersonalAccountsService.Setup(s => s.GetPatientAccountAsync(Hdid)).ReturnsAsync(mockPersonalAccount);
+            mockPersonalAccountsService.Setup(s => s.GetPatientAccountAsync(Hdid, It.IsAny<CancellationToken>())).ReturnsAsync(mockPersonalAccount);
 
             return mockPersonalAccountsService.Object;
         }
@@ -193,9 +194,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             Mock<IWebAlertApi> mockWebAlertApi = new();
 
-            mockWebAlertApi.Setup(s => s.GetWebAlertsAsync(Pid)).ReturnsAsync(GetPhsaWebAlerts());
-            mockWebAlertApi.Setup(s => s.DeleteWebAlertsAsync(Pid)).Returns(Task.CompletedTask);
-            mockWebAlertApi.Setup(s => s.DeleteWebAlertAsync(Pid, WebAlertId)).Returns(Task.CompletedTask);
+            mockWebAlertApi.Setup(s => s.GetWebAlertsAsync(Pid, It.IsAny<CancellationToken>())).ReturnsAsync(GetPhsaWebAlerts());
+            mockWebAlertApi.Setup(s => s.DeleteWebAlertsAsync(Pid, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
+            mockWebAlertApi.Setup(s => s.DeleteWebAlertAsync(Pid, WebAlertId, It.IsAny<CancellationToken>())).Returns(Task.CompletedTask);
 
             return new WebAlertService(
                 new Mock<ILogger<WebAlertService>>().Object,

--- a/Apps/GatewayApi/test/unit/Validations/UserProfileValidatorTests.cs
+++ b/Apps/GatewayApi/test/unit/Validations/UserProfileValidatorTests.cs
@@ -15,8 +15,12 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApiTests.Validations
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentValidation.Results;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.GatewayApi.Validations;
+    using Moq;
     using Xunit;
 
     /// <summary>
@@ -29,6 +33,7 @@ namespace HealthGateway.GatewayApiTests.Validations
         /// </summary>
         /// <param name="phoneNumber">Valid phone number.</param>
         /// <param name="comment">Reason for valid result.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
         [InlineData("3345678901", "Valid entry")]
         [InlineData("4345678901", "Valid entry")]
@@ -37,7 +42,7 @@ namespace HealthGateway.GatewayApiTests.Validations
         [InlineData("2507001000", "Valid entry")]
         [InlineData("", "Allow empty strings to clear profile of sms number")]
         [InlineData(null, "Allow null value to clear profile of sms number")]
-        public void ShouldBeValid(string? phoneNumber, string comment)
+        public async Task ShouldBeValid(string? phoneNumber, string comment)
         {
             UserProfile profile = new()
             {
@@ -45,8 +50,9 @@ namespace HealthGateway.GatewayApiTests.Validations
             };
 
             // Both methods of validating should result in the same output.
-            Assert.True(new UserProfileValidator().Validate(profile).IsValid, comment);
-            Assert.True(UserProfileValidator.ValidateUserProfileSmsNumber(phoneNumber), comment);
+            ValidationResult validationResult = await new UserProfileValidator().ValidateAsync(profile, It.IsAny<CancellationToken>());
+            Assert.True(validationResult.IsValid);
+            Assert.True(await UserProfileValidator.ValidateUserProfileSmsNumberAsync(phoneNumber), comment);
         }
 
         /// <summary>

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -298,7 +298,7 @@ namespace HealthGateway.PatientTests.Services
         private Mock<IPersonalAccountsService> GetMockPersonalAccountService()
         {
             Mock<IPersonalAccountsService> personalAccountService = new();
-            personalAccountService.Setup(o => o.GetPatientAccountAsync(this.hdid))
+            personalAccountService.Setup(o => o.GetPatientAccountAsync(this.hdid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new PersonalAccount
                     {


### PR DESCRIPTION
# Implements [AB#16544](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16544)

## Description

Made GatewayApi async and added Cancellation Token to:

- Controllers
- Services: Added DB result checking in some cases as that DB result was never checked and assumed to be successful
- Delegates
- Updated unit tests

Created [AB#16590](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/16590) to convert Job Scheduler to async for delegates calls that were not converted to async in this ticket.

Also created [AB#16591](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/16591) to veirify and refactor unit tests:

- Clean up and simplify unit tests
- Some of the mocks are no longer due to previous code changes (i.e., not this PR)

<img width="1234" alt="Screenshot 2023-12-18 at 3 00 06 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/018c53bd-f599-44c7-aacb-846b503d1f9c">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
