### PR TITLE
Re-enable web client auth and fix flakiness (incl admin) for AB#16603.

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/unauthorized.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/unauthorized.cy.js
@@ -8,16 +8,14 @@ describe("Unauthorized", () => {
         skipOn("localhost");
         cy.logout();
         cy.visit("/");
-
         cy.get("[data-testid=sign-in-btn]")
             .should("be.visible")
             .should("not.be.disabled")
             .click();
-
+        cy.get("#kc-page-title", { timeout: 10000 }).should("be.visible");
         cy.get("#username").should("be.visible").type(username);
         cy.get("#password").should("be.visible").type(password, { log: false });
         cy.get("input[name=login]").should("be.visible").click();
-
         cy.url().should("include", "/unauthorized");
     });
 });

--- a/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
+++ b/Testing/functional/tests/cypress/integration/e2e/authentication/auth.js
@@ -1,6 +1,7 @@
-const { AuthMethod, localDevUri } = require("../../../support/constants");
+import { skipOn } from "@cypress/skip-test";
+const { AuthMethod } = require("../../../support/constants");
 
-describe("Authentication", () => {
+describe("Authentication", { defaultCommandTimeout: 6000 }, () => {
     beforeEach(() => {
         cy.configureSettings({});
     });
@@ -10,88 +11,31 @@ describe("Authentication", () => {
     });
 
     it("BCSC UI Login", () => {
-        if (Cypress.config().baseUrl != localDevUri) {
-            cy.login(
-                Cypress.env("bcsc.username"),
-                Cypress.env("bcsc.password"),
-                AuthMethod.BCSC
-            );
-            cy.checkTimelineHasLoaded();
-
-            cy.get("[data-testid=headerDropdownBtn]").click();
-            cy.get("[data-testid=logoutBtn]")
-                .should("be.visible")
-                .should("not.be.disabled");
-        } else {
-            cy.log("Skipped BCSC UI Login as running locally");
-        }
-    });
-
-    it("KeyCloak UI Login", () => {
-        if (Cypress.config().baseUrl != localDevUri) {
-            cy.login(
-                Cypress.env("keycloak.username"),
-                Cypress.env("keycloak.password"),
-                AuthMethod.KeyCloakUI
-            );
-            cy.checkTimelineHasLoaded();
-            cy.get("[data-testid=headerDropdownBtn]").click();
-            cy.get("[data-testid=logoutBtn]")
-                .should("be.visible")
-                .should("not.be.disabled");
-        } else {
-            cy.log("Skipped KeyCloak UI Login as running locally");
-        }
-    });
-
-    it("Logout", () => {
+        skipOn("localhost");
         cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
+            Cypress.env("bcsc.username"),
+            Cypress.env("bcsc.password"),
+            AuthMethod.BCSC,
             "/home"
         );
+        cy.url().should("include", "/home");
+
         cy.get("[data-testid=headerDropdownBtn]").click();
-        cy.get("[data-testid=logoutBtn]").click();
-        cy.get("[data-testid=ratingModalSkipBtn]").click();
-        cy.get("[data-testid=logout-complete-msg]").should("be.visible");
-        cy.get("[data-testid=loginBtn]")
+        cy.get("[data-testid=logoutBtn]")
             .should("be.visible")
             .should("not.be.disabled");
     });
 
-    it("IDIR Blocked", () => {
-        if (Cypress.config().baseUrl != localDevUri) {
-            cy.logout();
-            cy.visit("/login");
-            cy.log(
-                `Authenticating as IDIR user ${Cypress.env("idir.username")}`
-            );
-            cy.get("[data-testid=IDIRBtn]")
-                .should("be.visible")
-                .should("not.be.disabled")
-                .click();
-            cy.get("#user")
-                .should("be.visible")
-                .type(Cypress.env("idir.username"));
-            cy.get("#password")
-                .should("be.visible")
-                .type(Cypress.env("idir.password"), { log: false });
-            cy.get('input[name="btnSubmit"]').should("be.visible").click();
-            cy.contains("h1", "403");
-            cy.contains("h2", "IDIR Login");
-        } else {
-            cy.log("Skipped IDIR Blocked Test as running locally");
-        }
-    });
-
-    it("KeyCloak Login", () => {
+    it("KeyCloak UI Login", () => {
+        skipOn("localhost");
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
+            AuthMethod.KeyCloakUI,
             "/home"
         );
+        cy.url().should("include", "/home");
+
         cy.get("[data-testid=headerDropdownBtn]").click();
         cy.get("[data-testid=logoutBtn]")
             .should("be.visible")
@@ -108,22 +52,41 @@ describe("Authentication", () => {
         cy.url().should("include", "/patientRetrievalError");
     });
 
-    // it('Idle Timeout', () => {
-    // // Work in Progress, clock not working correctly.
-    //     cy.server()
-    //     cy.fixture('AllDisabledConfig').then((config) => {
-    //         config.webClient.timeouts.idle = 1000
-    //     }).as('config')
-    //     cy.route('GET', '/configuration/', '@config')
-    //     cy.login(Cypress.env('keycloak.username'), Cypress.env('keycloak.password'), AuthMethod.KeyCloak)
-    //     const now = Date.now()
-    //     cy.clock(now)
-    //       .tick(1000)
-    //     cy.get('[data-testid=idleModal]').contains('Are you still there?')
-    //     cy.get('[data-testid=idleModalText]').contains('You will be automatically logged out in 60 seconds.')
-    //     cy.tick(55000)
-    //     cy.get('[data-testid=idleModalText]').contains('You will be automatically logged out in 5 seconds.')
-    //     cy.get('[data-testid=idleModal]')
-    //       .find('footer').find('button').should('have.text', "I'm here!")
-    // })
+    it("Keycloak Login and Logout", () => {
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/home"
+        );
+        cy.url().should("include", "/home");
+        cy.get("[data-testid=headerDropdownBtn]").click();
+        cy.get("[data-testid=logoutBtn]").click();
+        cy.get("[data-testid=ratingModalSkipBtn]").click();
+        cy.get("[data-testid=logout-complete-msg]").should("be.visible");
+        cy.get("[data-testid=loginBtn]")
+            .should("be.visible")
+            .should("not.be.disabled");
+    });
+
+    it("IDIR Blocked", () => {
+        skipOn("localhost");
+        cy.logout();
+        cy.visit("/login");
+        cy.log(`Authenticating as IDIR user ${Cypress.env("idir.username")}`);
+        cy.url().should("include", "/login");
+        cy.get("[data-testid=IDIRBtn]")
+            .should("be.visible")
+            .should("be.enabled")
+            .click();
+        cy.get("#idirLogo", { timeout: 10000 }).should("be.visible");
+        cy.get("#user").should("be.visible").type(Cypress.env("idir.username"));
+        cy.get("#password")
+            .should("be.visible")
+            .type(Cypress.env("idir.password"), { log: false });
+        cy.get('input[name="btnSubmit"]').should("be.visible").click();
+        cy.url({ timeout: 10000 }).should("include", "idirLoggedIn");
+        cy.contains("h1", "403");
+        cy.contains("h2", "IDIR Login");
+    });
 });

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -235,6 +235,7 @@ Cypress.Commands.add(
                 .should("be.visible")
                 .should("have.text", "KeyCloak")
                 .click();
+            cy.get("#kc-page-title", { timeout: 10000 }).should("be.visible");
             cy.get("#username").should("be.visible").type(username);
             cy.get("#password")
                 .should("be.visible")

--- a/Testing/functional/tests/package-lock.json
+++ b/Testing/functional/tests/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
+                "@cypress/skip-test": "^2.6.1",
                 "cy-verify-downloads": "^0.1.17",
                 "cypress": "^13.6.0",
                 "cypress-multi-reporters": "^1.6.4",
@@ -73,6 +74,12 @@
             "engines": {
                 "node": ">= 6"
             }
+        },
+        "node_modules/@cypress/skip-test": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
+            "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
+            "dev": true
         },
         "node_modules/@cypress/xvfb": {
             "version": "1.2.4",

--- a/Testing/functional/tests/package.json
+++ b/Testing/functional/tests/package.json
@@ -12,6 +12,7 @@
     "author": "",
     "license": "Apache-2.0",
     "devDependencies": {
+        "@cypress/skip-test": "^2.6.1",
         "cy-verify-downloads": "^0.1.17",
         "cypress": "^13.6.0",
         "cypress-multi-reporters": "^1.6.4",

--- a/Tools/Pipelines/scripts/azp_runFunctionalTests.sh
+++ b/Tools/Pipelines/scripts/azp_runFunctionalTests.sh
@@ -40,7 +40,7 @@ TZ=America/Vancouver npx cypress run \
   --ci-build-id "$buildId" \
   --group "$buildId" \
   --tag "$tags" \
-  --spec "cypress/integration/ui/**/*,cypress/integration/e2e/**/!(auth.js)" \
+  --spec "cypress/integration/ui/**/*,cypress/integration/e2e/**/*" \
   --headless \
   --browser chrome
 popd


### PR DESCRIPTION
# Fixes [AB#16603](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16603)

## Description

- Re-enabled  web client auth tests
- Fixed login via Keycloak UI test
- Fixed login via IDIR test
- Consolidated Keycloak Login/Logout tests
- Moved IDIR to bottom of tests
- Fixed flakey admin unauthorized test
- Add defaultCommandTineout to auth test
- Add timeout where defaultCommandTimeout not suffucient
- Installed skip test package (used in admin) in web client to avoid having to code check base url to local const value

**Web Client:**

<img width="2259" alt="Screenshot 2024-01-20 at 10 03 51 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/cb36b14a-498a-4a7f-bcac-9ce59ab3139d">

**Admin:**

<img width="2252" alt="Screenshot 2024-01-20 at 7 17 34 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/95b3a898-c43c-4627-a744-4512bbd68c24">


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

NO

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
