### PR TITLE
Resolve DateOnly issues in drug parsers AB#16648

### DIFF
--- a/Apps/DBMaintainer/Parsers/FederalDrugProductParser.cs
+++ b/Apps/DBMaintainer/Parsers/FederalDrugProductParser.cs
@@ -28,7 +28,7 @@ namespace HealthGateway.DBMaintainer.Parsers
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    /// Concrete implemention of the <see cref="IDrugProductParser"/>.
+    /// Concrete implementation of the <see cref="IDrugProductParser"/>.
     /// </summary>
     public class FederalDrugProductParser : IDrugProductParser
     {
@@ -55,10 +55,9 @@ namespace HealthGateway.DBMaintainer.Parsers
             using CsvReader csv = new(reader, csvConfig);
             TypeConverterOptions options = new()
             {
-                Formats = new[] { "dd-MMM-yyyy" },
-                DateTimeStyle = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                Formats = ["dd-MMM-yyyy"],
             };
-            csv.Context.TypeConverterOptionsCache.AddOptions<DateTime>(options);
+            csv.Context.TypeConverterOptionsCache.AddOptions<DateOnly>(options);
             DrugProductMapper mapper = new(fileDownload);
             csv.Context.RegisterClassMap(mapper);
             List<DrugProduct> records = csv.GetRecords<DrugProduct>().ToList();
@@ -110,7 +109,7 @@ namespace HealthGateway.DBMaintainer.Parsers
             using CsvReader csv = new(reader, csvConfig);
             TypeConverterOptions options = new()
             {
-                Formats = new[] { "dd-MMM-yyyy" },
+                Formats = ["dd-MMM-yyyy"],
                 DateTimeStyle = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
             };
             csv.Context.TypeConverterOptionsCache.AddOptions<DateTime>(options);
@@ -234,7 +233,7 @@ namespace HealthGateway.DBMaintainer.Parsers
         }
 
         /// <summary>
-        /// Searchs teh SourceFolder and returns a single file matching the pattern.
+        /// Searches the source folder and returns a single file matching the pattern.
         /// </summary>
         /// <param name="sourceFolder">The source folder to search.</param>
         /// <param name="fileMatch">The file pattern to match.</param>

--- a/Apps/DBMaintainer/Parsers/PharmaCareDrugParser.cs
+++ b/Apps/DBMaintainer/Parsers/PharmaCareDrugParser.cs
@@ -29,7 +29,7 @@ namespace HealthGateway.DBMaintainer.Parsers
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    /// Concrete implemention of the <see cref="IPharmaCareDrugParser"/>.
+    /// Concrete implementation of the <see cref="IPharmaCareDrugParser"/>.
     /// </summary>
     public class PharmaCareDrugParser : IPharmaCareDrugParser
     {
@@ -53,10 +53,9 @@ namespace HealthGateway.DBMaintainer.Parsers
             using CsvReader csv = new(reader, csvConfig);
             TypeConverterOptions options = new()
             {
-                Formats = new[] { "yyyyMMdd" },
-                DateTimeStyle = DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                Formats = ["yyyyMMdd"],
             };
-            csv.Context.TypeConverterOptionsCache.AddOptions<DateTime>(options);
+            csv.Context.TypeConverterOptionsCache.AddOptions<DateOnly>(options);
             PharmaCareDrugMapper mapper = new(fileDownload);
             csv.Context.RegisterClassMap(mapper);
             List<PharmaCareDrug> records = new();


### PR DESCRIPTION
# Fixes [AB#16648](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16648)

## Description

Updates Job Scheduler drug parsers to provide a hint about the date format when deserializing DateOnly properties.  These properties were previously DateTimes and the hint previously helped to deserialize DateTimes.

To test the changes, I cleared the FileDownload, DrugProduct, and PharmaDrug tables in my local DB, then ran the Provincial Drug Loader job and 4 Federal Drug Loader jobs.

The jobs succeeded and the new rows in the PharmaDrug and DrugProduct tables were populated with dates that matched the input .csv and .txt files.

![Screenshot 2024-02-16 165134](https://github.com/bcgov/healthgateway/assets/16570293/54913232-ee9d-4a86-a813-4afae0302130)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
