### PR TITLE
Include dataset for BC Cancer download analytics event AB#16635

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/BcCancerScreeningTimelineComponent.vue
@@ -10,7 +10,7 @@ import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { PatientDataFile } from "@/models/patientDataResponse";
 import BcCancerScreeningTimelineEntry from "@/models/timeline/bcCancerScreeningTimelineEntry";
-import { Action, Actor, Format, Text } from "@/plugins/extensions";
+import { Action, Actor, Dataset, Format, Text } from "@/plugins/extensions";
 import { ILogger, ITrackingService } from "@/services/interfaces";
 import { usePatientDataStore } from "@/stores/patientData";
 import EventDataUtility from "@/utility/eventDataUtility";
@@ -55,6 +55,7 @@ function downloadFile(): void {
         trackingService.trackEvent({
             action: Action.Download,
             text: Text.Document,
+            dataset: Dataset.BcCancer,
             type: EventDataUtility.getType(props.entry.screeningType),
             format: Format.Pdf,
             actor: Actor.User,


### PR DESCRIPTION
# Fixes [AB#16635](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16635)

## Description

Adds the dataset property that was missing from the analytics event issued when viewing letters associated with BC Cancer screening results and recalls.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
