### PR TITLE
Add cancellation token to Immunization

### DIFF
--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -290,7 +290,7 @@ namespace AccountDataAccessTest
                         It.Is<IEnumerable<MessageEnvelope>>(
                             me => AssertDataSourcesBlockedEvent(
                                 blockedAccess,
-                                me.Select(envelope => envelope.Content as DataSourcesBlockedEvent)!.First())),
+                                me.Select(envelope => envelope.Content as DataSourcesBlockedEvent).First())),
                         It.IsAny<CancellationToken>()));
             }
         }

--- a/Apps/Admin/Server/Program.cs
+++ b/Apps/Admin/Server/Program.cs
@@ -35,7 +35,6 @@ namespace HealthGateway.Admin.Server
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.MapProfiles;
     using HealthGateway.Common.Models.PHSA;
-    using HealthGateway.Common.Services;
     using HealthGateway.Common.Utils.Phsa;
     using HealthGateway.Database.Delegates;
     using Microsoft.AspNetCore.Builder;

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.Admin.Server.Services
                         }
                         catch (ProblemDetailsException e)
                         {
-                            logger.Error($"Error retrieving patient details for hdid {hdid}: {e.Message}");
+                            logger.Error("Error retrieving patient details for hdid {Hdid}: {EMessage}", hdid, e.Message);
                         }
 
                         return new ProtectedDependentRecord(hdid, patient?.Items.SingleOrDefault()?.Phn);

