### PR TITLE
Update cancer category name for AB#16625

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/site/NotificationCentreComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/NotificationCentreComponent.vue
@@ -21,7 +21,7 @@ enum AlertCategory {
     Medication = "Medications",
     Note = "MyNote",
     SpecialAuthority = "SpecialAuthority",
-    BcCancerScreening = "BcCancerScreening",
+    BcCancerScreening = "CancerScreening",
 }
 
 const router = useRouter();


### PR DESCRIPTION
# Fixes or Implements [AB#16625](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16625)

## Description
1. Data being returned from PHSA for BC Cancer notifications is "CancerScreening", the category code was checking for "BcCancerScreening"


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
None the button works now.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
