### PR TITLE
Change Dependent and Patient V2 Birthdates to DateOnly AB#16623

### DIFF
--- a/Apps/CommonData/src/Validations/DateOfBirthValidator.cs
+++ b/Apps/CommonData/src/Validations/DateOfBirthValidator.cs
@@ -21,17 +21,17 @@ namespace HealthGateway.Common.Data.Validations
     /// <summary>
     /// Validates date of birth.
     /// </summary>
-    public class DateOfBirthValidator : AbstractValidator<DateTime>
+    public class DateOfBirthValidator : AbstractValidator<DateOnly>
     {
-        private readonly DateTime referenceDate;
+        private readonly DateOnly referenceDate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DateOfBirthValidator"/> class.
         /// </summary>
-        /// <param name="referenceDate">A reference point to validate against, defaults to UtcNow.</param>
-        public DateOfBirthValidator(DateTime? referenceDate = null)
+        /// <param name="referenceDate">A reference point to validate against, defaults to DateTime.Today.</param>
+        public DateOfBirthValidator(DateOnly? referenceDate = null)
         {
-            referenceDate ??= DateTime.UtcNow;
+            referenceDate ??= DateOnly.FromDateTime(DateTime.Today);
             this.referenceDate = referenceDate.Value;
 
             this.RuleFor(v => v).NotEmpty().Must(this.IsValidInternal).WithMessage("Invalid date");
@@ -42,15 +42,14 @@ namespace HealthGateway.Common.Data.Validations
         /// </summary>
         /// <param name="dateOfBirth">Date of birth to validate.</param>
         /// <returns>True if valid, false if not.</returns>
-        public static bool IsValid(DateTime dateOfBirth)
+        public static bool IsValid(DateOnly dateOfBirth)
         {
             return new DateOfBirthValidator().Validate(dateOfBirth).IsValid;
         }
 
-        private bool IsValidInternal(DateTime dob)
+        private bool IsValidInternal(DateOnly dob)
         {
-            bool isValid = dob.Date <= this.referenceDate.Date;
-            return isValid;
+            return dob <= this.referenceDate;
         }
     }
 }

--- a/Apps/CommonData/src/Validations/DateOnlyAgeRangeValidator.cs
+++ b/Apps/CommonData/src/Validations/DateOnlyAgeRangeValidator.cs
@@ -1,0 +1,74 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+
+namespace HealthGateway.Common.Data.Validations
+{
+    using System;
+    using FluentValidation;
+
+    /// <summary>
+    /// Validates a minimum and maximum age by date of birth.
+    /// </summary>
+    public class DateOnlyAgeRangeValidator : AbstractValidator<DateOnly>
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DateOnlyAgeRangeValidator"/> class.
+        /// </summary>
+        /// <param name="olderThan">Must be older than or at this age.</param>
+        /// <param name="youngerThan">Must be younger than this age.</param>
+        /// <param name="referenceDate">A reference point for age calculation, defaults to UtcNow.</param>
+        public DateOnlyAgeRangeValidator(int? olderThan = null, int? youngerThan = null, DateOnly? referenceDate = null)
+        {
+            referenceDate ??= DateOnly.FromDateTime(DateTime.Today);
+
+            this
+                .RuleFor(v => CalculateAge(referenceDate.Value, v))
+                .GreaterThanOrEqualTo(olderThan ?? 0)
+                .When(_ => olderThan.HasValue, ApplyConditionTo.CurrentValidator)
+                .LessThan(youngerThan ?? 0)
+                .When(_ => youngerThan.HasValue, ApplyConditionTo.CurrentValidator)
+                .OverridePropertyName("Age");
+        }
+
+        /// <summary>
+        /// Validate a date of birth.
+        /// </summary>
+        /// <param name="dateOfBirth">date of birth to validate.</param>
+        /// <param name="olderThan">optional older than age.</param>
+        /// <param name="youngerThan">optional younger than age.</param>
+        /// <returns>true if valid, false if not.</returns>
+        public static bool IsValid(DateOnly dateOfBirth, int? olderThan = null, int? youngerThan = null)
+        {
+            return new DateOnlyAgeRangeValidator(olderThan, youngerThan).Validate(dateOfBirth).IsValid;
+        }
+
+        /// <summary>
+        /// Calculates a person's age (in years) at a given date.
+        /// </summary>
+        /// <param name="referenceDate">Date at which to calculate age.</param>
+        /// <param name="dateOfBirth">Date of birth.</param>
+        /// <returns>Age in years.</returns>
+        public static int CalculateAge(DateOnly referenceDate, DateOnly dateOfBirth)
+        {
+            // convert to yyyyMMdd integers
+            int referenceDateValue = (((referenceDate.Year * 100) + referenceDate.Month) * 100) + referenceDate.Day;
+            int dobDateValue = (((dateOfBirth.Year * 100) + dateOfBirth.Month) * 100) + dateOfBirth.Day;
+
+            // calculate age and trim non year values
+            return (referenceDateValue - dobDateValue) / 10000;
+        }
+    }
+}

