### PR TITLE
Improve problem details handling AB#16649

### DIFF
--- a/Apps/Admin/Server/Services/CovidSupportService.cs
+++ b/Apps/Admin/Server/Services/CovidSupportService.cs
@@ -187,7 +187,7 @@ namespace HealthGateway.Admin.Server.Services
             {
                 if (result.ResultError != null)
                 {
-                    throw new UpstreamServiceException(result.ResultError.ResultMessage, ErrorCodes.UpstreamError);
+                    throw new UpstreamServiceException(result.ResultError.ResultMessage);
                 }
 
                 throw new NotFoundException(ErrorMessages.CannotGetVaccineProofPdf);
@@ -214,9 +214,7 @@ namespace HealthGateway.Admin.Server.Services
                     response.ResultError?.ErrorCode,
                     response.ResultError?.ResultMessage);
 
-                throw new UpstreamServiceException(
-                    response.ResultError?.ResultMessage,
-                    ErrorCodes.ServerError);
+                throw new UpstreamServiceException(response.ResultError?.ResultMessage);
             }
         }
     }

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -10,6 +10,7 @@
             }
         }
     },
+    "IncludeExceptionDetailsInResponse": true,
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "RequireHttpsMetadata": "false",

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -11,6 +11,7 @@
             }
         }
     },
+    "IncludeExceptionDetailsInResponse": true,
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "Callbacks": {

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -34,6 +34,7 @@
             "/js/*"
         ]
     },
+    "IncludeExceptionDetailsInResponse": false,
     "OpenIdConnect": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "ClientId": "hg-admin",

--- a/Apps/Common/src/ErrorHandling/DefaultExceptionHandler.cs
+++ b/Apps/Common/src/ErrorHandling/DefaultExceptionHandler.cs
@@ -19,21 +19,20 @@ namespace HealthGateway.Common.ErrorHandling
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Diagnostics;
-    using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Configuration;
     using ProblemDetails = Microsoft.AspNetCore.Mvc.ProblemDetails;
 
     /// <inheritdoc/>
     /// <summary>
     /// Transforms any exception into the appropriate problem details response.
     /// </summary>
