### PR TITLE
Update Rider and SonarCloud filters for code coverage AB#16669

### DIFF
--- a/Apps/.runsettings
+++ b/Apps/.runsettings
@@ -4,40 +4,4 @@
     <RunConfiguration>
         <MaxCpuCount>4</MaxCpuCount>
     </RunConfiguration>
-    <DataCollectionRunSettings>
-        <DataCollectors>
-            <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-                <Configuration>
-                    <CodeCoverage>
-
-
-                        <!-- Exclude .dll's by file name pattern -->
-                        <ModulePaths>
-                            <Exclude>
-                                <ModulePath>Admin.Client.dll</ModulePath>
-                                <ModulePath>Admin.Common.dll</ModulePath>
-                                <ModulePath>Admin.Server.dll</ModulePath>
-                                <ModulePath>Database.dll</ModulePath>
-                                <ModulePath>DBMaintainer.dll</ModulePath>
-                                <ModulePath>JobScheduler.dll</ModulePath>
-                                <ModulePath>Mock.dll</ModulePath>
-                                <ModulePath>.*Tests.dll</ModulePath>
-                                <ModulePath>dapper.dll</ModulePath>
-                                <ModulePath>moq.dll</ModulePath>
-                                <ModulePath>refit.dll</ModulePath>
-                                <ModulePath>refit.httpclientfactory.dll</ModulePath>
-                                <ModulePath>spekt.testlogger.dll</ModulePath>
-                                <ModulePath>.*xunit.*</ModulePath>
-                            </Exclude>
-                        </ModulePaths>                      
-                        
-                        <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
-                        <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
-                        <CollectFromChildProcesses>True</CollectFromChildProcesses>
-                        <CollectAspDotNet>False</CollectAspDotNet>
-                    </CodeCoverage>
-                </Configuration>
-            </DataCollector>
-        </DataCollectors>
-    </DataCollectionRunSettings>
 </RunSettings>

--- a/Apps/HealthGateway.sln.DotSettings
+++ b/Apps/HealthGateway.sln.DotSettings
@@ -72,6 +72,16 @@
     &amp;lt;Reformat&amp;gt;false&amp;lt;/Reformat&amp;gt;&#xD;
   &amp;lt;/Language&amp;gt;&#xD;
 &amp;lt;/profile&amp;gt;&lt;/RIDER_SETTINGS&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;AspOptimizeRegisterDirectives&gt;True&lt;/AspOptimizeRegisterDirectives&gt;&lt;CSharpFormatDocComments&gt;True&lt;/CSharpFormatDocComments&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;FormatAttributeQuoteDescriptor&gt;True&lt;/FormatAttributeQuoteDescriptor&gt;&lt;XAMLCollapseEmptyTags&gt;False&lt;/XAMLCollapseEmptyTags&gt;&lt;/Profile&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=AdminWebClient_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=Admin_002EClient_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=Database_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=DBMaintainer_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=JobScheduler_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=_002ATests_003B_002A_003B_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=_002A_003B_002A_003B_002AController_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/ExcludeCoverageFilters/=_002A_003B_002A_003BAspNetCoreGeneratedDocument_002E_002A_003B_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/FileMasksToExclude/=_002A_002A_002FModels_002F_002A_002A_002F_002A/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/Filtering/HideAutoProperties/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>

--- a/Apps/sonar-config.xml
+++ b/Apps/sonar-config.xml
@@ -16,10 +16,10 @@
   The following flags need to be used to set their value: /n:[SonarQube Project Name] /k:[SonarQube Project Key] /v:[SonarQube Project Version]
 
 -->
-<SonarQubeAnalysisProperties  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
-  <Property Name="sonar.exclusions">**/node_modules/**,**/wwwroot/**,**/ClientApp/public/**,**/Startup.cs,**/Mock/**,**/AdminWebClient/**</Property>
+<SonarQubeAnalysisProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
+  <Property Name="sonar.exclusions">**/node_modules/**/*,**/wwwroot/**/*,**/ClientApp/public/**/*,**/Startup.cs,**/AdminWebClient/**/*</Property>
   <Property Name="sonar.test.inclusions">**/test/**/*Tests.cs,**/Tests/**/*Tests.cs</Property>
-  <Property Name="sonar.coverage.exclusions">**/*Controller.cs,**/Common/src/Models/**/*,**/Admin/**/*,**/Database/**/*,**/DBMaintainer/**/*,**/JobScheduler/**/*,**/WebClient/**/*</Property>
+  <Property Name="sonar.coverage.exclusions">**/*Controller.cs,**/Models/**/*,**/Admin/Client/**/*,**/Database/**/*,**/DBMaintainer/**/*,**/JobScheduler/**/*,**/ClientApp/**/*</Property>
   <Property Name="sonar.host.url">https://sonarcloud.io</Property>
   <Property Name="sonar.cs.dotcover.reportsPaths">**/dotCover.Output.html</Property>
   <Property Name="sonar.excludeTestProjects">true</Property>


### PR DESCRIPTION
# Implements [AB#16669](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16669)

## Description

- updates SonarCloud code coverage filters to exclude files inside "Models" folders and include back-end files for WebClient, Admin.Server, and Admin.Common
- updates Rider code coverage filters to match SonarCloud
- removes code coverage filters from .runsettings file since they're currently unused

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
