### PR TITLE
Add post-function plugin to Kong for AB#16627

### DIFF
--- a/Tools/Kong/config.tmpl
+++ b/Tools/Kong/config.tmpl
@@ -12,6 +12,11 @@
         protocols:
           - http
           - https
+      - name: post-function
+        tags: [ ns.$KONG_NAMESPACE.$ENVIRONMENT ]
+        config:
+          rewrite:
+          - "--"
     routes:
       - name: $SERVICE-$KONG_NAMESPACE-get-post-put-delete
         methods:


### PR DESCRIPTION
# Fixes [AB#16627](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16627)

## Description
1. Add post-function plugin to remove the default response rewriting for common error codes.
    * Followed advice from: https://bcgov.github.io/aps-infra-platform/gateway/common-config/#disabling-global-error-handling


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## Notes
### Before Config Change for Kong Service:
![image](https://github.com/bcgov/healthgateway/assets/19548348/d683cb95-e4ef-4fe8-8de5-12f40b2c92a2)
### After Config Change for Kong Service:
![image](https://github.com/bcgov/healthgateway/assets/19548348/05b2f07c-160a-4a10-96e6-01007fc78b91)


## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
