### PR TITLE
Moved webclient and gateway api overrides from helm to appsettings

### DIFF
--- a/Apps/Common/src/Models/CDogs/CDogsConfig.cs
+++ b/Apps/Common/src/Models/CDogs/CDogsConfig.cs
@@ -26,30 +26,8 @@ namespace HealthGateway.Common.Models.CDogs
         public const string CDogsConfigSectionKey = "CDOGS";
 
         /// <summary>
-        /// Gets or sets the OpenShift service name.
-        /// </summary>
-        public string ServiceName { get; set; } = "HGCDOGS_SERVICE";
-
-        /// <summary>
-        /// Gets or sets the host suffix used to lookup the service host.
-        /// </summary>
-        public string ServiceHostSuffix { get; set; } = "_HOST";
-
-        /// <summary>
-        /// Gets or sets the port suffix used to lookup the service port.
-        /// </summary>
-        public string ServicePortSuffix { get; set; } = "_PORT";
-
-        /// <summary>
         /// Gets or sets the base Url used to connect to the ODR Proxy.
         /// </summary>
         public string BaseEndpoint { get; set; } = string.Empty;
-
-        /// <summary>
-        /// Gets or sets a value indicating whether dynamic service lookup should occur.
-        /// if enabled, the Url will be created using environment variables.
-        /// If not enabled, the configured Url will be used.
-        /// </summary>
-        public bool DynamicServiceLookup { get; set; }
     }
 }

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -22,7 +22,6 @@ namespace HealthGateway.GatewayApi
     using HealthGateway.Common.Api;
     using HealthGateway.Common.AspNetConfiguration;
     using HealthGateway.Common.AspNetConfiguration.Modules;
-    using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.MapProfiles;
     using HealthGateway.Common.Models.CDogs;
@@ -121,14 +120,6 @@ namespace HealthGateway.GatewayApi
             CDogsConfig cdogsConfig = new();
             this.startupConfig.Configuration.Bind(CDogsConfig.CDogsConfigSectionKey, cdogsConfig);
             string cdogsEndpoint = cdogsConfig.BaseEndpoint;
-            if (cdogsConfig.DynamicServiceLookup)
-            {
-                cdogsEndpoint = ConfigurationUtility.ConstructServiceEndpoint(
-                    cdogsConfig.BaseEndpoint,
-                    $"{cdogsConfig.ServiceName}{cdogsConfig.ServiceHostSuffix}",
-                    $"{cdogsConfig.ServiceName}{cdogsConfig.ServicePortSuffix}");
-            }
-
             services.AddRefitClient<ICDogsApi>().ConfigureHttpClient(c => c.BaseAddress = new Uri(cdogsEndpoint));
 
             PhsaConfigV2 phsaConfig = new();

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -40,8 +40,7 @@
         "TraceConsoleExporterEnabled": true
     },
     "CDOGS": {
-        "DynamicServiceLookup": "false",
-        "BaseEndpoint": "https://dev-hgcdogs.healthgateway.gov.bc.ca"
+        "BaseEndpoint": "https://dev-hgcdogs.apps.gold.devops.gov.bc.ca"
     },
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",

