### PR TITLE
Make Clinical Documents async for AB#16579.

### DIFF
--- a/Apps/ClinicalDocument/src/Api/IClinicalDocumentsApi.cs
+++ b/Apps/ClinicalDocument/src/Api/IClinicalDocumentsApi.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.ClinicalDocument.Api
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.ClinicalDocument.Models.PHSA;
     using HealthGateway.Common.Data.Models.PHSA;
@@ -30,17 +31,19 @@ namespace HealthGateway.ClinicalDocument.Api
         /// Retrieves clinical document records by patient identifier.
         /// </summary>
         /// <param name="pid">The patient id to get clinical document records.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The clinical document records for the patient identifier.</returns>
         [Get("/patient/{pid}/health-data?Categories=4")]
-        Task<PhsaHealthDataResponse> GetClinicalDocumentRecordsAsync(string pid);
+        Task<PhsaHealthDataResponse> GetClinicalDocumentRecordsAsync(string pid, CancellationToken ct);
 
         /// <summary>
         /// Retrieves clinical document file by patient identifier and file id.
         /// </summary>
         /// <param name="pid">The patient id to get a clinical document file.</param>
         /// <param name="id">The file id to get a clinical document file.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The clinical document file for the patient identifier and file id.</returns>
         [Get("/patient/{pid}/file/{id}")]
-        Task<EncodedMedia> GetClinicalDocumentFileAsync(Guid pid, string id);
+        Task<EncodedMedia> GetClinicalDocumentFileAsync(Guid pid, string id, CancellationToken ct);
     }
 }

--- a/Apps/ClinicalDocument/src/Controllers/ClinicalDocumentController.cs
+++ b/Apps/ClinicalDocument/src/Controllers/ClinicalDocumentController.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.ClinicalDocument.Controllers
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.ClinicalDocument.Models;
     using HealthGateway.ClinicalDocument.Services;
@@ -57,6 +58,7 @@ namespace HealthGateway.ClinicalDocument.Controllers
         /// Gets the collection of clinical document records associated with the given HDID.
         /// </summary>
         /// <param name="hdid">The subject's HDID.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The collection of clinical document records.</returns>
         /// <response code="200">Returns the collection of clinical document records.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -69,10 +71,10 @@ namespace HealthGateway.ClinicalDocument.Controllers
         [Produces("application/json")]
         [Route("{hdid}")]
         [Authorize(Policy = ClinicalDocumentPolicy.Read)]
-        public async Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecords(string hdid)
+        public async Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecords(string hdid, CancellationToken ct)
         {
             this.logger.LogDebug("Getting clinical document records for HDID: {Hdid}", hdid);
-            RequestResult<IEnumerable<ClinicalDocumentRecord>> result = await this.clinicalDocumentService.GetRecordsAsync(hdid).ConfigureAwait(true);
+            RequestResult<IEnumerable<ClinicalDocumentRecord>> result = await this.clinicalDocumentService.GetRecordsAsync(hdid, ct);
             this.logger.LogDebug("Finished getting clinical document records for HDID: {Hdid}", hdid);
             return result;
         }
@@ -82,6 +84,7 @@ namespace HealthGateway.ClinicalDocument.Controllers
         /// </summary>
         /// <param name="hdid">The subject's HDID.</param>
         /// <param name="fileId">The ID of the file to fetch.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The specified clinical document file.</returns>
         /// <response code="200">Returns the specified clinical document file.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -94,10 +97,10 @@ namespace HealthGateway.ClinicalDocument.Controllers
         [Produces("application/json")]
         [Route("{hdid}/file/{fileId}")]
         [Authorize(Policy = ClinicalDocumentPolicy.Read)]
-        public async Task<RequestResult<EncodedMedia>> GetFile(string hdid, string fileId)
+        public async Task<RequestResult<EncodedMedia>> GetFile(string hdid, string fileId, CancellationToken ct)
         {
             this.logger.LogDebug("Getting clinical document file for Hdid: {Hdid} with file ID: {FileId}", hdid, fileId);
-            RequestResult<EncodedMedia> result = await this.clinicalDocumentService.GetFileAsync(hdid, fileId).ConfigureAwait(true);
+            RequestResult<EncodedMedia> result = await this.clinicalDocumentService.GetFileAsync(hdid, fileId, ct);
             this.logger.LogDebug("Finished getting clinical document file for Hdid: {Hdid} with file ID: {FileId}", hdid, fileId);
             return result;
         }

--- a/Apps/ClinicalDocument/src/Services/IClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/IClinicalDocumentService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.ClinicalDocument.Services
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.ClinicalDocument.Models;
     using HealthGateway.Common.Data.Models.PHSA;
@@ -30,15 +31,17 @@ namespace HealthGateway.ClinicalDocument.Services
         /// Gets the collection of clinical document records associated with the given HDID.
         /// </summary>
         /// <param name="hdid">The subject's HDID.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The collection of clinical document records.</returns>
-        Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecordsAsync(string hdid);
+        Task<RequestResult<IEnumerable<ClinicalDocumentRecord>>> GetRecordsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets a specific clinical document file associated with the given HDID and file ID.
         /// </summary>
         /// <param name="hdid">The subject's HDID.</param>
         /// <param name="fileId">The ID of the file to fetch.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The specified clinical document file.</returns>
