### PR TITLE
Fix error when medication statement collection is null AB#16668

### DIFF
--- a/Apps/Medication/src/Services/RestMedicationStatementService.cs
+++ b/Apps/Medication/src/Services/RestMedicationStatementService.cs
@@ -139,7 +139,7 @@ namespace HealthGateway.Medication.Services
                     return RequestResultFactory.Error<IList<MedicationStatement>>(response.ResultError);
                 }
 
-                IList<MedicationStatement>? payload = response.ResourcePayload.Results?.Select(this.mappingService.MapToMedicationStatement).ToList();
+                IList<MedicationStatement> payload = response.ResourcePayload.Results?.Select(this.mappingService.MapToMedicationStatement).ToList() ?? [];
                 await this.PopulateMedicationSummaryAsync(payload.Select(r => r.MedicationSummary).ToList(), ct);
 
                 return RequestResultFactory.Success(payload, response.TotalResultCount, response.PageIndex, response.PageSize);


### PR DESCRIPTION
# Fixes [AB#16668](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16668)

## Description

Resolves an exception being thrown on line 143 when payload is null, caused by the response containing a null Results property.  In that scenario, an empty collection will now stored instead of null.  The type of the payload variable has been adjusted to be non-nullable to reflect that null is not a valid value for it.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