--- a/Apps/GatewayApi/src/appsettings.hgdev.json
+++ b/Apps/GatewayApi/src/appsettings.hgdev.json
@@ -51,5 +51,8 @@
     },
     "EmailTemplate": {
         "Host": "https://dev.healthgateway.gov.bc.ca"
+    },
+    "CDOGS": {
+        "BaseEndpoint": "http://dev-hgcdogs-svc:3000"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.hgtest.json
+++ b/Apps/GatewayApi/src/appsettings.hgtest.json
@@ -31,5 +31,8 @@
     },
     "EmailTemplate": {
         "Host": "https://test.healthgateway.gov.bc.ca"
+    },
+    "CDOGS": {
+        "BaseEndpoint": "http://test-hgcdogs-svc:3000"
     }
 }

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -107,11 +107,7 @@
         ]
     },
     "CDOGS": {
-        "ServiceName": "HGCDOGS_SERVICE",
-        "ServiceHostSuffix": "_HOST",
-        "ServicePortSuffix": "_PORT",
-        "DynamicServiceLookup": "true",
-        "BaseEndpoint": "http://${serviceHost}:${servicePort}"
+        "BaseEndpoint": "http://prod-hgcdogs-svc:3000"
     },
     "HttpClient": {
         "Timeout": "00:02:00"

--- a/Apps/WebClient/src/appsettings.hgdev.json
+++ b/Apps/WebClient/src/appsettings.hgdev.json
@@ -38,26 +38,25 @@
         }
     ],
     "WebClient": {
-        "RedirectToWWW": false,
         "LogLevel": "Debug",
         "TimeOuts": {
             "ResendSMS": "1"
         }
     },
     "ServiceEndpoints": {
-        "ClinicalDocument": "https://hg-dev.api.gov.bc.ca/api/clinicaldocumentservice/",
-        "Encounter": "https://hg-dev.api.gov.bc.ca/api/encounterservice/",
-        "HospitalVisit": "https://hg-dev.api.gov.bc.ca/api/encounterservice/",
-        "GatewayApi": "https://hg-dev.api.gov.bc.ca/api/gatewayapiservice/",
-        "Immunization": "https://hg-dev.api.gov.bc.ca/api/immunizationservice/",
-        "Laboratory": "https://hg-dev.api.gov.bc.ca/api/laboratoryservice/",
-        "Medication": "https://hg-dev.api.gov.bc.ca/api/medicationservice/",
-        "SpecialAuthority": "https://hg-dev.api.gov.bc.ca/api/medicationservice/",
-        "Patient": "https://hg-dev.api.gov.bc.ca/api/patientservice/",
-        "PatientData": "https://hg-dev.api.gov.bc.ca/api/patientservice/"
+        "ClinicalDocument": "https://hg.dev.api.gov.bc.ca/api/clinicaldocumentservice/",
+        "Encounter": "https://hg.dev.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg.dev.api.gov.bc.ca/api/encounterservice/",
+        "GatewayApi": "https://hg.dev.api.gov.bc.ca/api/gatewayapiservice/",
+        "Immunization": "https://hg.dev.api.gov.bc.ca/api/immunizationservice/",
+        "Laboratory": "https://hg.dev.api.gov.bc.ca/api/laboratoryservice/",
+        "Medication": "https://hg.dev.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg.dev.api.gov.bc.ca/api/medicationservice/",
+        "Patient": "https://hg.dev.api.gov.bc.ca/api/patientservice/",
+        "PatientData": "https://hg.dev.api.gov.bc.ca/api/patientservice/"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/ https://hg-dev.api.gov.bc.ca/ https://hg.dev.api.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://dev.loginproxy.gov.bc.ca/ https://hg.dev.api.gov.bc.ca/",
         "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
@@ -66,7 +65,7 @@
         "TraceConsoleExporterEnabled": false
     },
     "MobileConfiguration": {
-        "BaseUrl": "https://dev.healthgateway.gov.bc.ca/",
+        "BaseUrl": "https://hg.dev.api.gov.bc.ca/",
         "Authentication": {
             "Endpoint": "https://dev.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
         }

--- a/Apps/WebClient/src/appsettings.hgmock.json
+++ b/Apps/WebClient/src/appsettings.hgmock.json
@@ -31,7 +31,6 @@
         }
     ],
     "WebClient": {
-        "RedirectToWWW": false,
         "LogLevel": "Debug",
         "TimeOuts": {
             "ResendSMS": "1"

--- a/Apps/WebClient/src/appsettings.hgpoc.json
+++ b/Apps/WebClient/src/appsettings.hgpoc.json
@@ -31,7 +31,6 @@
         }
     ],
     "WebClient": {
-        "RedirectToWWW": false,
         "LogLevel": "Debug",
         "TimeOuts": {
             "ResendSMS": "1"

--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -8,23 +8,22 @@
         "Authority": "https://test.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
     },
     "WebClient": {
-        "RedirectToWWW": false,
         "LogLevel": "Debug"
     },
     "ServiceEndpoints": {
-        "ClinicalDocument": "https://hg-test.api.gov.bc.ca/api/clinicaldocumentservice/",
-        "Encounter": "https://hg-test.api.gov.bc.ca/api/encounterservice/",
-        "HospitalVisit": "https://hg-test.api.gov.bc.ca/api/encounterservice/",
-        "GatewayApi": "https://hg-test.api.gov.bc.ca/api/gatewayapiservice/",
-        "Immunization": "https://hg-test.api.gov.bc.ca/api/immunizationservice/",
-        "Laboratory": "https://hg-test.api.gov.bc.ca/api/laboratoryservice/",
-        "Medication": "https://hg-test.api.gov.bc.ca/api/medicationservice/",
-        "SpecialAuthority": "https://hg-test.api.gov.bc.ca/api/medicationservice/",
-        "Patient": "https://hg-test.api.gov.bc.ca/api/patientservice/",
-        "PatientData": "https://hg-test.api.gov.bc.ca/api/patientservice/"
+        "ClinicalDocument": "https://hg.test.api.gov.bc.ca/api/clinicaldocumentservice/",
+        "Encounter": "https://hg.test.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg.test.api.gov.bc.ca/api/encounterservice/",
+        "GatewayApi": "https://hg.test.api.gov.bc.ca/api/gatewayapiservice/",
+        "Immunization": "https://hg.test.api.gov.bc.ca/api/immunizationservice/",
+        "Laboratory": "https://hg.test.api.gov.bc.ca/api/laboratoryservice/",
+        "Medication": "https://hg.test.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg.test.api.gov.bc.ca/api/medicationservice/",
+        "Patient": "https://hg.test.api.gov.bc.ca/api/patientservice/",
+        "PatientData": "https://hg.test.api.gov.bc.ca/api/patientservice/"
     },
     "ContentSecurityPolicy": {
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/ https://hg-test.api.gov.bc.ca/ https://hg.test.api.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://test.loginproxy.gov.bc.ca/ https://hg.test.api.gov.bc.ca/",
         "FrameSource": "'self' https://test.loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://test.loginproxy.gov.bc.ca/"
     },
@@ -33,7 +32,7 @@
         "TraceConsoleExporterEnabled": true
     },
     "MobileConfiguration": {
-        "BaseUrl": "https://hg-test.api.gov.bc.ca/",
+        "BaseUrl": "https://hg.test.api.gov.bc.ca/",
         "Authentication": {
             "Endpoint": "https://test.loginproxy.gov.bc.ca/auth/realms/health-gateway-gold"
         }

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -99,7 +99,7 @@
         "Base": "'self'",
         "DefaultSource": "'self'",
         "ScriptSource": "'self' 'unsafe-eval' 'sha256-Tui7QoFlnLXkJCSl1/JvEZdIXTmBttnWNxzJpXomQjg=' 'sha256-vY0Cwh5hLv8sUQ61m3KQgfrqeAmcY7t6wJ2FAdYPNyU=' https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js",
-        "ConnectSource",: "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/ https://hg.api.gov.bc.ca/",
+        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/ https://hg.api.gov.bc.ca/",
         "ImageSource": "'self' data:",
         "StyleSource": "'self' 'unsafe-inline' https://fonts.googleapis.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",
         "FormAction": "'self'",

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -61,10 +61,10 @@
         }
     ],
     "WebClient": {
-        "RedirectToWWW": true,
+        "RedirectToWWW": false,
         "LogLevel": "Info",
         "TimeOuts": {
-            "Idle": "900000",
+            "Idle": "300000",
             "LogoutRedirect": "10000",
             "ResendSMS": "1"
         },
@@ -76,19 +76,20 @@
         "MinPatientAge": 12,
         "MaxDependentAge": 12,
         "EmailVerificationExpirySeconds": 43200,
-        "UserProfileHistoryRecordLimit": 4
+        "UserProfileHistoryRecordLimit": 4,
+        "FeatureToggleFilePath": "/app/config/featuretoggleconfig.json"
     },
     "ServiceEndpoints": {
-        "ClinicalDocument": "https://hg-prod.api.gov.bc.ca/api/clinicaldocumentservice/",
-        "GatewayApi": "https://hg-prod.api.gov.bc.ca/api/gatewayapiservice/",
-        "Immunization": "https://hg-prod.api.gov.bc.ca/api/immunizationservice/",
-        "Patient": "https://hg-prod.api.gov.bc.ca/api/patientservice/",
-        "PatientData": "https://hg-prod.api.gov.bc.ca/api/patientservice/",
-        "Medication": "https://hg-prod.api.gov.bc.ca/api/medicationservice/",
-        "SpecialAuthority": "https://hg-prod.api.gov.bc.ca/api/medicationservice/",
-        "Laboratory": "https://hg-prod.api.gov.bc.ca/api/laboratoryservice/",
-        "Encounter": "https://hg-prod.api.gov.bc.ca/api/encounterservice/",
-        "HospitalVisit": "https://hg-prod.api.gov.bc.ca/api/encounterservice/"
+        "ClinicalDocument": "https://hg.api.gov.bc.ca/api/clinicaldocumentservice/",
+        "GatewayApi": "https://hg.api.gov.bc.ca/api/gatewayapiservice/",
+        "Immunization": "https://hg.api.gov.bc.ca/api/immunizationservice/",
+        "Patient": "https://hg.api.gov.bc.ca/api/patientservice/",
+        "PatientData": "https://hg.api.gov.bc.ca/api/patientservice/",
+        "Medication": "https://hg.api.gov.bc.ca/api/medicationservice/",
+        "SpecialAuthority": "https://hg.api.gov.bc.ca/api/medicationservice/",
+        "Laboratory": "https://hg.api.gov.bc.ca/api/laboratoryservice/",
+        "Encounter": "https://hg.api.gov.bc.ca/api/encounterservice/",
+        "HospitalVisit": "https://hg.api.gov.bc.ca/api/encounterservice/"
     },
     "AvailabilityFilter": {
         "DumpHeaders": false,
@@ -98,7 +99,7 @@
         "Base": "'self'",
         "DefaultSource": "'self'",
         "ScriptSource": "'self' 'unsafe-eval' 'sha256-Tui7QoFlnLXkJCSl1/JvEZdIXTmBttnWNxzJpXomQjg=' 'sha256-vY0Cwh5hLv8sUQ61m3KQgfrqeAmcY7t6wJ2FAdYPNyU=' https://www2.gov.bc.ca/StaticWebResources/static/sp/sp-2-14-0.js",
-        "ConnectSource": "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/ https://hg-prod.api.gov.bc.ca/ https://hg.api.gov.bc.ca/",
+        "ConnectSource",: "'self' file: data: blob: filesystem: https://spt.apps.gov.bc.ca/com.snowplowanalytics.snowplow/tp2 https://loginproxy.gov.bc.ca/ https://hg.api.gov.bc.ca/",
         "ImageSource": "'self' data:",
         "StyleSource": "'self' 'unsafe-inline' https://fonts.googleapis.com/ https://cdn.jsdelivr.net/ https://use.fontawesome.com/",
         "FormAction": "'self'",
@@ -130,7 +131,7 @@
     },
     "MobileConfiguration": {
         "Online": true,
-        "BaseUrl": "https://hg-prod.api.gov.bc.ca/",
+        "BaseUrl": "https://hg.api.gov.bc.ca/",
         "Authentication": {
             "Endpoint": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
             "IdentityProviderId": "bcsc-mobile",

--- a/Tools/Helm/Charts/healthgateway/templates/route.tpl
+++ b/Tools/Helm/Charts/healthgateway/templates/route.tpl
@@ -23,7 +23,7 @@ spec:
   host: {{ $host.host }}
   path: {{ $host.path | default "" }}
   port:
-    targetPort: {{ printf "%d-%s" $port $protocol }}
+    targetPort: {{ printf "%s-%s" ($port | toString) $protocol }}
   tls:
     insecureEdgeTerminationPolicy: Redirect
     termination: edge


### PR DESCRIPTION
# Implements [AB#16643](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16643)

## Description

- Moved cdogs overrides from helm to appsettings. Note: removed dynamic service lookup as discussed with @sslaws 
- Moved web client overrides from helm to appsettings
- Fixed hełm route template and updated cdog server for local development for [AB#16646](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16646)

Note:

Left following in helm:

- HealthGateway_PatientService__CacheTTL: "5760"
- Serilog__MinimumLevel__Override__System.Net.Http.HttpClient: Information

Following will be commented out in helm:

-  HealthGateway_WebClient__OfflineMode__StartDateTime
-  HealthGateway_WebClient__OfflineMode__EndDateTime
-  HealthGateway_WebClient__OfflineMode__Message
-  HealthGateway_WebClient__OfflineMode__WhiteList__0
-  HealthGateway_WebClient__OfflineMode__WhiteList__1
-  HealthGateway_WebClient__OfflineMode__WhiteList__2

Helm cleanup will be done with [AB#16640](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16640), [AB#16650](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16650) and [AB#16653](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16653)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
