### PR TITLE
Update wording for BC Cancer letters AB#16632

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -440,8 +440,8 @@ watch(vaccineRecordState, () => {
                 </template>
                 <p class="text-body-1">
                     View and manage all your available health records, including
-                    dispensed medications, health visits, COVID‑19 test results,
-                    immunizations and more.
+                    dispensed medications, health visits, lab results,
+                    immunizations, BC Cancer cervix screenings and more.
                 </p>
             </HgCardComponent>
         </v-col>

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -699,9 +699,9 @@ setPageFromDate(linearDate.value);
                 variant="outlined"
                 border
             >
-                Only BC Cancer cervix screening notifications are available
-                here. Cervix or colon cancer screening lab reports are in your
-                Health Gateway lab results.
+                Only BC Cancer cervix screening letters are available here. Your
+                Health Gateway timeline may include these and other screening
+                test results in lab or imaging reports.
                 <a
                     href="http://www.bccancer.bc.ca/screening"
                     target="_blank"

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
@@ -95,9 +95,8 @@ function downloadFile(): void {
                 v-if="props.entry.isResult"
                 data-testid="bc-cancer-result-body"
             >
-                Download your cervix screening result notification. It may
-                include important information about next steps. If you have
-                questions,
+                Download your cervix screening result letter. It may include
+                important information about next steps. If you have questions,
                 <a
                     href="http://www.bccancer.bc.ca/screening/cervix"
                     target="_blank"

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
@@ -40,13 +40,13 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
 
     private setEntryProperties(): void {
         if (this.screeningType === BcCancerScreeningType.Result) {
-            this.title = "BC Cancer Screening Result Notification";
+            this.title = "BC Cancer Screening Result Letter";
             this.callToActionText = "View Letter";
             this.documentType = "Screening results";
             this.fileName = "bc_cancer_result";
             this.eventText = "BC Cancer Result PDF";
         } else {
-            this.title = "BC Cancer Screening Reminder Notification";
+            this.title = "BC Cancer Screening Reminder Letter";
             this.callToActionText = "View Letter";
             this.documentType = "Screening letter";
             this.fileName = "bc_cancer_screening";


### PR DESCRIPTION
# Implements AB#16632

## Description

Updates text on the Health Records tile on the home page, the timeline banner when only the BC Cancer dataset is selected, and the BC Cancer timeline card titles and body.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

![scrnli_2_2_2024_12-17-55 PM](https://github.com/bcgov/healthgateway/assets/16570293/3da83f8b-cd22-450d-9f4d-13bf3931ec1d)

![scrnli_2_2_2024_12-36-13 PM](https://github.com/bcgov/healthgateway/assets/16570293/0ee873f0-0c6d-4992-9777-cd2043b8a96e)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
