### PR TITLE
Make Patient, PatientRepository and PatientDataRepository async for AB#16547.

### DIFF
--- a/Apps/AccountDataAccess/src/Audit/AuditRepository.cs
+++ b/Apps/AccountDataAccess/src/Audit/AuditRepository.cs
@@ -38,9 +38,9 @@ namespace HealthGateway.AccountDataAccess.Audit
         }
 
         /// <inheritdoc/>
-        public async Task<IEnumerable<AgentAudit>> Handle(AgentAuditQuery query, CancellationToken ct = default)
+        public async Task<IEnumerable<AgentAudit>> HandleAsync(AgentAuditQuery query, CancellationToken ct = default)
         {
-            return await this.agentAuditDelegate.GetAgentAuditsAsync(query.Hdid, query.Group, ct).ConfigureAwait(true);
+            return await this.agentAuditDelegate.GetAgentAuditsAsync(query.Hdid, query.Group, ct);
         }
     }
 }

--- a/Apps/AccountDataAccess/src/Audit/IAuditRepository.cs
+++ b/Apps/AccountDataAccess/src/Audit/IAuditRepository.cs
@@ -32,7 +32,7 @@ namespace HealthGateway.AccountDataAccess.Audit
         /// <param name="query">The query.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>The list of agent audits..</returns>
-        Task<IEnumerable<AgentAudit>> Handle(AgentAuditQuery query, CancellationToken ct = default);
+        Task<IEnumerable<AgentAudit>> HandleAsync(AgentAuditQuery query, CancellationToken ct = default);
     }
 
     /// <summary>

--- a/Apps/AccountDataAccess/src/Patient/Api/IPatientIdentityApi.cs
+++ b/Apps/AccountDataAccess/src/Patient/Api/IPatientIdentityApi.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.AccountDataAccess.Patient.Api
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Refit;
 
@@ -27,8 +28,9 @@ namespace HealthGateway.AccountDataAccess.Patient.Api
         /// Get patient identity by Hdid.
         /// </summary>
         /// <param name="hdid">The Hdid to lookup.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient identity matching the id.</returns>
         [Get("/patient-identity/hdid/{hdid}")]
-        Task<PatientIdentity> GetPatientIdentityAsync(string hdid);
+        Task<PatientIdentity> GetPatientIdentityAsync(string hdid, CancellationToken ct);
     }
 }

--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.AccountDataAccess.Patient
     using System.Globalization;
     using System.Linq;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
@@ -59,7 +60,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         private static ActivitySource Source { get; } = new(nameof(ClientRegistriesDelegate));
 
         /// <inheritdoc/>
-        public async Task<PatientModel?> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false)
+        public async Task<PatientModel?> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false, CancellationToken ct = default)
         {
             this.logger.LogDebug("Getting patient for type: {Type} and value: {Identifier} started", type, identifier);
             using Activity? activity = Source.StartActivity();
@@ -68,7 +69,7 @@ namespace HealthGateway.AccountDataAccess.Patient
             HCIM_IN_GetDemographicsRequest request = CreateRequest(type, identifier);
 
             // Perform the request
-            HCIM_IN_GetDemographicsResponse1 reply = await this.clientRegistriesClient.HCIM_IN_GetDemographicsAsync(request).ConfigureAwait(true);
+            HCIM_IN_GetDemographicsResponse1 reply = await this.clientRegistriesClient.HCIM_IN_GetDemographicsAsync(request);
             return this.ParseResponse(reply, disableIdValidation);
         }
 

--- a/Apps/AccountDataAccess/src/Patient/IClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/IClientRegistriesDelegate.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.AccountDataAccess.Patient
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
 
@@ -29,7 +30,8 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="type">The oid type value.</param>
         /// <param name="identifier">The associated oid type's identifier to retrieve the patient demographics information.</param>
         /// <param name="disableIdValidation">Disables the validation on HDID/PHN when true.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient model wrapped in an api result object.</returns>
-        Task<PatientModel?> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false);
+        Task<PatientModel?> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false, CancellationToken ct = default);
     }
 }

--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -53,7 +53,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="query">The query.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>The patient model wrapped in a patient query result object.</returns>
-        Task<PatientQueryResult> Query(PatientQuery query, CancellationToken ct = default);
+        Task<PatientQueryResult> QueryAsync(PatientQuery query, CancellationToken ct = default);
 
         /// <summary>
         /// Returns true if data source can be accessed and false if it cannot.

--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -70,7 +70,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="hdid">The hdid to query on.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>The blocked access or null if not found.</returns>
-        Task<BlockedAccess?> GetBlockedAccessRecords(string hdid, CancellationToken ct = default);
+        Task<BlockedAccess?> GetBlockedAccessRecordsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the blocked access's data sources for the hdid.

--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// Gets the patient record.
         /// </summary>
         /// <param name="query">The query.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient model wrapped in a patient query result object.</returns>
         Task<PatientQueryResult> QueryAsync(PatientQuery query, CancellationToken ct = default);
 
@@ -60,7 +60,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// </summary>
         /// <param name="hdid">The hdid to query on.</param>
         /// <param name="dataSource">The data source to check.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The blocked access or null if not found.</returns>
         Task<bool> CanAccessDataSourceAsync(string hdid, DataSource dataSource, CancellationToken ct = default);
 
@@ -68,7 +68,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// Gets the blocked access record.
         /// </summary>
         /// <param name="hdid">The hdid to query on.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The blocked access or null if not found.</returns>
         Task<BlockedAccess?> GetBlockedAccessRecordsAsync(string hdid, CancellationToken ct = default);
 
@@ -76,7 +76,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// Gets the blocked access's data sources for the hdid.
         /// </summary>
         /// <param name="hdid">The hdid to query on.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A list of blocked access data source values.</returns>
         Task<IEnumerable<DataSource>> GetDataSourcesAsync(string hdid, CancellationToken ct = default);
 
@@ -84,7 +84,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// Block access to data sources associated with the hdid.
         /// </summary>
         /// <param name="command">The command details used to block access.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The agent audit entry created from the operation.</returns>
         Task BlockAccessAsync(BlockAccessCommand command, CancellationToken ct = default);
     }

--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -78,7 +78,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="hdid">The hdid to query on.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>A list of blocked access data source values.</returns>
-        Task<IEnumerable<DataSource>> GetDataSources(string hdid, CancellationToken ct = default);
+        Task<IEnumerable<DataSource>> GetDataSourcesAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Block access to data sources associated with the hdid.

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.AccountDataAccess.Patient
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading;
@@ -85,7 +86,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         }
 
         /// <inheritdoc/>
-        public async Task<PatientQueryResult> Query(PatientQuery query, CancellationToken ct = default)
+        public async Task<PatientQueryResult> QueryAsync(PatientQuery query, CancellationToken ct = default)
         {
             return query switch
             {
@@ -159,7 +160,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         }
 
         /// <inheritdoc/>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Performance", "CA1863:Use 'CompositeFormat'", Justification = "Team decision")]
+        [SuppressMessage("Performance", "CA1863:Use 'CompositeFormat'", Justification = "Team decision")]
         public async Task<IEnumerable<DataSource>> GetDataSources(string hdid, CancellationToken ct = default)
         {
             string blockedAccessCacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, hdid);

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -154,7 +154,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         }
 
         /// <inheritdoc/>
-        public async Task<BlockedAccess?> GetBlockedAccessRecords(string hdid, CancellationToken ct = default)
+        public async Task<BlockedAccess?> GetBlockedAccessRecordsAsync(string hdid, CancellationToken ct = default)
         {
             return await this.blockedAccessDelegate.GetBlockedAccessAsync(hdid).ConfigureAwait(true);
         }

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -99,7 +99,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <inheritdoc/>
         public async Task<bool> CanAccessDataSourceAsync(string hdid, DataSource dataSource, CancellationToken ct = default)
         {
-            IEnumerable<DataSource> blockedDataSources = await this.GetDataSources(hdid, ct);
+            IEnumerable<DataSource> blockedDataSources = await this.GetDataSourcesAsync(hdid, ct);
             this.logger.LogDebug("Blocked data sources for hdid: {Hdid} - {DataSources}", hdid, blockedDataSources);
 
             return !blockedDataSources.Contains(dataSource);
@@ -161,7 +161,7 @@ namespace HealthGateway.AccountDataAccess.Patient
 
         /// <inheritdoc/>
         [SuppressMessage("Performance", "CA1863:Use 'CompositeFormat'", Justification = "Team decision")]
-        public async Task<IEnumerable<DataSource>> GetDataSources(string hdid, CancellationToken ct = default)
+        public async Task<IEnumerable<DataSource>> GetDataSourcesAsync(string hdid, CancellationToken ct = default)
         {
             string blockedAccessCacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, hdid);
             string message = $"Getting item from cache for key: {blockedAccessCacheKey}";

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
 
                 try
                 {
-                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier);
+                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier, ct);
                     patient = this.mapper.Map<PatientModel>(result);
                 }
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
 {
     using System.Net;
     using System.ServiceModel;
+    using System.Threading;
     using System.Threading.Tasks;
     using AutoMapper;
     using HealthGateway.AccountDataAccess.Patient.Api;
@@ -59,13 +60,13 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         }
 
         /// <inheritdoc/>