-    internal sealed class DefaultExceptionHandler(IWebHostEnvironment environment) : IExceptionHandler
+    internal sealed class DefaultExceptionHandler(IConfiguration configuration) : IExceptionHandler
     {
         /// <inheritdoc/>
         public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
         {
-            bool includeException = environment.IsDevelopment();
+            bool includeException = configuration.GetValue("IncludeExceptionDetailsInResponse", false);
 
             ProblemDetails problemDetails = ExceptionUtilities.ToProblemDetails(exception, httpContext, includeException);
 

--- a/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
+++ b/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
@@ -57,10 +57,10 @@ namespace HealthGateway.Common.ErrorHandling
         {
             ValidationProblemDetails problemDetails = new()
             {
+                Type = ErrorCodes.InvalidInput,
                 Title = "A validation error occurred.",
                 Status = StatusCodes.Status400BadRequest,
                 Instance = httpContext.Request.Path,
-                Type = validationException.GetType().ToString(),
                 Extensions =
                 {
                     ["traceId"] = httpContext.TraceIdentifier,
@@ -91,11 +91,13 @@ namespace HealthGateway.Common.ErrorHandling
         private static ProblemDetails HealthGatewayExceptionToProblemDetails(HealthGatewayException healthGatewayException, HttpContext httpContext, bool includeException = false)
         {
             ProblemDetails problemDetails = TransformException(healthGatewayException, httpContext, includeException);
+            problemDetails.Type = healthGatewayException.ErrorCode;
             problemDetails.Title = healthGatewayException switch
             {
+                AlreadyExistsException => "Record already exists.",
+                DatabaseException => "A database error occurred.",
                 InvalidDataException => "Data does not match.",
                 NotFoundException => "Record was not found",
-                AlreadyExistsException => "Record already exists.",
                 UpstreamServiceException => "An error occurred with an upstream service.",
                 _ => "An error occurred.",
             };
@@ -107,10 +109,9 @@ namespace HealthGateway.Common.ErrorHandling
         {
             ProblemDetails problemDetails = new()
             {
+                Type = ErrorCodes.ServerError,
                 Title = "An error occurred.",
-                Detail = exception.Message,
                 Instance = httpContext.Request.Path,
-                Type = exception.GetType().ToString(),
                 Extensions =
                 {
                     ["traceId"] = httpContext.TraceIdentifier,

--- a/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
+++ b/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
@@ -36,14 +36,21 @@ namespace HealthGateway.Common.ErrorHandling
         /// <param name="httpContext">The HTTP context of the request.</param>
         /// <param name="includeException">Used to determine if the exception details are passed to the client.</param>
         /// <returns>A <see cref="ProblemDetails"/> model to return the consumer.</returns>
-        public static ProblemDetails ToProblemDetails(Exception exception, HttpContext httpContext, bool includeException = false)
+        public static ProblemDetails ToProblemDetails(Exception exception, HttpContext httpContext, bool includeException)
         {
-            return exception switch
+            ProblemDetails problemDetails = exception switch
             {
-                HealthGatewayException healthGatewayException => HealthGatewayExceptionToProblemDetails(healthGatewayException, httpContext, includeException),
-                ValidationException validationException => ValidationExceptionToProblemDetails(validationException, httpContext, includeException),
-                _ => TransformException(exception, httpContext, includeException),
+                HealthGatewayException healthGatewayException => TransformHealthGatewayException(healthGatewayException, httpContext),
+                ValidationException validationException => TransformValidationException(validationException, httpContext),
+                _ => TransformException(exception, httpContext),
             };
+
+            if (includeException)
+            {
+                problemDetails.Extensions["exception"] = FormatExceptionDetails(exception);
+            }
+
+            return problemDetails;
         }
 
         /// <summary>
@@ -51,9 +58,8 @@ namespace HealthGateway.Common.ErrorHandling
         /// </summary>
         /// <param name="validationException">A Fluent Validation <see cref="ValidationException"/>.</param>
         /// <param name="httpContext">The HTTP context of the request.</param>
-        /// <param name="includeException">Used to determine if the exception details are passed to the client.</param>
         /// <returns>A <see cref="ProblemDetails"/> model to return the consumer.</returns>
-        private static ValidationProblemDetails ValidationExceptionToProblemDetails(ValidationException validationException, HttpContext httpContext, bool includeException = false)
+        private static ValidationProblemDetails TransformValidationException(ValidationException validationException, HttpContext httpContext)
         {
             ValidationProblemDetails problemDetails = new()
             {
@@ -66,6 +72,7 @@ namespace HealthGateway.Common.ErrorHandling
                     ["traceId"] = httpContext.TraceIdentifier,
                 },
             };
+
             foreach (ValidationFailure error in validationException.Errors)
             {
                 if (problemDetails.Errors.TryGetValue(error.PropertyName, out string[]? value))
@@ -78,7 +85,7 @@ namespace HealthGateway.Common.ErrorHandling
                 }
             }
 
-            return (AddExceptionDetailsExtension(problemDetails, validationException, includeException) as ValidationProblemDetails)!;
+            return problemDetails;
         }
 
         /// <summary>
@@ -86,11 +93,11 @@ namespace HealthGateway.Common.ErrorHandling
         /// </summary>
         /// <param name="healthGatewayException">A <see cref="HealthGatewayException"/> describing an error within Health Gateway.</param>
         /// <param name="httpContext">The HTTP context of the request.</param>
-        /// <param name="includeException">Used to determine if the exception details are passed to the client.</param>
         /// <returns>A <see cref="ProblemDetails"/> model to return the consumer.</returns>
-        private static ProblemDetails HealthGatewayExceptionToProblemDetails(HealthGatewayException healthGatewayException, HttpContext httpContext, bool includeException = false)
+        private static ProblemDetails TransformHealthGatewayException(HealthGatewayException healthGatewayException, HttpContext httpContext)
         {
-            ProblemDetails problemDetails = TransformException(healthGatewayException, httpContext, includeException);
+            ProblemDetails problemDetails = TransformException(healthGatewayException, httpContext);
+
             problemDetails.Type = healthGatewayException.ErrorCode;
             problemDetails.Title = healthGatewayException switch
             {
@@ -102,12 +109,13 @@ namespace HealthGateway.Common.ErrorHandling
                 _ => "An error occurred.",
             };
             problemDetails.Status = (int?)healthGatewayException.StatusCode;
+
             return problemDetails;
         }
 
-        private static ProblemDetails TransformException(Exception exception, HttpContext httpContext, bool includeException = false)
+        private static ProblemDetails TransformException(Exception exception, HttpContext httpContext)
         {
-            ProblemDetails problemDetails = new()
+            return new()
             {
                 Type = ErrorCodes.ServerError,
                 Title = "An error occurred.",
@@ -123,29 +131,21 @@ namespace HealthGateway.Common.ErrorHandling
                     _ => StatusCodes.Status500InternalServerError,
                 },
             };
-
-            return AddExceptionDetailsExtension(problemDetails, exception, includeException);
         }
 
-        private static ProblemDetails AddExceptionDetailsExtension(ProblemDetails problemDetails, Exception exception, bool includeException = false)
+        private static object? FormatExceptionDetails(Exception? e, int maxDepth = 9)
         {
-            if (includeException)
+            if (e == null)
             {
-                problemDetails.Extensions["exception"] = new
-                {
-                    exception.Message,
-                    exception.StackTrace,
-                    InnerException = exception.InnerException != null
-                        ? new
-                        {
-                            exception.InnerException.Message,
-                            exception.InnerException.StackTrace,
-                        }
-                        : null,
-                };
+                return null;
             }
 
-            return problemDetails;
+            if (maxDepth == 0)
+            {
+                return new { e.Message, e.StackTrace };
+            }
+
+            return new { e.Message, e.StackTrace, InnerException = FormatExceptionDetails(e.InnerException, maxDepth - 1) };
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
+++ b/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
@@ -118,6 +118,7 @@ namespace HealthGateway.Common.ErrorHandling
                 Status = exception switch
                 {
                     CommunicationException => StatusCodes.Status502BadGateway,
+                    UnauthorizedAccessException => StatusCodes.Status401Unauthorized,
                     _ => StatusCodes.Status500InternalServerError,
                 },
             };

--- a/Apps/Common/src/ErrorHandling/Exceptions/AlreadyExistsException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/AlreadyExistsException.cs
@@ -15,19 +15,19 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.ErrorHandling.Exceptions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Net;
 
-    /// <inheritdoc/>
     /// <summary>
-    /// AlreadyExistsException is used when a desired action conflicts with a record that already exists.
-    /// The default error code is RecordAlreadyExists.
-    /// The default status code is 409.
+    /// <see cref="AlreadyExistsException"/> is used when a desired action conflicts with a record that already exists.
+    /// The default error code is <see cref="ErrorCodes.RecordAlreadyExists"/>.
+    /// The default status code is <see cref="HttpStatusCode.Conflict"/> (409).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     public class AlreadyExistsException : HealthGatewayException
     {
-        private readonly HttpStatusCode defaultStatusCode = HttpStatusCode.Conflict;
+        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.Conflict;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class.
@@ -37,7 +37,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         public AlreadyExistsException(string message, string? errorCode = ErrorCodes.RecordAlreadyExists)
             : base(message)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -46,10 +46,10 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public AlreadyExistsException(string message, System.Exception innerException, string errorCode = ErrorCodes.RecordAlreadyExists)
+        public AlreadyExistsException(string message, Exception innerException, string errorCode = ErrorCodes.RecordAlreadyExists)
             : base(message, innerException)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         public AlreadyExistsException()
         {
-            this.SetErrorProperties(this.defaultStatusCode, ErrorCodes.RecordAlreadyExists);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.RecordAlreadyExists);
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/DatabaseException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/DatabaseException.cs
@@ -15,19 +15,19 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.ErrorHandling.Exceptions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Net;
 
-    /// <inheritdoc/>
     /// <summary>
-    /// DatabaseException is used when a desired record is not found.
-    /// The default error code is RecordNotFound.
-    /// The default status code is 404.
+    /// <see cref="DatabaseException"/> is used when an unexpected database error occurs.
+    /// The default error code is <see cref="ErrorCodes.DatabaseError"/>.
+    /// The default status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     public class DatabaseException : HealthGatewayException
     {
-        private readonly HttpStatusCode defaultStatusCode = HttpStatusCode.InternalServerError;
+        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DatabaseException"/> class.
@@ -37,7 +37,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         public DatabaseException(string message, string errorCode = ErrorCodes.DatabaseError)
             : base(message)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -46,10 +46,10 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public DatabaseException(string message, System.Exception innerException, string? errorCode = ErrorCodes.DatabaseError)
+        public DatabaseException(string message, Exception innerException, string? errorCode = ErrorCodes.DatabaseError)
             : base(message, innerException)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         public DatabaseException()
         {
-            this.SetErrorProperties(this.defaultStatusCode, ErrorCodes.DatabaseError);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.DatabaseError);
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/HealthGatewayException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/HealthGatewayException.cs
@@ -20,12 +20,12 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     using System.Net;
 
     /// <summary>
-    /// Exception class for Health Gateway.
+    /// Abstract exception class for Health Gateway.
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     public abstract class HealthGatewayException : Exception
     {
-        private readonly HttpStatusCode defaultStatusCode = HttpStatusCode.InternalServerError;
+        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="HealthGatewayException"/> class.
@@ -35,7 +35,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         protected HealthGatewayException(string message, string? errorCode = ErrorCodes.ServerError)
             : base(message)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         protected HealthGatewayException(string message, Exception innerException, string errorCode = ErrorCodes.ServerError)
             : base(message, innerException)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -55,16 +55,16 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         protected HealthGatewayException()
         {
-            this.SetErrorProperties(this.defaultStatusCode, ErrorCodes.ServerError);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.ServerError);
         }
 
         /// <summary>
-        /// Gets or sets the error codes.
+        /// Gets or sets the error code.
         /// </summary>
         public string? ErrorCode { get; protected set; }
 
         /// <summary>
-        /// Gets or sets the http status code.
+        /// Gets or sets the HTTP status code.
         /// </summary>
         public HttpStatusCode StatusCode { get; set; }
 

--- a/Apps/Common/src/ErrorHandling/Exceptions/InvalidDataException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/InvalidDataException.cs
@@ -15,19 +15,19 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.ErrorHandling.Exceptions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Net;
 
-    /// <inheritdoc/>
     /// <summary>
-    /// DataMismatchException is used when an expected input or data record does not match the desired requirements.
-    /// The default error code is UndesiredResults.
-    /// The default status code is 400.
+    /// <see cref="InvalidDataException"/> is used when an expected input or data record does not match the desired requirements.
+    /// The default error code is <see cref="ErrorCodes.InvalidData"/>.
+    /// The default status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     public class InvalidDataException : HealthGatewayException
     {
-        private readonly HttpStatusCode defaultStatusCode = HttpStatusCode.InternalServerError;
+        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidDataException"/> class.
@@ -37,7 +37,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         public InvalidDataException(string message, string? errorCode = ErrorCodes.InvalidData)
             : base(message)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -46,10 +46,10 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public InvalidDataException(string message, System.Exception innerException, string? errorCode = ErrorCodes.InvalidData)
+        public InvalidDataException(string message, Exception innerException, string? errorCode = ErrorCodes.InvalidData)
             : base(message, innerException)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         public InvalidDataException()
         {
-            this.SetErrorProperties(this.defaultStatusCode, ErrorCodes.InvalidData);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.InvalidData);
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/NotFoundException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/NotFoundException.cs
@@ -15,19 +15,19 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.ErrorHandling.Exceptions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Net;
 
-    /// <inheritdoc/>
     /// <summary>
-    /// NotFoundException is used when a desired record is not found.
-    /// The default error code is RecordNotFound.
-    /// The default status code is 404.
+    /// <see cref="NotFoundException"/> is used when a desired record is not found.
+    /// The default error code is <see cref="ErrorCodes.RecordNotFound"/>.
+    /// The default status code is <see cref="HttpStatusCode.NotFound"/> (404).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     public class NotFoundException : HealthGatewayException
     {
-        private readonly HttpStatusCode defaultStatusCode = HttpStatusCode.NotFound;
+        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.NotFound;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="NotFoundException"/> class.
@@ -37,7 +37,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         public NotFoundException(string message, string errorCode = ErrorCodes.RecordNotFound)
             : base(message)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -46,10 +46,10 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public NotFoundException(string message, System.Exception innerException, string? errorCode = ErrorCodes.RecordNotFound)
+        public NotFoundException(string message, Exception innerException, string? errorCode = ErrorCodes.RecordNotFound)
             : base(message, innerException)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         public NotFoundException()
         {
-            this.SetErrorProperties(this.defaultStatusCode, ErrorCodes.RecordNotFound);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.RecordNotFound);
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
@@ -15,21 +15,19 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Common.ErrorHandling.Exceptions
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Net;
 
-    /// <inheritdoc/>
     /// <summary>
-    /// RefreshInProgressException is used when a upstream service reports that data is being refreshed and should be retried
-    /// later.
-    /// The default error code is RefreshInProgress.
-    /// The default status code is 503.
+    /// <see cref="UpstreamServiceException"/> is used when a remote service fails to respond appropriately.
+    /// The default error code is <see cref="ErrorCodes.RefreshInProgress"/>.
+    /// The default status code is <see cref="HttpStatusCode.BadGateway"/> (502).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     public class UpstreamServiceException : HealthGatewayException
     {
-        // Default private values
-        private readonly HttpStatusCode defaultStatusCode = HttpStatusCode.BadGateway;
+        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.BadGateway;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UpstreamServiceException"/> class.
@@ -39,7 +37,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         public UpstreamServiceException(string message, string? errorCode = ErrorCodes.RefreshInProgress)
             : base(message)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -48,10 +46,10 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public UpstreamServiceException(string message, System.Exception innerException, string? errorCode = ErrorCodes.RefreshInProgress)
+        public UpstreamServiceException(string message, Exception innerException, string? errorCode = ErrorCodes.RefreshInProgress)
             : base(message, innerException)
         {
-            this.SetErrorProperties(this.defaultStatusCode, errorCode);
+            this.SetErrorProperties(DefaultStatusCode, errorCode);
         }
 
         /// <summary>
@@ -59,7 +57,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         public UpstreamServiceException()
         {
-            this.SetErrorProperties(this.defaultStatusCode, ErrorCodes.RefreshInProgress);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.RefreshInProgress);
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
@@ -21,7 +21,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
 
     /// <summary>
     /// <see cref="UpstreamServiceException"/> is used when a remote service fails to respond appropriately.
-    /// The default error code is <see cref="ErrorCodes.RefreshInProgress"/>.
+    /// The default error code is <see cref="ErrorCodes.UpstreamError"/>.
     /// The default status code is <see cref="HttpStatusCode.BadGateway"/> (502).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
@@ -34,7 +34,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public UpstreamServiceException(string message, string? errorCode = ErrorCodes.RefreshInProgress)
+        public UpstreamServiceException(string message, string? errorCode = ErrorCodes.UpstreamError)
             : base(message)
         {
             this.SetErrorProperties(DefaultStatusCode, errorCode);
@@ -46,7 +46,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
         /// <param name="errorCode">A concise coded reason for the failure.</param>
-        public UpstreamServiceException(string message, Exception innerException, string? errorCode = ErrorCodes.RefreshInProgress)
+        public UpstreamServiceException(string message, Exception innerException, string? errorCode = ErrorCodes.UpstreamError)
             : base(message, innerException)
         {
             this.SetErrorProperties(DefaultStatusCode, errorCode);
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
         /// </summary>
         public UpstreamServiceException()
         {
-            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.RefreshInProgress);
+            this.SetErrorProperties(DefaultStatusCode, ErrorCodes.UpstreamError);
         }
     }
 }

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -10,6 +10,7 @@
             }
         }
     },
+    "IncludeExceptionDetailsInResponse": true,
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "RequireHttpsMetadata": "false"

--- a/Apps/GatewayApi/src/appsettings.hgdev.json
+++ b/Apps/GatewayApi/src/appsettings.hgdev.json
@@ -11,6 +11,7 @@
             }
         }
     },
+    "IncludeExceptionDetailsInResponse": true,
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
     },

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -26,10 +26,9 @@
         ]
     },
     "RequestLogging": {
-        "ExcludedPaths": [
-            "/health"
-        ]
+        "ExcludedPaths": ["/health"]
     },
+    "IncludeExceptionDetailsInResponse": false,
     "OpenIdConnect": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "ClientId": "hg",
@@ -127,7 +126,7 @@
         "TokenCacheEnabled": true
     },
     "EmailTemplate": {
-      "Host": "https://www.healthgateway.gov.bc.ca"
+        "Host": "https://www.healthgateway.gov.bc.ca"
     },
     "ChangeFeed": {
         "Dependents": {

--- a/Apps/Patient/src/appsettings.Development.json
+++ b/Apps/Patient/src/appsettings.Development.json
@@ -10,6 +10,7 @@
             }
         }
     },
