### PR TITLE
Fix patient retrieval errors reporting as site too busy AB#16645

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/error/PatientRetrievalErrorView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/error/PatientRetrievalErrorView.vue
@@ -18,7 +18,7 @@ const isTooManyRequestsError = computed(
         <p
             v-if="isTooManyRequestsError"
             class="text-body-1"
-            data-testid="app-warning"
+            data-testid="too-busy"
         >
             We are unable to retrieve the patient details from our Client
             Registry as the site is too busy. Please try again later.

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -395,13 +395,12 @@ export const useUserStore = defineStore("user", () => {
 
     function retrieveEssentialData(): Promise<void> {
         status.value = LoadStatus.REQUESTED;
-        appStore.setAppError(AppErrorType.TooManyRequests);
         return patientService
             .getPatient(user.value.hdid)
             .then((result: Patient) => {
                 if (!result) {
-                    logger.debug("Patient retrieval failed");
                     patientRetrievalFailed.value = true;
+                    logger.debug("Patient retrieval failed");
                     return;
                 }
                 setPatient(result);
@@ -431,6 +430,7 @@ export const useUserStore = defineStore("user", () => {
                     });
             })
             .catch((resultError: ResultError) => {
+                patientRetrievalFailed.value = true;
                 if (resultError.statusCode === 429) {
                     logger.debug(
                         "Patient retrieval failed because of too many requests"
@@ -438,7 +438,6 @@ export const useUserStore = defineStore("user", () => {
                     appStore.setAppError(AppErrorType.TooManyRequests);
                 } else {
                     logger.debug("Patient retrieval failed");
-                    patientRetrievalFailed.value = true;
                 }
             });
     }

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -33,10 +33,11 @@ function testGetProfileErrorOnLoad(statusCode = serverErrorStatusCode) {
     });
     cy.reload();
 
+    cy.get("[data-testid=patient-retrieval-error]").should("be.visible");
     if (statusCode === tooManyRequestsStatusCode) {
-        cy.get("[data-testid=app-warning]").should("be.visible");
+        cy.get("[data-testid=too-busy]").should("be.visible");
     } else {
-        cy.get("[data-testid=patient-retrieval-error]").should("be.visible");
+        cy.get("[data-testid=too-busy]").should("not.exist");
     }
 }
 


### PR DESCRIPTION
# Fixes [AB#16645](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16645)

## Description

All errors that occurred when retrieving essential data (patient and user profile) were mistakenly being treated as 429 errors.  This has been corrected, allowing the appropriate error message to show.

The functional tests have been updated to check that the 429 message doesn't display when there's no 429.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

![image](https://github.com/bcgov/healthgateway/assets/16570293/b0e19d23-9dcb-423d-a8ca-b9dc45df3786)

## Notes

There was also a possible path where receiving a 429 error when retrieving the patient data would not correctly take you to the error page, which was due to a change in logic between our Vue 2 and Vue 3 apps.  This has been fixed as well.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