-        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request)
+        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
-            PatientModel? patient = request.UseCache ? this.GetFromCache(request.Identifier, PatientIdentifierType.Hdid) : null;
+            PatientModel? patient = request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null;
 
             try
             {
-                patient ??= await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation).ConfigureAwait(true);
+                patient ??= await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation, ct);
             }
             catch (CommunicationException ce)
             {
@@ -73,7 +74,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
 
                 try
                 {
-                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier).ConfigureAwait(true);
+                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier);
                     patient = this.mapper.Map<PatientModel>(result);
                 }
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
@@ -82,7 +83,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
                 }
             }
 
-            this.CachePatient(patient, request.DisabledValidation);
+            await this.CachePatientAsync(patient, request.DisabledValidation, ct);
             return patient;
         }
     }

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidEmpiStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidEmpiStrategy.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.AccountDataAccess.Patient.Strategy
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Constants;
@@ -46,12 +47,12 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         }
 
         /// <inheritdoc/>
-        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request)
+        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
-            PatientModel? patient = (request.UseCache ? this.GetFromCache(request.Identifier, PatientIdentifierType.Hdid) : null) ??
-                                    await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation).ConfigureAwait(true);
+            PatientModel? patient = (request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null) ??
+                                    await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation, ct);
 
-            this.CachePatient(patient, request.DisabledValidation);
+            await this.CachePatientAsync(patient, request.DisabledValidation, ct);
             return patient;
         }
     }

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
@@ -63,7 +63,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
             {
                 try
                 {
-                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier);
+                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier, ct);
                     patient = this.mapper.Map<PatientModel>(result);
                 }
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)

--- a/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryContext.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryContext.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.AccountDataAccess.Patient.Strategy
 {
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -49,10 +50,11 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         /// Returns patient from the specified source in the patient request.
         /// </summary>
         /// <param name="patientRequest">The patient request parameters to use.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient model.</returns>
-        public async Task<PatientModel?> GetPatientAsync(PatientRequest patientRequest)
+        public async Task<PatientModel?> GetPatientAsync(PatientRequest patientRequest, CancellationToken ct)
         {
-            return await this.patientQueryStrategy.GetPatientAsync(patientRequest).ConfigureAwait(true);
+            return await this.patientQueryStrategy.GetPatientAsync(patientRequest, ct);
         }
     }
 }

--- a/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
@@ -54,7 +54,7 @@ namespace AccountDataAccessTest
             AuditRepository auditRepository = GetAuditRepository(agentAudits);
 
             // Act
-            IEnumerable<AgentAudit> actual = await auditRepository.Handle(query);
+            IEnumerable<AgentAudit> actual = await auditRepository.HandleAsync(query);
 
             // Verify
             IEnumerable<AgentAudit> collection = actual.ToList();

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -383,7 +383,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(blockedAccess);
 
             // Act
-            IEnumerable<DataSource> actual = await patientRepository.GetDataSources(hdid);
+            IEnumerable<DataSource> actual = await patientRepository.GetDataSourcesAsync(hdid);
 
             // Verify
             dataSources.ShouldDeepEqual(actual);

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -531,8 +531,9 @@ namespace AccountDataAccessTest
             serviceCollection.AddScoped<PhnEmpiStrategy>(_ => phnEmpiStrategy);
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdid))!.ReturnsAsync(patientIdentity);
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdidNotFound)).Throws(MockRefitExceptionHelper.CreateApiException(HttpStatusCode.NotFound, HttpMethod.Get));
+            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdid, It.IsAny<CancellationToken>()))!.ReturnsAsync(patientIdentity);
+            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdidNotFound, It.IsAny<CancellationToken>()))
+                .Throws(MockRefitExceptionHelper.CreateApiException(HttpStatusCode.NotFound, HttpMethod.Get));
 
             HdidAllStrategy hdidAllStrategy = new(
                 GetConfiguration(),

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -75,7 +75,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery);
 
             // Act
-            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
+            PatientQueryResult result = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
@@ -100,7 +100,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery);
 
             // Act
-            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
+            PatientQueryResult result = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
@@ -129,7 +129,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientResult, cachedPatient);
 
             // Act
-            PatientQueryResult result = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
+            PatientQueryResult result = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
@@ -172,7 +172,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientIdentity, cachedPatient);
 
             // Act
-            PatientQueryResult actual = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
+            PatientQueryResult actual = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             expectedPatient.ShouldDeepEqual(actual.Items.SingleOrDefault());
@@ -195,7 +195,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientIdentity, cachedPatient);
 
             // Act
-            PatientQueryResult actual = await patientRepository.Query(patientDetailsQuery, CancellationToken.None);
+            PatientQueryResult actual = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
 
             // Verify
             Assert.Null(actual.Items.SingleOrDefault());
@@ -223,7 +223,7 @@ namespace AccountDataAccessTest
             // Act
             async Task Actual()
             {
-                await patientRepository.Query(patientQuery, CancellationToken.None);
+                await patientRepository.QueryAsync(patientQuery, CancellationToken.None);
             }
 
             // Verify

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -352,7 +352,7 @@ namespace AccountDataAccessTest
             PatientRepository patientRepository = GetPatientRepository(blockedAccess);
 
             // Act
-            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecords(hdid);
+            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecordsAsync(hdid);
 
             // Verify
             blockedAccess.ShouldDeepEqual(actual);

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -508,12 +508,12 @@ namespace AccountDataAccessTest
             ServiceCollection serviceCollection = new();
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{patientDetailsQuery.Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(p => p.GetItemAsync<PatientModel>($"{PatientCacheDomain}:HDID:{patientDetailsQuery.Hdid}", It.IsAny<CancellationToken>())).ReturnsAsync(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, patientDetailsQuery.Hdid, false)).ReturnsAsync(patient);
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Phn, patientDetailsQuery.Phn, false)).ReturnsAsync(patient);
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdid, false))
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, patientDetailsQuery.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Phn, patientDetailsQuery.Phn, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdid, false, It.IsAny<CancellationToken>()))
                 .Throws(new CommunicationException("Unit test PHSA get patient identity."));
 
             HdidEmpiStrategy hdidEmpiStrategy = new(

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -156,7 +156,7 @@ namespace AccountDataAccessTest.Strategy
                 .Throws(new CommunicationException("Unit test PHSA get patient identity."));
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdid))!.ReturnsAsync(patientIdentity);
+            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdid, It.IsAny<CancellationToken>()))!.ReturnsAsync(patientIdentity);
 
             HdidAllStrategy hdidAllStrategy = new(
                 GetConfiguration(),

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -151,8 +151,8 @@ namespace AccountDataAccessTest.Strategy
             cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false)).ReturnsAsync(patient);
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdid, false))
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdid, false, It.IsAny<CancellationToken>()))
                 .Throws(new CommunicationException("Unit test PHSA get patient identity."));
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
@@ -72,7 +72,7 @@ namespace AccountDataAccessTest.Strategy
             cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false)).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
 
             HdidEmpiStrategy hdidEmpiStrategy = new(
                 GetConfiguration(),

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -96,7 +96,7 @@ namespace AccountDataAccessTest.Strategy
             cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(Hdid))!.ReturnsAsync(patientIdentity);
