### PR TITLE
Reduce reliance on AuthenticationStateProvider in Admin.Client AB#16477

### DIFF
--- a/Apps/Admin/Client/Components/Details/AccountTab.razor
+++ b/Apps/Admin/Client/Components/Details/AccountTab.razor
@@ -7,12 +7,14 @@
         Account Details
     </MudText>
     <MudGrid Spacing="2">
-        @if (CanViewHdid && !string.IsNullOrWhiteSpace(Patient.Hdid))
-        {
-            <MudItem xs="12">
-                <HgField Label="HDID" Value="@Patient.Hdid" data-testid="patient-hdid" />
-            </MudItem>
-        }
+        <AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
+            @if (!string.IsNullOrWhiteSpace(Patient.Hdid))
+            {
+                <MudItem xs="12">
+                    <HgField Label="HDID" Value="@Patient.Hdid" data-testid="patient-hdid" />
+                </MudItem>
+            }
+        </AuthorizeView>
 
         @if (IsDefaultPatientStatus)
         {
@@ -34,7 +36,9 @@
     </MudGrid>
 }
 
-@if (CanViewMessagingVerifications && IsDefaultPatientStatus)
-{
-    <MessageVerificationTable Data="@MessagingVerifications" IsLoading="@PatientSupportDetailsLoading" />
-}
+<AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
+    @if (IsDefaultPatientStatus)
+    {
+        <MessageVerificationTable Data="@MessagingVerifications" IsLoading="@PatientSupportDetailsLoading" />
+    }
+</AuthorizeView>

--- a/Apps/Admin/Client/Components/Details/AccountTab.razor.cs
+++ b/Apps/Admin/Client/Components/Details/AccountTab.razor.cs
@@ -18,10 +18,8 @@ namespace HealthGateway.Admin.Client.Components.Details
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
-    using HealthGateway.Admin.Client.Authorization;
     using HealthGateway.Admin.Client.Services;
     using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Client.Store.PatientSupport;
@@ -69,22 +67,6 @@ namespace HealthGateway.Admin.Client.Components.Details
 
         private bool PatientSupportDetailsLoading => this.PatientDetailsState.Value.IsLoading;
 
-        private bool CanViewHdid => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
-
-        private bool CanViewMessagingVerifications => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
-
         private bool IsDefaultPatientStatus => this.Patient?.Status == PatientStatus.Default;
-
-        /// <inheritdoc/>
-        protected override async Task OnInitializedAsync()
-        {
-            await base.OnInitializedAsync();
-            this.AuthenticationState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
-        }
-
-        private bool UserHasRole(string role)
-        {
-            return this.AuthenticationState?.User.IsInRole(role) == true;
-        }
     }
 }

--- a/Apps/Admin/Client/Components/Details/ManageTab.razor
+++ b/Apps/Admin/Client/Components/Details/ManageTab.razor
@@ -1,13 +1,13 @@
 ﻿@using HealthGateway.Admin.Client.Components.Support
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
+<AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
+    @if (!string.IsNullOrWhiteSpace(Hdid))
+    {
+        <DatasetAccessSection Data="@BlockedDataSources" IsLoading="@PatientSupportDetailsLoading" Hdid="@Hdid" CanEdit="@CanEditDatasetAccess" />
+    }
+</AuthorizeView>
 
-@if (CanViewDatasetAccess)
-{
-    <DatasetAccessSection Data="@BlockedDataSources" IsLoading="@PatientSupportDetailsLoading" Hdid="@Hdid" CanEdit="@CanEditDatasetAccess" />
-}
-
-@if (CanViewDependents)
-{
+<AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
     <DependentTable Data="@Dependents" IsLoading="@PatientSupportDetailsLoading" />
-}
+</AuthorizeView>

--- a/Apps/Admin/Client/Components/Details/ManageTab.razor.cs
+++ b/Apps/Admin/Client/Components/Details/ManageTab.razor.cs
@@ -62,22 +62,13 @@ namespace HealthGateway.Admin.Client.Components.Details
 
         private bool PatientSupportDetailsLoading => this.PatientDetailsState.Value.IsLoading;
 
