### PR TITLE
Fix timeline filter positioning when scrolling AB#16633

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineComponent.vue
@@ -786,5 +786,7 @@ setPageFromDate(linearDate.value);
 .timeline-filter-banner {
     z-index: 2;
     width: calc(100% + 32px);
+    top: var(--v-layout-top);
+    transition: 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 }
 </style>


### PR DESCRIPTION
# Fixes [AB#16633](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16633)

## Description

Fixes positioning of the sticky timeline filter, making it visible when the toolbar is displayed (after scrolling up), and preventing it from being covered by the banner that appears in non-production environments.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

### Prod - Before (filter disappears after scrolling up)

[scrnli_2_22_2024_2-12-11 PM.webm](https://github.com/bcgov/healthgateway/assets/16570293/2799f375-4623-4369-abcf-993b4e4af518)

### Prod - After

[scrnli_2_22_2024_2-14-35 PM.webm](https://github.com/bcgov/healthgateway/assets/16570293/f50d8761-05e1-4507-ab04-eaf20100ab30)

### Non-Prod - Before (filter is half covered, filter disappears after scrolling up)

[scrnli_2_22_2024_2-13-40 PM.webm](https://github.com/bcgov/healthgateway/assets/16570293/3a51abff-04ad-42bb-a0fa-5ee30ecffbb6)

### Non-Prod - After

[scrnli_2_22_2024_2-15-27 PM.webm](https://github.com/bcgov/healthgateway/assets/16570293/5f2ee4d3-b9ac-4f38-964a-f1da62190a17)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
