### PR TITLE
Move configuration overrides from Helm to Appsettings for AB#16636.

### DIFF
--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -139,10 +139,10 @@
     },
     "ChangeFeed": {
         "Dependents": {
-            "Enabled": false
+            "Enabled": true
         },
         "BlockedDataSources": {
-            "Enabled": false
+            "Enabled": true
         }
     },
     "OpenTelemetry": {

--- a/Apps/Common/src/AspNetConfiguration/Modules/GatewayCache.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/GatewayCache.cs
@@ -36,8 +36,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// <param name="services">The services collection provider.</param>
         /// <param name="logger">The logger to use.</param>
         /// <param name="configuration">The configuration to use.</param>
-        /// <param name="keyPrefix">an optional prefix that is appended to all keys.</param>
-        public static void ConfigureCaching(IServiceCollection services, ILogger logger, IConfiguration configuration, string? keyPrefix = null)
+        public static void ConfigureCaching(IServiceCollection services, ILogger logger, IConfiguration configuration)
         {
             EnableRedis(services, logger, configuration);
             services.TryAddSingleton<ICacheProvider, DistributedCacheProvider>();

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -128,5 +128,16 @@
     },
     "EmailTemplate": {
       "Host": "https://www.healthgateway.gov.bc.ca"
+    },
+    "ChangeFeed": {
+        "Dependents": {
+            "Enabled": true
+        },
+        "Accounts": {
+            "Enabled": true
+        },
+        "Notifications": {
+            "Enabled": true
+        }
     }
 }

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -211,5 +211,10 @@
     },
     "AdminFeedback": {
         "AdminEmail": "healthgateway@gov.bc.ca"
+    },
+    "ChangeFeed": {
+        "Accounts": {
+            "Enabled": true
+        }
     }
 }


### PR DESCRIPTION
# Implements [AB#16636](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16636)

## Description

- Move configuration overrides from Helm to Appsettings.
- Also changed GatewayCache.  Removed unused keyPrefix parameter.  It was originally removed in [AB#16628](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16628) but was accidentally put back in [AB#16639](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16639).

Note: after this PR is merged, the configuration files for dev, prod and test will be changed.  Dev will be tested.  See task [AB#16640](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/16640)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x]  Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