-        private bool CanViewDatasetAccess => (this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer)) && !string.IsNullOrWhiteSpace(this.Hdid);
-
-        private bool CanEditDatasetAccess => this.UserHasRole(Roles.Admin);
-
-        private bool CanViewDependents => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
+        private bool CanEditDatasetAccess => this.AuthenticationState?.User.IsInRole(Roles.Admin) == true;
 
         /// <inheritdoc/>
         protected override async Task OnInitializedAsync()
         {
             await base.OnInitializedAsync();
             this.AuthenticationState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
-        }
-
-        private bool UserHasRole(string role)
-        {
-            return this.AuthenticationState?.User.IsInRole(role) == true;
         }
     }
 }

--- a/Apps/Admin/Client/Components/Details/NotesTab.razor
+++ b/Apps/Admin/Client/Components/Details/NotesTab.razor
@@ -1,7 +1,6 @@
 ﻿@using HealthGateway.Admin.Client.Components.AgentAudit
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
-@if (CanViewAgentAuditHistory)
-{
+<AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
     <AgentAuditHistory Title="Notes" AgentActions="@AgentAuditHistory" IsLoading="@PatientSupportDetailsLoading" />
-}
+</AuthorizeView>

--- a/Apps/Admin/Client/Components/Details/NotesTab.razor.cs
+++ b/Apps/Admin/Client/Components/Details/NotesTab.razor.cs
@@ -17,14 +17,11 @@ namespace HealthGateway.Admin.Client.Components.Details
 {
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
-    using HealthGateway.Admin.Client.Authorization;
     using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Common.Models;
     using Microsoft.AspNetCore.Components;
-    using Microsoft.AspNetCore.Components.Authorization;
 
     /// <summary>
     /// Backing logic for the NotesTab component.
@@ -34,28 +31,9 @@ namespace HealthGateway.Admin.Client.Components.Details
         [Inject]
         private IState<PatientDetailsState> PatientDetailsState { get; set; } = default!;
 
-        [Inject]
-        private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
-
-        private AuthenticationState? AuthenticationState { get; set; }
-
         private IEnumerable<AgentAction> AgentAuditHistory =>
             (this.PatientDetailsState.Value.AgentActions ?? []).OrderByDescending(a => a.TransactionDateTime);
 
         private bool PatientSupportDetailsLoading => this.PatientDetailsState.Value.IsLoading;
-
-        private bool CanViewAgentAuditHistory => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
-
-        /// <inheritdoc/>
-        protected override async Task OnInitializedAsync()
-        {
-            await base.OnInitializedAsync();
-            this.AuthenticationState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
-        }
-
-        private bool UserHasRole(string role)
-        {
-            return this.AuthenticationState?.User.IsInRole(role) == true;
-        }
     }
 }

--- a/Apps/Admin/Client/Components/Details/ProfileTab.razor
+++ b/Apps/Admin/Client/Components/Details/ProfileTab.razor
@@ -1,5 +1,5 @@
-﻿@using HealthGateway.Common.Data.Utils
-@using HealthGateway.Admin.Client.Components.Support
+﻿@using HealthGateway.Admin.Client.Components.Support
+@using HealthGateway.Common.Data.Utils
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 @if (Patient != null)
@@ -25,8 +25,7 @@
         </MudItem>
     </MudGrid>
 
-    if (CanViewCovidDetails)
-    {
+    <AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Support}")">
         <MudExpansionPanels Class="mt-6">
             <MudProgressLinear Class="rounding-t overlow-hidden" hidden="@(!PatientSupportDetailsLoading)" Color="Color.Primary" Indeterminate="true"></MudProgressLinear>
             <MudExpansionPanel IsInitiallyExpanded>
@@ -51,5 +50,5 @@
                 </ChildContent>
             </MudExpansionPanel>
         </MudExpansionPanels>
-    }
+    </AuthorizeView>
 }

