### PR TITLE
Disable connection-tracking cookies on OpenShift routes AB#16655

### DIFF
--- a/Tools/Helm/Charts/healthgateway/templates/route.tpl
+++ b/Tools/Helm/Charts/healthgateway/templates/route.tpl
@@ -18,6 +18,7 @@ metadata:
   annotations:
     haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload
     haproxy.router.openshift.io/balance: leastconn
+    haproxy.router.openshift.io/disable_cookies: 'true'
     haproxy.router.openshift.io/timeout: {{ $timeout }}
 spec:
   host: {{ $host.host }}


### PR DESCRIPTION
# Fixes [AB#16655](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16655)

## Description

Updates Helm template to address OWASP concerns with the cookies used for load balancing on OpenShift routes.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