+    "IncludeExceptionDetailsInResponse": true,
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "RequireHttpsMetadata": "false"

--- a/Apps/Patient/src/appsettings.hgdev.json
+++ b/Apps/Patient/src/appsettings.hgdev.json
@@ -11,6 +11,7 @@
             }
         }
     },
+    "IncludeExceptionDetailsInResponse": true,
     "OpenIdConnect": {
         "Authority": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
     },

--- a/Apps/Patient/src/appsettings.json
+++ b/Apps/Patient/src/appsettings.json
@@ -26,10 +26,9 @@
         ]
     },
     "RequestLogging": {
-        "ExcludedPaths": [
-            "/health"
-        ]
+        "ExcludedPaths": ["/health"]
     },
+    "IncludeExceptionDetailsInResponse": false,
     "OpenIdConnect": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
         "ClientId": "hg",
@@ -73,9 +72,7 @@
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",
-        "IgnorePathPrefixes": [
-            "/health"
-        ]
+        "IgnorePathPrefixes": ["/health"]
     },
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd.azure-api.net/identity",


### PR DESCRIPTION
# Implements [AB#16649](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16649)

## Description

- cleans up and updates documentation for HealthGatewayExceptions
- changes default error code for UpstreamServiceException from RefreshInProgress to UpstreamError
- maps UnauthorizedAccessExceptions to HTTP 401 responses instead of HTTP 500
- returns error code in problem details as type property
  - the type property is the most important, and it's supposed to be used to identify what the problem is, so it fit better than adding the error code as an extension property 
    - the type property is technically supposed to be a URI that links to further information about the problem, but this would be excessive for our use
- adds "IncludeExceptionDetailsInResponse" to appsettings, so the exception details can be returned in the dev environment as well as locally
- refactors ExceptionUtilities to return nested InnerExceptions (and tidies up)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
