### PR TITLE
Upgrade Vuetify for AB#16537

### DIFF
--- a/Apps/WebClient/src/ClientApp/package-lock.json
+++ b/Apps/WebClient/src/ClientApp/package-lock.json
@@ -26,7 +26,7 @@
                 "vue": "^3.4.14",
                 "vue-clipboard3": "^2.0.0",
                 "vue-router": "^4.2.5",
-                "vuetify": "^3.3.23"
+                "vuetify": "^3.5.1"
             },
             "devDependencies": {
                 "@babel/types": "^7.23.6",
@@ -2850,9 +2850,9 @@
             }
         },
         "node_modules/vite": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.1.tgz",
-            "integrity": "sha512-AXXFaAJ8yebyqzoNB9fu2pHoo/nWX+xZlaRwoeYUxEqBO+Zj4msE5G+BhGBll9lYEKv9Hfks52PAF2X7qDYXQA==",
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+            "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
             "devOptional": true,
             "dependencies": {
                 "esbuild": "^0.18.10",
@@ -3036,8 +3036,9 @@
             }
         },
         "node_modules/vuetify": {
-            "version": "3.3.23",
-            "license": "MIT",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-3.5.1.tgz",
+            "integrity": "sha512-fkhU4UFnX/lBARXg+n9mBCDPTaEDHoYGx9SZ5A/1LlzM7LohoqldmrNgza4WgpPTLIWqr6NvYp2NvT2IrcTfhg==",
             "engines": {
                 "node": "^12.20 || >=14.13"
             },
@@ -3047,10 +3048,10 @@
             },
             "peerDependencies": {
                 "typescript": ">=4.7",
-                "vite-plugin-vuetify": "^1.0.0-alpha.12",
-                "vue": "^3.2.0",
+                "vite-plugin-vuetify": ">=1.0.0-alpha.12",
+                "vue": "^3.3.0",
                 "vue-i18n": "^9.0.0",
-                "webpack-plugin-vuetify": "^2.0.0-alpha.11"
+                "webpack-plugin-vuetify": ">=2.0.0-alpha.11"
             },
             "peerDependenciesMeta": {
                 "typescript": {

--- a/Apps/WebClient/src/ClientApp/package.json
+++ b/Apps/WebClient/src/ClientApp/package.json
@@ -28,7 +28,7 @@
         "vue": "^3.4.14",
         "vue-clipboard3": "^2.0.0",
         "vue-router": "^4.2.5",
-        "vuetify": "^3.3.23"
+        "vuetify": "^3.5.1"
     },
     "devDependencies": {
         "@babel/types": "^7.23.6",

--- a/Apps/WebClient/src/ClientApp/src/components/common/HgDatePickerComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/HgDatePickerComponent.vue
@@ -9,7 +9,7 @@ import { computed, ref, watch } from "vue";
 
 import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
 import { DateWrapper, IDateWrapper } from "@/models/dateWrapper";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import ValidationUtil from "@/utility/validationUtil";
 
 interface Props {
@@ -41,7 +41,7 @@ const maskOptions = {
     postProcess: (value: string) => value.toUpperCase(),
 };
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const internalValue = ref(fromIsoFormat(props.modelValue));
 

--- a/Apps/WebClient/src/ClientApp/src/components/common/HgDatePickerComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/HgDatePickerComponent.vue
@@ -9,7 +9,7 @@ import { computed, ref, watch } from "vue";
 
 import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
 import { DateWrapper, IDateWrapper } from "@/models/dateWrapper";
-import { useAppStore } from "@/stores/app";
+import { useNavigationStore } from "@/stores/navigation";
 import ValidationUtil from "@/utility/validationUtil";
 
 interface Props {
@@ -41,7 +41,7 @@ const maskOptions = {
     postProcess: (value: string) => value.toUpperCase(),
 };
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const internalValue = ref(fromIsoFormat(props.modelValue));
 
@@ -140,7 +140,7 @@ watch(
                 :offset="16"
                 calendar-cell-class-name="rounded-circle"
                 :teleport="true"
-                :teleport-center="appStore.isMobile"
+                :teleport-center="layoutStore.isMobile"
             >
                 <template #trigger>
                     <HgIconButtonComponent icon="fas fa-calendar" />

--- a/Apps/WebClient/src/ClientApp/src/components/common/InfoPopoverComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/InfoPopoverComponent.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
-import { useAppStore } from "@/stores/app";
+import { useNavigationStore } from "@/stores/navigation";
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 interface Props {
     buttonId?: string;
@@ -44,7 +44,7 @@ withDefaults(defineProps<Props>(), {
         >
             <v-card
                 class="pa-2 text-body-2"
-                :width="appStore.isMobile ? 250 : 472"
+                :width="layoutStore.isMobile ? 250 : 472"
             >
                 <slot />
             </v-card>

--- a/Apps/WebClient/src/ClientApp/src/components/common/InfoPopoverComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/InfoPopoverComponent.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 interface Props {
     buttonId?: string;

--- a/Apps/WebClient/src/ClientApp/src/components/common/PageTitleComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/PageTitleComponent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, useSlots } from "vue";
 
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 
 interface Props {
     title: string;
@@ -9,7 +9,7 @@ interface Props {
 defineProps<Props>();
 
 const slots = useSlots();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const hasPrependSlot = computed(() => slots.prepend !== undefined);
 const hasAppendSlot = computed(() => slots.append !== undefined);

--- a/Apps/WebClient/src/ClientApp/src/components/common/PageTitleComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/PageTitleComponent.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, useSlots } from "vue";
 
-import { useAppStore } from "@/stores/app";
+import { useNavigationStore } from "@/stores/navigation";
 
 interface Props {
     title: string;
@@ -9,7 +9,7 @@ interface Props {
 defineProps<Props>();
 
 const slots = useSlots();
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const hasPrependSlot = computed(() => slots.prepend !== undefined);
 const hasAppendSlot = computed(() => slots.append !== undefined);
@@ -25,7 +25,7 @@ const hasAppendSlot = computed(() => slots.append !== undefined);
                 <h1
                     id="subject"
                     class="text-primary font-weight-bold"
-                    :class="appStore.isMobile ? 'text-h5' : 'text-h4'"
+                    :class="layoutStore.isMobile ? 'text-h5' : 'text-h4'"
                 >
                     {{ title }}
                 </h1>

--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/RecommendationsDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/RecommendationsDialogComponent.vue
@@ -23,7 +23,7 @@ import RequestResult from "@/models/requestResult";
 import { Action, Actor, Destination, Origin, Text } from "@/plugins/extensions";
 import { ILogger, ITrackingService } from "@/services/interfaces";
 import { useErrorStore } from "@/stores/error";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useReportStore } from "@/stores/report";
 import EventDataUtility from "@/utility/eventDataUtility";
 
@@ -46,7 +46,7 @@ const trackingService = container.get<ITrackingService>(
 
 const reportStore = useReportStore();
 const errorStore = useErrorStore();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const messageModal = ref<InstanceType<typeof MessageModalComponent>>();
 const recommendationsReportComponent =

--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/RecommendationsDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/RecommendationsDialogComponent.vue
@@ -22,8 +22,8 @@ import {
 import RequestResult from "@/models/requestResult";
 import { Action, Actor, Destination, Origin, Text } from "@/plugins/extensions";
 import { ILogger, ITrackingService } from "@/services/interfaces";
-import { useAppStore } from "@/stores/app";
 import { useErrorStore } from "@/stores/error";
+import { useNavigationStore } from "@/stores/navigation";
 import { useReportStore } from "@/stores/report";
 import EventDataUtility from "@/utility/eventDataUtility";
 
@@ -46,7 +46,7 @@ const trackingService = container.get<ITrackingService>(
 
 const reportStore = useReportStore();
 const errorStore = useErrorStore();
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const messageModal = ref<InstanceType<typeof MessageModalComponent>>();
 const recommendationsReportComponent =
@@ -137,12 +137,12 @@ function showDialog() {
         <v-dialog
             v-model="isVisible"
             max-width="1000px"
-            :fullscreen="appStore.isMobile"
+            :fullscreen="layoutStore.isMobile"
             persistent
         >
             <v-card
                 data-testid="recommendations-dialog"
-                :class="{ 'mobile-padding': appStore.isMobile }"
+                :class="{ 'mobile-padding': layoutStore.isMobile }"
             >
                 <v-card-title class="px-0">
                     <v-toolbar
@@ -220,7 +220,7 @@ function showDialog() {
                 </v-card-text>
                 <v-card-actions
                     class="pa-4 justify-end"
-                    :class="{ 'fixed-bottom-actions': appStore.isMobile }"
+                    :class="{ 'fixed-bottom-actions': layoutStore.isMobile }"
                 >
                     <HgButtonComponent
                         variant="secondary"

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/FilterComponent.vue
@@ -14,8 +14,8 @@ import { useHealthVisitStore } from "@/stores/healthVisit";
 import { useHospitalVisitStore } from "@/stores/hospitalVisit";
 import { useImmunizationStore } from "@/stores/immunization";
 import { useLabResultStore } from "@/stores/labResult";
+import { useLayoutStore } from "@/stores/layout";
 import { useMedicationStore } from "@/stores/medication";
-import { useNavigationStore } from "@/stores/navigation";
 import { useNoteStore } from "@/stores/note";
 import { usePatientDataStore } from "@/stores/patientData";
 import { useSpecialAuthorityRequestStore } from "@/stores/specialAuthorityRequest";
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<Props>(), {
     entryTypes: () => [],
 });
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const timelineStore = useTimelineStore();
 const clinicalDocumentStore = useClinicalDocumentStore();
 const covid19TestResultStore = useCovid19TestResultStore();

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/FilterComponent.vue
@@ -8,7 +8,6 @@ import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.v
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { PatientDataType } from "@/models/patientDataResponse";
 import { TimelineFilterBuilder } from "@/models/timeline/timelineFilter";
-import { useAppStore } from "@/stores/app";
 import { useClinicalDocumentStore } from "@/stores/clinicalDocument";
 import { useCovid19TestResultStore } from "@/stores/covid19TestResult";
 import { useHealthVisitStore } from "@/stores/healthVisit";
@@ -16,6 +15,7 @@ import { useHospitalVisitStore } from "@/stores/hospitalVisit";
 import { useImmunizationStore } from "@/stores/immunization";
 import { useLabResultStore } from "@/stores/labResult";
 import { useMedicationStore } from "@/stores/medication";
+import { useNavigationStore } from "@/stores/navigation";
 import { useNoteStore } from "@/stores/note";
 import { usePatientDataStore } from "@/stores/patientData";
 import { useSpecialAuthorityRequestStore } from "@/stores/specialAuthorityRequest";
@@ -34,7 +34,7 @@ const props = withDefaults(defineProps<Props>(), {
     entryTypes: () => [],
 });
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const timelineStore = useTimelineStore();
 const clinicalDocumentStore = useClinicalDocumentStore();
 const covid19TestResultStore = useCovid19TestResultStore();
@@ -161,8 +161,8 @@ function getFormattedFilterCount(entryType: EntryType): string {
             persistent
             no-click-animation
             scrollable
-            :fullscreen="appStore.isMobile"
-            :width="appStore.isMobile ? 'auto' : 550"
+            :fullscreen="layoutStore.isMobile"
+            :width="layoutStore.isMobile ? 'auto' : 550"
         >
             <v-card>
                 <v-card-title class="px-0">

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/FullscreenTimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/FullscreenTimelineEntryComponent.vue
@@ -5,7 +5,6 @@ import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue
 import ErrorCardComponent from "@/components/error/ErrorCardComponent.vue";
 import { entryTypeMap } from "@/constants/entryType";
 import TimelineEntry from "@/models/timeline/timelineEntry";
-import { useAppStore } from "@/stores/app";
 import { EventName, useEventStore } from "@/stores/event";
 import { useNavigationStore } from "@/stores/navigation";
 
@@ -17,7 +16,7 @@ withDefaults(defineProps<Props>(), {
     commentsAreEnabled: false,
 });
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const eventStore = useEventStore();
 const navigationStore = useNavigationStore();
 
@@ -53,7 +52,7 @@ function handleEntryUpdate(entryId: string): void {
 }
 
 watch(
-    () => appStore.isMobile,
+    () => layoutStore.isMobile,
     (value) => {
         if (!value) {
             closeDialog();

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/FullscreenTimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/FullscreenTimelineEntryComponent.vue
@@ -6,7 +6,7 @@ import ErrorCardComponent from "@/components/error/ErrorCardComponent.vue";
 import { entryTypeMap } from "@/constants/entryType";
 import TimelineEntry from "@/models/timeline/timelineEntry";
 import { EventName, useEventStore } from "@/stores/event";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 
 interface Props {
     hdid: string;
@@ -16,9 +16,9 @@ withDefaults(defineProps<Props>(), {
     commentsAreEnabled: false,
 });
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const eventStore = useEventStore();
-const navigationStore = useNavigationStore();
+const navigationStore = useLayoutStore();
 
 const entry = ref<TimelineEntry>();
 const entryDate = ref("");

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/FullscreenTimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/FullscreenTimelineEntryComponent.vue
@@ -18,7 +18,6 @@ withDefaults(defineProps<Props>(), {
 
 const layoutStore = useLayoutStore();
 const eventStore = useEventStore();
-const navigationStore = useLayoutStore();
 
 const entry = ref<TimelineEntry>();
 const entryDate = ref("");
@@ -36,7 +35,7 @@ function openDialog(incomingEntry: TimelineEntry): void {
     entryDate.value = incomingEntry.date.toISO();
 
     isVisible.value = true;
-    navigationStore.setHeaderState(false);
+    layoutStore.setHeaderState(false);
 }
 
 function closeDialog(): void {

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/NoteDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/NoteDialogComponent.vue
@@ -18,6 +18,7 @@ import { useAppStore } from "@/stores/app";
 import { useErrorStore } from "@/stores/error";
 import { EventName, useEventStore } from "@/stores/event";
 import { useLoadingStore } from "@/stores/loading";
+import { useNavigationStore } from "@/stores/navigation";
 import { useNoteStore } from "@/stores/note";
 import { useTimelineStore } from "@/stores/timeline";
 import { useUserStore } from "@/stores/user";
@@ -27,6 +28,7 @@ const defaultDateString = DateWrapper.today().toISODate();
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const errorStore = useErrorStore();
 const eventStore = useEventStore();
 const loadingStore = useLoadingStore();
@@ -167,8 +169,8 @@ eventStore.subscribe(EventName.OpenNoteDialog, openDialog);
             persistent
             no-click-animation
             scrollable
-            :fullscreen="appStore.isMobile"
-            :width="appStore.isMobile ? 960 : 700"
+            :fullscreen="layoutStore.isMobile"
+            :width="layoutStore.isMobile ? 960 : 700"
         >
             <v-card :loading="isLoading">
                 <template #loader="{ isActive }">

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/NoteDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/NoteDialogComponent.vue
@@ -17,8 +17,8 @@ import { ILogger } from "@/services/interfaces";
 import { useAppStore } from "@/stores/app";
 import { useErrorStore } from "@/stores/error";
 import { EventName, useEventStore } from "@/stores/event";
+import { useLayoutStore } from "@/stores/layout";
 import { useLoadingStore } from "@/stores/loading";
-import { useNavigationStore } from "@/stores/navigation";
 import { useNoteStore } from "@/stores/note";
 import { useTimelineStore } from "@/stores/timeline";
 import { useUserStore } from "@/stores/user";
@@ -28,7 +28,7 @@ const defaultDateString = DateWrapper.today().toISODate();
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const appStore = useAppStore();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const errorStore = useErrorStore();
 const eventStore = useEventStore();
 const loadingStore = useLoadingStore();

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -38,7 +38,6 @@ import TimelineEntry, { DateGroup } from "@/models/timeline/timelineEntry";
 import { TimelineFilterBuilder } from "@/models/timeline/timelineFilter";
 import { ILogger } from "@/services/interfaces";
 import { entryTypeToPatientDataTypeMap } from "@/services/restPatientDataService";
-import { useAppStore } from "@/stores/app";
 import { useClinicalDocumentStore } from "@/stores/clinicalDocument";
 import { useCommentStore } from "@/stores/comment";
 import { useCovid19TestResultStore } from "@/stores/covid19TestResult";
@@ -48,6 +47,7 @@ import { useHospitalVisitStore } from "@/stores/hospitalVisit";
 import { useImmunizationStore } from "@/stores/immunization";
 import { useLabResultStore } from "@/stores/labResult";
 import { useMedicationStore } from "@/stores/medication";
+import { useNavigationStore } from "@/stores/navigation";
 import { useNoteStore } from "@/stores/note";
 import { usePatientDataStore } from "@/stores/patientData";
 import { useSpecialAuthorityRequestStore } from "@/stores/specialAuthorityRequest";
@@ -75,7 +75,7 @@ enum FilterLabelType {
 const pageSize = 25;
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const clinicalDocumentStore = useClinicalDocumentStore();
 const commentStore = useCommentStore();
 const covid19TestResultStore = useCovid19TestResultStore();
@@ -611,7 +611,7 @@ setPageFromDate(linearDate.value);
                             class="mr-1 mb-1"
                             :title="`${label} Filter`"
                             closable
-                            :size="appStore.isMobile ? 'small' : 'default'"
+                            :size="layoutStore.isMobile ? 'small' : 'default'"
                             @click:close="clearFilter(label, value)"
                         >
                             {{ value }}
@@ -741,8 +741,8 @@ setPageFromDate(linearDate.value);
                 v-model="currentPage"
                 data-testid="pagination"
                 :length="numberOfPages"
-                :total-visible="appStore.isMobile ? 3 : 8"
-                :density="appStore.isMobile ? 'comfortable' : 'default'"
+                :total-visible="layoutStore.isMobile ? 3 : 8"
+                :density="layoutStore.isMobile ? 'comfortable' : 'default'"
             />
         </div>
         <div

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -46,8 +46,8 @@ import { useHealthVisitStore } from "@/stores/healthVisit";
 import { useHospitalVisitStore } from "@/stores/hospitalVisit";
 import { useImmunizationStore } from "@/stores/immunization";
 import { useLabResultStore } from "@/stores/labResult";
+import { useLayoutStore } from "@/stores/layout";
 import { useMedicationStore } from "@/stores/medication";
-import { useNavigationStore } from "@/stores/navigation";
 import { useNoteStore } from "@/stores/note";
 import { usePatientDataStore } from "@/stores/patientData";
 import { useSpecialAuthorityRequestStore } from "@/stores/specialAuthorityRequest";
@@ -75,7 +75,7 @@ enum FilterLabelType {
 const pageSize = 25;
 
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const clinicalDocumentStore = useClinicalDocumentStore();
 const commentStore = useCommentStore();
 const covid19TestResultStore = useCovid19TestResultStore();

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
@@ -5,7 +5,7 @@ import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue
 import CommentSectionComponent from "@/components/private/timeline/comment/CommentSectionComponent.vue";
 import TimelineEntry from "@/models/timeline/timelineEntry";
 import { EventName, useEventStore } from "@/stores/event";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 
 interface Props {
     cardId: string;
@@ -33,7 +33,7 @@ const emit = defineEmits<{
     (e: "click-attachment-button"): void;
 }>();
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const eventStore = useEventStore();
 
 const detailsVisible = ref(props.isMobileDetails);

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
@@ -4,8 +4,8 @@ import { computed, ref, watch } from "vue";
 import HgIconButtonComponent from "@/components/common/HgIconButtonComponent.vue";
 import CommentSectionComponent from "@/components/private/timeline/comment/CommentSectionComponent.vue";
 import TimelineEntry from "@/models/timeline/timelineEntry";
-import { useAppStore } from "@/stores/app";
 import { EventName, useEventStore } from "@/stores/event";
+import { useNavigationStore } from "@/stores/navigation";
 
 interface Props {
     cardId: string;
@@ -33,15 +33,15 @@ const emit = defineEmits<{
     (e: "click-attachment-button"): void;
 }>();
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const eventStore = useEventStore();
 
 const detailsVisible = ref(props.isMobileDetails);
 
 const isInteractive = computed(
     () =>
-        (!appStore.isMobile && props.canShowDetails) ||
-        (appStore.isMobile && !props.isMobileDetails)
+        (!layoutStore.isMobile && props.canShowDetails) ||
+        (layoutStore.isMobile && !props.isMobileDetails)
 );
 const displayTitle = computed(() =>
     props.title === "" ? props.entry.type.toString() : props.title
@@ -50,15 +50,15 @@ const dateString = computed(() => props.entry.date.format());
 const commentCount = computed(() => props.entry.comments?.length ?? 0);
 
 function handleCardClick(): void {
-    if (appStore.isMobile && !props.isMobileDetails) {
+    if (layoutStore.isMobile && !props.isMobileDetails) {
         eventStore.emit(EventName.OpenFullscreenTimelineEntry, props.entry);
-    } else if (!appStore.isMobile && props.canShowDetails) {
+    } else if (!layoutStore.isMobile && props.canShowDetails) {
         detailsVisible.value = !detailsVisible.value;
     }
 }
 
 watch(
-    () => appStore.isMobile,
+    () => layoutStore.isMobile,
     (value) => {
         if (value && !props.isMobileDetails) {
             detailsVisible.value = false;

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentComponent.vue
@@ -10,7 +10,7 @@ import type { UserComment } from "@/models/userComment";
 import { ILogger } from "@/services/interfaces";
 import { useAppStore } from "@/stores/app";
 import { useCommentStore } from "@/stores/comment";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useUserStore } from "@/stores/user";
 
 interface Props {
@@ -22,7 +22,7 @@ const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const userStore = useUserStore();
 const commentStore = useCommentStore();
 const appStore = useAppStore();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const commentInput = ref("");
 const isEditMode = ref(false);

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentComponent.vue
@@ -10,6 +10,7 @@ import type { UserComment } from "@/models/userComment";
 import { ILogger } from "@/services/interfaces";
 import { useAppStore } from "@/stores/app";
 import { useCommentStore } from "@/stores/comment";
+import { useNavigationStore } from "@/stores/navigation";
 import { useUserStore } from "@/stores/user";
 
 interface Props {
@@ -21,12 +22,13 @@ const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const userStore = useUserStore();
 const commentStore = useCommentStore();
 const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const commentInput = ref("");
 const isEditMode = ref(false);
 const isUpdating = ref(false);
 
-const isMobile = computed(() => appStore.isMobile);
+const isMobile = computed(() => layoutStore.isMobile);
 
 function formatDate(date: string): string {
     return DateWrapper.fromIso(date).format(

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentSectionComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentSectionComponent.vue
@@ -12,8 +12,8 @@ import { DateWrapper } from "@/models/dateWrapper";
 import TimelineEntry from "@/models/timeline/timelineEntry";
 import { UserComment } from "@/models/userComment";
 import { ILogger } from "@/services/interfaces";
-import { useAppStore } from "@/stores/app";
 import { useCommentStore } from "@/stores/comment";
+import { useNavigationStore } from "@/stores/navigation";
 import { useUserStore } from "@/stores/user";
 
 interface Props {
@@ -41,7 +41,7 @@ const newComment: UserComment = {
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const userStore = useUserStore();
 const commentStore = useCommentStore();
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const showComments = ref(false);
 const isLoadingComments = ref(false);
@@ -65,7 +65,7 @@ for (const c of props.parentEntry.comments ?? []) {
 }
 
 function handleCommentExpandChange(): void {
-    if (appStore.isMobile) {
+    if (layoutStore.isMobile) {
         commentList.value?.$el.scrollIntoView({
             behavior: "smooth",
         });

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentSectionComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/comment/CommentSectionComponent.vue
@@ -13,7 +13,7 @@ import TimelineEntry from "@/models/timeline/timelineEntry";
 import { UserComment } from "@/models/userComment";
 import { ILogger } from "@/services/interfaces";
 import { useCommentStore } from "@/stores/comment";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useUserStore } from "@/stores/user";
 
 interface Props {
@@ -41,7 +41,7 @@ const newComment: UserComment = {
 const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 const userStore = useUserStore();
 const commentStore = useCommentStore();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const showComments = ref(false);
 const isLoadingComments = ref(false);

--- a/Apps/WebClient/src/ClientApp/src/components/public/landing/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/public/landing/LandingView.vue
@@ -10,7 +10,7 @@ import { ServiceName } from "@/constants/serviceName";
 import { InfoTile } from "@/models/infoTile";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import ConfigUtil from "@/utility/configUtil";
 
 enum PreviewDevice {
@@ -35,7 +35,7 @@ const serviceEntryTypes: EntryType[] = [EntryType.BcCancerScreening];
 
 const configStore = useConfigStore();
 const authStore = useAuthStore();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const selectedPreviewDevice = ref(PreviewDevice.laptop);
 const { mdAndUp } = useDisplay();

--- a/Apps/WebClient/src/ClientApp/src/components/public/landing/LandingView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/public/landing/LandingView.vue
@@ -8,9 +8,9 @@ import TileComponent from "@/components/public/landing/TileComponent.vue";
 import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { ServiceName } from "@/constants/serviceName";
 import { InfoTile } from "@/models/infoTile";
-import { useAppStore } from "@/stores/app";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
+import { useNavigationStore } from "@/stores/navigation";
 import ConfigUtil from "@/utility/configUtil";
 
 enum PreviewDevice {
@@ -35,7 +35,7 @@ const serviceEntryTypes: EntryType[] = [EntryType.BcCancerScreening];
 
 const configStore = useConfigStore();
 const authStore = useAuthStore();
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const selectedPreviewDevice = ref(PreviewDevice.laptop);
 const { mdAndUp } = useDisplay();
@@ -400,7 +400,7 @@ function selectPreviewDevice(previewDevice: PreviewDevice): void {
                 </p>
                 <div
                     class="d-flex justify-center"
-                    :class="{ 'flex-column': appStore.isMobile }"
+                    :class="{ 'flex-column': layoutStore.isMobile }"
                 >
                     <a
                         href="https://play.google.com/store/apps/details?id=ca.bc.gov.myhealth&hl=en_CA&gl=US"

--- a/Apps/WebClient/src/ClientApp/src/components/public/pcr-test-kit-registration/PcrTestKitRegistrationForm.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/public/pcr-test-kit-registration/PcrTestKitRegistrationForm.vue
@@ -255,8 +255,8 @@ const validations = computed(() => ({
 
 const v$ = useVuelidate(validations, pcrTest);
 
-function setHasNoPhn(value: boolean): void {
-    noPhn.value = value;
+function setHasNoPhn(value: boolean | null): void {
+    noPhn.value = value ?? false;
     const phnField = v$.value.phn;
     if (phnField) {
         pcrTest.value.phn = "";

--- a/Apps/WebClient/src/ClientApp/src/components/public/vaccine-card/VaccineCardView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/public/vaccine-card/VaccineCardView.vue
@@ -20,8 +20,8 @@ import { DateWrapper, StringISODate } from "@/models/dateWrapper";
 import VaccinationStatus from "@/models/vaccinationStatus";
 import { Action, Actor, Format, Text, Type } from "@/plugins/extensions";
 import { ILogger, ITrackingService } from "@/services/interfaces";
-import { useAppStore } from "@/stores/app";
 import { useConfigStore } from "@/stores/config";
+import { useNavigationStore } from "@/stores/navigation";
 import { useVaccinationStatusPublicStore } from "@/stores/vaccinationStatusPublic";
 import { phnMask } from "@/utility/masks";
 import ValidationUtil from "@/utility/validationUtil";
@@ -38,7 +38,7 @@ const trackingService = container.get<ITrackingService>(
     SERVICE_IDENTIFIER.TrackingService
 );
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const configStore = useConfigStore();
 const vaccinationStatusPublicStore = useVaccinationStatusPublicStore();
 
@@ -371,8 +371,8 @@ watch(vaccineRecord, (value) => {
                     data-testid="vaccineCardFormTitle"
                     class="vaccine-card-form-title text-center font-weight-bold"
                     :class="{
-                        'text-h6': appStore.isMobile,
-                        'text-h5': !appStore.isMobile,
+                        'text-h6': layoutStore.isMobile,
+                        'text-h5': !layoutStore.isMobile,
                     }"
                 >
                     Get your proof of vaccination

--- a/Apps/WebClient/src/ClientApp/src/components/public/vaccine-card/VaccineCardView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/public/vaccine-card/VaccineCardView.vue
@@ -21,7 +21,7 @@ import VaccinationStatus from "@/models/vaccinationStatus";
 import { Action, Actor, Format, Text, Type } from "@/plugins/extensions";
 import { ILogger, ITrackingService } from "@/services/interfaces";
 import { useConfigStore } from "@/stores/config";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useVaccinationStatusPublicStore } from "@/stores/vaccinationStatusPublic";
 import { phnMask } from "@/utility/masks";
 import ValidationUtil from "@/utility/validationUtil";
@@ -38,7 +38,7 @@ const trackingService = container.get<ITrackingService>(
     SERVICE_IDENTIFIER.TrackingService
 );
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const configStore = useConfigStore();
 const vaccinationStatusPublicStore = useVaccinationStatusPublicStore();
 

--- a/Apps/WebClient/src/ClientApp/src/components/site/DevBannerComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/DevBannerComponent.vue
@@ -2,9 +2,9 @@
 import { computed, ref } from "vue";
 
 import Process, { EnvironmentType } from "@/constants/process";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const host = ref(window.location.hostname.toLocaleUpperCase());
 

--- a/Apps/WebClient/src/ClientApp/src/components/site/DevBannerComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/DevBannerComponent.vue
@@ -2,9 +2,9 @@
 import { computed, ref } from "vue";
 
 import Process, { EnvironmentType } from "@/constants/process";
-import { useAppStore } from "@/stores/app";
+import { useNavigationStore } from "@/stores/navigation";
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const host = ref(window.location.hostname.toLocaleUpperCase());
 
@@ -22,7 +22,8 @@ const isProduction = computed(
         class="d-flex justify-center bg-accent small d-print-none"
     >
         <p>
-            <span v-if="!appStore.isMobile">Non-production environment: </span
+            <span v-if="!layoutStore.isMobile"
+                >Non-production environment: </span
             ><strong>{{ host }}</strong>
         </p>
     </v-system-bar>

--- a/Apps/WebClient/src/ClientApp/src/components/site/FooterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/FooterComponent.vue
@@ -4,13 +4,13 @@ import { computed } from "vue";
 import { Path } from "@/constants/path";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useUserStore } from "@/stores/user";
 
 const authStore = useAuthStore();
 const configStore = useConfigStore();
 const userStore = useUserStore();
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 
 const isFooterShown = computed(
     () =>

--- a/Apps/WebClient/src/ClientApp/src/components/site/FooterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/FooterComponent.vue
@@ -2,15 +2,15 @@
 import { computed } from "vue";
 
 import { Path } from "@/constants/path";
-import { useAppStore } from "@/stores/app";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
+import { useNavigationStore } from "@/stores/navigation";
 import { useUserStore } from "@/stores/user";
 
 const authStore = useAuthStore();
 const configStore = useConfigStore();
 const userStore = useUserStore();
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 
 const isFooterShown = computed(
     () =>
@@ -19,7 +19,7 @@ const isFooterShown = computed(
             !userStore.isValidIdentityProvider ||
             userStore.userIsRegistered)
 );
-const isFooterFixed = computed(() => !appStore.isMobile);
+const isFooterFixed = computed(() => !layoutStore.isMobile);
 </script>
 
 <template>

--- a/Apps/WebClient/src/ClientApp/src/components/site/HeaderComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/HeaderComponent.vue
@@ -22,7 +22,6 @@ const configStore = useConfigStore();
 const userStore = useUserStore();
 const notificationStore = useNotificationStore();
 const authStore = useAuthStore();
-const navigationStore = useLayoutStore();
 
 const route = useRoute();
 const router = useRouter();
@@ -43,7 +42,7 @@ const isValidIdentityProvider = computed(
     () => userStore.isValidIdentityProvider
 );
 const isHeaderShown = computed(
-    () => navigationStore.isHeaderShown || isScrollNearBottom.value
+    () => layoutStore.isHeaderShown || isScrollNearBottom.value
 );
 const user = computed(() => userStore.user);
 const userIsRegistered = computed(() => userStore.userIsRegistered);
@@ -124,11 +123,11 @@ function testIfScrollIsNearBottom() {
 }
 
 function toggleSidebar(): void {
-    navigationStore.toggleSidebar();
+    layoutStore.toggleSidebar();
 }
 
 function setHeaderState(isOpen: boolean): void {
-    navigationStore.setHeaderState(isOpen);
+    layoutStore.setHeaderState(isOpen);
 }
 
 function handleNotificationCentreClick(): void {

--- a/Apps/WebClient/src/ClientApp/src/components/site/HeaderComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/HeaderComponent.vue
@@ -11,18 +11,18 @@ import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { ILogger } from "@/services/interfaces";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useNotificationStore } from "@/stores/notification";
 import { useUserStore } from "@/stores/user";
 
 const headerScrollThreshold = 100;
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const configStore = useConfigStore();
 const userStore = useUserStore();
 const notificationStore = useNotificationStore();
 const authStore = useAuthStore();
-const navigationStore = useNavigationStore();
+const navigationStore = useLayoutStore();
 
 const route = useRoute();
 const router = useRouter();

--- a/Apps/WebClient/src/ClientApp/src/components/site/HeaderComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/HeaderComponent.vue
@@ -9,7 +9,6 @@ import RatingComponent from "@/components/site/RatingComponent.vue";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { ILogger } from "@/services/interfaces";
-import { useAppStore } from "@/stores/app";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { useNavigationStore } from "@/stores/navigation";
@@ -18,7 +17,7 @@ import { useUserStore } from "@/stores/user";
 
 const headerScrollThreshold = 100;
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const configStore = useConfigStore();
 const userStore = useUserStore();
 const notificationStore = useNotificationStore();
@@ -37,7 +36,7 @@ const isHeaderVisible = ref();
 const ratingComponent = ref<InstanceType<typeof RatingComponent>>();
 const appTourComponent = ref<InstanceType<typeof AppTourComponent>>();
 
-const isMobileWidth = computed(() => appStore.isMobile);
+const isMobileWidth = computed(() => layoutStore.isMobile);
 const isOffline = computed(() => configStore.isOffline);
 const oidcIsAuthenticated = computed(() => authStore.oidcIsAuthenticated);
 const isValidIdentityProvider = computed(

--- a/Apps/WebClient/src/ClientApp/src/components/site/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/SidebarComponent.vue
@@ -4,13 +4,13 @@ import { computed, ref, watch } from "vue";
 import FeedbackComponent from "@/components/site/FeedbackComponent.vue";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
-import { useNavigationStore } from "@/stores/navigation";
+import { useLayoutStore } from "@/stores/layout";
 import { useUserStore } from "@/stores/user";
 
-const layoutStore = useNavigationStore();
+const layoutStore = useLayoutStore();
 const authStore = useAuthStore();
 const configStore = useConfigStore();
-const navigationStore = useNavigationStore();
+const navigationStore = useLayoutStore();
 const userStore = useUserStore();
 
 const collapsedOnDesktop = ref(false);

--- a/Apps/WebClient/src/ClientApp/src/components/site/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/SidebarComponent.vue
@@ -2,13 +2,12 @@
 import { computed, ref, watch } from "vue";
 
 import FeedbackComponent from "@/components/site/FeedbackComponent.vue";
-import { useAppStore } from "@/stores/app";
 import { useAuthStore } from "@/stores/auth";
 import { useConfigStore } from "@/stores/config";
 import { useNavigationStore } from "@/stores/navigation";
 import { useUserStore } from "@/stores/user";
 
-const appStore = useAppStore();
+const layoutStore = useNavigationStore();
 const authStore = useAuthStore();
 const configStore = useConfigStore();
 const navigationStore = useNavigationStore();
@@ -17,7 +16,7 @@ const userStore = useUserStore();
 const collapsedOnDesktop = ref(false);
 const feedbackDialog = ref<InstanceType<typeof FeedbackComponent>>();
 
-const isMobile = computed(() => appStore.isMobile);
+const isMobile = computed(() => layoutStore.isMobile);
 const isSidebarOpen = computed(() => navigationStore.isSidebarOpen);
 const isDependentEnabled = computed(
     () => configStore.webConfig.featureToggleConfiguration.dependents.enabled

--- a/Apps/WebClient/src/ClientApp/src/components/site/SidebarComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/SidebarComponent.vue
@@ -10,14 +10,13 @@ import { useUserStore } from "@/stores/user";
 const layoutStore = useLayoutStore();
 const authStore = useAuthStore();
 const configStore = useConfigStore();
-const navigationStore = useLayoutStore();
 const userStore = useUserStore();
 
 const collapsedOnDesktop = ref(false);
 const feedbackDialog = ref<InstanceType<typeof FeedbackComponent>>();
 
 const isMobile = computed(() => layoutStore.isMobile);
-const isSidebarOpen = computed(() => navigationStore.isSidebarOpen);
+const isSidebarOpen = computed(() => layoutStore.isSidebarOpen);
 const isDependentEnabled = computed(
     () => configStore.webConfig.featureToggleConfiguration.dependents.enabled
 );
@@ -40,7 +39,7 @@ const visibleOnMobile = computed({
     },
     set(value: boolean) {
         if (isSidebarOpen.value !== value) {
-            navigationStore.toggleSidebar();
+            layoutStore.toggleSidebar();
         }
     },
 });

--- a/Apps/WebClient/src/ClientApp/src/plugins/vuetify.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/vuetify.ts
@@ -5,7 +5,6 @@ import { far } from "@fortawesome/free-regular-svg-icons";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 import { createVuetify } from "vuetify";
 import { aliases, fa } from "vuetify/iconsets/fa-svg";
-import { VSkeletonLoader } from "vuetify/labs/VSkeletonLoader";
 
 library.add(far, fas);
 
@@ -39,9 +38,6 @@ export default createVuetify({
         sets: {
             fa,
         },
-    },
-    components: {
-        VSkeletonLoader,
     },
     theme: {
         themes: {

--- a/Apps/WebClient/src/ClientApp/src/stores/app.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/app.ts
@@ -1,17 +1,13 @@
 import { defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { useDisplay } from "vuetify";
 
 import { AppErrorType } from "@/constants/errorType";
 import { DateWrapper } from "@/models/dateWrapper";
 
 export const useAppStore = defineStore("app", () => {
-    const display = useDisplay();
-
     const appError = ref<AppErrorType>();
     const isIdle = ref(false);
 
-    const isMobile = computed(() => !display.mdAndUp.value);
     const isPacificTime = computed(
         () =>
             DateWrapper.now().offset() === DateWrapper.now().toLocal().offset()
@@ -27,7 +23,6 @@ export const useAppStore = defineStore("app", () => {
 
     return {
         appError,
-        isMobile,
         isIdle,
         isPacificTime,
         setAppError,

--- a/Apps/WebClient/src/ClientApp/src/stores/layout.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/layout.ts
@@ -6,7 +6,7 @@ import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { ILogger } from "@/services/interfaces";
 
-export const useNavigationStore = defineStore("navigation", () => {
+export const useLayoutStore = defineStore("layout", () => {
     const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
 
     const isSidebarOpenField = ref<boolean>();

--- a/Apps/WebClient/src/ClientApp/src/stores/navigation.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/navigation.ts
@@ -1,26 +1,27 @@
 ﻿import { defineStore } from "pinia";
 import { computed, ref } from "vue";
+import { useDisplay } from "vuetify";
 
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { ILogger } from "@/services/interfaces";
-import { useAppStore } from "@/stores/app";
 
 export const useNavigationStore = defineStore("navigation", () => {
     const logger = container.get<ILogger>(SERVICE_IDENTIFIER.Logger);
-    const appStore = useAppStore();
 
     const isSidebarOpenField = ref<boolean>();
     const isHeaderShown = ref<boolean>(true);
+    const display = useDisplay();
+    const isMobile = computed(() => !display.mdAndUp.value);
 
     const isSidebarOpen = computed(
-        () => isSidebarOpenField.value ?? !appStore.isMobile
+        () => isSidebarOpenField.value ?? !isMobile.value
     );
 
     function toggleSidebar() {
         logger.verbose(`toggleSidebar`);
         // default state for desktop is open, this ensures the first click toggles the sidebar correctly.
-        if (isSidebarOpenField.value === undefined && !appStore.isMobile) {
+        if (isSidebarOpenField.value === undefined && !isMobile.value) {
             isSidebarOpenField.value = false;
         } else {
             isSidebarOpenField.value = !isSidebarOpenField.value;
@@ -33,6 +34,7 @@ export const useNavigationStore = defineStore("navigation", () => {
     }
 
     return {
+        isMobile,
         isSidebarOpen,
         isHeaderShown,
         toggleSidebar,


### PR DESCRIPTION
# Fixes [AB#16537](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16537)

## Description

- Upgraded Vuetify to version 3.5.1
- Fixed compilation errors

**Issues:**

- useDisplay() from App Store has to be called within a setup function, i.e. inside one of our component's <script setup> sections, not in main.ts.
- useDisplay() from App Store is currently used inside useAppStore(), which is called by useUserStore(), which is called by main.ts (and called by useAuthStore() and useNotificationStore(), also called by main.ts).

**Solution:**

- Move isMobile into a different store like navigation store.
- Renamed navigation store to layout store

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