-        Task<RequestResult<EncodedMedia>> GetFileAsync(string hdid, string fileId);
+        Task<RequestResult<EncodedMedia>> GetFileAsync(string hdid, string fileId, CancellationToken ct = default);
     }
 }

--- a/Apps/Common/src/Services/IPersonalAccountsService.cs
+++ b/Apps/Common/src/Services/IPersonalAccountsService.cs
@@ -37,7 +37,8 @@ namespace HealthGateway.Common.Services
         /// Gets personal account information from PHSA using the supplied HDID.
         /// </summary>
         /// <param name="hdid">The HDID to look up.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The personal account model wrapped in a RequestResult.</returns>
-        Task<RequestResult<PersonalAccount>> GetPatientAccountResultAsync(string hdid);
+        Task<RequestResult<PersonalAccount>> GetPatientAccountResultAsync(string hdid, CancellationToken ct = default);
     }
 }

--- a/Apps/Common/src/Services/PersonalAccountsService.cs
+++ b/Apps/Common/src/Services/PersonalAccountsService.cs
@@ -71,19 +71,19 @@ namespace HealthGateway.Common.Services
         /// <inheritdoc/>
         public async Task<PersonalAccount> GetPatientAccountAsync(string hdid, CancellationToken ct = default)
         {
-            PersonalAccount? account = this.GetFromCache(hdid);
+            PersonalAccount? account = await this.GetFromCacheAsync(hdid, ct);
             if (account is not null)
             {
                 return account;
             }
 
             account = await this.personalAccountsApi.AccountLookupByHdidAsync(hdid, ct);
-            this.PutCache(hdid, account);
+            await this.PutCacheAsync(hdid, account, ct);
             return account;
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PersonalAccount>> GetPatientAccountResultAsync(string hdid)
+        public async Task<RequestResult<PersonalAccount>> GetPatientAccountResultAsync(string hdid, CancellationToken ct = default)
         {
             RequestResult<PersonalAccount> requestResult = new()
             {
@@ -93,7 +93,7 @@ namespace HealthGateway.Common.Services
 
             try
             {
-                requestResult.ResourcePayload = await this.GetPatientAccountAsync(hdid).ConfigureAwait(true);
+                requestResult.ResourcePayload = await this.GetPatientAccountAsync(hdid, ct);
                 requestResult.ResultStatus = ResultType.Success;
                 requestResult.TotalResultCount = 1;
             }
@@ -115,14 +115,16 @@ namespace HealthGateway.Common.Services
         /// </summary>
         /// <param name="hdid">The hdid to use to retrieve the Personal Account.</param>
         /// <param name="personalAccount">The Personal Account to be cached.</param>
-        private void PutCache(string hdid, PersonalAccount personalAccount)
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+        private async Task PutCacheAsync(string hdid, PersonalAccount personalAccount, CancellationToken ct)
         {
             using Activity? activity = Source.StartActivity();
             string cacheKey = $"{CacheDomain}:HDID:{hdid}";
             if (this.phsaConfig.PersonalAccountsCacheTtl > 0)
             {
                 this.logger.LogDebug("Attempting to cache Personal Account for cache key: {Key}", cacheKey);
-                this.cacheProvider.AddItem(cacheKey, personalAccount, TimeSpan.FromMinutes(this.phsaConfig.PersonalAccountsCacheTtl));
+                await this.cacheProvider.AddItemAsync(cacheKey, personalAccount, TimeSpan.FromMinutes(this.phsaConfig.PersonalAccountsCacheTtl), ct);
             }
             else
             {
@@ -136,15 +138,16 @@ namespace HealthGateway.Common.Services
         /// Attempts to get the Personal Account from the cache.
         /// </summary>
         /// <param name="hdid">The hdid used to create the key to retrieve.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The Personal Account or null.</returns>
-        private PersonalAccount? GetFromCache(string hdid)
+        private async Task<PersonalAccount?> GetFromCacheAsync(string hdid, CancellationToken ct)
         {
             using Activity? activity = Source.StartActivity();
             PersonalAccount? cacheItem = null;
             if (this.phsaConfig.PersonalAccountsCacheTtl > 0)
             {
                 string cacheKey = $"{CacheDomain}:HDID:{hdid}";
-                cacheItem = this.cacheProvider.GetItem<PersonalAccount>(cacheKey);
+                cacheItem = await this.cacheProvider.GetItemAsync<PersonalAccount>(cacheKey, ct);
                 this.logger.LogDebug("Cache key: {CacheKey} was {Found} found in cache", cacheKey, cacheItem == null ? "not" : string.Empty);
             }
 


### PR DESCRIPTION
# Implements AB#16579

## Description

- Added Cancellation Token to Clinical Document controllers and services
- Changed services methods to async where needed
- Updated unit tests to 100% coverage

**Coverage:**

<img width="572" alt="Screenshot 2024-01-05 at 4 52 41 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/c5e42766-3d39-4631-9310-5c1212ce1ce8">

<img width="530" alt="Screenshot 2024-01-05 at 4 53 31 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/0a8eb22c-81e2-4cb5-8502-7123a569db0d">

<img width="1225" alt="Screenshot 2024-01-05 at 4 52 49 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/ea508ba1-0650-4d20-8f24-f9df10fdb61b">

<img width="753" alt="Screenshot 2024-01-05 at 4 53 11 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/3a544944-6fba-407c-a2ff-22cdee844c66">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