--- a/Apps/Common/src/Services/EmailQueueService.cs
+++ b/Apps/Common/src/Services/EmailQueueService.cs
@@ -71,7 +71,7 @@ namespace HealthGateway.Common.Services
         /// <inheritdoc/>
         public async Task QueueNewEmailAsync(string toEmail, string templateName, Dictionary<string, string> keyValues, bool shouldCommit = true, CancellationToken ct = default)
         {
-            EmailTemplate? emailTemplate = await this.GetEmailTemplateAsync(templateName, ct) ?? throw new ProblemDetailsException(
+            EmailTemplate emailTemplate = await this.GetEmailTemplateAsync(templateName, ct) ?? throw new ProblemDetailsException(
                 ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", ErrorMessages.EmailTemplateNotFound));
             await this.QueueNewEmailAsync(toEmail, emailTemplate, keyValues, shouldCommit, ct);
         }

--- a/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
+++ b/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
@@ -114,13 +114,10 @@ namespace HealthGateway.CommonTests.Services
         [Theory]
         [InlineData(true, CommunicationType.Banner)]
         [InlineData(false, CommunicationType.Banner)]
-        //[InlineData(DbStatusCode.Error, CommunicationType.Banner)]
         [InlineData(true, CommunicationType.InApp)]
         [InlineData(false, CommunicationType.InApp)]
-        //[InlineData(DbStatusCode.Error, CommunicationType.InApp)]
         [InlineData(true, CommunicationType.Mobile)]
         [InlineData(false, CommunicationType.Mobile)]
-        //[InlineData(DbStatusCode.Error, CommunicationType.Mobile)]
         public async Task ShouldGetActiveCommunicationFromDb(bool communicationExists, CommunicationType communicationType)
         {
             Communication? communication = null;

--- a/Apps/Common/test/unit/Services/EmailQueueServiceTests.cs
+++ b/Apps/Common/test/unit/Services/EmailQueueServiceTests.cs
@@ -36,11 +36,13 @@ namespace HealthGateway.CommonTests.Services
     /// <summary>
     /// EmailQueueService's Unit Tests.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
     public class EmailQueueServiceTests
     {
         /// <summary>
         /// QueueNewEmail - Happy Path.
         /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         public async Task ShouldQueueEmail()
         {

--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -337,7 +337,7 @@ namespace HealthGateway.GatewayApi.Services
 
         private async Task UpdateNotificationSettingsAsync(string dependentHdid, string delegateHdid, bool isDelete = false, CancellationToken ct = default)
         {
-            UserProfile? delegateUserProfile = await this.userProfileDelegate.GetUserProfileAsync(delegateHdid, ct) ?? throw new ProblemDetailsException(
+            UserProfile delegateUserProfile = await this.userProfileDelegate.GetUserProfileAsync(delegateHdid, ct) ?? throw new ProblemDetailsException(
                 ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", ErrorMessages.DelegateUserProfileNotFound));
 
             // Update the notification settings

--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -266,7 +266,7 @@ namespace HealthGateway.GatewayApi.Services
                 [EmailTemplateVariable.ExpiryHours] = verificationExpiryHours.ToString("0", CultureInfo.CurrentCulture),
             };
 
-            EmailTemplate? emailTemplate = await this.emailQueueService.GetEmailTemplateAsync(EmailTemplateName.RegistrationTemplate, ct) ?? throw new ProblemDetailsException(
+            EmailTemplate emailTemplate = await this.emailQueueService.GetEmailTemplateAsync(EmailTemplateName.RegistrationTemplate, ct) ?? throw new ProblemDetailsException(
                 ExceptionUtility.CreateServerError($"{ServiceType.Database}:{ErrorType.CommunicationInternal}", ErrorMessages.EmailTemplateNotFound));
 
             MessagingVerification messageVerification = new()

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -194,7 +194,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task InvalidInviteLastSent(string? hdid, bool validated, bool deleted, bool userProfileExists)
         {
             // Arrange
-            const string invalidHdid = "doesn't match";
             Guid inviteKey = Guid.NewGuid();
             MessagingVerification? verificationByInviteKey = hdid != null
                 ? new()
@@ -204,7 +203,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 }
                 : null;
 
-            MessagingVerification? lastVerificationForUser = new()
+            MessagingVerification lastVerificationForUser = new()
             {
                 UserProfileId = HdIdMock,
                 Validated = validated,

--- a/Apps/Immunization/src/Api/IImmunizationApi.cs
+++ b/Apps/Immunization/src/Api/IImmunizationApi.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Api;
 
+using System.Threading;
 using System.Threading.Tasks;
 using HealthGateway.Common.Data.Models.PHSA;
 using HealthGateway.Common.Models.PHSA;
@@ -30,9 +31,10 @@ public interface IImmunizationApi
     /// </summary>
     /// <param name="immunizationId">The ID of the immunization to retrieve.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
+    /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
     /// <returns>A PhsaResult containing the immunization that matches the given ID.</returns>
     [Get("/api/v1/Immunizations/{ImmunizationId}")]
-    Task<PhsaResult<ImmunizationViewResponse>> GetImmunizationAsync(string immunizationId, [Authorize] string token);
+    Task<PhsaResult<ImmunizationViewResponse>> GetImmunizationAsync(string immunizationId, [Authorize] string token, CancellationToken ct);
 
     /// <summary>
     /// Retrieves a PhsaResult containing the immunizations and recommendations of a given patient.
@@ -40,11 +42,12 @@ public interface IImmunizationApi
     /// <param name="subjectHdid">The Hdid to query immunizations and recommendations.</param>
     /// <param name="limit">The Limit to query immunizations and recommendations.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
+    /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
     /// <returns>
     /// A PhsaResult containing the immunizations and recommendations of a given patient.
     /// </returns>
     [Get("/api/v1/Immunizations?subjectHdid={subjectHdid}&limit={limit}")]
-    Task<PhsaResult<ImmunizationResponse>> GetImmunizationsAsync(string subjectHdid, int? limit, [Authorize] string token);
+    Task<PhsaResult<ImmunizationResponse>> GetImmunizationsAsync(string subjectHdid, int? limit, [Authorize] string token, CancellationToken ct);
 
     /// <summary>
     /// Retrieves a PhsaResult containing the vaccine status of a given patient.
@@ -52,9 +55,10 @@ public interface IImmunizationApi
     /// <param name="subjectHdid">The HDID identifying the subject of the request.</param>
     /// <param name="federalPvc">A value indicating if the federal proof of vaccination should be included in the response.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
+    /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
     /// <returns>
     /// A PhsaResult containing the vaccine status of a given patient.
     /// </returns>
     [Post("/api/v1/Immunizations/VaccineStatusIndicator?subjectHdid={subjectHdid}&federalPvc={federalPvc}")]
-    Task<PhsaResult<VaccineStatusResult>> GetVaccineStatusAsync(string subjectHdid, bool federalPvc, [Authorize] string token);
+    Task<PhsaResult<VaccineStatusResult>> GetVaccineStatusAsync(string subjectHdid, bool federalPvc, [Authorize] string token, CancellationToken ct);
 }

--- a/Apps/Immunization/src/Api/IImmunizationPublicApi.cs
+++ b/Apps/Immunization/src/Api/IImmunizationPublicApi.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Api;
 
+using System.Threading;
 using System.Threading.Tasks;
 using HealthGateway.Common.Data.Models.PHSA;
 using HealthGateway.Common.Models.PHSA;
@@ -31,6 +32,7 @@ public interface IImmunizationPublicApi
     /// <param name="query">The model containing details of the request.</param>
     /// <param name="token">The bearer token to authorize the call.</param>
     /// <param name="clientIp">The ip of the client calling the service.</param>
+    /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
     /// <returns>
     /// A PhsaResult containing the vaccine status of a given patient.
     /// </returns>
@@ -38,5 +40,6 @@ public interface IImmunizationPublicApi
     Task<PhsaResult<VaccineStatusResult>> GetVaccineStatusAsync(
         VaccineStatusQuery query,
         [Authorize] string token,
-        [Header("X-Forwarded-For")] string clientIp);
+        [Header("X-Forwarded-For")] string clientIp,
+        CancellationToken ct);
 }

--- a/Apps/Immunization/src/Controllers/AuthenticatedVaccineStatusController.cs
+++ b/Apps/Immunization/src/Controllers/AuthenticatedVaccineStatusController.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Controllers
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
@@ -55,6 +56,7 @@ namespace HealthGateway.Immunization.Controllers
         /// Requests the vaccine status for the supplied HDID.
         /// </summary>
         /// <param name="hdid">The patient's HDID.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped vaccine status.</returns>
         /// <response code="200">Returns the Vaccine Status.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -66,10 +68,10 @@ namespace HealthGateway.Immunization.Controllers
         [HttpGet]
         [Produces("application/json")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<RequestResult<VaccineStatus>> GetVaccineStatus([FromQuery] string hdid)
+        public async Task<RequestResult<VaccineStatus>> GetVaccineStatus([FromQuery] string hdid, CancellationToken ct)
         {
             this.logger.LogDebug("Getting vaccine status for HDID {Hdid}", hdid);
-            RequestResult<VaccineStatus> result = await this.vaccineStatusService.GetAuthenticatedVaccineStatus(hdid).ConfigureAwait(true);
+            RequestResult<VaccineStatus> result = await this.vaccineStatusService.GetAuthenticatedVaccineStatusAsync(hdid, ct);
             this.logger.LogDebug("Finished getting vaccine status for HDID {Hdid}", hdid);
 
             return result;
@@ -79,6 +81,7 @@ namespace HealthGateway.Immunization.Controllers
         /// Requests the COVID-19 Vaccine Proof for the supplied HDID if the user is the owner.
         /// </summary>
         /// <param name="hdid">The patient's HDID.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The PDF Vaccine Proof.</returns>
         /// <response code="200">Returns the Vaccine Proof.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -91,10 +94,10 @@ namespace HealthGateway.Immunization.Controllers
         [Produces("application/json")]
         [Route("pdf")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<RequestResult<VaccineProofDocument>> GetVaccineProof([FromQuery] string hdid)
+        public async Task<RequestResult<VaccineProofDocument>> GetVaccineProof([FromQuery] string hdid, CancellationToken ct)
         {
             this.logger.LogDebug("Getting  Vaccine Proof for HDID {Hdid}", hdid);
-            RequestResult<VaccineProofDocument> result = await this.vaccineStatusService.GetAuthenticatedVaccineProof(hdid).ConfigureAwait(true);
+            RequestResult<VaccineProofDocument> result = await this.vaccineStatusService.GetAuthenticatedVaccineProofAsync(hdid, ct);
             this.logger.LogDebug("Finished getting Vaccine Proof for HDID {Hdid}", hdid);
 
             return result;

--- a/Apps/Immunization/src/Controllers/ImmunizationController.cs
+++ b/Apps/Immunization/src/Controllers/ImmunizationController.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Controllers
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
@@ -61,6 +62,7 @@ namespace HealthGateway.Immunization.Controllers
         /// </summary>
         /// <param name="hdid">The hdid patient id.</param>
         /// <param name="immunizationId">The immunization id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The immunization record with the given id.</returns>
         /// <response code="200">Returns the List of Immunization records.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -73,10 +75,10 @@ namespace HealthGateway.Immunization.Controllers
         [Produces("application/json")]
         [Route("{immunizationId}")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<RequestResult<ImmunizationEvent>> GetImmunization([FromQuery] string hdid, string immunizationId)
+        public async Task<RequestResult<ImmunizationEvent>> GetImmunization([FromQuery] string hdid, string immunizationId, CancellationToken ct)
         {
             this.logger.LogDebug("Getting immunization {ImmunizationId} for user {Hdid}", immunizationId, hdid);
-            RequestResult<ImmunizationEvent> result = await this.service.GetImmunization(immunizationId).ConfigureAwait(true);
+            RequestResult<ImmunizationEvent> result = await this.service.GetImmunizationAsync(immunizationId, ct);
 
             this.logger.LogDebug("Finished getting immunization {ImmunizationId} for user {Hdid}", immunizationId, hdid);
             return result;
@@ -86,6 +88,7 @@ namespace HealthGateway.Immunization.Controllers
         /// Gets a json list of immunization records.
         /// </summary>
         /// <param name="hdid">The hdid patient id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of immunization records for the given patient identifier.</returns>
         /// <response code="200">Returns the List of Immunization records.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -97,10 +100,10 @@ namespace HealthGateway.Immunization.Controllers
         [HttpGet]
         [Produces("application/json")]
         [Authorize(Policy = ImmunizationPolicy.Read)]
-        public async Task<RequestResult<ImmunizationResult>> GetImmunizations([FromQuery] string hdid)
+        public async Task<RequestResult<ImmunizationResult>> GetImmunizations([FromQuery] string hdid, CancellationToken ct)
         {
             this.logger.LogDebug("Getting immunizations for user {Hdid}", hdid);
-            RequestResult<ImmunizationResult> result = await this.service.GetImmunizations(hdid).ConfigureAwait(true);
+            RequestResult<ImmunizationResult> result = await this.service.GetImmunizationsAsync(hdid, ct);
 
             this.logger.LogDebug("Finished getting immunizations for user {Hdid}", hdid);
             return result;

--- a/Apps/Immunization/src/Controllers/PublicVaccineStatusController.cs
+++ b/Apps/Immunization/src/Controllers/PublicVaccineStatusController.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Controllers
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Filters;
@@ -56,6 +57,7 @@ namespace HealthGateway.Immunization.Controllers
         /// <param name="phn">The personal health number to query.</param>
         /// <param name="dateOfBirth">The date of birth (yyyy-MM-dd) for the supplied PHN.</param>
         /// <param name="dateOfVaccine">The date of one of the vaccine doses (yyyy-MM-dd) for the supplied PHN.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped vaccine status.</returns>
         /// <response code="200">Returns the Vaccine status.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -66,10 +68,10 @@ namespace HealthGateway.Immunization.Controllers
         /// <response code="503">The service is unavailable for use.</response>
         [HttpGet]
         [Produces("application/json")]
-        public async Task<RequestResult<VaccineStatus>> GetVaccineStatus([FromHeader] string phn, [FromHeader] string dateOfBirth, [FromHeader] string dateOfVaccine)
+        public async Task<RequestResult<VaccineStatus>> GetVaccineStatus([FromHeader] string phn, [FromHeader] string dateOfBirth, [FromHeader] string dateOfVaccine, CancellationToken ct)
         {
             this.logger.LogTrace("Getting vaccine status for PHN: {Phn}, DOB: {DateOfBirth}, and DOV: {DateOfVaccine}", phn, dateOfBirth, dateOfVaccine);
-            RequestResult<VaccineStatus> result = await this.vaccineStatusService.GetPublicVaccineStatus(phn, dateOfBirth, dateOfVaccine).ConfigureAwait(true);
+            RequestResult<VaccineStatus> result = await this.vaccineStatusService.GetPublicVaccineStatusAsync(phn, dateOfBirth, dateOfVaccine, ct);
             this.logger.LogTrace("Finished getting vaccine status for PHN: {Phn}, DOB: {DateOfBirth}, and DOV: {DateOfVaccine}", phn, dateOfBirth, dateOfVaccine);
 
             return result;
@@ -81,6 +83,7 @@ namespace HealthGateway.Immunization.Controllers
         /// <param name="phn">The personal health number to query.</param>
         /// <param name="dateOfBirth">The date of birth (yyyy-MM-dd) for the supplied PHN.</param>
         /// <param name="dateOfVaccine">The date of one of the vaccine doses (yyyy-MM-dd) for the supplied PHN.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped vaccine proof.</returns>
         /// <response code="200">Returns the vaccine proof.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -92,10 +95,10 @@ namespace HealthGateway.Immunization.Controllers
         [HttpGet]
         [Route("pdf")]
         [Produces("application/json")]
-        public async Task<RequestResult<VaccineProofDocument>> GetVaccineProof([FromHeader] string phn, [FromHeader] string dateOfBirth, [FromHeader] string dateOfVaccine)
+        public async Task<RequestResult<VaccineProofDocument>> GetVaccineProof([FromHeader] string phn, [FromHeader] string dateOfBirth, [FromHeader] string dateOfVaccine, CancellationToken ct)
         {
             this.logger.LogDebug("Getting Vaccine Proof for PHN: {Phn}, DOB: {DateOfBirth}, and DOV: {DateOfVaccine}", phn, dateOfBirth, dateOfVaccine);
-            RequestResult<VaccineProofDocument> result = await this.vaccineStatusService.GetPublicVaccineProof(phn, dateOfBirth, dateOfVaccine).ConfigureAwait(true);
+            RequestResult<VaccineProofDocument> result = await this.vaccineStatusService.GetPublicVaccineProofAsync(phn, dateOfBirth, dateOfVaccine, ct);
             this.logger.LogDebug("Finished getting Vaccine Proof for PHN: {Phn}, DOB: {DateOfBirth}, and DOV: {DateOfVaccine}", phn, dateOfBirth, dateOfVaccine);
 
             return result;

--- a/Apps/Immunization/src/Delegates/IImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/IImmunizationDelegate.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Delegates
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.PHSA;
@@ -28,15 +29,17 @@ namespace HealthGateway.Immunization.Delegates
         /// Returns the matching immunization for the given id.
         /// </summary>
         /// <param name="immunizationId">The id of the immunization to retrieve.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The immunization that matches the given id.</returns>
-        Task<RequestResult<PhsaResult<ImmunizationViewResponse>>> GetImmunizationAsync(string immunizationId);
+        Task<RequestResult<PhsaResult<ImmunizationViewResponse>>> GetImmunizationAsync(string immunizationId, CancellationToken ct = default);
 
         /// <summary>
         /// Returns a PHSA Result including the load state and a List of Immunizations for the authenticated user.
         /// It has a collection of one or more Immunizations.
         /// </summary>
         /// <param name="hdid">The hdid patient id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The PhsaResult including the load state and the list of Immunizations available for the user hdid.</returns>
-        Task<RequestResult<PhsaResult<ImmunizationResponse>>> GetImmunizationsAsync(string hdid);
+        Task<RequestResult<PhsaResult<ImmunizationResponse>>> GetImmunizationsAsync(string hdid, CancellationToken ct = default);
     }
 }

--- a/Apps/Immunization/src/Delegates/IVaccineStatusDelegate.cs
+++ b/Apps/Immunization/src/Delegates/IVaccineStatusDelegate.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Delegates
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models.PHSA;
     using HealthGateway.Common.Data.ViewModels;
@@ -34,8 +35,9 @@ namespace HealthGateway.Immunization.Delegates
         /// response.
         /// </param>
         /// <param name="accessToken">The bearer token to authorize the call.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The vaccine status result for the given patient.</returns>
-        Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatus(string hdid, bool includeFederalPvc, string accessToken);
+        Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusAsync(string hdid, bool includeFederalPvc, string accessToken, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves the vaccine status for the patient identified by the query.
@@ -43,7 +45,8 @@ namespace HealthGateway.Immunization.Delegates
         /// <param name="query">The vaccine status query.</param>
         /// <param name="accessToken">The bearer token to authorize the call.</param>
         /// <param name="clientIp">The IP of the client calling the service.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The vaccine status result for the given patient.</returns>
-        Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublic(VaccineStatusQuery query, string accessToken, string clientIp);
+        Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublicAsync(VaccineStatusQuery query, string accessToken, string clientIp, CancellationToken ct = default);
     }
 }

--- a/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Immunization.Delegates
     using System;
     using System.Diagnostics;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Data.Constants;
@@ -66,7 +67,7 @@ namespace HealthGateway.Immunization.Delegates
         private static ActivitySource Source { get; } = new(nameof(RestImmunizationDelegate));
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PhsaResult<ImmunizationViewResponse>>> GetImmunizationAsync(string immunizationId)
+        public async Task<RequestResult<PhsaResult<ImmunizationViewResponse>>> GetImmunizationAsync(string immunizationId, CancellationToken ct = default)
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Getting immunization {ImmunizationId}", immunizationId);
@@ -77,7 +78,7 @@ namespace HealthGateway.Immunization.Delegates
             try
             {
                 PhsaResult<ImmunizationViewResponse> response =
-                    await this.immunizationApi.GetImmunizationAsync(immunizationId, accessToken).ConfigureAwait(true);
+                    await this.immunizationApi.GetImmunizationAsync(immunizationId, accessToken, ct);
                 requestResult.ResultStatus = ResultType.Success;
                 requestResult.ResourcePayload!.Result = response.Result;
                 requestResult.TotalResultCount = 1;
@@ -96,7 +97,7 @@ namespace HealthGateway.Immunization.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PhsaResult<ImmunizationResponse>>> GetImmunizationsAsync(string hdid)
+        public async Task<RequestResult<PhsaResult<ImmunizationResponse>>> GetImmunizationsAsync(string hdid, CancellationToken ct = default)
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Getting immunizations for hdid: {Hdid}", hdid);
@@ -107,7 +108,7 @@ namespace HealthGateway.Immunization.Delegates
             try
             {
                 PhsaResult<ImmunizationResponse> response =
-                    await this.immunizationApi.GetImmunizationsAsync(hdid, this.phsaConfig.FetchSize, accessToken).ConfigureAwait(true);
+                    await this.immunizationApi.GetImmunizationsAsync(hdid, this.phsaConfig.FetchSize, accessToken, ct);
                 requestResult.ResultStatus = ResultType.Success;
                 requestResult.ResourcePayload = response;
                 requestResult.TotalResultCount = 1;

--- a/Apps/Immunization/src/Delegates/RestVaccineStatusDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestVaccineStatusDelegate.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Immunization.Delegates
     using System;
     using System.Diagnostics;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models.PHSA;
@@ -53,7 +54,7 @@ namespace HealthGateway.Immunization.Delegates
         private static ActivitySource Source { get; } = new(nameof(RestVaccineStatusDelegate));
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatus(string hdid, bool includeFederalPvc, string accessToken)
+        public async Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusAsync(string hdid, bool includeFederalPvc, string accessToken, CancellationToken ct = default)
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug("Getting vaccine status for HDID {Hdid} with includeFederalPvc = {IncludeFederalPvc}", hdid, includeFederalPvc);
@@ -66,7 +67,7 @@ namespace HealthGateway.Immunization.Delegates
             try
             {
                 PhsaResult<VaccineStatusResult> phsaResult =
-                    await this.immunizationApi.GetVaccineStatusAsync(hdid, includeFederalPvc, accessToken).ConfigureAwait(true);
+                    await this.immunizationApi.GetVaccineStatusAsync(hdid, includeFederalPvc, accessToken, ct);
 
                 if (phsaResult.Result != null)
                 {
@@ -94,7 +95,7 @@ namespace HealthGateway.Immunization.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublic(VaccineStatusQuery query, string accessToken, string clientIp)
+        public async Task<RequestResult<PhsaResult<VaccineStatusResult>>> GetVaccineStatusPublicAsync(VaccineStatusQuery query, string accessToken, string clientIp, CancellationToken ct = default)
         {
             using Activity? activity = Source.StartActivity();
             this.logger.LogDebug(
@@ -111,7 +112,7 @@ namespace HealthGateway.Immunization.Delegates
 
             try
             {
-                PhsaResult<VaccineStatusResult> phsaResult = await this.immunizationPublicApi.GetVaccineStatusAsync(query, accessToken, clientIp).ConfigureAwait(true);
+                PhsaResult<VaccineStatusResult> phsaResult = await this.immunizationPublicApi.GetVaccineStatusAsync(query, accessToken, clientIp, ct);
 
                 if (phsaResult.Result != null)
                 {

--- a/Apps/Immunization/src/Services/IImmunizationService.cs
+++ b/Apps/Immunization/src/Services/IImmunizationService.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Services
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Common.Models.Immunization;
@@ -29,14 +30,16 @@ namespace HealthGateway.Immunization.Services
         /// Gets the ImmunizationEvent for the given id.
         /// </summary>
         /// <param name="immunizationId">The security token representing the authenticated user.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>Returns a list of immunizations.</returns>
-        Task<RequestResult<ImmunizationEvent>> GetImmunization(string immunizationId);
+        Task<RequestResult<ImmunizationEvent>> GetImmunizationAsync(string immunizationId, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the ImmunizationResult inluding load state and a list of immunization records.
         /// </summary>
         /// <param name="hdid">The hdid patient id.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>Returns a list of immunizations.</returns>
-        Task<RequestResult<ImmunizationResult>> GetImmunizations(string hdid);
+        Task<RequestResult<ImmunizationResult>> GetImmunizationsAsync(string hdid, CancellationToken ct = default);
     }
 }

--- a/Apps/Immunization/src/Services/IVaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/IVaccineStatusService.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Services
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.ViewModels;
     using HealthGateway.Immunization.Models;
@@ -30,15 +31,17 @@ namespace HealthGateway.Immunization.Services
         /// <param name="phn">The patient's Personal Health Number.</param>
         /// <param name="dateOfBirth">The patient's date of birth in yyyy-MM-dd format.</param>
         /// <param name="dateOfVaccine">The date of one of the patient's vaccine doses in yyyy-MM-dd format.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>Returns the vaccine status.</returns>
-        Task<RequestResult<VaccineStatus>> GetPublicVaccineStatus(string phn, string dateOfBirth, string dateOfVaccine);
+        Task<RequestResult<VaccineStatus>> GetPublicVaccineStatusAsync(string phn, string dateOfBirth, string dateOfVaccine, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the COVID-19 vaccine status for the given HDID.
         /// </summary>
         /// <param name="hdid">The identifier to fetch the vaccine status for.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>Returns the vaccine status.</returns>
-        Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatus(string hdid);
+        Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatusAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the COVID-19 Vaccine Proof PDF for the given patient info.
@@ -46,14 +49,16 @@ namespace HealthGateway.Immunization.Services
         /// <param name="phn">The patient's Personal Health Number.</param>
         /// <param name="dateOfBirth">The patient's date of birth in yyyy-MM-dd format.</param>
         /// <param name="dateOfVaccine">The date of one of the patient's vaccine doses in yyyy-MM-dd format.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The base64-encoded PDF and QR Code in a RequestResult.</returns>
-        Task<RequestResult<VaccineProofDocument>> GetPublicVaccineProof(string phn, string dateOfBirth, string dateOfVaccine);
+        Task<RequestResult<VaccineProofDocument>> GetPublicVaccineProofAsync(string phn, string dateOfBirth, string dateOfVaccine, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the COVID-19 Vaccine Proof PDF for the given HDID.
         /// </summary>
         /// <param name="hdid">The identifier to fetch the PDF for.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The base64-encoded PDF and QR Code in a RequestResult.</returns>
-        Task<RequestResult<VaccineProofDocument>> GetAuthenticatedVaccineProof(string hdid);
+        Task<RequestResult<VaccineProofDocument>> GetAuthenticatedVaccineProofAsync(string hdid, CancellationToken ct = default);
     }
 }

--- a/Apps/Immunization/src/Services/ImmunizationService.cs
+++ b/Apps/Immunization/src/Services/ImmunizationService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Immunization.Services
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using AutoMapper;
     using HealthGateway.AccountDataAccess.Patient;
@@ -50,9 +51,9 @@ namespace HealthGateway.Immunization.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<ImmunizationEvent>> GetImmunization(string immunizationId)
+        public async Task<RequestResult<ImmunizationEvent>> GetImmunizationAsync(string immunizationId, CancellationToken ct = default)
         {
-            RequestResult<PhsaResult<ImmunizationViewResponse>> delegateResult = await this.immunizationDelegate.GetImmunizationAsync(immunizationId).ConfigureAwait(true);
+            RequestResult<PhsaResult<ImmunizationViewResponse>> delegateResult = await this.immunizationDelegate.GetImmunizationAsync(immunizationId, ct);
             if (delegateResult.ResultStatus == ResultType.Success)
             {
                 return new RequestResult<ImmunizationEvent>
@@ -73,9 +74,9 @@ namespace HealthGateway.Immunization.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<ImmunizationResult>> GetImmunizations(string hdid)
+        public async Task<RequestResult<ImmunizationResult>> GetImmunizationsAsync(string hdid, CancellationToken ct = default)
         {
-            if (!await this.patientRepository.CanAccessDataSourceAsync(hdid, DataSource.Immunization).ConfigureAwait(true))
+            if (!await this.patientRepository.CanAccessDataSourceAsync(hdid, DataSource.Immunization, ct))
             {
                 return new RequestResult<ImmunizationResult>
                 {
@@ -85,7 +86,7 @@ namespace HealthGateway.Immunization.Services
                 };
             }
 
-            RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = await this.immunizationDelegate.GetImmunizationsAsync(hdid).ConfigureAwait(true);
+            RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = await this.immunizationDelegate.GetImmunizationsAsync(hdid, ct);
             if (delegateResult.ResultStatus == ResultType.Success)
             {
                 return new RequestResult<ImmunizationResult>

--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Immunization.Services
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using AutoMapper;
     using FluentValidation.Results;
@@ -87,24 +88,24 @@ namespace HealthGateway.Immunization.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<VaccineStatus>> GetPublicVaccineStatus(string phn, string dateOfBirth, string dateOfVaccine)
+        public async Task<RequestResult<VaccineStatus>> GetPublicVaccineStatusAsync(string phn, string dateOfBirth, string dateOfVaccine, CancellationToken ct = default)
         {
             bool includeVaccineProof = false;
-            return await this.GetPublicVaccineStatusWithOptionalProof(phn, dateOfBirth, dateOfVaccine, includeVaccineProof).ConfigureAwait(true);
+            return await this.GetPublicVaccineStatusWithOptionalProofAsync(phn, dateOfBirth, dateOfVaccine, includeVaccineProof, ct);
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatus(string hdid)
+        public async Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatusAsync(string hdid, CancellationToken ct = default)
         {
             bool includeVaccineProof = false;
-            return await this.GetAuthenticatedVaccineStatusWithOptionalProof(hdid, includeVaccineProof).ConfigureAwait(true);
+            return await this.GetAuthenticatedVaccineStatusWithOptionalProofAsync(hdid, includeVaccineProof, ct);
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<VaccineProofDocument>> GetPublicVaccineProof(string phn, string dateOfBirth, string dateOfVaccine)
+        public async Task<RequestResult<VaccineProofDocument>> GetPublicVaccineProofAsync(string phn, string dateOfBirth, string dateOfVaccine, CancellationToken ct = default)
         {
             bool includeVaccineProof = true;
-            RequestResult<VaccineStatus> vaccineStatusResult = await this.GetPublicVaccineStatusWithOptionalProof(phn, dateOfBirth, dateOfVaccine, includeVaccineProof).ConfigureAwait(true);
+            RequestResult<VaccineStatus> vaccineStatusResult = await this.GetPublicVaccineStatusWithOptionalProofAsync(phn, dateOfBirth, dateOfVaccine, includeVaccineProof, ct);
             VaccineStatus payload = vaccineStatusResult.ResourcePayload!;
 
             RequestResult<VaccineProofDocument> retVal = new()
@@ -146,10 +147,10 @@ namespace HealthGateway.Immunization.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<VaccineProofDocument>> GetAuthenticatedVaccineProof(string hdid)
+        public async Task<RequestResult<VaccineProofDocument>> GetAuthenticatedVaccineProofAsync(string hdid, CancellationToken ct = default)
         {
             bool includeVaccineProof = true;
-            RequestResult<VaccineStatus> vaccineStatusResult = await this.GetAuthenticatedVaccineStatusWithOptionalProof(hdid, includeVaccineProof).ConfigureAwait(true);
+            RequestResult<VaccineStatus> vaccineStatusResult = await this.GetAuthenticatedVaccineStatusWithOptionalProofAsync(hdid, includeVaccineProof, ct);
             VaccineStatus payload = vaccineStatusResult.ResourcePayload!;
 
             RequestResult<VaccineProofDocument> retVal = new()
@@ -190,7 +191,12 @@ namespace HealthGateway.Immunization.Services
             return retVal;
         }
 
-        private async Task<RequestResult<VaccineStatus>> GetPublicVaccineStatusWithOptionalProof(string phn, string dateOfBirth, string dateOfVaccine, bool includeVaccineProof)
+        private async Task<RequestResult<VaccineStatus>> GetPublicVaccineStatusWithOptionalProofAsync(
+            string phn,
+            string dateOfBirth,
+            string dateOfVaccine,
+            bool includeVaccineProof,
+            CancellationToken ct)
         {
             if (!DateFormatter.TryParse(dateOfBirth, "yyyy-MM-dd", out DateTime dob))
             {
@@ -210,19 +216,19 @@ namespace HealthGateway.Immunization.Services
                 IncludeFederalVaccineProof = includeVaccineProof,
             };
 
-            ValidationResult validationResults = await new VaccineStatusQueryValidator().ValidateAsync(query).ConfigureAwait(true);
+            ValidationResult validationResults = await new VaccineStatusQueryValidator().ValidateAsync(query, ct);
             if (!validationResults.IsValid)
             {
                 return RequestResultFactory.Error<VaccineStatus>(ErrorType.InvalidState, validationResults.Errors);
             }
 
             string? accessToken = this.authDelegate.AuthenticateAsSystem(this.tokenUri, this.tokenRequest).AccessToken;
-            RequestResult<VaccineStatus> retVal = await this.GetVaccineStatusFromDelegate(query, accessToken, phn).ConfigureAwait(true);
+            RequestResult<VaccineStatus> retVal = await this.GetVaccineStatusFromDelegateAsync(query, accessToken, phn, ct);
 
             return retVal;
         }
 
-        private async Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatusWithOptionalProof(string hdid, bool includeVaccineProof)
+        private async Task<RequestResult<VaccineStatus>> GetAuthenticatedVaccineStatusWithOptionalProofAsync(string hdid, bool includeVaccineProof, CancellationToken ct)
         {
             // Gets the current user access token and pass it along to PHSA
             string? bearerToken = this.authDelegate.FetchAuthenticatedUserToken();
@@ -233,12 +239,12 @@ namespace HealthGateway.Immunization.Services
                 IncludeFederalVaccineProof = includeVaccineProof,
             };
 
-            RequestResult<VaccineStatus> retVal = await this.GetVaccineStatusFromDelegate(query, bearerToken).ConfigureAwait(true);
+            RequestResult<VaccineStatus> retVal = await this.GetVaccineStatusFromDelegateAsync(query, bearerToken, ct: ct);
 
             return retVal;
         }
 
-        private async Task<RequestResult<VaccineStatus>> GetVaccineStatusFromDelegate(VaccineStatusQuery query, string accessToken, string? phn = null)
+        private async Task<RequestResult<VaccineStatus>> GetVaccineStatusFromDelegateAsync(VaccineStatusQuery query, string accessToken, string? phn = null, CancellationToken ct = default)
         {
             RequestResult<VaccineStatus> retVal = new()
             {
@@ -248,8 +254,8 @@ namespace HealthGateway.Immunization.Services
 
             string ipAddress = this.httpContextAccessor?.HttpContext?.Connection.RemoteIpAddress?.MapToIPv4().ToString() ?? "0.0.0.0";
             RequestResult<PhsaResult<VaccineStatusResult>> result = string.IsNullOrEmpty(query.HdId)
-                ? await this.vaccineStatusDelegate.GetVaccineStatusPublic(query, accessToken, ipAddress).ConfigureAwait(true)
-                : await this.vaccineStatusDelegate.GetVaccineStatus(query.HdId, query.IncludeFederalVaccineProof, accessToken).ConfigureAwait(true);
+                ? await this.vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, accessToken, ipAddress, ct)
+                : await this.vaccineStatusDelegate.GetVaccineStatusAsync(query.HdId, query.IncludeFederalVaccineProof, accessToken, ct);
 
             VaccineStatusResult? payload = result.ResourcePayload?.Result;
             PhsaLoadState? loadState = result.ResourcePayload?.LoadState;

--- a/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/ImmunizationControllerTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.ViewModels;
@@ -86,12 +87,12 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
             };
 
             Mock<IImmunizationService> svcMock = new();
-            svcMock.Setup(s => s.GetImmunizations(It.IsAny<string>())).ReturnsAsync(expectedRequestResult);
+            svcMock.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(expectedRequestResult);
 
             ImmunizationController controller = new(new Mock<ILogger<ImmunizationController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<ImmunizationResult> actual = await controller.GetImmunizations(this.hdid);
+            RequestResult<ImmunizationResult> actual = await controller.GetImmunizations(this.hdid, default);
 
             // Verify
             Assert.True(actual.ResultStatus == ResultType.Success);
@@ -133,12 +134,12 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
 
             string immunizationId = "test_immunization_id";
             Mock<IImmunizationService> svcMock = new();
-            svcMock.Setup(s => s.GetImmunization(immunizationId)).ReturnsAsync(expectedRequestResult);
+            svcMock.Setup(s => s.GetImmunizationAsync(immunizationId, It.IsAny<CancellationToken>())).ReturnsAsync(expectedRequestResult);
 
             ImmunizationController controller = new(new Mock<ILogger<ImmunizationController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<ImmunizationEvent> actual = await controller.GetImmunization(this.hdid, immunizationId);
+            RequestResult<ImmunizationEvent> actual = await controller.GetImmunization(this.hdid, immunizationId, default);
 
             // Verify
             Assert.True(actual != null && actual.ResultStatus == ResultType.Success);

--- a/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
 {
     using System;
     using System.Globalization;
+    using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
@@ -59,12 +60,12 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
             };
 
             Mock<IVaccineStatusService> svcMock = new();
-            svcMock.Setup(s => s.GetPublicVaccineStatus(this.phn, this.dob, this.dov)).ReturnsAsync(expectedRequestResult);
+            svcMock.Setup(s => s.GetPublicVaccineStatusAsync(this.phn, this.dob, this.dov, It.IsAny<CancellationToken>())).ReturnsAsync(expectedRequestResult);
 
             PublicVaccineStatusController controller = new(new Mock<ILogger<PublicVaccineStatusController>>().Object, svcMock.Object);
 
             // Act
-            RequestResult<VaccineStatus> actual = await controller.GetVaccineStatus(this.phn, this.dob, this.dov);
+            RequestResult<VaccineStatus> actual = await controller.GetVaccineStatus(this.phn, this.dob, this.dov, default);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
     using System.Linq;
     using System.Net;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Data.Constants;
@@ -182,14 +183,14 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             Mock<IImmunizationApi> mockImmunizationApi = new();
             if (!throwException)
             {
-                mockImmunizationApi.Setup(s => s.GetImmunizationAsync(It.IsAny<string>(), AccessToken))
+                mockImmunizationApi.Setup(s => s.GetImmunizationAsync(It.IsAny<string>(), AccessToken, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(response);
             }
             else
             {
                 mockImmunizationApi.Setup(
                         s =>
-                            s.GetImmunizationAsync(It.IsAny<string>(), AccessToken))
+                            s.GetImmunizationAsync(It.IsAny<string>(), AccessToken, It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
             }
 
@@ -214,14 +215,14 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             Mock<IImmunizationApi> mockImmunizationApi = new();
             if (!throwException)
             {
-                mockImmunizationApi.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken))
+                mockImmunizationApi.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken, It.IsAny<CancellationToken>()))
                     .ReturnsAsync(response);
             }
             else
             {
                 mockImmunizationApi.Setup(
                         s =>
-                            s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken))
+                            s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<int?>(), AccessToken, It.IsAny<CancellationToken>()))
                     .ThrowsAsync(new HttpRequestException("Unit Test HTTP Request Exception"));
             }
 

--- a/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
     using System.Globalization;
     using System.Net;
     using System.Net.Http;
+    using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
     using HealthGateway.Common.Data.Constants;
@@ -60,7 +61,8 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
 
             Mock<IImmunizationApi> mockImmunizationApi = new(MockBehavior.Strict);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new();
-            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatusAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).ReturnsAsync(expectedPayload);
+            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatusAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedPayload);
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IVaccineStatusDelegate vaccineStatusDelegate = new RestVaccineStatusDelegate(
@@ -75,7 +77,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty);
+                await vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -92,7 +94,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
 
             Mock<IImmunizationApi> mockImmunizationApi = new(MockBehavior.Strict);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new();
-            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatusAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>()))
+            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatusAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.BadRequest));
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
@@ -108,7 +110,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty);
+                await vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -126,7 +128,8 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
 
             Mock<IImmunizationApi> mockImmunizationApi = new(MockBehavior.Strict);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new();
-            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatusAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).ReturnsAsync(expectedPayload);
+            mockImmunizationPublicApi.Setup(a => a.GetVaccineStatusAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(expectedPayload);
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
             IVaccineStatusDelegate vaccineStatusDelegate = new RestVaccineStatusDelegate(
@@ -141,7 +144,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatusPublic(query, this.accessToken, string.Empty);
+                await vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -164,7 +167,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             };
 
             Mock<IImmunizationApi> mockImmunizationApi = new();
-            mockImmunizationApi.Setup(a => a.GetVaccineStatusAsync(this.hdId, It.IsAny<bool>(), this.accessToken)).ReturnsAsync(expectedPayload);
+            mockImmunizationApi.Setup(a => a.GetVaccineStatusAsync(this.hdId, It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(expectedPayload);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new(MockBehavior.Strict);
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
@@ -174,7 +177,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 mockImmunizationPublicApi.Object);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken);
+                await vaccineStatusDelegate.GetVaccineStatusAsync(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
             expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
@@ -191,7 +194,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             RequestResultError expectedError = GetRequestResultError();
 
             Mock<IImmunizationApi> mockImmunizationApi = new();
-            mockImmunizationApi.Setup(a => a.GetVaccineStatusAsync(this.hdId, It.IsAny<bool>(), this.accessToken)).ReturnsAsync(expectedPayload);
+            mockImmunizationApi.Setup(a => a.GetVaccineStatusAsync(this.hdId, It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(expectedPayload);
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new(MockBehavior.Strict);
 
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
@@ -201,7 +204,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 mockImmunizationPublicApi.Object);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken);
+                await vaccineStatusDelegate.GetVaccineStatusAsync(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);
@@ -217,7 +220,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
             RequestResultError expectedError = GetRequestResultError();
 
             Mock<IImmunizationApi> mockImmunizationApi = new();
-            mockImmunizationApi.Setup(a => a.GetVaccineStatusAsync(this.hdId, It.IsAny<bool>(), this.accessToken))
+            mockImmunizationApi.Setup(a => a.GetVaccineStatusAsync(this.hdId, It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException(null, null, HttpStatusCode.BadRequest));
             Mock<IImmunizationPublicApi> mockImmunizationPublicApi = new(MockBehavior.Strict);
 
@@ -228,7 +231,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 mockImmunizationPublicApi.Object);
 
             RequestResult<PhsaResult<VaccineStatusResult>> actualResult =
-                await vaccineStatusDelegate.GetVaccineStatus(this.hdId, true, this.accessToken);
+                await vaccineStatusDelegate.GetVaccineStatusAsync(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
             expectedError.ShouldDeepEqual(actualResult.ResultError);

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -101,14 +101,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 TotalResultCount = delegateResult.TotalResultCount,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>())).ReturnsAsync(delegateResult);
+            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(canAccessDataSource);
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizations(It.IsAny<string>());
+            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizationsAsync(It.IsAny<string>());
 
             if (canAccessDataSource)
             {
@@ -160,14 +160,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 TotalResultCount = delegateResult.TotalResultCount,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizationAsync(It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetImmunizationAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            RequestResult<ImmunizationEvent> actualResult = await service.GetImmunization("immz_id");
+            RequestResult<ImmunizationEvent> actualResult = await service.GetImmunizationAsync("immz_id");
 
             expectedResult.ShouldDeepEqual(actualResult);
         }
@@ -195,14 +195,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 TotalResultCount = delegateResult.TotalResultCount,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizations(It.IsAny<string>());
+            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizationsAsync(It.IsAny<string>());
 
             expectedResult.ShouldDeepEqual(actualResult);
             Assert.Single(expectedResult.ResourcePayload.Recommendations);
@@ -246,14 +246,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 ResultError = delegateResult.ResultError,
             };
 
-            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, this.autoMapper);
 
-            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizations(It.IsAny<string>());
+            RequestResult<ImmunizationResult> actualResult = await service.GetImmunizationsAsync(It.IsAny<string>());
 
             expectedResult.ShouldDeepEqual(actualResult);
         }

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -285,9 +285,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
             mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(delegateResult));
+                .ReturnsAsync(delegateResult);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -475,9 +475,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
             mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(delegateResult));
+                .ReturnsAsync(delegateResult);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -108,9 +108,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
             mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(delegateResult));
+                .ReturnsAsync(delegateResult);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -378,9 +378,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
             mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(delegateResult));
+                .ReturnsAsync(delegateResult);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -194,9 +194,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
             mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(delegateResult));
+                .ReturnsAsync(delegateResult);
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 {
     using System;
     using System.Globalization;
+    using System.Threading;
     using System.Threading.Tasks;
     using AutoMapper;
     using DeepEqual.Syntax;
@@ -107,8 +108,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken)).Returns(Task.FromResult(delegateResult));
-            mockDelegate.Setup(s => s.GetVaccineStatusPublic(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
@@ -126,13 +128,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             {
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
-                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatusAsync(this.phn, dobString, dovString);
 
                 expectedResult.ShouldDeepEqual(actualResultPublic);
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatusAsync(this.hdid);
 
                 expectedResult.ShouldDeepEqual(actualResultAuthenticated);
             }
@@ -192,8 +194,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken)).Returns(Task.FromResult(delegateResult));
-            mockDelegate.Setup(s => s.GetVaccineStatusPublic(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
@@ -211,14 +214,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatusAsync(this.phn, dobString, dovString);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultPublic.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultPublic.ResultError?.ActionCode);
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatusAsync(this.hdid);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultAuthenticated.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultAuthenticated.ResultError?.ActionCode);
@@ -282,8 +285,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken)).Returns(Task.FromResult(delegateResult));
-            mockDelegate.Setup(s => s.GetVaccineStatusPublic(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
@@ -302,7 +306,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatusAsync(this.phn, dobString, dovString);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultPublic.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultPublic.ResultError?.ActionCode);
@@ -310,7 +314,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatusAsync(this.hdid);
                 Assert.Equal(ResultType.ActionRequired, actualResultAuthenticated.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultAuthenticated.ResultError?.ActionCode);
                 Assert.Equal(expectedResult.ResourcePayload.RetryIn, actualResultAuthenticated.ResourcePayload?.RetryIn);
@@ -374,8 +378,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken)).Returns(Task.FromResult(delegateResult));
-            mockDelegate.Setup(s => s.GetVaccineStatusPublic(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
@@ -394,14 +399,14 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatus(this.phn, dobString, dovString);
+                RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatusAsync(this.phn, dobString, dovString);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultPublic.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultPublic.ResultError?.ActionCode);
             }
             else
             {
-                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatus(this.hdid);
+                RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatusAsync(this.hdid);
 
                 Assert.Equal(ResultType.ActionRequired, actualResultAuthenticated.ResultStatus);
                 Assert.Equal(expectedResult.ResultError.ActionCode, actualResultAuthenticated.ResultError?.ActionCode);
@@ -470,8 +475,9 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             };
 
             Mock<IVaccineStatusDelegate> mockDelegate = new();
-            mockDelegate.Setup(s => s.GetVaccineStatus(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken)).Returns(Task.FromResult(delegateResult));
-            mockDelegate.Setup(s => s.GetVaccineStatusPublic(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusAsync(It.IsAny<string>(), It.IsAny<bool>(), this.accessToken, It.IsAny<CancellationToken>())).Returns(Task.FromResult(delegateResult));
+            mockDelegate.Setup(s => s.GetVaccineStatusPublicAsync(It.IsAny<VaccineStatusQuery>(), this.accessToken, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(delegateResult));
 
             Mock<IAuthenticationDelegate> mockAuthDelegate = new();
             mockAuthDelegate.Setup(s => s.AuthenticateAsSystem(It.IsAny<Uri>(), It.IsAny<ClientCredentialsTokenRequest>(), It.IsAny<bool>())).Returns(jwtModel);
@@ -490,7 +496,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-                RequestResult<VaccineProofDocument> actualResultPublic = await service.GetPublicVaccineProof(this.phn, dobString, dovString);
+                RequestResult<VaccineProofDocument> actualResultPublic = await service.GetPublicVaccineProofAsync(this.phn, dobString, dovString);
 
                 Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResultPublic.ResourcePayload?.Document.Data);
                 Assert.NotNull(actualResultPublic.ResourcePayload?.Document.Data);
@@ -498,7 +504,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             }
             else
             {
-                RequestResult<VaccineProofDocument> actualResultAuthenticated = await service.GetAuthenticatedVaccineProof(this.hdid);
+                RequestResult<VaccineProofDocument> actualResultAuthenticated = await service.GetAuthenticatedVaccineProofAsync(this.hdid);
 
                 Assert.Equal(expectedResult.ResourcePayload.FederalVaccineProof.Data, actualResultAuthenticated.ResourcePayload?.Document.Data);
                 Assert.NotNull(actualResultAuthenticated.ResourcePayload?.Document.Data);
@@ -526,7 +532,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatus("123", dobString, dovString);
+            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatusAsync("123", dobString, dovString);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -550,7 +556,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatus(this.phn, "yyyyMMddx", dovString);
+            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatusAsync(this.phn, "yyyyMMddx", dovString);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
@@ -572,7 +578,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             string dobString = this.dob.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
 
-            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatus(this.phn, dobString, "yyyyMMddx");
+            RequestResult<VaccineStatus> actualResult = await service.GetPublicVaccineStatusAsync(this.phn, dobString, "yyyyMMddx");
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }

--- a/Apps/Laboratory/src/Services/LaboratoryService.cs
+++ b/Apps/Laboratory/src/Services/LaboratoryService.cs
@@ -155,7 +155,7 @@ namespace HealthGateway.Laboratory.Services
                 return RequestResultFactory.Error<LaboratoryOrderResult>(UnauthorizedResultError());
             }
 
-            RequestResult<PhsaResult<PhsaLaboratorySummary>> delegateResult = await this.laboratoryDelegate.GetLaboratorySummaryAsync(hdid, accessToken);
+            RequestResult<PhsaResult<PhsaLaboratorySummary>> delegateResult = await this.laboratoryDelegate.GetLaboratorySummaryAsync(hdid, accessToken, ct);
 
             PhsaLoadState? loadState = delegateResult.ResourcePayload?.LoadState;
             if (loadState != null && loadState.RefreshInProgress)
@@ -198,7 +198,7 @@ namespace HealthGateway.Laboratory.Services
                 return RequestResultFactory.Error<LaboratoryReport>(UnauthorizedResultError());
             }
 
-            return await this.laboratoryDelegate.GetLabReportAsync(id, hdid, accessToken, isCovid19);
+            return await this.laboratoryDelegate.GetLabReportAsync(id, hdid, accessToken, isCovid19, ct);
         }
 
         private static RequestResultError UnauthorizedResultError()

--- a/Testing/integration/tests/WebAppFixture.cs
+++ b/Testing/integration/tests/WebAppFixture.cs
@@ -16,6 +16,7 @@
 
 namespace HealthGateway.IntegrationTests;
 
+using System.Data;
 using System.Data.Common;
 using Alba;
 using DotNet.Testcontainers.Containers;
@@ -84,7 +85,7 @@ public class WebAppFixture : IAsyncLifetime
             await this.postgreSqlContainer.StartAsync();
 
             DbContextOptionsBuilder<GatewayDbContext> builder = new();
-            builder.UseNpgsql(this.postgreSqlContainer.GetConnectionString(), builder => builder.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
+            builder.UseNpgsql(this.postgreSqlContainer.GetConnectionString(), optionsBuilder => optionsBuilder.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
             using GatewayDbContext dbCtx = new(builder.Options);
             await MigrateDatabase(dbCtx);
             await SeedData(dbCtx);
@@ -110,7 +111,7 @@ public class WebAppFixture : IAsyncLifetime
     private static async Task SeedData(GatewayDbContext ctx)
     {
         DbConnection conn = ctx.Database.GetDbConnection();
-        if (conn.State != System.Data.ConnectionState.Open)
+        if (conn.State != ConnectionState.Open)
         {
             await conn.OpenAsync();
         }


### PR DESCRIPTION
# Implements [AB#16598](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16598)

## Description

- Add Cancellation Token to Immunization
- Updated unit tests for Immunization

Note: For unit tests on service did not pass in default for cancellation token as default had already been defined in service interface if no value was passed in.

Also fixed warning in other projects - see commits:

- un-used import
- unnecessary null checks
- naming issues
- cancellation token should be propagated

<img width="425" alt="Screenshot 2024-01-09 at 10 31 02 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/bca57544-a14a-4223-a1f0-d255a2c99565">

<img width="418" alt="Screenshot 2024-01-09 at 10 31 07 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/505387b3-4706-4b82-a033-79987755616b">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

no

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
