### PR TITLE
Revert "Change cypress Url to prevent loadbalancing"

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress.config.js
+++ b/Apps/Admin/Tests/Functional/cypress.config.js
@@ -4,7 +4,7 @@ const { isFileExist, findFiles } = require("cy-verify-downloads");
 module.exports = defineConfig({
     projectId: "rccf87",
     e2e: {
-        baseUrl: "https://dev-admin-k.healthgateway.gov.bc.ca",
+        baseUrl: "https://dev-admin.healthgateway.gov.bc.ca",
         defaultCommandTimeout: 30000,
         blockHosts: ["spt.apps.gov.bc.ca"],
         specPattern: "cypress/integration/**/*.cy.{js,jsx,ts,tsx}",

--- a/Testing/functional/tests/cypress.config.js
+++ b/Testing/functional/tests/cypress.config.js
@@ -45,7 +45,7 @@ module.exports = defineConfig({
         setupNodeEvents(on, _config) {
             on("task", verifyDownloadTasks);
         },
-        baseUrl: "https://dev-k.healthgateway.gov.bc.ca",
+        baseUrl: "https://dev.healthgateway.gov.bc.ca",
         specPattern: "cypress/integration/**/*.{js,jsx,ts,tsx}",
     },
 });


### PR DESCRIPTION
Issue discovered in the tests relates to an API error and the test failing rather than any timeout due to web client not being delivered in time.