--- a/Apps/Admin/Client/Components/Details/ProfileTab.razor.cs
+++ b/Apps/Admin/Client/Components/Details/ProfileTab.razor.cs
@@ -17,10 +17,8 @@ namespace HealthGateway.Admin.Client.Components.Details
 {
     using System.Collections.Generic;
     using System.Linq;
-    using System.Threading.Tasks;
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
-    using HealthGateway.Admin.Client.Authorization;
     using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Client.Store.PatientSupport;
     using HealthGateway.Admin.Common.Models;
@@ -28,7 +26,6 @@ namespace HealthGateway.Admin.Client.Components.Details
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.Utils;
     using Microsoft.AspNetCore.Components;
-    using Microsoft.AspNetCore.Components.Authorization;
 
     /// <summary>
     /// Backing logic for the ProfileTab component.
@@ -47,11 +44,6 @@ namespace HealthGateway.Admin.Client.Components.Details
         [Inject]
         private IState<PatientSupportState> PatientSupportState { get; set; } = default!;
 
-        [Inject]
-        private AuthenticationStateProvider AuthenticationStateProvider { get; set; } = default!;
-
-        private AuthenticationState? AuthenticationState { get; set; }
-
         private PatientSupportResult? Patient =>
             this.PatientSupportState.Value.Result?.SingleOrDefault(x => x.PersonalHealthNumber == this.Phn);
 
@@ -68,22 +60,8 @@ namespace HealthGateway.Admin.Client.Components.Details
         private IEnumerable<PreviousAssessmentDetails> AssessmentDetails =>
             (this.AssessmentInfo?.PreviousAssessmentDetailsList ?? []).OrderByDescending(a => a.DateTimeOfAssessment);
 
-        private bool CanViewCovidDetails => this.UserHasRole(Roles.Support) || this.UserHasRole(Roles.Admin);
-
         private bool ImmunizationsAreBlocked => this.VaccineDetails?.Blocked ?? false;
 
         private bool PatientSupportDetailsLoading => this.PatientDetailsState.Value.IsLoading;
-
-        /// <inheritdoc/>
-        protected override async Task OnInitializedAsync()
-        {
-            await base.OnInitializedAsync();
-            this.AuthenticationState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
-        }
-
-        private bool UserHasRole(string role)
-        {
-            return this.AuthenticationState?.User.IsInRole(role) == true;
-        }
     }
 }

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -1,9 +1,9 @@
 @page "/patient-details"
 @layout MainLayout
 @attribute [Authorize(Roles = $"{Roles.Admin},{Roles.Reviewer},{Roles.Support}")]
+@using HealthGateway.Admin.Client.Components.Details
 @using HealthGateway.Admin.Client.Store.PatientDetails
 @using HealthGateway.Admin.Client.Store.PatientSupport
-@using HealthGateway.Admin.Client.Components.Details
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <PageTitle>Health Gateway Admin Patient Details</PageTitle>
@@ -65,24 +65,30 @@
             <MudTabPanel Text="Profile">
                 <ProfileTab Phn="@Phn" />
             </MudTabPanel>
-            @if (CanViewAccountDetails)
-            {
+
+            <AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
                 <MudTabPanel Text="Account">
                     <AccountTab Phn="@Phn" />
                 </MudTabPanel>
-            }
-            @if (CanViewManageProfile && IsGatewayUser)
-            {
-                <MudTabPanel Text="Manage">
-                    <ManageTab Phn="@Phn" />
-                </MudTabPanel>
-            }
-            @if (CanViewNotes && IsGatewayUser)
-            {
-                <MudTabPanel Text="Notes">
-                    <NotesTab />
-                </MudTabPanel>
-            }
+            </AuthorizeView>
+
+            <AuthorizeView Roles="@($"{Roles.Admin}, {Roles.Reviewer}")">
+                @if (IsGatewayUser)
+                {
+                    <MudTabPanel Text="Manage">
+                        <ManageTab Phn="@Phn" />
+                    </MudTabPanel>
+                }
+            </AuthorizeView>
+
+            <AuthorizeView Roles="@Roles.Admin">
+                @if (IsGatewayUser)
+                {
+                    <MudTabPanel Text="Notes">
+                        <NotesTab />
+                    </MudTabPanel>
+                }
+            </AuthorizeView>
         </ChildContent>
     </HgTabs>
 }

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -27,6 +27,7 @@ namespace HealthGateway.Admin.Client.Pages
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Extensions;
     using Microsoft.AspNetCore.Components;
     using Microsoft.AspNetCore.Components.Authorization;
     using Microsoft.AspNetCore.WebUtilities;