+            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(Hdid, It.IsAny<CancellationToken>()))!.ReturnsAsync(patientIdentity);
 
             HdidPhsaStrategy hdidPhsaStrategy = new(
                 GetConfiguration(),

--- a/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
@@ -99,7 +99,7 @@ namespace AccountDataAccessTest.Strategy
             cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:PHN:{Phn}")).Returns(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Phn, Phn, false)).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Phn, Phn, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
 
             PhnEmpiStrategy phnEmpiStrategy = new(
                 GetConfiguration(),

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -47,7 +47,7 @@ namespace HealthGateway.Admin.Server.Services
                         PatientQueryResult? patient = null;
                         try
                         {
-                            patient = await patientRepository.Query(query, ct);
+                            patient = await patientRepository.QueryAsync(query, ct);
                         }
                         catch (ProblemDetailsException e)
                         {

--- a/Apps/Admin/Server/Services/CovidSupportService.cs
+++ b/Apps/Admin/Server/Services/CovidSupportService.cs
@@ -104,7 +104,7 @@ namespace HealthGateway.Admin.Server.Services
         private async Task<PatientModel> GetPatientAsync(string phn, CancellationToken ct = default)
         {
             PatientDetailsQuery query = new(phn, Source: PatientDetailSource.Empi, UseCache: true);
-            PatientModel? patient = (await patientRepository.Query(query, ct).ConfigureAwait(true)).Items.SingleOrDefault();
+            PatientModel? patient = (await patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
             if (patient == null)
             {
                 throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.ClientRegistryRecordsNotFound, HttpStatusCode.NotFound, nameof(CovidSupportService)));

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.Admin.Server.Services
         public async Task<DelegationInfo> GetDelegationInformationAsync(string phn, CancellationToken ct = default)
         {
             // Get dependent patient information
-            RequestResult<PatientModel> dependentPatientResult = await patientService.GetPatient(phn, PatientIdentifierType.Phn, ct: ct);
+            RequestResult<PatientModel> dependentPatientResult = await patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, ct: ct);
             this.ValidatePatientResult(dependentPatientResult);
 
             ValidationResult? validationResults = await new DependentPatientValidator(this.maxDependentAge).ValidateAsync(dependentPatientResult.ResourcePayload, ct).ConfigureAwait(true);
@@ -95,7 +95,7 @@ namespace HealthGateway.Admin.Server.Services
                 List<DelegateInfo> delegates = new();
                 foreach (ResourceDelegate resourceDelegate in dbResourceDelegates)
                 {
-                    RequestResult<PatientModel> delegatePatientResult = await patientService.GetPatient(resourceDelegate.ProfileHdid, ct: ct);
+                    RequestResult<PatientModel> delegatePatientResult = await patientService.GetPatientAsync(resourceDelegate.ProfileHdid, ct: ct);
                     this.ValidatePatientResult(delegatePatientResult);
 
                     DelegateInfo delegateInfo = autoMapper.Map<DelegateInfo>(delegatePatientResult.ResourcePayload);
@@ -112,7 +112,7 @@ namespace HealthGateway.Admin.Server.Services
 
                     foreach (AllowedDelegation allowedDelegation in dependent.AllowedDelegations.Where(ad => delegates.TrueForAll(d => d.Hdid != ad.DelegateHdId)))
                     {
-                        RequestResult<PatientModel> delegatePatientResult = await patientService.GetPatient(allowedDelegation.DelegateHdId, ct: ct);
+                        RequestResult<PatientModel> delegatePatientResult = await patientService.GetPatientAsync(allowedDelegation.DelegateHdId, ct: ct);
 
                         DelegateInfo delegateInfo = autoMapper.Map<DelegateInfo>(delegatePatientResult.ResourcePayload);
                         delegateInfo.DelegationStatus = DelegationStatus.Allowed;
@@ -134,7 +134,7 @@ namespace HealthGateway.Admin.Server.Services
         /// <inheritdoc/>
         public async Task<DelegateInfo> GetDelegateInformationAsync(string phn, CancellationToken ct = default)
         {
-            RequestResult<PatientModel> delegatePatientResult = await patientService.GetPatient(phn, PatientIdentifierType.Phn, false, ct);
+            RequestResult<PatientModel> delegatePatientResult = await patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, false, ct);
             this.ValidatePatientResult(delegatePatientResult);
 
             ValidationResult? validationResults = await new DelegatePatientValidator(this.minDelegateAge).ValidateAsync(delegatePatientResult.ResourcePayload, ct);

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -124,7 +124,7 @@ namespace HealthGateway.Admin.Server.Services
 
                 // Get agent audits
                 AgentAuditQuery agentAuditQuery = new(dependentPatientInfo.HdId, AuditGroup.Dependent);
-                IEnumerable<AgentAudit> agentAudits = await auditRepository.Handle(agentAuditQuery, ct).ConfigureAwait(true);
+                IEnumerable<AgentAudit> agentAudits = await auditRepository.HandleAsync(agentAuditQuery, ct);
                 delegationInfo.AgentActions = agentAudits.Select(a => autoMapper.Map<AgentAction>(a));
             }
 

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -184,7 +184,7 @@ namespace HealthGateway.Admin.Server.Services
             logger.LogDebug("{Message}", message);
             await cacheProvider.RemoveItemAsync(blockedAccessCacheKey, ct);
 
-            return await patientRepository.GetDataSources(hdid, ct);
+            return await patientRepository.GetDataSourcesAsync(hdid, ct);
         }
 
         private async Task<IEnumerable<AgentAction>> GetAgentActionsAsync(string hdid, CancellationToken ct)

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -150,7 +150,7 @@ namespace HealthGateway.Admin.Server.Services
 
         private async Task<PatientModel> GetPatientAsync(PatientDetailsQuery query, CancellationToken ct = default)
         {
-            PatientModel? patient = (await patientRepository.Query(query, ct)).Items.SingleOrDefault();
+            PatientModel? patient = (await patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
             return patient ?? throw new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.ClientRegistryRecordsNotFound, HttpStatusCode.NotFound, nameof(SupportService)));
         }
 

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -189,8 +189,8 @@ namespace HealthGateway.Admin.Server.Services
 
         private async Task<IEnumerable<AgentAction>> GetAgentActionsAsync(string hdid, CancellationToken ct)
         {
-            IEnumerable<AgentAudit> audits = await auditRepository.Handle(new(hdid), ct);
-            return audits.Select(audit => autoMapper.Map<AgentAudit, AgentAction>(audit));
+            IEnumerable<AgentAudit> audits = await auditRepository.HandleAsync(new(hdid), ct);
+            return audits.Select(autoMapper.Map<AgentAudit, AgentAction>);
         }
 
         private async Task<IEnumerable<PatientSupportDependentInfo>> GetAllDependentInfoAsync(string delegateHdid, CancellationToken ct)

--- a/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
@@ -777,7 +777,7 @@ namespace HealthGateway.Admin.Tests.Services
             foreach ((PatientDetailsQuery query, PatientModel? patient) in pairs)
             {
                 PatientQueryResult result = new(patient == null ? [] : [patient]);
-                mock.Setup(p => p.Query(query, It.IsAny<CancellationToken>())).ReturnsAsync(result);
+                mock.Setup(p => p.QueryAsync(query, It.IsAny<CancellationToken>())).ReturnsAsync(result);
             }
 
             return mock;

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -387,7 +387,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             Mock<IPatientService> patientService = new();
-            patientService.Setup(p => p.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult);
+            patientService.Setup(p => p.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult);
 
             IDelegationService delegationService = new DelegationService(
                 this.configuration,
@@ -724,12 +724,12 @@ namespace HealthGateway.Admin.Tests.Services
                 ResultError = new RequestResultError { ResultMessage = "Client Registry did not find any records", ErrorCode = "Admin.ServerServer-CE-CR" },
             };
 
-            patientService.Setup(p => p.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientErrorResult);
-            patientService.Setup(p => p.GetPatient(ProtectedDelegateHdid1, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult1);
-            patientService.Setup(p => p.GetPatient(ProtectedDelegateHdid2, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult2);
-            patientService.Setup(p => p.GetPatient(dependentResult.ResourcePayload!.PersonalHealthNumber, PatientIdentifierType.Phn, false, It.IsAny<CancellationToken>()))
+            patientService.Setup(p => p.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientErrorResult);
+            patientService.Setup(p => p.GetPatientAsync(ProtectedDelegateHdid1, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult1);
+            patientService.Setup(p => p.GetPatientAsync(ProtectedDelegateHdid2, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult2);
+            patientService.Setup(p => p.GetPatientAsync(dependentResult.ResourcePayload!.PersonalHealthNumber, PatientIdentifierType.Phn, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dependentResult);
-            patientService.Setup(p => p.GetPatient(delegateResult.ResourcePayload!.HdId, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
+            patientService.Setup(p => p.GetPatientAsync(delegateResult.ResourcePayload!.HdId, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
 
             ResourceDelegateQueryResult result = new()
             {
@@ -792,7 +792,7 @@ namespace HealthGateway.Admin.Tests.Services
         private DelegationService GetDelegationService(RequestResult<PatientModel> patient)
         {
             Mock<IPatientService> patientService = new();
-            patientService.Setup(p => p.GetPatient(It.IsAny<string>(), PatientIdentifierType.Phn, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+            patientService.Setup(p => p.GetPatientAsync(It.IsAny<string>(), PatientIdentifierType.Phn, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
             return new(
                 this.configuration,
                 patientService.Object,

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -745,7 +745,7 @@ namespace HealthGateway.Admin.Tests.Services
             delegationDelegate.Setup(p => p.GetDependentAsync(DependentHdid, true, CancellationToken.None)).ReturnsAsync(protectedDependent);
 
             Mock<IAuditRepository> agentAuditRepository = new();
-            agentAuditRepository.Setup(p => p.Handle(It.IsAny<AgentAuditQuery>(), It.IsAny<CancellationToken>()))
+            agentAuditRepository.Setup(p => p.HandleAsync(It.IsAny<AgentAuditQuery>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(agentAudits);
 
             return new DelegationService(

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -915,7 +915,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             if (dataSources != null)
             {
-                mock.Setup(s => s.GetDataSources(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(dataSources);
+                mock.Setup(s => s.GetDataSourcesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(dataSources);
             }
 
             return mock;

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -910,7 +910,7 @@ namespace HealthGateway.Admin.Tests.Services
             foreach ((PatientDetailsQuery query, PatientModel? patient) in pairs)
             {
                 PatientQueryResult result = new(patient == null ? [] : [patient]);
-                mock.Setup(p => p.Query(query, It.IsAny<CancellationToken>())).ReturnsAsync(result);
+                mock.Setup(p => p.QueryAsync(query, It.IsAny<CancellationToken>())).ReturnsAsync(result);
             }
 
             if (dataSources != null)

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -879,7 +879,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             foreach ((AgentAuditQuery query, IEnumerable<AgentAudit> agentAudits) in pairs)
             {
-                mock.Setup(p => p.Handle(query, It.IsAny<CancellationToken>())).ReturnsAsync(agentAudits);
+                mock.Setup(p => p.HandleAsync(query, It.IsAny<CancellationToken>())).ReturnsAsync(agentAudits);
             }
 
             return mock;

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -104,7 +104,7 @@ namespace HealthGateway.Admin.Services
         /// <inheritdoc/>
         public async Task<RequestResult<CovidInformation>> GetCovidInformation(string phn, bool refresh)
         {
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, true).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, true);
 
             if (patientResult.ResultStatus != ResultType.Success)
             {
@@ -133,7 +133,7 @@ namespace HealthGateway.Admin.Services
         /// <inheritdoc/>
         public async Task<RequestResult<bool>> MailVaccineCardAsync(MailDocumentRequest request)
         {
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(request.PersonalHealthNumber, PatientIdentifierType.Phn, true).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(request.PersonalHealthNumber, PatientIdentifierType.Phn, true);
 
             if (patientResult.ResultStatus != ResultType.Success)
             {
@@ -209,7 +209,7 @@ namespace HealthGateway.Admin.Services
             this.logger.LogDebug("Retrieving vaccine record");
             this.logger.LogTrace("For PHN: {Phn}", phn);
 
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, true).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, true);
 
             if (patientResult.ResultStatus != ResultType.Success)
             {

--- a/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/CovidSupportService.cs
@@ -104,7 +104,7 @@ namespace HealthGateway.Admin.Services
         /// <inheritdoc/>
         public async Task<RequestResult<CovidInformation>> GetCovidInformation(string phn, bool refresh)
         {
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(phn, PatientIdentifierType.Phn, true).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, true).ConfigureAwait(true);
 
             if (patientResult.ResultStatus != ResultType.Success)
             {
@@ -133,7 +133,7 @@ namespace HealthGateway.Admin.Services
         /// <inheritdoc/>
         public async Task<RequestResult<bool>> MailVaccineCardAsync(MailDocumentRequest request)
         {
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(request.PersonalHealthNumber, PatientIdentifierType.Phn, true).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(request.PersonalHealthNumber, PatientIdentifierType.Phn, true).ConfigureAwait(true);
 
             if (patientResult.ResultStatus != ResultType.Success)
             {
@@ -209,7 +209,7 @@ namespace HealthGateway.Admin.Services
             this.logger.LogDebug("Retrieving vaccine record");
             this.logger.LogTrace("For PHN: {Phn}", phn);
 
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(phn, PatientIdentifierType.Phn, true).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, true).ConfigureAwait(true);
 
             if (patientResult.ResultStatus != ResultType.Success)
             {

--- a/Apps/AdminWebClient/src/Server/Services/SupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/SupportService.cs
@@ -131,7 +131,7 @@ namespace HealthGateway.Admin.Services
 
         private void PopulatePatientSupportDetails(RequestResult<IEnumerable<PatientSupportDetails>> result, PatientIdentifierType patientIdentifierType, string queryString)
         {
-            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatientAsync(queryString, patientIdentifierType).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatientAsync(queryString, patientIdentifierType)).Result;
             if (patientResult.ResultStatus == ResultType.Success && patientResult.ResourcePayload != null)
             {
                 List<PatientSupportDetails> patients = new();
@@ -164,7 +164,7 @@ namespace HealthGateway.Admin.Services
 
         private async Task PopulatePatientSupportDetails(RequestResult<IEnumerable<PatientSupportDetails>> result, UserQueryType queryType, string queryString)
         {
-            IEnumerable<UserProfile> profiles = await this.userProfileDelegate.GetUserProfilesAsync(queryType, queryString).ConfigureAwait(true);
+            IEnumerable<UserProfile> profiles = await this.userProfileDelegate.GetUserProfilesAsync(queryType, queryString);
             result.ResourcePayload = this.autoMapper.Map<IEnumerable<PatientSupportDetails>>(profiles);
             result.ResultStatus = ResultType.Success;
         }

--- a/Apps/AdminWebClient/src/Server/Services/SupportService.cs
+++ b/Apps/AdminWebClient/src/Server/Services/SupportService.cs
@@ -34,6 +34,7 @@ namespace HealthGateway.Admin.Services
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Wrapper;
     using Microsoft.IdentityModel.Tokens;
+    using UserProfile = HealthGateway.Common.Data.Models.UserProfile;
 
     /// <inheritdoc/>
     public class SupportService : ISupportService
@@ -130,11 +131,11 @@ namespace HealthGateway.Admin.Services
 
         private void PopulatePatientSupportDetails(RequestResult<IEnumerable<PatientSupportDetails>> result, PatientIdentifierType patientIdentifierType, string queryString)
         {
-            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatient(queryString, patientIdentifierType).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatientAsync(queryString, patientIdentifierType).ConfigureAwait(true)).Result;
             if (patientResult.ResultStatus == ResultType.Success && patientResult.ResourcePayload != null)
             {
                 List<PatientSupportDetails> patients = new();
-                DbResult<Common.Data.Models.UserProfile> dbResult = this.userProfileDelegate.GetUserProfile(patientResult.ResourcePayload.HdId);
+                DbResult<UserProfile> dbResult = this.userProfileDelegate.GetUserProfile(patientResult.ResourcePayload.HdId);
                 if (dbResult.Status == DbStatusCode.Read)
                 {
                     PatientSupportDetails patientSupportDetails = PatientSupportDetailsMapUtils.ToUiModel(dbResult.Payload, patientResult.ResourcePayload, this.autoMapper);
@@ -163,7 +164,7 @@ namespace HealthGateway.Admin.Services
 
         private async Task PopulatePatientSupportDetails(RequestResult<IEnumerable<PatientSupportDetails>> result, UserQueryType queryType, string queryString)
         {
-            IEnumerable<Common.Data.Models.UserProfile> profiles = await this.userProfileDelegate.GetUserProfilesAsync(queryType, queryString).ConfigureAwait(true);
+            IEnumerable<UserProfile> profiles = await this.userProfileDelegate.GetUserProfilesAsync(queryType, queryString).ConfigureAwait(true);
             result.ResourcePayload = this.autoMapper.Map<IEnumerable<PatientSupportDetails>>(profiles);
             result.ResultStatus = ResultType.Success;
         }

--- a/Apps/AdminWebClient/test/unit/Services.Test/SupportServiceTests.cs
+++ b/Apps/AdminWebClient/test/unit/Services.Test/SupportServiceTests.cs
@@ -385,7 +385,7 @@ namespace HealthGateway.AdminWebClientTests.Services.Test
             Mock<IPatientService> mockPatientService = new();
             if (patientResult != null)
             {
-                mockPatientService.Setup(p => p.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult);
+                mockPatientService.Setup(p => p.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult);
             }
 
             Mock<IUserProfileDelegate> mockUserProfileDelegate = new();

--- a/Apps/Common/src/AccessManagement/Authorization/Handlers/UserDelegatedAccessHandler.cs
+++ b/Apps/Common/src/AccessManagement/Authorization/Handlers/UserDelegatedAccessHandler.cs
@@ -144,7 +144,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
                 return false;
             }
 
-            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatient(resourceHdid).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatientAsync(resourceHdid).ConfigureAwait(true)).Result;
 
             return patientResult.ResourcePayload!.Birthdate.AddYears(this.maxDependentAge.Value) < DateTime.Now;
         }

--- a/Apps/Common/src/AccessManagement/Authorization/Handlers/UserDelegatedAccessHandler.cs
+++ b/Apps/Common/src/AccessManagement/Authorization/Handlers/UserDelegatedAccessHandler.cs
@@ -144,7 +144,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
                 return false;
             }
 
-            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatientAsync(resourceHdid).ConfigureAwait(true)).Result;
+            RequestResult<PatientModel> patientResult = Task.Run(async () => await this.patientService.GetPatientAsync(resourceHdid)).Result;
 
             return patientResult.ResourcePayload!.Birthdate.AddYears(this.maxDependentAge.Value) < DateTime.Now;
         }

--- a/Apps/Common/src/Services/IPatientService.cs
+++ b/Apps/Common/src/Services/IPatientService.cs
@@ -48,7 +48,7 @@ namespace HealthGateway.Common.Services
         /// <param name="disableIdValidation">Disables the validation on HDID/PHN when true.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient model.</returns>
-        Task<RequestResult<PatientModel>> GetPatient(
+        Task<RequestResult<PatientModel>> GetPatientAsync(
             string identifier,
             PatientIdentifierType identifierType = PatientIdentifierType.Hdid,
             bool disableIdValidation = false,

--- a/Apps/Common/src/Services/PatientService.cs
+++ b/Apps/Common/src/Services/PatientService.cs
@@ -84,7 +84,7 @@ namespace HealthGateway.Common.Services
                 },
                 ResultStatus = ResultType.Error,
             };
-            RequestResult<PatientModel> patientResult = await this.GetPatientAsync(hdid).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.GetPatientAsync(hdid);
             retVal.ResultError = patientResult.ResultError;
             retVal.ResultStatus = patientResult.ResultStatus;
             if (patientResult.ResultStatus == ResultType.Success && patientResult.ResourcePayload != null)
@@ -100,7 +100,7 @@ namespace HealthGateway.Common.Services
         public async Task<string> GetPatientHdid(string phn)
         {
             using Activity? activity = Source.StartActivity();
-            RequestResult<PatientModel> patientResult = await this.GetPatientAsync(phn, PatientIdentifierType.Phn).ConfigureAwait(true);
+            RequestResult<PatientModel> patientResult = await this.GetPatientAsync(phn, PatientIdentifierType.Phn);
             if (patientResult.ResultStatus != ResultType.Success || patientResult.ResourcePayload == null)
             {
                 throw new ProblemDetailsException(

--- a/Apps/Common/test/unit/AccessManagement/Authorization/UserDelegatedAccessHandlerTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authorization/UserDelegatedAccessHandlerTests.cs
@@ -206,7 +206,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             Mock<IPatientService> mockPatientService = new();
             mockPatientService
-                .Setup(s => s.GetPatient(this.resourceHdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .Setup(s => s.GetPatientAsync(this.resourceHdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(getPatientResult);
 
             UserDelegatedAccessHandler authHandler = new(
@@ -248,7 +248,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             Mock<IPatientService> mockPatientService = new();
             mockPatientService
-                .Setup(s => s.GetPatient(this.resourceHdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .Setup(s => s.GetPatientAsync(this.resourceHdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(getPatientResult);
 
             UserDelegatedAccessHandler authHandler = new(

--- a/Apps/Common/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PatientServiceTests.cs
@@ -134,7 +134,7 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICacheProvider>().Object);
 
             // Act
-            RequestResult<PatientModel> actual = await service.GetPatient(Phn, PatientIdentifierType.Phn);
+            RequestResult<PatientModel> actual = await service.GetPatientAsync(Phn, PatientIdentifierType.Phn);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -174,7 +174,7 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICacheProvider>().Object);
 
             // Act
-            RequestResult<PatientModel> actual = await service.GetPatient("abc123", PatientIdentifierType.Phn);
+            RequestResult<PatientModel> actual = await service.GetPatientAsync("abc123", PatientIdentifierType.Phn);
 
             // Verify
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
@@ -214,7 +214,7 @@ namespace HealthGateway.CommonTests.Services
                 patientDelegateMock.Object,
                 new Mock<ICacheProvider>().Object);
 
-            await Assert.ThrowsAsync<NotImplementedException>(() => service.GetPatient("abc123", (PatientIdentifierType)23));
+            await Assert.ThrowsAsync<NotImplementedException>(() => service.GetPatientAsync("abc123", (PatientIdentifierType)23));
         }
 
         private static RequestResult<string> GetPatientPhn(Dictionary<string, string?> configDictionary, bool returnNullPatientResult)
@@ -290,7 +290,7 @@ namespace HealthGateway.CommonTests.Services
                 cacheProviderMock.Object);
 
             // Act
-            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatient(identifierType == PatientIdentifierType.Hdid ? Hdid : Phn, identifierType)).Result;
+            RequestResult<PatientModel> actual = Task.Run(async () => await service.GetPatientAsync(identifierType == PatientIdentifierType.Hdid ? Hdid : Phn, identifierType)).Result;
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);

--- a/Apps/Encounter/src/Services/EncounterService.cs
+++ b/Apps/Encounter/src/Services/EncounterService.cs
@@ -113,7 +113,7 @@ namespace HealthGateway.Encounter.Services
             }
 
             // Retrieve the phn
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
             if (patientResult is { ResultStatus: ResultType.Success, ResourcePayload: not null })
             {
                 PatientModel patient = patientResult.ResourcePayload;

--- a/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
@@ -189,10 +189,10 @@ namespace HealthGateway.EncounterTests.Services
 
             Mock<IMspVisitDelegate> mockMspDelegate = new();
             mockMspDelegate.Setup(s => s.GetMspVisitHistoryAsync(It.IsAny<OdrHistoryQuery>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult(delegateResult));
+                .ReturnsAsync(delegateResult);
 
             Mock<IPatientService> mockPatientService = new();
-            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(this.patientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(this.patientResult);
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new();
             mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(this.GetHttpContext());
@@ -245,7 +245,7 @@ namespace HealthGateway.EncounterTests.Services
             };
 
             Mock<IPatientService> mockPatientService = new();
-            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(errorPatientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(errorPatientResult);
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new();
             mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(this.GetHttpContext());

--- a/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
@@ -133,7 +133,7 @@ namespace HealthGateway.EncounterTests.Services
             mockMspDelegate.Setup(s => s.GetMspVisitHistoryAsync(It.IsAny<OdrHistoryQuery>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
 
             Mock<IPatientService> mockPatientService = new();
-            mockPatientService.Setup(s => s.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(this.patientResult);
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(this.patientResult);
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new();
             mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(this.GetHttpContext());
@@ -192,7 +192,7 @@ namespace HealthGateway.EncounterTests.Services
                 .Returns(Task.FromResult(delegateResult));
 
             Mock<IPatientService> mockPatientService = new();
-            mockPatientService.Setup(s => s.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(this.patientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(this.patientResult));
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new();
             mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(this.GetHttpContext());
@@ -245,7 +245,7 @@ namespace HealthGateway.EncounterTests.Services
             };
 
             Mock<IPatientService> mockPatientService = new();
-            mockPatientService.Setup(s => s.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(errorPatientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(errorPatientResult));
 
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new();
             mockHttpContextAccessor.Setup(x => x.HttpContext).Returns(this.GetHttpContext());

--- a/Apps/GatewayApi/src/Services/DependentService.cs
+++ b/Apps/GatewayApi/src/Services/DependentService.cs
@@ -167,7 +167,7 @@ namespace HealthGateway.GatewayApi.Services
             foreach (ResourceDelegate resourceDelegate in resourceDelegates)
             {
                 this.logger.LogDebug("Getting dependent details for Dependent hdid: {DependentHdid}", resourceDelegate.ResourceOwnerHdid);
-                RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(resourceDelegate.ResourceOwnerHdid, ct: ct);
+                RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(resourceDelegate.ResourceOwnerHdid, ct: ct);
 
                 if (patientResult.ResourcePayload != null)
                 {
@@ -332,7 +332,7 @@ namespace HealthGateway.GatewayApi.Services
 
         private async Task<RequestResult<PatientModel>> GetDependentAsPatientAsync(string phn, CancellationToken ct)
         {
-            return await this.patientService.GetPatient(phn, PatientIdentifierType.Phn, ct: ct);
+            return await this.patientService.GetPatientAsync(phn, PatientIdentifierType.Phn, ct: ct);
         }
 
         private async Task UpdateNotificationSettingsAsync(string dependentHdid, string delegateHdid, bool isDelete = false, CancellationToken ct = default)

--- a/Apps/GatewayApi/src/Services/PatientDetailsService.cs
+++ b/Apps/GatewayApi/src/Services/PatientDetailsService.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.GatewayApi.Services
 
             this.logger.LogDebug("Starting GetPatient for identifier type: {IdentifierType} and patient data source: {Source}", identifierType, query.Source);
 
-            PatientModel? patientDetails = (await this.patientRepository.Query(query, ct).ConfigureAwait(true)).Items.SingleOrDefault();
+            PatientModel? patientDetails = (await this.patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
 
             if (patientDetails == null)
             {

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -499,7 +499,7 @@ namespace HealthGateway.GatewayApi.Services
                                               profileHistoryCollection.Length != 0 &&
                                               latestTourChangeDateTime != null &&
                                               profileHistoryCollection.Max(x => x.LastLoginDateTime) < latestTourChangeDateTime;
-            userProfileModel.BlockedDataSources = await this.patientRepository.GetDataSources(userProfile.HdId, ct);
+            userProfileModel.BlockedDataSources = await this.patientRepository.GetDataSourcesAsync(userProfile.HdId, ct);
             return userProfileModel;
         }
 

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -170,7 +170,7 @@ namespace HealthGateway.GatewayApi.Services
                 userProfile.LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType();
 
                 // Update user year of birth.
-                RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
+                RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
                 DateTime? birthDate = patientResult.ResourcePayload?.Birthdate;
                 userProfile.YearOfBirth = birthDate?.Year;
 
@@ -235,7 +235,7 @@ namespace HealthGateway.GatewayApi.Services
 
             string hdid = createProfileRequest.Profile.HdId;
 
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
             DateTime? birthDate = patientResult.ResourcePayload?.Birthdate;
 
             // Create profile
@@ -418,7 +418,7 @@ namespace HealthGateway.GatewayApi.Services
                 return RequestResultFactory.Success(true);
             }
 
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
 
             if (patientResult.ResultStatus != ResultType.Success || patientResult.ResourcePayload == null)
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -474,7 +474,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 },
             };
 
-            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(patientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult);
 
             Mock<IMessageSender> mockMessageSender = new();
             mockMessageSender.Setup(s => s.SendAsync(It.IsAny<IEnumerable<MessageEnvelope>>(), It.IsAny<CancellationToken>()));
@@ -531,7 +531,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 },
             };
 
-            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(patientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(patientResult);
 
             ResourceDelegate expectedDbDependent = new() { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId };
 

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -474,7 +474,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 },
             };
 
-            mockPatientService.Setup(s => s.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(patientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(patientResult));
 
             Mock<IMessageSender> mockMessageSender = new();
             mockMessageSender.Setup(s => s.SendAsync(It.IsAny<IEnumerable<MessageEnvelope>>(), It.IsAny<CancellationToken>()));
@@ -531,7 +531,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 },
             };
 
-            mockPatientService.Setup(s => s.GetPatient(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(patientResult));
+            mockPatientService.Setup(s => s.GetPatientAsync(It.IsAny<string>(), It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).Returns(Task.FromResult(patientResult));
 
             ResourceDelegate expectedDbDependent = new() { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId };
 

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/PatientRepositoryMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/PatientRepositoryMock.cs
@@ -33,7 +33,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="dataSources">A list of data sources.</param>
         public PatientRepositoryMock(string hdid, IEnumerable<DataSource> dataSources)
         {
-            this.Setup(s => s.GetDataSources(hdid, It.IsAny<CancellationToken>())).ReturnsAsync(dataSources);
+            this.Setup(s => s.GetDataSourcesAsync(hdid, It.IsAny<CancellationToken>())).ReturnsAsync(dataSources);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/PatientServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/PatientServiceMock.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         /// <param name="patientModel">patient model.</param>
         public PatientServiceMock(string hdid, PatientModel patientModel)
         {
-            this.Setup(s => s.GetPatient(hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            this.Setup(s => s.GetPatientAsync(hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<PatientModel>
                     {

--- a/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/Mock/UserProfileServiceMock.cs
@@ -281,7 +281,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test.Mock
         public UserProfileServiceMock SetupPatientServiceMockCustomPatient(string hdid, PatientModel patient)
         {
             this.patientServiceMock
-                .Setup(s => s.GetPatient(hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .Setup(s => s.GetPatientAsync(hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<PatientModel>
                     {

--- a/Apps/Immunization/src/Services/IImmunizationService.cs
+++ b/Apps/Immunization/src/Services/IImmunizationService.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.Immunization.Services
         Task<RequestResult<ImmunizationEvent>> GetImmunizationAsync(string immunizationId, CancellationToken ct = default);
 
         /// <summary>
-        /// Gets the ImmunizationResult inluding load state and a list of immunization records.
+        /// Gets the ImmunizationResult including load state and a list of immunization records.
         /// </summary>
         /// <param name="hdid">The hdid patient id.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>

--- a/Apps/Medication/src/Services/MedicationRequestService.cs
+++ b/Apps/Medication/src/Services/MedicationRequestService.cs
@@ -65,7 +65,7 @@ namespace HealthGateway.Medication.Services
             }
 
             // Retrieve the phn
-            RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
+            RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
             if (patientResult.ResultStatus == ResultType.Success && patientResult.ResourcePayload != null)
             {
                 PatientModel patient = patientResult.ResourcePayload;

--- a/Apps/Medication/src/Services/RestMedicationStatementService.cs
+++ b/Apps/Medication/src/Services/RestMedicationStatementService.cs
@@ -112,7 +112,7 @@ namespace HealthGateway.Medication.Services
                 }
 
                 // Retrieve the phn
-                RequestResult<PatientModel> patientResult = await this.patientService.GetPatient(hdid, ct: ct);
+                RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
                 if (patientResult.ResultStatus != ResultType.Success || patientResult.ResourcePayload == null)
                 {
                     return RequestResultFactory.Error<IList<MedicationStatement>>(patientResult.ResultError);

--- a/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
@@ -183,7 +183,7 @@ namespace HealthGateway.MedicationTests.Services
         private static Mock<IPatientService> CreatePatientService(string hdid, RequestResult<PatientModel> response)
         {
             Mock<IPatientService> mockPatientService = new();
-            mockPatientService.Setup(s => s.GetPatient(hdid, It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(response);
+            mockPatientService.Setup(s => s.GetPatientAsync(hdid, It.IsAny<PatientIdentifierType>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(response);
             return mockPatientService;
         }
     }

--- a/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
@@ -131,7 +131,7 @@ namespace HealthGateway.MedicationTests.Services
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
             Mock<IPatientService> patientServiceMock = new();
-            patientServiceMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientServiceMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .Returns(
                     Task.FromResult(
                         new RequestResult<PatientModel>
@@ -193,7 +193,7 @@ namespace HealthGateway.MedicationTests.Services
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<PatientModel>
                     {
@@ -254,7 +254,7 @@ namespace HealthGateway.MedicationTests.Services
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .Returns(
                     Task.FromResult(
                         new RequestResult<PatientModel>
@@ -350,7 +350,7 @@ namespace HealthGateway.MedicationTests.Services
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .Returns(
                     Task.FromResult(
                         new RequestResult<PatientModel>
@@ -429,7 +429,7 @@ namespace HealthGateway.MedicationTests.Services
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .Returns(
                     Task.FromResult(
                         new RequestResult<PatientModel>
@@ -511,7 +511,7 @@ namespace HealthGateway.MedicationTests.Services
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .Returns(
                     Task.FromResult(
                         new RequestResult<PatientModel>
@@ -568,7 +568,7 @@ namespace HealthGateway.MedicationTests.Services
         {
             Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatient(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .Returns(
                     Task.FromResult(
                         new RequestResult<PatientModel>

--- a/Apps/Patient/src/Controllers/PatientController.cs
+++ b/Apps/Patient/src/Controllers/PatientController.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Patient.Controllers
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.ViewModels;
@@ -59,6 +60,7 @@ namespace HealthGateway.Patient.Controllers
         /// </summary>
         /// <returns>The patient record.</returns>
         /// <param name="hdid">The patient hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">Returns the patient record.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -70,15 +72,16 @@ namespace HealthGateway.Patient.Controllers
         [ApiVersion("1.0")]
         [Route("{hdid}")]
         [Authorize(Policy = PatientPolicy.Read)]
-        public async Task<RequestResult<PatientModel>> GetPatient(string hdid)
+        public async Task<RequestResult<PatientModel>> GetPatient(string hdid, CancellationToken ct)
         {
-            return await this.service.GetPatient(hdid).ConfigureAwait(true);
+            return await this.service.GetPatientAsync(hdid, ct: ct);
         }
 
         /// <summary>
         /// Gets a json of patient record.
         /// </summary>
         /// <param name="hdid">The patient hdid.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient record.</returns>
         /// <response code="200">Returns the patient record.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -98,9 +101,9 @@ namespace HealthGateway.Patient.Controllers
         [ApiVersion("2.0")]
         [Route("{hdid}")]
         [Authorize(Policy = PatientPolicy.Read)]
-        public async Task<ActionResult<PatientDetails>> GetPatientV2(string hdid)
+        public async Task<ActionResult<PatientDetails>> GetPatientV2(string hdid, CancellationToken ct)
         {
-            var patientDetails = await this.serviceV2.GetPatientAsync(hdid).ConfigureAwait(true);
+            PatientDetails patientDetails = await this.serviceV2.GetPatientAsync(hdid, ct: ct);
             return this.Ok(patientDetails);
         }
     }

--- a/Apps/Patient/src/Controllers/PatientDataController.cs
+++ b/Apps/Patient/src/Controllers/PatientDataController.cs
@@ -71,7 +71,7 @@ namespace HealthGateway.Patient.Controllers
                 throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(patientDataTypes), "Must have at least one data type"));
             }
 
-            return await this.patientDataService.Query(new PatientDataQuery(hdid, patientDataTypes), ct).ConfigureAwait(true);
+            return await this.patientDataService.QueryAsync(new PatientDataQuery(hdid, patientDataTypes), ct).ConfigureAwait(true);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace HealthGateway.Patient.Controllers
                 throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(fileId), "File id is missing"));
             }
 
-            return await this.patientDataService.Query(new PatientFileQuery(hdid, fileId), ct).ConfigureAwait(true) ??
+            return await this.patientDataService.QueryAsync(new PatientFileQuery(hdid, fileId), ct).ConfigureAwait(true) ??
                    throw new ProblemDetailsException(ExceptionUtility.CreateNotFoundError($"file {fileId} not found"));
         }
     }

--- a/Apps/Patient/src/Controllers/PatientDataController.cs
+++ b/Apps/Patient/src/Controllers/PatientDataController.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.Patient.Controllers
         /// </summary>
         /// <param name="hdid">The patient hdid.</param>
         /// <param name="patientDataTypes">array of data types to query.</param>
-        /// <param name="ct">cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>object with an array of patient data information.</returns>
         [HttpGet("{hdid}")]
         [Authorize(policy: PatientPolicy.Read)]
@@ -79,7 +79,7 @@ namespace HealthGateway.Patient.Controllers
         /// </summary>
         /// <param name="hdid">The patient hdid.</param>
         /// <param name="fileId">The file id.</param>
-        /// <param name="ct">cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient file.</returns>
         [HttpGet("{hdid}/file/{fileId}")]
         [Authorize(policy: PatientPolicy.Read)]

--- a/Apps/Patient/src/Controllers/PatientDataController.cs
+++ b/Apps/Patient/src/Controllers/PatientDataController.cs
@@ -71,7 +71,7 @@ namespace HealthGateway.Patient.Controllers
                 throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(patientDataTypes), "Must have at least one data type"));
             }
 
-            return await this.patientDataService.QueryAsync(new PatientDataQuery(hdid, patientDataTypes), ct).ConfigureAwait(true);
+            return await this.patientDataService.QueryAsync(new PatientDataQuery(hdid, patientDataTypes), ct);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace HealthGateway.Patient.Controllers
                 throw new ProblemDetailsException(ExceptionUtility.CreateValidationError(nameof(fileId), "File id is missing"));
             }
 
-            return await this.patientDataService.QueryAsync(new PatientFileQuery(hdid, fileId), ct).ConfigureAwait(true) ??
+            return await this.patientDataService.QueryAsync(new PatientFileQuery(hdid, fileId), ct) ??
                    throw new ProblemDetailsException(ExceptionUtility.CreateNotFoundError($"file {fileId} not found"));
         }
     }

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -91,7 +91,7 @@ namespace HealthGateway.Patient
             Auth.UseAuth(app, logger);
             HttpWeb.UseRest(app, logger);
 
-            await app.RunAsync().ConfigureAwait(true);
+            await app.RunAsync();
         }
     }
 }

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -34,7 +34,7 @@ namespace HealthGateway.Patient.Services
         /// Query data services.
         /// </summary>
         /// <param name="query">The query message.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The Response message.</returns>
         Task<PatientDataResponse> QueryAsync(PatientDataQuery query, CancellationToken ct);
 
@@ -42,7 +42,7 @@ namespace HealthGateway.Patient.Services
         /// Query patient files.
         /// </summary>
         /// <param name="query">The query.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>Patient file or null if not found.</returns>
         Task<PatientFileResponse?> QueryAsync(PatientFileQuery query, CancellationToken ct);
     }

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -36,7 +36,7 @@ namespace HealthGateway.Patient.Services
         /// <param name="query">The query message.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>The Response message.</returns>
-        Task<PatientDataResponse> Query(PatientDataQuery query, CancellationToken ct);
+        Task<PatientDataResponse> QueryAsync(PatientDataQuery query, CancellationToken ct);
 
         /// <summary>
         /// Query patient files.
@@ -44,7 +44,7 @@ namespace HealthGateway.Patient.Services
         /// <param name="query">The query.</param>
         /// <param name="ct">The cancellation token.</param>
         /// <returns>Patient file or null if not found.</returns>
-        Task<PatientFileResponse?> Query(PatientFileQuery query, CancellationToken ct);
+        Task<PatientFileResponse?> QueryAsync(PatientFileQuery query, CancellationToken ct);
     }
 
     /// <summary>

--- a/Apps/Patient/src/Services/IPatientService.cs
+++ b/Apps/Patient/src/Services/IPatientService.cs
@@ -31,7 +31,7 @@ namespace HealthGateway.Patient.Services
         /// <param name="identifier">The patient identifier.</param>
         /// <param name="identifierType">The type of identifier being passed in.</param>
         /// <param name="disableIdValidation">Disables the validation on HDID/PHN when true.</param>
-        /// <param name="ct">The cancellation token.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient model.</returns>
         Task<PatientDetails> GetPatientAsync(
             string identifier,

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -53,15 +53,14 @@ namespace HealthGateway.Patient.Services
 
             Guid pid = await this.ResolvePidFromHdidAsync(query.Hdid, ct);
             HealthQuery healthQuery = new(pid, unblockedPatientDataTypes.Select(t => this.mapper.Map<HealthCategory>(t)));
-            PatientDataQueryResult result = await this.patientDataRepository.Query(healthQuery, ct)
-                .ConfigureAwait(true);
+            PatientDataQueryResult result = await this.patientDataRepository.QueryAsync(healthQuery, ct);
             return new PatientDataResponse(result.Items.Select(i => this.mapper.Map<PatientData>(i)));
         }
 
         public async Task<PatientFileResponse?> QueryAsync(PatientFileQuery query, CancellationToken ct)
         {
             Guid pid = await this.ResolvePidFromHdidAsync(query.Hdid, ct);
-            PatientFile? file = (await this.patientDataRepository.Query(new PatientDataAccess.PatientFileQuery(pid, query.FileId), ct)).Items.OfType<PatientFile>()
+            PatientFile? file = (await this.patientDataRepository.QueryAsync(new PatientDataAccess.PatientFileQuery(pid, query.FileId), ct)).Items.OfType<PatientFile>()
                 .FirstOrDefault();
 
             return file != null

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -43,25 +43,25 @@ namespace HealthGateway.Patient.Services
             this.mapper = mapper;
         }
 
-        public async Task<PatientDataResponse> Query(PatientDataQuery query, CancellationToken ct)
+        public async Task<PatientDataResponse> QueryAsync(PatientDataQuery query, CancellationToken ct)
         {
-            IList<PatientDataType> unblockedPatientDataTypes = await this.GetUnblockedPatientDataTypesAsync(query.Hdid, query.PatientDataTypes).ConfigureAwait(true);
+            IList<PatientDataType> unblockedPatientDataTypes = await this.GetUnblockedPatientDataTypesAsync(query.Hdid, query.PatientDataTypes, ct);
             if (!unblockedPatientDataTypes.Any())
             {
                 return new PatientDataResponse(Enumerable.Empty<PatientData>());
             }
 
-            Guid pid = await this.ResolvePidFromHdid(query.Hdid).ConfigureAwait(true);
+            Guid pid = await this.ResolvePidFromHdidAsync(query.Hdid, ct);
             HealthQuery healthQuery = new(pid, unblockedPatientDataTypes.Select(t => this.mapper.Map<HealthCategory>(t)));
             PatientDataQueryResult result = await this.patientDataRepository.Query(healthQuery, ct)
                 .ConfigureAwait(true);
             return new PatientDataResponse(result.Items.Select(i => this.mapper.Map<PatientData>(i)));
         }
 
-        public async Task<PatientFileResponse?> Query(PatientFileQuery query, CancellationToken ct)
+        public async Task<PatientFileResponse?> QueryAsync(PatientFileQuery query, CancellationToken ct)
         {
-            Guid pid = await this.ResolvePidFromHdid(query.Hdid).ConfigureAwait(true);
-            PatientFile? file = (await this.patientDataRepository.Query(new PatientDataAccess.PatientFileQuery(pid, query.FileId), ct).ConfigureAwait(true)).Items.OfType<PatientFile>()
+            Guid pid = await this.ResolvePidFromHdidAsync(query.Hdid, ct);
+            PatientFile? file = (await this.patientDataRepository.Query(new PatientDataAccess.PatientFileQuery(pid, query.FileId), ct)).Items.OfType<PatientFile>()
                 .FirstOrDefault();
 
             return file != null
@@ -69,13 +69,13 @@ namespace HealthGateway.Patient.Services
                 : null;
         }
 
-        private async Task<IList<PatientDataType>> GetUnblockedPatientDataTypesAsync(string hdid, IEnumerable<PatientDataType> patientDataTypes)
+        private async Task<IList<PatientDataType>> GetUnblockedPatientDataTypesAsync(string hdid, IEnumerable<PatientDataType> patientDataTypes, CancellationToken ct)
         {
             List<PatientDataType> unblockedPatientDataTypes = new();
             foreach (PatientDataType patientDataType in patientDataTypes)
             {
                 DataSource dataSource = this.mapper.Map<DataSource>(patientDataType);
-                if (await this.patientRepository.CanAccessDataSourceAsync(hdid, dataSource).ConfigureAwait(true))
+                if (await this.patientRepository.CanAccessDataSourceAsync(hdid, dataSource, ct))
                 {
                     unblockedPatientDataTypes.Add(patientDataType);
                 }
@@ -84,9 +84,9 @@ namespace HealthGateway.Patient.Services
             return unblockedPatientDataTypes;
         }
 
-        private async Task<Guid> ResolvePidFromHdid(string patientHdid)
+        private async Task<Guid> ResolvePidFromHdidAsync(string patientHdid, CancellationToken ct)
         {
-            return (await this.personalAccountsService.GetPatientAccountAsync(patientHdid).ConfigureAwait(true)).PatientIdentity.Pid;
+            return (await this.personalAccountsService.GetPatientAccountAsync(patientHdid, ct)).PatientIdentity.Pid;
         }
     }
 #pragma warning restore SA1600

--- a/Apps/Patient/src/Services/PatientService.cs
+++ b/Apps/Patient/src/Services/PatientService.cs
@@ -66,7 +66,7 @@ namespace HealthGateway.Patient.Services
 
             this.logger.LogDebug("Starting GetPatient for identifier type: {IdentifierType} and patient data source: {Source}", identifierType, query.Source);
 
-            PatientModel? patientDetails = (await this.patientRepository.Query(query, ct).ConfigureAwait(true)).Items.SingleOrDefault();
+            PatientModel? patientDetails = (await this.patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
 
             if (patientDetails == null)
             {

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -75,7 +75,7 @@ namespace HealthGateway.PatientTests.Controllers
             };
 
             // Act
-            RequestResult<PatientModel> actualResult = await patientController.GetPatient("123");
+            RequestResult<PatientModel> actualResult = await patientController.GetPatient("123", default);
 
             // Assert
             expectedResult.ShouldDeepEqual(actualResult);
@@ -92,7 +92,7 @@ namespace HealthGateway.PatientTests.Controllers
             PatientController patientController = CreatePatientController();
 
             // Act
-            ActionResult<PatientDetails> actualResult = await patientController.GetPatientV2(MockedHdid);
+            ActionResult<PatientDetails> actualResult = await patientController.GetPatientV2(MockedHdid, default);
 
             // Assert
             OkObjectResult ok = actualResult.Result.ShouldBeOfType<OkObjectResult>();
@@ -167,7 +167,7 @@ namespace HealthGateway.PatientTests.Controllers
             PatientDetails patientDetails = GetPatientModelV2();
 
             patientServiceV2.Setup(x => x.GetPatientAsync(It.IsAny<string>(), PatientIdentifierType.Hdid, false, new CancellationToken(false))).ReturnsAsync(patientDetails);
-            patientServiceV1.Setup(x => x.GetPatient(It.IsAny<string>(), PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(requestResult);
+            patientServiceV1.Setup(x => x.GetPatientAsync(It.IsAny<string>(), PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(requestResult);
             return new(patientServiceV1.Object, patientServiceV2.Object);
         }
     }

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -142,7 +142,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None)
+            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None)
                 ;
 
             if (canAccessDataSource)
@@ -184,7 +184,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.BcCancerScreening }), CancellationToken.None)
+            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, new[] { PatientDataType.BcCancerScreening }), CancellationToken.None)
                 ;
 
             if (canAccessDataSource)
@@ -230,7 +230,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientDataResponse result = await sut.Query(new PatientDataQuery(this.hdid, new[] { PatientDataType.DiagnosticImaging }), CancellationToken.None)
+            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, new[] { PatientDataType.DiagnosticImaging }), CancellationToken.None)
                 ;
 
             if (canAccessDataSource)
@@ -268,7 +268,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientFileResponse? result = await sut.Query(new Patient.Services.PatientFileQuery(this.hdid, expected.FileId), CancellationToken.None);
+            PatientFileResponse? result = await sut.QueryAsync(new Patient.Services.PatientFileQuery(this.hdid, expected.FileId), CancellationToken.None);
 
             PatientFileResponse actual = result.ShouldBeOfType<PatientFileResponse>();
             actual.Content.ShouldBe(expected.Content);
@@ -290,7 +290,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, this.mapper);
 
-            PatientFileResponse? result = await sut.Query(new Patient.Services.PatientFileQuery(this.hdid, fileId), CancellationToken.None);
+            PatientFileResponse? result = await sut.QueryAsync(new Patient.Services.PatientFileQuery(this.hdid, fileId), CancellationToken.None);
 
             result.ShouldBeNull();
         }

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -201,14 +201,14 @@ namespace HealthGateway.PatientTests.Services
             Mock<IPatientRepository> patientRepository = new();
             if (patientDetailsQuery != null)
             {
-                patientRepository.Setup(p => p.Query(patientDetailsQuery, It.IsAny<CancellationToken>()))
+                patientRepository.Setup(p => p.QueryAsync(patientDetailsQuery, It.IsAny<CancellationToken>()))
                     .Throws(new ProblemDetailsException(ExceptionUtility.CreateProblemDetails(ErrorMessages.PhnInvalid, HttpStatusCode.NotFound, nameof(PatientRepository))));
             }
             else
             {
-                patientRepository.Setup(p => p.Query(new PatientDetailsQuery(null, Hdid, PatientDetailSource.All, true), It.IsAny<CancellationToken>()))
+                patientRepository.Setup(p => p.QueryAsync(new PatientDetailsQuery(null, Hdid, PatientDetailSource.All, true), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(patientQueryResult);
-                patientRepository.Setup(p => p.Query(new PatientDetailsQuery(Phn, null, PatientDetailSource.All, true), It.IsAny<CancellationToken>()))
+                patientRepository.Setup(p => p.QueryAsync(new PatientDetailsQuery(Phn, null, PatientDetailSource.All, true), It.IsAny<CancellationToken>()))
                     .ReturnsAsync(patientQueryResult);
             }
 

--- a/Apps/Patient/test/unit/Utils/MockPatientDataRepositoryExtension.cs
+++ b/Apps/Patient/test/unit/Utils/MockPatientDataRepositoryExtension.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.PatientTests.Utils
         {
             repo
                 .Setup(
-                    o => o.Query(
+                    o => o.QueryAsync(
                         It.Is<T>(q => predicate(q)),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new PatientDataQueryResult(data));

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.PatientDataAccess.Api
     internal interface IPatientApi
     {
         [Get("/patient/{pid}/file/{fileId}")]
-        Task<FileResult?> GetFile(Guid pid, string fileId, CancellationToken ct);
+        Task<FileResult?> GetFileAsync(Guid pid, string fileId, CancellationToken ct);
 
         [Get("/patient/{pid}/health-options")]
         Task<HealthOptionsResult?> GetHealthOptionsAsync(Guid pid, [Query(CollectionFormat.Multi)] string[] categories, CancellationToken ct);

--- a/Apps/PatientDataAccess/src/IPatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/IPatientDataRepository.cs
@@ -32,7 +32,7 @@ namespace HealthGateway.PatientDataAccess
         /// <param name="query">The query.</param>
         /// <param name="ct">Cancellation token.</param>
         /// <returns>The query result.</returns>
-        Task<PatientDataQueryResult> Query(PatientDataQuery query, CancellationToken ct);
+        Task<PatientDataQueryResult> QueryAsync(PatientDataQuery query, CancellationToken ct);
     }
 
     /// <summary>

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -51,7 +51,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.OrganDonorRegistrationStatus }), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.OrganDonorRegistrationStatus }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.OrganDonorRegistration
@@ -88,7 +88,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.BcCancerScreening }), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.BcCancerScreening }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.BcCancerScreening exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.BcCancerScreening>();
@@ -128,7 +128,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging }), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging }), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.DiagnosticImagingExam exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.DiagnosticImagingExam>();
@@ -163,7 +163,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening }), CancellationToken.None)
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening }), CancellationToken.None)
                 ;
 
             result.ShouldNotBeNull();
@@ -182,12 +182,12 @@ namespace PatientDataAccessTests
             FileResult expectedFile = new("text/plain", "somedata", "encoding");
 
             patientApi
-                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFileAsync(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedFile);
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull();
             PatientFile actualFile = result.Items.ShouldHaveSingleItem().ShouldBeOfType<PatientFile>();
@@ -204,12 +204,12 @@ namespace PatientDataAccessTests
             string fileId = Guid.NewGuid().ToString();
 
             patientApi
-                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFileAsync(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync((FileResult?)null);
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
@@ -222,13 +222,13 @@ namespace PatientDataAccessTests
 
 #pragma warning disable CA2000 // Dispose objects before losing scope
             patientApi
-                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFileAsync(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ThrowsAsync(await ApiException.Create(new HttpRequestMessage(), HttpMethod.Get, new HttpResponseMessage(HttpStatusCode.NotFound), new RefitSettings()));
 #pragma warning restore CA2000 // Dispose objects before losing scope
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }
@@ -241,12 +241,12 @@ namespace PatientDataAccessTests
             FileResult expectedFile = new(null, null, null);
 
             patientApi
-                .Setup(api => api.GetFile(this.pid, fileId, It.IsAny<CancellationToken>()))
+                .Setup(api => api.GetFileAsync(this.pid, fileId, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(expectedFile);
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.Query(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new PatientFileQuery(this.pid, fileId), CancellationToken.None);
 
             result.ShouldNotBeNull().Items.ShouldBeEmpty();
         }


### PR DESCRIPTION
# Implements [AB#16547](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16547)

## Description

- Add cancellation token, 'async' suffix and removed 'ConfigureAwait' for Patient
- Add cancellation token, 'async' suffix and removed 'ConfigureAwait' for  PatientData
- Add cancellation token, 'async' suffix  and removed 'ConfigureAwait' for PatientRepository
- Add cancellation token, 'async' suffix  and removed 'ConfigureAwait' for PatientDataRepository
- Updated unit tests

Note: did not update database delegate related code as that will be handled in another task [AB#16597](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16597)

<img width="561" alt="Screenshot 2024-01-09 at 4 36 53 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/a5b1429e-7ae2-4fda-a567-2ec2296e6e43">

<img width="578" alt="Screenshot 2024-01-09 at 4 36 59 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/efe35d81-87bc-466b-a021-6cb8742ecad4">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