--- a/Apps/CommonData/test/unit/Validations/DateOfBirthValidatorTests.cs
+++ b/Apps/CommonData/test/unit/Validations/DateOfBirthValidatorTests.cs
@@ -25,7 +25,7 @@ namespace HealthGateway.Common.Data.Tests.Validations
     /// </summary>
     public class DateOfBirthValidatorTests
     {
-        private static readonly DateTime ReferenceDate = new(2022, 12, 21, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateOnly ReferenceDate = new(2022, 12, 21);
 
         /// <summary>
         /// Tests for DateOfBirthValidatorTests.
@@ -40,7 +40,7 @@ namespace HealthGateway.Common.Data.Tests.Validations
         {
             DateOfBirthValidator validator = new(referenceDate: ReferenceDate);
 
-            ValidationResult? validationResult = validator.Validate(dob);
+            ValidationResult? validationResult = validator.Validate(DateOnly.FromDateTime(dob));
             Assert.Equal(shouldBeValid, validationResult.IsValid);
         }
     }

--- a/Apps/CommonData/test/unit/Validations/DateOnlyAgeRangeValidatorTests.cs
+++ b/Apps/CommonData/test/unit/Validations/DateOnlyAgeRangeValidatorTests.cs
@@ -1,0 +1,91 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+
+namespace HealthGateway.Common.Data.Tests.Validations
+{
+    using System;
+    using FluentValidation.Results;
+    using HealthGateway.Common.Data.Validations;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for DateOnlyAgeRangeValidator.
+    /// </summary>
+    public class DateOnlyAgeRangeValidatorTests
+    {
+        private static readonly DateOnly ReferenceDate = new(2022, 12, 21);
+
+        /// <summary>
+        /// Tests for DateOnlyAgeRangeValidatorTests.
+        /// </summary>
+        /// <param name="dob">Date of birth to test.</param>
+        /// <param name="youngerThan">Younger than age.</param>
+        /// <param name="shouldBeValid">The validation result to verify.</param>
+        [Theory]
+        [InlineData("2010-12-20", 12, false)]
+        [InlineData("2010-12-21", 12, false)]
+        [InlineData("2010-12-22", 12, true)]
+        public void ValidateYoungerThan(DateTime dob, int youngerThan, bool shouldBeValid)
+        {
+            DateOnlyAgeRangeValidator validator = new(youngerThan: youngerThan, referenceDate: ReferenceDate);
+
+            ValidationResult? validationResult = validator.Validate(DateOnly.FromDateTime(dob));
+            Assert.Equal(shouldBeValid, validationResult.IsValid);
+        }
+
+        /// <summary>
+        /// Tests for DateOnlyAgeRangeValidatorTests.
+        /// </summary>
+        /// <param name="dob">Date of birth to test.</param>
+        /// <param name="olderThan">Older than age.</param>
+        /// <param name="shouldBeValid">The validation result to verify.</param>
+        [Theory]
+        [InlineData("2010-12-20", 12, true)]
+        [InlineData("2010-12-21", 12, true)]
+        [InlineData("2010-12-22", 12, false)]
+        public void ValidateOlderThan(DateTime dob, int olderThan, bool shouldBeValid)
+        {
+            DateOnlyAgeRangeValidator validator = new(olderThan, referenceDate: ReferenceDate);
+
+            ValidationResult? validationResult = validator.Validate(DateOnly.FromDateTime(dob));
+            Assert.Equal(shouldBeValid, validationResult.IsValid);
+        }
+
+        /// <summary>
+        /// Tests for DateOnlyAgeRangeValidatorTests.
+        /// </summary>
+        /// <param name="dob">Date of birth to test.</param>
+        /// <param name="olderThan">Older than age.</param>
+        /// <param name="youngerThan">Younger than age.</param>
+        /// <param name="shouldBeValid">The validation result to verify.</param>
+        [Theory]
+        [InlineData("2008-05-03", 12, 14, false)]
+        [InlineData("2008-12-20", 12, 14, false)]
+        [InlineData("2008-12-21", 12, 14, false)]
+        [InlineData("2008-12-22", 12, 14, true)]
+        [InlineData("2010-03-05", 12, 14, true)]
+        [InlineData("2010-12-20", 12, 14, true)]
+        [InlineData("2010-12-21", 12, 14, true)]
+        [InlineData("2010-12-22", 12, 14, false)]
+        public void ValidateOlderThanAndYoungerThan(DateTime dob, int olderThan, int youngerThan, bool shouldBeValid)
+        {
+            DateOnlyAgeRangeValidator validator = new(olderThan, youngerThan, ReferenceDate);
+
+            ValidationResult? validationResult = validator.Validate(DateOnly.FromDateTime(dob));
+            Assert.Equal(shouldBeValid, validationResult.IsValid);
+        }
+    }
+}

--- a/Apps/Database/src/Delegates/DbDrugLookupDelegate.cs
+++ b/Apps/Database/src/Delegates/DbDrugLookupDelegate.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.Database.Delegates
         {
             this.logger.LogDebug("Getting list of PharmaCare drug products from DB");
             List<string> uniqueDrugIdentifiers = drugIdentifiers.Distinct().ToList();
-            DateOnly today = DateOnly.FromDateTime(DateTime.UtcNow);
+            DateOnly today = DateOnly.FromDateTime(DateTime.Today);
 
             IList<PharmaCareDrug> pharmaCareDrugs = await this.dbContext.PharmaCareDrug
                 .Where(dp => uniqueDrugIdentifiers.Contains(dp.DinPin) && today > dp.EffectiveDate && today <= dp.EndDate)

--- a/Apps/GatewayApi/src/MapProfiles/DependentInformationProfile.cs
+++ b/Apps/GatewayApi/src/MapProfiles/DependentInformationProfile.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.MapProfiles
 {
+    using System;
     using AutoMapper;
     using HealthGateway.Common.Models;
     using HealthGateway.GatewayApi.Models;
@@ -30,7 +31,7 @@ namespace HealthGateway.GatewayApi.MapProfiles
         public DependentInformationProfile()
         {
             this.CreateMap<PatientModel, DependentInformation>()
-                .ForMember(dest => dest.DateOfBirth, opt => opt.MapFrom(src => src.Birthdate))
+                .ForMember(dest => dest.DateOfBirth, opt => opt.MapFrom(src => DateOnly.FromDateTime(src.Birthdate)))
                 .ForMember(dest => dest.Phn, opt => opt.MapFrom(src => src.PersonalHealthNumber))
                 .ReverseMap();
         }

--- a/Apps/GatewayApi/src/MapProfiles/PatientDetailsProfile.cs
+++ b/Apps/GatewayApi/src/MapProfiles/PatientDetailsProfile.cs
@@ -15,8 +15,10 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.GatewayApi.MapProfiles
 {
+    using System;
     using AutoMapper;
     using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Common.Data.Utils;
     using HealthGateway.GatewayApi.Models;
 
     /// <summary>
@@ -29,7 +31,10 @@ namespace HealthGateway.GatewayApi.MapProfiles
         /// </summary>
         public PatientDetailsProfile()
         {
-            this.CreateMap<PatientModel, PatientDetails>();
+            this.CreateMap<PatientModel, PatientDetails>()
+                .ForMember(
+                    d => d.Birthdate,
+                    opts => opts.MapFrom(s => DateOnly.FromDateTime(s.Birthdate)));
         }
     }
 }

--- a/Apps/GatewayApi/src/Models/AddDependentRequest.cs
+++ b/Apps/GatewayApi/src/Models/AddDependentRequest.cs
@@ -36,7 +36,7 @@ namespace HealthGateway.GatewayApi.Models
         /// <summary>
         /// Gets or sets the Date Of Birth.
         /// </summary>
-        public DateTime DateOfBirth { get; set; }
+        public DateOnly DateOfBirth { get; set; }
 
         /// <summary>
         /// Gets or sets the dependent's PHN.

--- a/Apps/GatewayApi/src/Models/DependentInformation.cs
+++ b/Apps/GatewayApi/src/Models/DependentInformation.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.GatewayApi.Models
         /// <summary>
         /// Gets or sets the Date Of Birth.
         /// </summary>
-        public DateTime DateOfBirth { get; set; }
+        public DateOnly DateOfBirth { get; set; }
 
         /// <summary>
         /// Gets or sets the gender.

--- a/Apps/GatewayApi/src/Models/PatientDetails.cs
+++ b/Apps/GatewayApi/src/Models/PatientDetails.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.GatewayApi.Models
         /// Gets or sets the patient's date of birth.
         /// </summary>
         [JsonPropertyName("birthdate")]
-        public DateTime Birthdate { get; set; }
+        public DateOnly Birthdate { get; set; }
 
         /// <summary>
         /// Gets or sets the patient's gender.

--- a/Apps/GatewayApi/src/Validations/AddDependentRequestValidator.cs
+++ b/Apps/GatewayApi/src/Validations/AddDependentRequestValidator.cs
@@ -33,7 +33,7 @@ namespace HealthGateway.GatewayApi.Validations
         {
             this.RuleFor(v => v.Phn).SetValidator(new PhnValidator());
             this.RuleFor(v => v.DateOfBirth).SetValidator(new DateOfBirthValidator());
-            this.RuleFor(v => v.DateOfBirth).SetValidator(new AgeRangeValidator(youngerThan: maxDependentAge));
+            this.RuleFor(v => v.DateOfBirth).SetValidator(new DateOnlyAgeRangeValidator(youngerThan: maxDependentAge));
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
@@ -79,8 +79,8 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         [Fact]
         public async Task ShouldAddDependent()
         {
-            DateTime dateOfBirth = DateTime.Parse("1980-01-01", CultureInfo.InvariantCulture);
-            DateOnly expiryDate = DateOnly.FromDateTime(dateOfBirth.AddYears(12));
+            DateOnly dateOfBirth = DateOnly.Parse("1980-01-01", CultureInfo.InvariantCulture);
+            DateOnly expiryDate = dateOfBirth.AddYears(12);
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
             Mock<IDependentService> dependentServiceMock = new();
             DependentModel expectedDependent = new()
@@ -181,8 +181,8 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 
             for (int i = 0; i < 10; i++)
             {
-                DateTime dateOfBirth = new(1980 + i, 1, 1, 0, 0, 0, DateTimeKind.Local);
-                DateOnly expiryDate = DateOnly.FromDateTime(dateOfBirth);
+                DateOnly dateOfBirth = DateOnly.FromDateTime(new DateTime(1980 + i, 1, 1, 0, 0, 0, DateTimeKind.Local));
+                DateOnly expiryDate = dateOfBirth;
 
                 dependentModels.Add(
                     new DependentModel

--- a/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
@@ -126,7 +126,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                         DependentInformation = new DependentInformation
                         {
                             Phn = $"{dependentModels}-{i}",
-                            DateOfBirth = new DateTime(1980 + i, 1, 1, 0, 0, 0, DateTimeKind.Local),
+                            DateOfBirth = new DateOnly(1980 + i, 1, 1),
                             Gender = "Female",
                             FirstName = "first",
                             LastName = "last-{i}",

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -202,7 +202,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 (await Should.ThrowAsync<ProblemDetailsException>(async () => await service.AddDependentAsync(this.mockParentHdid, addDependentRequest)))
                 .ShouldNotBeNull();
 
-            exception.ProblemDetails!.Status.ShouldBe(System.Net.HttpStatusCode.InternalServerError);
+            exception.ProblemDetails!.Status.ShouldBe(HttpStatusCode.InternalServerError);
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ValidateAddDependentWithWrongDateOfBirth()
         {
             AddDependentRequest addDependentRequest = this.SetupMockInput();
-            addDependentRequest.DateOfBirth = DateTime.Now;
+            addDependentRequest.DateOfBirth = DateOnly.FromDateTime(DateTime.Now);
             IDependentService service = this.SetupMockDependentService(addDependentRequest);
 
             RequestResult<DependentModel> actualResult = await service.AddDependentAsync(this.mockParentHdid, addDependentRequest);
@@ -588,7 +588,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Phn = this.mockPhn,
                 FirstName = this.mockFirstName,
                 LastName = this.mockLastName,
-                DateOfBirth = this.mockDateOfBirth,
+                DateOfBirth = DateOnly.FromDateTime(this.mockDateOfBirth),
             };
         }
     }

--- a/Apps/Patient/src/Mappings/AccountDataAccessMappings.cs
+++ b/Apps/Patient/src/Mappings/AccountDataAccessMappings.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Patient.Mappings
 {
+    using System;
     using AutoMapper;
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Patient.Models;
@@ -29,7 +30,10 @@ namespace HealthGateway.Patient.Mappings
         /// </summary>
         public AccountDataAccessMappings()
         {
-            this.CreateMap<PatientModel, PatientDetails>();
+            this.CreateMap<PatientModel, PatientDetails>()
+                .ForMember(
+                    d => d.Birthdate,
+                    opts => opts.MapFrom(s => DateOnly.FromDateTime(s.Birthdate)));
             this.CreateMap<Address, Common.Data.Models.Address>();
         }
     }

--- a/Apps/Patient/src/Models/PatientDetails.cs
+++ b/Apps/Patient/src/Models/PatientDetails.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.Patient.Models
         /// Gets or sets the patient's date of birth.
         /// </summary>
         [JsonPropertyName("birthdate")]
-        public DateTime Birthdate { get; set; }
+        public DateOnly Birthdate { get; set; }
 
         /// <summary>
         /// Gets or sets the patient's gender.

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -130,7 +130,7 @@ namespace HealthGateway.PatientTests.Controllers
         {
             return new()
             {
-                Birthdate = MockedBirthDate,
+                Birthdate = DateOnly.FromDateTime(MockedBirthDate),
                 CommonName = new Name
                 {
                     GivenName = MockedFirstName,

--- a/Testing/functional/tests/cypress/fixtures/PatientService/patientCombinedAddress.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientService/patientCombinedAddress.json
@@ -3,7 +3,7 @@
     "personalhealthnumber": "9735353315",
     "firstname": "BONNET",
     "lastname": "PROTERVITY",
-    "birthdate": "1967-06-02T00:00:00",
+    "birthdate": "1967-06-02",
     "gender": "Female",
     "physicalAddress": {
         "streetLines": ["3815 HILLSPOINT STREET"],

--- a/Testing/functional/tests/cypress/fixtures/PatientService/patientDifferentAddress.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientService/patientDifferentAddress.json
@@ -3,7 +3,7 @@
     "personalhealthnumber": "9735353315",
     "firstname": "BONNET",
     "lastname": "PROTERVITY",
-    "birthdate": "1967-06-02T00:00:00",
+    "birthdate": "1967-06-02",
     "gender": "Female",
     "physicalAddress": {
         "streetLines": ["1234 LEE AVENUE"],

--- a/Testing/functional/tests/cypress/fixtures/PatientService/patientNoAddress.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientService/patientNoAddress.json
@@ -3,7 +3,7 @@
     "personalhealthnumber": "9735353315",
     "firstname": "CHOIR",
     "lastname": "ORPHANING",
-    "birthdate": "1964-06-04T00:00:00",
+    "birthdate": "1964-06-04",
     "gender": "Female",
     "physicalAddress": null,
     "postalAddress": null

--- a/Testing/functional/tests/cypress/fixtures/PatientService/patientOnlyPhysicalAddress.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientService/patientOnlyPhysicalAddress.json
@@ -3,7 +3,7 @@
     "personalhealthnumber": "9735353315",
     "firstname": "CRYOPHORUS",
     "lastname": "FOGEYDOM",
-    "birthdate": "1961-09-25T00:00:00",
+    "birthdate": "1961-09-25",
     "gender": "Female",
     "physicalAddress": {
         "streetLines": ["4790 RAD CLOSE"],

--- a/Testing/functional/tests/cypress/fixtures/PatientService/patientOnlyPostalAddress.json
+++ b/Testing/functional/tests/cypress/fixtures/PatientService/patientOnlyPostalAddress.json
@@ -3,7 +3,7 @@
     "personalhealthnumber": "9735353315",
     "firstname": "MIKES",
     "lastname": "ORDINATE",
-    "birthdate": "1955-04-06T00:00:00",
+    "birthdate": "1955-04-06",
     "gender": "Male",
     "physicalAddress": null,
     "postalAddress": {

--- a/Testing/functional/tests/cypress/fixtures/UserProfileService/dependent.json
+++ b/Testing/functional/tests/cypress/fixtures/UserProfileService/dependent.json
@@ -6,7 +6,7 @@
                 "firstname": "Sam",
                 "lastname": "Testfive",
                 "PHN": "9874307168",
-                "dateOfBirth": "2014-03-15T00:00:00",
+                "dateOfBirth": "2014-03-15",
                 "gender": "Female"
             },
             "ownerId": "645645767756756767",

--- a/Testing/integration/tests/Dependents/GatewayApiDependentTests.cs
+++ b/Testing/integration/tests/Dependents/GatewayApiDependentTests.cs
@@ -29,7 +29,7 @@ using Xunit.Categories;
 [IntegrationTest]
 public class GatewayApiDependentTests : ScenarioContextBase<GatewayApi.Program>
 {
-    private readonly DateTime dependentDob = DateTime.Parse("2014-Mar-15", CultureInfo.InstalledUICulture);
+    private readonly DateOnly dependentDob = DateOnly.Parse("2014-Mar-15", CultureInfo.InstalledUICulture);
     private readonly string dependentPhn = "9874307168";
     private readonly string dependentFirstName = "Sam";
     private readonly string dependentLastName = "Testfive";


### PR DESCRIPTION
# Implements [AB#16623](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16623)

## Description

- updates Birthdate to DateOnly
  - PatientService.PatientController
    - GetPatient v2.0
  - GatewayApi.DependentController
    - GetAll
    - AddDependent
  - GatewayApi.PhsaController
    - GetAll (Dependents)
    - GetPatient
- updates DateOfBirthValidator to support DateOnly and introduces DateOnlyAgeRangeValidator
- fixes PharmaCareDrug effective date calculation relying on UTC date instead of local date

## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