@@ -67,13 +68,7 @@ namespace HealthGateway.Admin.Client.Pages
 
         private bool IsGatewayUser => this.Patient?.Status == PatientStatus.Default;
 
-        private bool ShowStatusWarning => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer) || this.Patient?.Status != PatientStatus.NotUser;
-
-        private bool CanViewAccountDetails => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
-
-        private bool CanViewManageProfile => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer);
-
-        private bool CanViewNotes => this.UserHasRole(Roles.Admin);
+        private bool ShowStatusWarning => (this.AuthenticationState?.User).IsInAnyRole(Roles.Admin, Roles.Reviewer) || this.Patient?.Status != PatientStatus.NotUser;
 
         private AuthenticationState? AuthenticationState { get; set; }
 
@@ -116,11 +111,6 @@ namespace HealthGateway.Admin.Client.Pages
             }
 
             this.PreviousSearchedPhn = this.Phn;
-        }
-
-        private bool UserHasRole(string role)
-        {
-            return this.AuthenticationState?.User.IsInRole(role) == true;
         }
     }
 }

--- a/Apps/Admin/Client/Pages/SupportPage.razor.cs
+++ b/Apps/Admin/Client/Pages/SupportPage.razor.cs
@@ -29,6 +29,7 @@ namespace HealthGateway.Admin.Client.Pages
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Extensions;
     using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Data.Validations;
     using Microsoft.AspNetCore.Components;
@@ -66,7 +67,7 @@ namespace HealthGateway.Admin.Client.Pages
         [Inject]
         private IJSRuntime JsRuntime { get; set; } = default!;
 
-        private List<PatientQueryType> QueryTypes => this.UserHasRole(Roles.Admin) || this.UserHasRole(Roles.Reviewer)
+        private List<PatientQueryType> QueryTypes => (this.AuthenticationState?.User).IsInAnyRole(Roles.Admin, Roles.Reviewer)
             ? [PatientQueryType.Phn, PatientQueryType.Email, PatientQueryType.Sms, PatientQueryType.Hdid, PatientQueryType.Dependent]
             : [PatientQueryType.Phn];
 
@@ -164,11 +165,6 @@ namespace HealthGateway.Admin.Client.Pages
             }
 
             base.Dispose(disposing);
-        }
-
-        private bool UserHasRole(string role)
-        {
-            return this.AuthenticationState?.User.IsInRole(role) == true;
         }
 
         private void Clear()

--- a/Apps/CommonData/src/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Apps/CommonData/src/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,0 +1,23 @@
+﻿namespace HealthGateway.Common.Data.Extensions
+{
+    using System.Linq;
+    using System.Security.Claims;
+
+    /// <summary>
+    /// Extension methods for <see cref="ClaimsPrincipal"/>.
+    /// </summary>
+    public static class ClaimsPrincipalExtensions
+    {
+        /// <summary>
+        /// Returns a value that indicates whether the entity (user) represented by this claims principal is in any of the
+        /// specified roles.
+        /// </summary>
+        /// <param name="user">The claims principal in question.</param>
+        /// <param name="roles">The roles for which to check.</param>
+        /// <returns>true if claims principal is in any of the specified roles; otherwise, false.</returns>
+        public static bool IsInAnyRole(this ClaimsPrincipal? user, params string[] roles)
+        {
+            return user != null && roles.Any(user.IsInRole);
+        }
+    }
+}

--- a/Apps/CommonData/src/Extensions/ClaimsPrincipalExtensions.cs
+++ b/Apps/CommonData/src/Extensions/ClaimsPrincipalExtensions.cs
@@ -1,4 +1,19 @@
-﻿namespace HealthGateway.Common.Data.Extensions
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.Data.Extensions
 {
     using System.Linq;
     using System.Security.Claims;


### PR DESCRIPTION
# Implements [AB#16477](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16477) ([AB#16611](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16611))

## Description

- where possible, uses `<AuthorizeView>` in the Razor view to replace retrieving AuthenticationState in the code-behind
- introduces extension method to cleanly check authorization for multiple roles at once, without needing to duplicate a helper method in every code-behind

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
