### PR TITLE
Update routing when user state is invalid AB#16654

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/ClientApp/src/router/index.ts
@@ -219,13 +219,7 @@ const routes = [
         path: Path.VaccineCard,
         component: PublicVaccineCardView,
         meta: {
-            validStates: [
-                UserState.unauthenticated,
-                UserState.invalidIdentityProvider,
-                UserState.noPatient,
-                UserState.registered,
-                UserState.pendingDeletion,
-            ],
+            validStates: [UserState.unauthenticated, UserState.registered],
         },
     },
     {
@@ -268,12 +262,7 @@ const routes = [
         component: PcrTestKitRegistrationView,
         props: false,
         meta: {
-            validStates: [
-                UserState.unauthenticated,
-                UserState.registered,
-                UserState.notRegistered,
-                UserState.pendingDeletion,
-            ],
+            validStates: [UserState.unauthenticated, UserState.registered],
             requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>
                 config.covid19.pcrTestEnabled,
         },
@@ -283,12 +272,7 @@ const routes = [
         component: PcrTestKitRegistrationView,
         props: true,
         meta: {
-            validStates: [
-                UserState.unauthenticated,
-                UserState.registered,
-                UserState.notRegistered,
-                UserState.pendingDeletion,
-            ],
+            validStates: [UserState.unauthenticated, UserState.registered],
             requiredFeaturesEnabled: (config: FeatureToggleConfiguration) =>
                 config.covid19.pcrTestEnabled,
         },

--- a/Apps/WebClient/src/ClientApp/src/router/index.ts
+++ b/Apps/WebClient/src/ClientApp/src/router/index.ts
@@ -121,8 +121,6 @@ const routes = [
         meta: {
             validStates: [
                 UserState.unauthenticated,
-                UserState.invalidIdentityProvider,
-                UserState.noPatient,
                 UserState.registered,
                 UserState.offline,
             ],


### PR DESCRIPTION
# Fixes [AB#16654](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16654)

## Description

Updates routing on public pages for several invalid user states to redirect to the more appropriate default page associated with the state.

- redirects from landing page to error page when user state is invalid
  - when authenticated via IDIR
  - when patient data cannot be retrieved
- redirects away from vaccine card and test kit pages when user state is invalid
  - when authenticated via IDIR
  - when patient data cannot be retrieved
  - when user is authenticated but has marked account for deletion

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

This logic was not applied to the public Terms of Service page, which seems important to leave accessible even in the states described above.

The only time users are redirected when navigating to the ToS page is when they haven't completed registration (redirected to the registration page which has the ToS embedded) or when the ToS has updated since their last visit (redirected to a page dedicated to the new ToS to accept before continuing to the home page).

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
