### PR TITLE
Increase code coverage and fix sonar cloud smells for Patient and Medication for AB#16663

### DIFF
--- a/Apps/Medication/test/unit/Controllers/MedicationControllerTests.cs
+++ b/Apps/Medication/test/unit/Controllers/MedicationControllerTests.cs
@@ -107,7 +107,7 @@ namespace HealthGateway.MedicationTests.Controllers
             Mock<IMedicationService> serviceMock = new();
             serviceMock.Setup(s => s.GetMedicationsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new Dictionary<string, MedicationInformation>());
 
-            List<string> drugIdentifiers = new() { "000001", "000003", "000003" };
+            List<string> drugIdentifiers = ["000001", "000003", "000003"];
             List<string> paddedDinList = drugIdentifiers.Select(x => x.PadLeft(8, '0')).ToList();
             MedicationController controller = new(serviceMock.Object);
 

--- a/Apps/Medication/test/unit/Controllers/MedicationStatementControllerTests.cs
+++ b/Apps/Medication/test/unit/Controllers/MedicationStatementControllerTests.cs
@@ -55,8 +55,8 @@ namespace HealthGateway.MedicationTests.Controllers
             RequestResult<IList<MedicationStatement>> expectedResult = new()
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new List<MedicationStatement>
-                {
+                ResourcePayload =
+                [
                     new()
                     {
                         PrescriptionIdentifier = "identifier",
@@ -92,7 +92,7 @@ namespace HealthGateway.MedicationTests.Controllers
                         },
                         PractitionerSurname = "Surname",
                     },
-                },
+                ],
             };
 
             Mock<IMedicationStatementService> svcMock = new();

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.MedicationTests.Delegates
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Net.Http;
     using System.Threading;
@@ -46,13 +45,14 @@ namespace HealthGateway.MedicationTests.Delegates
     /// </summary>
     public class MedicationDelegateTests
     {
+        private const string Hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+        private const string Ip = "10.0.0.1";
+        private const string OdrConfigSectionKey = "ODR";
+        private const string Phn = "9735361219";
+
         private readonly IConfiguration configuration;
-        private readonly string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-        private readonly string ip = "10.0.0.1";
         private readonly ILoggerFactory loggerFactory;
         private readonly OdrConfig odrConfig = new();
-        private readonly string odrConfigSectionKey = "ODR";
-        private readonly string phn = "9735361219";
         private readonly OdrHistoryQuery query = new()
         {
             StartDate = DateTime.Parse("1990/01/01", CultureInfo.CurrentCulture),
@@ -66,7 +66,7 @@ namespace HealthGateway.MedicationTests.Delegates
         public MedicationDelegateTests()
         {
             this.configuration = GetIConfigurationRoot();
-            this.configuration.Bind(this.odrConfigSectionKey, this.odrConfig);
+            this.configuration.Bind(OdrConfigSectionKey, this.odrConfig);
             this.loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
         }
 
@@ -82,16 +82,16 @@ namespace HealthGateway.MedicationTests.Delegates
             MedicationHistory medicationHistory = new()
             {
                 Id = Guid.Parse("ee37267e-cb2c-48e1-a3c9-16c36ce7466b"),
-                RequestorHdid = this.hdid,
-                RequestorIp = this.ip,
+                RequestorHdid = Hdid,
+                RequestorIp = Ip,
                 Query = this.query,
                 Response = new MedicationHistoryResponse
                 {
                     Id = Guid.Parse("ee37267e-cb2c-48e1-a3c9-16c36ce7466b"),
                     Pages = 1,
                     TotalRecords = 1,
-                    Results = new List<MedicationResult>
-                    {
+                    Results =
+                    [
                         new()
                         {
                             Din = "00000000",
@@ -126,7 +126,7 @@ namespace HealthGateway.MedicationTests.Delegates
                             Quantity = 1,
                             Refills = 1,
                         },
-                    },
+                    ],
                 },
             };
 
@@ -134,7 +134,7 @@ namespace HealthGateway.MedicationTests.Delegates
             mockOdrApi.Setup(s => s.GetMedicationHistoryAsync(It.IsAny<MedicationHistory>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(medicationHistory);
             mockOdrApi.Setup(s => s.GetProtectiveWordAsync(It.IsAny<ProtectiveWord>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(this.GetProtectiveWord());
+                .ReturnsAsync(GetProtectiveWord());
 
             IMedicationStatementDelegate medicationStatementDelegate = new RestMedicationStatementDelegate(
                 this.loggerFactory.CreateLogger<RestMedicationStatementDelegate>(),
@@ -166,21 +166,21 @@ namespace HealthGateway.MedicationTests.Delegates
             MedicationHistory medicationHistory = new()
             {
                 Id = Guid.Parse("ee37267e-cb2c-48e1-a3c9-16c36ce7466b"),
-                RequestorHdid = this.hdid,
-                RequestorIp = this.ip,
+                RequestorHdid = Hdid,
+                RequestorIp = Ip,
                 Query = this.query,
                 Response = new MedicationHistoryResponse
                 {
                     Id = Guid.Parse("ee37267e-cb2c-48e1-a3c9-16c36ce7466b"),
                     Pages = 1,
                     TotalRecords = 1,
-                    Results = new List<MedicationResult>
-                    {
+                    Results =
+                    [
                         new()
                         {
                             Din = "00000000",
                         },
-                    },
+                    ],
                 },
             };
 
@@ -188,7 +188,7 @@ namespace HealthGateway.MedicationTests.Delegates
             mockOdrApi.Setup(s => s.GetMedicationHistoryAsync(It.IsAny<MedicationHistory>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(medicationHistory);
             mockOdrApi.Setup(s => s.GetProtectiveWordAsync(It.IsAny<ProtectiveWord>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(this.GetProtectiveWord());
+                .ReturnsAsync(GetProtectiveWord());
 
             byte[] salt = HmacHashDelegate.GenerateSalt();
             HmacHash hmacHash = new()
@@ -196,7 +196,7 @@ namespace HealthGateway.MedicationTests.Delegates
                 PseudoRandomFunction = HashFunction.HmacSha512,
                 Iterations = 21013,
                 Salt = Convert.ToBase64String(salt),
-                Hash = Convert.ToBase64String(KeyDerivation.Pbkdf2(this.GetProtectiveWord().QueryResponse.Value, salt, HmacHashDelegateConfig.DefaultPseudoRandomFunction, 21013, 64)),
+                Hash = Convert.ToBase64String(KeyDerivation.Pbkdf2(GetProtectiveWord().QueryResponse.Value, salt, HmacHashDelegateConfig.DefaultPseudoRandomFunction, 21013, 64)),
             };
             IHashDelegate mockHashDelegate = GetHashDelegate();
             Mock<ICacheProvider> mockCacheProvider = new();
@@ -228,7 +228,7 @@ namespace HealthGateway.MedicationTests.Delegates
         [Fact]
         public async Task InvalidProtectiveWord()
         {
-            ProtectiveWord protectiveWord = this.GetProtectiveWord("ProtectiveWord");
+            ProtectiveWord protectiveWord = GetProtectiveWord("ProtectiveWord");
 
             Mock<IOdrApi> mockOdrApi = new();
             mockOdrApi.Setup(s => s.GetProtectiveWordAsync(It.IsAny<ProtectiveWord>(), It.IsAny<CancellationToken>()))
@@ -317,7 +317,7 @@ namespace HealthGateway.MedicationTests.Delegates
             mockHashDelegate.Setup(s => s.Hash(It.IsAny<string>())).Returns(hash);
             mockHashDelegate.Setup(s => s.Compare(It.IsAny<string>(), It.IsAny<IHash>())).Returns(true);
 
-            ProtectiveWord protectiveWord = this.GetProtectiveWord("ProtectiveWord");
+            ProtectiveWord protectiveWord = GetProtectiveWord("ProtectiveWord");
             Mock<IOdrApi> mockOdrApi = new();
             mockOdrApi.Setup(s => s.GetMedicationHistoryAsync(It.IsAny<MedicationHistory>(), It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpRequestException("Fake Exception"));
@@ -360,16 +360,16 @@ namespace HealthGateway.MedicationTests.Delegates
             return mockHashDelegate.Object;
         }
 
-        private ProtectiveWord GetProtectiveWord(string value = "")
+        private static ProtectiveWord GetProtectiveWord(string value = "")
         {
             ProtectiveWord protectiveWord = new()
             {
                 Id = Guid.Parse("ed428f08-1c07-4439-b2a3-acbb16b8fb65"),
-                RequestorHdid = this.hdid,
-                RequestorIp = this.ip,
+                RequestorHdid = Hdid,
+                RequestorIp = Ip,
                 QueryResponse = new ProtectiveWordQueryResponse
                 {
-                    Phn = this.phn,
+                    Phn = Phn,
                     Operator = ProtectiveWordOperator.Get,
                     Value = value,
                 },

--- a/Apps/Medication/test/unit/Delegates/SalesforceMedicationRequestDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/SalesforceMedicationRequestDelegateTests.cs
@@ -65,15 +65,15 @@ namespace HealthGateway.MedicationTests.Delegates
                 Password = "TEST_PASSWORD",
                 Username = "TEST_USERNAME",
             };
-            IEnumerable<KeyValuePair<string, string?>> configurationParams = new List<KeyValuePair<string, string?>>
-            {
+            IEnumerable<KeyValuePair<string, string?>> configurationParams =
+            [
                 new("Salesforce:Endpoint", endpoint),
                 new("Salesforce:TokenUri", tokenUri.ToString()),
                 new("Salesforce:ClientAuthentication:ClientId", requestParameters.ClientId),
                 new("Salesforce:ClientAuthentication:ClientSecret", requestParameters.ClientSecret),
                 new("Salesforce:ClientAuthentication:Username", requestParameters.Username),
                 new("Salesforce:ClientAuthentication:Password", requestParameters.Password),
-            };
+            ];
             IConfiguration configuration = CreateConfiguration(configurationParams);
 
             // Setup Authentication
@@ -139,15 +139,15 @@ namespace HealthGateway.MedicationTests.Delegates
                 Password = "TEST_PASSWORD",
                 Username = "TEST_USERNAME",
             };
-            IEnumerable<KeyValuePair<string, string?>> configurationParams = new List<KeyValuePair<string, string?>>
-            {
+            IEnumerable<KeyValuePair<string, string?>> configurationParams =
+            [
                 new("Salesforce:Endpoint", endpoint),
                 new("Salesforce:TokenUri", tokenUri.ToString()),
                 new("Salesforce:ClientAuthentication:ClientId", requestParameters.ClientId),
                 new("Salesforce:ClientAuthentication:ClientSecret", requestParameters.ClientSecret),
                 new("Salesforce:ClientAuthentication:Username", requestParameters.Username),
                 new("Salesforce:ClientAuthentication:Password", requestParameters.Password),
-            };
+            ];
             IConfiguration configuration = CreateConfiguration(configurationParams);
 
             // Setup Authentication
@@ -201,15 +201,15 @@ namespace HealthGateway.MedicationTests.Delegates
                 Password = "TEST_PASSWORD",
                 Username = "TEST_USERNAME",
             };
-            IEnumerable<KeyValuePair<string, string?>> configurationParams = new List<KeyValuePair<string, string?>>
-            {
+            IEnumerable<KeyValuePair<string, string?>> configurationParams =
+            [
                 new("Salesforce:Endpoint", endpoint),
                 new("Salesforce:TokenUri", tokenUri.ToString()),
                 new("Salesforce:ClientAuthentication:ClientId", requestParameters.ClientId),
                 new("Salesforce:ClientAuthentication:ClientSecret", requestParameters.ClientSecret),
                 new("Salesforce:ClientAuthentication:Username", requestParameters.Username),
                 new("Salesforce:ClientAuthentication:Password", requestParameters.Password),
-            };
+            ];
             IConfiguration configuration = CreateConfiguration(configurationParams);
 
             // Setup Authentication

--- a/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationRequestServiceTests.cs
@@ -63,11 +63,11 @@ namespace HealthGateway.MedicationTests.Services
             RequestResult<IList<MedicationRequest>> expectedDelegateResult = new()
             {
                 ResultStatus = ResultType.Success,
-                ResourcePayload = new List<MedicationRequest>
-                {
+                ResourcePayload =
+                [
                     new() { ReferenceNumber = "abc" },
                     new() { ReferenceNumber = "xyz" },
-                },
+                ],
                 TotalResultCount = 2,
             };
 

--- a/Apps/Medication/test/unit/Services/MedicationServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationServiceTests.cs
@@ -90,7 +90,7 @@ namespace HealthGateway.MedicationTests.Services
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
             IMedicationService service = new RestMedicationService(mockDelegate.Object);
-            IDictionary<string, MedicationInformation> actual = await service.GetMedicationsAsync(new List<string>());
+            IDictionary<string, MedicationInformation> actual = await service.GetMedicationsAsync([]);
             actual.ShouldDeepEqual(expected);
         }
 
@@ -139,7 +139,7 @@ namespace HealthGateway.MedicationTests.Services
             using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddConsole());
 
             IMedicationService service = new RestMedicationService(mockDelegate.Object);
-            IDictionary<string, MedicationInformation> actual = await service.GetMedicationsAsync(new List<string>());
+            IDictionary<string, MedicationInformation> actual = await service.GetMedicationsAsync([]);
             actual.ShouldDeepEqual(expected);
         }
     }

--- a/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
@@ -49,14 +49,14 @@ namespace HealthGateway.MedicationTests.Services
     /// </summary>
     public class MedicationStatementServiceTests
     {
-        private static readonly IMedicationMappingService MappingService = new MedicationMappingService(MapperUtil.InitializeAutoMapper());
+        private const string Din = "00000000";
+        private const string Hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+        private const string IpAddress = "10.0.0.1";
+        private const string Phn = "0009735353315";
+        private const string ProtectiveWord = "TestWord";
+        private const string UserId = "1001";
 
-        private readonly string din = "00000000";
-        private readonly string hdid = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-        private readonly string ipAddress = "10.0.0.1";
-        private readonly string phn = "0009735353315";
-        private readonly string protectiveWord = "TestWord";
-        private readonly string userId = "1001";
+        private static readonly IMedicationMappingService MappingService = new MedicationMappingService(MapperUtil.InitializeAutoMapper());
 
         /// <summary>
         /// GetMedicationStatementsHistory - Invalid Keyword.
@@ -65,26 +65,26 @@ namespace HealthGateway.MedicationTests.Services
         [Fact]
         public async Task InvalidProtectiveWord()
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientPhnAsync(this.hdid, It.IsAny<CancellationToken>()))
-                .Returns(
-                    Task.FromResult(
-                        new RequestResult<string>
-                        {
-                            ResourcePayload = this.phn,
-                            ResultStatus = ResultType.Success,
-                        }));
+            patientDelegateMock.Setup(s => s.GetPatientPhnAsync(Hdid, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new RequestResult<string>
+                    {
+                        ResourcePayload = Phn,
+                        ResultStatus = ResultType.Success,
+                    }
+                );
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
-            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<DrugProduct>());
+            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
 
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();
             RequestResult<MedicationHistoryResponse> requestResult = new()
             {
                 ResourcePayload = new MedicationHistoryResponse(),
             };
-            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
             Mock<IPatientRepository> patientRepository = new();
@@ -100,28 +100,28 @@ namespace HealthGateway.MedicationTests.Services
                 MappingService);
 
             // Run and Verify protective word too long
-            await this.VerifyProtectiveWordError("TOOLONG4U", ErrorMessages.ProtectiveWordTooLong, service);
+            await VerifyProtectiveWordError("TOOLONG4U", ErrorMessages.ProtectiveWordTooLong, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT", ErrorMessages.ProtectiveWordTooShort, service);
+            await VerifyProtectiveWordError("SHORT", ErrorMessages.ProtectiveWordTooShort, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT|", ErrorMessages.ProtectiveWordInvalidChars, service);
+            await VerifyProtectiveWordError("SHORT|", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT~", ErrorMessages.ProtectiveWordInvalidChars, service);
+            await VerifyProtectiveWordError("SHORT~", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT^", ErrorMessages.ProtectiveWordInvalidChars, service);
+            await VerifyProtectiveWordError("SHORT^", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT\\", ErrorMessages.ProtectiveWordInvalidChars, service);
+            await VerifyProtectiveWordError("SHORT\\", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("SHORT&", ErrorMessages.ProtectiveWordInvalidChars, service);
+            await VerifyProtectiveWordError("SHORT&", ErrorMessages.ProtectiveWordInvalidChars, service);
 
             // Run and Verify invalid char
-            await this.VerifyProtectiveWordError("      ", ErrorMessages.ProtectiveWordInvalidChars, service);
+            await VerifyProtectiveWordError("      ", ErrorMessages.ProtectiveWordInvalidChars, service);
         }
 
         /// <summary>
@@ -131,32 +131,32 @@ namespace HealthGateway.MedicationTests.Services
         [Fact]
         public async Task ShouldReturnProtectedActionNeededResponse()
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
             Mock<IPatientService> patientServiceMock = new();
-            patientServiceMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
-                .Returns(
-                    Task.FromResult(
-                        new RequestResult<PatientModel>
+            patientServiceMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new RequestResult<PatientModel>
+                    {
+                        ResourcePayload = new PatientModel
                         {
-                            ResourcePayload = new PatientModel
-                            {
-                                Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
-                                FirstName = "Patient",
-                                LastName = "Zero",
-                                HdId = this.hdid,
-                                PersonalHealthNumber = this.phn,
-                            },
-                            ResultStatus = ResultType.Success,
-                        }));
+                            Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
+                            FirstName = "Patient",
+                            LastName = "Zero",
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
+                        },
+                        ResultStatus = ResultType.Success,
+                    }
+                );
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
             drugLookupDelegateMock
                 .Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new List<DrugProduct>());
+                .ReturnsAsync([]);
 
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();
             medStatementDelegateMock
-                .Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), It.IsAny<string>(), this.hdid, this.ipAddress, It.IsAny<CancellationToken>()))
+                .Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), It.IsAny<string>(), Hdid, IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<MedicationHistoryResponse>
                     {
@@ -179,7 +179,7 @@ namespace HealthGateway.MedicationTests.Services
                 patientRepository.Object,
                 MappingService);
 
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, null);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, null);
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
             Assert.Equal(ActionType.Protected, actual.ResultError?.ActionCode);
             Assert.Equal(string.Empty, actual.ResultError?.ResultMessage);
@@ -192,10 +192,10 @@ namespace HealthGateway.MedicationTests.Services
         [Fact]
         public async Task ValidProtectiveWord()
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<PatientModel>
                     {
@@ -204,14 +204,14 @@ namespace HealthGateway.MedicationTests.Services
                             Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
                             FirstName = "Patient",
                             LastName = "Zero",
-                            HdId = this.hdid,
-                            PersonalHealthNumber = this.phn,
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
                         },
                         ResultStatus = ResultType.Success,
                     });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
-            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<DrugProduct>());
+            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
 
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();
             RequestResult<MedicationHistoryResponse> requestResult = new()
@@ -220,8 +220,11 @@ namespace HealthGateway.MedicationTests.Services
                 ResourcePayload = new MedicationHistoryResponse(),
             };
             medStatementDelegateMock
-                .Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), It.IsAny<string>(), It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+                .Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), It.IsAny<string>(), It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
+
+            Mock<IPatientRepository> patientRepositoryMock = new();
+            patientRepositoryMock.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
 
             IMedicationStatementService service = new RestMedicationStatementService(
                 new Mock<ILogger<RestMedicationStatementService>>().Object,
@@ -229,11 +232,11 @@ namespace HealthGateway.MedicationTests.Services
                 patientDelegateMock.Object,
                 drugLookupDelegateMock.Object,
                 medStatementDelegateMock.Object,
-                new Mock<IPatientRepository>().Object,
+                patientRepositoryMock.Object,
                 MappingService);
 
             // Run and Verify
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, this.protectiveWord);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, ProtectiveWord);
             Assert.Equal(ResultType.Success, actual.ResultStatus);
         }
 
@@ -252,33 +255,33 @@ namespace HealthGateway.MedicationTests.Services
         [InlineData(false)]
         public async Task ShouldGetMedications(bool canAccessDataSource)
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
-                .Returns(
-                    Task.FromResult(
-                        new RequestResult<PatientModel>
+            patientDelegateMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new RequestResult<PatientModel>
+                    {
+                        ResourcePayload = new PatientModel
                         {
-                            ResourcePayload = new PatientModel
-                            {
-                                Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
-                                FirstName = "Patient",
-                                LastName = "Zero",
-                                HdId = this.hdid,
-                                PersonalHealthNumber = this.phn,
-                            },
-                            ResultStatus = ResultType.Success,
-                        }));
+                            Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
+                            FirstName = "Patient",
+                            LastName = "Zero",
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
+                        },
+                        ResultStatus = ResultType.Success,
+                    }
+                );
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
 
             // We need two tests, one for Fed data and one for Provincial data
-            List<DrugProduct> drugList = new()
-            {
+            List<DrugProduct> drugList =
+            [
                 new DrugProduct
                 {
-                    DrugIdentificationNumber = this.din,
+                    DrugIdentificationNumber = Din,
                     BrandName = "Brand Name",
                     Form = new Form
                     {
@@ -294,7 +297,7 @@ namespace HealthGateway.MedicationTests.Services
                         CompanyName = "Company",
                     },
                 },
-            };
+            ];
 
             drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(drugList);
 
@@ -306,17 +309,17 @@ namespace HealthGateway.MedicationTests.Services
                 {
                     TotalRecords = 1,
                     Pages = 1,
-                    Results = new List<MedicationResult>
-                    {
+                    Results =
+                    [
                         new()
                         {
-                            Din = this.din,
+                            Din = Din,
                             GenericName = "Generic Name",
                         },
-                    },
+                    ],
                 },
             };
-            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
             Mock<IPatientRepository> patientRepository = new();
@@ -332,7 +335,7 @@ namespace HealthGateway.MedicationTests.Services
                 MappingService);
 
             // Act
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, null);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, null);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -348,36 +351,36 @@ namespace HealthGateway.MedicationTests.Services
         [Fact]
         public async Task ShouldGetMedicationsDrugInfoMissing()
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
-                .Returns(
-                    Task.FromResult(
-                        new RequestResult<PatientModel>
+            patientDelegateMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new RequestResult<PatientModel>
+                    {
+                        ResourcePayload = new PatientModel
                         {
-                            ResourcePayload = new PatientModel
-                            {
-                                Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
-                                FirstName = "Patient",
-                                LastName = "Zero",
-                                HdId = this.hdid,
-                                PersonalHealthNumber = this.phn,
-                            },
-                            ResultStatus = ResultType.Success,
-                        }));
+                            Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
+                            FirstName = "Patient",
+                            LastName = "Zero",
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
+                        },
+                        ResultStatus = ResultType.Success,
+                    }
+                );
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
 
             // We need two tests, one for Fed data and one for Provincial data
-            List<DrugProduct> drugList = new()
-            {
+            List<DrugProduct> drugList =
+            [
                 new DrugProduct
                 {
-                    DrugIdentificationNumber = this.din,
+                    DrugIdentificationNumber = Din,
                     BrandName = "Brand Name",
                 },
-            };
+            ];
 
             drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(drugList);
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();
@@ -388,17 +391,17 @@ namespace HealthGateway.MedicationTests.Services
                 {
                     TotalRecords = 1,
                     Pages = 1,
-                    Results = new List<MedicationResult>
-                    {
+                    Results =
+                    [
                         new()
                         {
-                            Din = this.din,
+                            Din = Din,
                             GenericName = "Generic Name",
                         },
-                    },
+                    ],
                 },
             };
-            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
             Mock<IPatientRepository> patientRepository = new();
@@ -414,7 +417,7 @@ namespace HealthGateway.MedicationTests.Services
                 MappingService);
 
             // Act
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, null);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, null);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -428,23 +431,22 @@ namespace HealthGateway.MedicationTests.Services
         [Fact]
         public async Task ShouldGetMedicationsProvLookup()
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
-                .Returns(
-                    Task.FromResult(
-                        new RequestResult<PatientModel>
+            patientDelegateMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new RequestResult<PatientModel>
+                    {
+                        ResourcePayload = new PatientModel
                         {
-                            ResourcePayload = new PatientModel
-                            {
-                                Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
-                                FirstName = "Patient",
-                                LastName = "Zero",
-                                HdId = this.hdid,
-                                PersonalHealthNumber = this.phn,
-                            },
-                            ResultStatus = ResultType.Success,
-                        }));
+                            Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
+                            FirstName = "Patient",
+                            LastName = "Zero",
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
+                        },
+                        ResultStatus = ResultType.Success,
+                    });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
 
@@ -453,7 +455,7 @@ namespace HealthGateway.MedicationTests.Services
             [
                 new PharmaCareDrug
                 {
-                    DinPin = this.din,
+                    DinPin = Din,
                     BrandName = "Brand Name",
                 },
             ];
@@ -469,17 +471,17 @@ namespace HealthGateway.MedicationTests.Services
                 {
                     TotalRecords = 1,
                     Pages = 1,
-                    Results = new List<MedicationResult>
-                    {
+                    Results =
+                    [
                         new()
                         {
-                            Din = this.din,
+                            Din = Din,
                             GenericName = "Generic Name",
                         },
-                    },
+                    ],
                 },
             };
-            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
             Mock<IPatientRepository> patientRepository = new();
@@ -495,7 +497,7 @@ namespace HealthGateway.MedicationTests.Services
                 MappingService);
 
             // Act
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, null);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, null);
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
@@ -523,10 +525,10 @@ namespace HealthGateway.MedicationTests.Services
         [InlineData(false, true, false)] // GetDrugProductsByDinAsync returns empty list
         public async Task ShouldGetEmptyMedications(bool medicationHistoryErrorExists, bool medicationHistoryPayloadExists, bool medicationStatementReturnsError)
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
 
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<PatientModel>
                     {
@@ -535,8 +537,8 @@ namespace HealthGateway.MedicationTests.Services
                             Birthdate = DateTime.Parse("2000/01/31", CultureInfo.CurrentCulture),
                             FirstName = "Patient",
                             LastName = "Zero",
-                            HdId = this.hdid,
-                            PersonalHealthNumber = this.phn,
+                            HdId = Hdid,
+                            PersonalHealthNumber = Phn,
                         },
                         ResultStatus = ResultType.Success,
                     });
@@ -557,7 +559,7 @@ namespace HealthGateway.MedicationTests.Services
                     : null,
             };
 
-            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
             Mock<IPatientRepository> patientRepository = new();
@@ -573,7 +575,7 @@ namespace HealthGateway.MedicationTests.Services
                 MappingService);
 
             // Act
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, null);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, null);
 
             // Verify
             if (medicationStatementReturnsError)
@@ -600,9 +602,9 @@ namespace HealthGateway.MedicationTests.Services
         [InlineData(false, false)] // GetPatientAsync returns status success and resource payload null
         public async Task ShouldGetPatientError(bool patientErrorExists, bool patientResourcePayloadExists)
         {
-            Mock<IHttpContextAccessor> httpContextAccessorMock = this.GetHttpContextAccessorMock();
+            Mock<IHttpContextAccessor> httpContextAccessorMock = GetHttpContextAccessorMock();
             Mock<IPatientService> patientDelegateMock = new();
-            patientDelegateMock.Setup(s => s.GetPatientAsync(this.hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
+            patientDelegateMock.Setup(s => s.GetPatientAsync(Hdid, PatientIdentifierType.Hdid, false, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
                     new RequestResult<PatientModel>
                     {
@@ -623,7 +625,7 @@ namespace HealthGateway.MedicationTests.Services
                 },
             };
             requestResult.ResourcePayload = new MedicationHistoryResponse();
-            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), this.ipAddress, It.IsAny<CancellationToken>()))
+            medStatementDelegateMock.Setup(p => p.GetMedicationStatementsAsync(It.IsAny<OdrHistoryQuery>(), null, It.IsAny<string>(), IpAddress, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
             Mock<IPatientRepository> patientRepository = new();
@@ -639,22 +641,22 @@ namespace HealthGateway.MedicationTests.Services
                 MappingService);
 
             // Act
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, null);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, null);
 
             // Verify
             Assert.Equal(ResultType.Error, actual.ResultStatus);
         }
 
-        private Mock<IHttpContextAccessor> GetHttpContextAccessorMock()
+        private static Mock<IHttpContextAccessor> GetHttpContextAccessorMock()
         {
             Mock<IIdentity> identityMock = new();
-            identityMock.Setup(s => s.Name).Returns(this.userId);
+            identityMock.Setup(s => s.Name).Returns(UserId);
 
             Mock<ClaimsPrincipal> claimsPrincipalMock = new();
             claimsPrincipalMock.Setup(s => s.Identity).Returns(identityMock.Object);
 
             Mock<ConnectionInfo> connectionInfoMock = new();
-            connectionInfoMock.Setup(s => s.RemoteIpAddress).Returns(IPAddress.Parse(this.ipAddress));
+            connectionInfoMock.Setup(s => s.RemoteIpAddress).Returns(IPAddress.Parse(IpAddress));
 
             IHeaderDictionary headerDictionary = new HeaderDictionary
             {
@@ -673,13 +675,13 @@ namespace HealthGateway.MedicationTests.Services
             return httpContextAccessorMock;
         }
 
-        private async Task VerifyProtectiveWordError(
+        private static async Task VerifyProtectiveWordError(
             string keyword,
             string errorMessage,
             IMedicationStatementService service)
         {
             // Run and Verify protective word too long
-            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(this.hdid, keyword);
+            RequestResult<IList<MedicationStatement>> actual = await service.GetMedicationStatementsAsync(Hdid, keyword);
             Assert.Equal(ResultType.ActionRequired, actual.ResultStatus);
             Assert.Equal(ActionType.Protected, actual.ResultError?.ActionCode);
             Assert.Equal(errorMessage, actual.ResultError?.ResultMessage);

--- a/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
@@ -18,7 +18,6 @@ namespace HealthGateway.MedicationTests.Services
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Net;
     using System.Security.Claims;
     using System.Security.Principal;
@@ -540,7 +539,7 @@ namespace HealthGateway.MedicationTests.Services
                     });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
-            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<DrugProduct>());
+            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
 
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();
             RequestResult<MedicationHistoryResponse> requestResult = new()
@@ -549,7 +548,7 @@ namespace HealthGateway.MedicationTests.Services
                 ResourcePayload = medicationHistoryPayloadExists
                     ? new MedicationHistoryResponse
                     {
-                        Results = Enumerable.Empty<MedicationResult>(),
+                        Results = [],
                         TotalRecords = 0,
                     }
                     : null,
@@ -609,7 +608,7 @@ namespace HealthGateway.MedicationTests.Services
                     });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
-            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<DrugProduct>());
+            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
 
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();
             RequestResult<MedicationHistoryResponse> requestResult = new()

--- a/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
+++ b/Apps/Medication/test/unit/Services/MedicationStatementServiceTests.cs
@@ -73,8 +73,7 @@ namespace HealthGateway.MedicationTests.Services
                     {
                         ResourcePayload = Phn,
                         ResultStatus = ResultType.Success,
-                    }
-                );
+                    });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
             drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
@@ -146,8 +145,7 @@ namespace HealthGateway.MedicationTests.Services
                             PersonalHealthNumber = Phn,
                         },
                         ResultStatus = ResultType.Success,
-                    }
-                );
+                    });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
             drugLookupDelegateMock
@@ -271,8 +269,7 @@ namespace HealthGateway.MedicationTests.Services
                             PersonalHealthNumber = Phn,
                         },
                         ResultStatus = ResultType.Success,
-                    }
-                );
+                    });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
 
@@ -367,8 +364,7 @@ namespace HealthGateway.MedicationTests.Services
                             PersonalHealthNumber = Phn,
                         },
                         ResultStatus = ResultType.Success,
-                    }
-                );
+                    });
 
             Mock<IDrugLookupDelegate> drugLookupDelegateMock = new();
 
@@ -460,7 +456,7 @@ namespace HealthGateway.MedicationTests.Services
                 },
             ];
 
-            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<DrugProduct>());
+            drugLookupDelegateMock.Setup(p => p.GetDrugProductsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync([]);
             drugLookupDelegateMock.Setup(p => p.GetPharmaCareDrugsByDinAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(drugList);
 
             Mock<IMedicationStatementDelegate> medStatementDelegateMock = new();

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.Patient.Services
 
         private async Task<IList<PatientDataType>> GetUnblockedPatientDataTypesAsync(string hdid, IEnumerable<PatientDataType> patientDataTypes, CancellationToken ct)
         {
-            List<PatientDataType> unblockedPatientDataTypes = new();
+            List<PatientDataType> unblockedPatientDataTypes = [];
             foreach (PatientDataType patientDataType in patientDataTypes)
             {
                 DataSource dataSource = this.mappingService.MapToDataSource(patientDataType);

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -15,7 +15,6 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.PatientTests.Services
 {
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using FluentValidation;
@@ -196,7 +195,7 @@ namespace HealthGateway.PatientTests.Services
 
         private static IPatientService GetPatientService(PatientModel? patient = null, PatientDetailsQuery? patientDetailsQuery = null)
         {
-            PatientQueryResult patientQueryResult = new(new List<PatientModel> { patient });
+            PatientQueryResult patientQueryResult = new([patient]);
 
             Mock<IPatientRepository> patientRepository = new();
             if (patientDetailsQuery != null)

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -124,33 +124,14 @@ namespace HealthGateway.PatientTests.Services
 
         private static PatientModel? GetPatient(bool commonNameExists = true, bool legalNameExists = true, string? errorMessage = null)
         {
-            switch (errorMessage)
+            return errorMessage switch
             {
-                case ErrorMessages.ClientRegistryReturnedDeceasedPerson:
-                {
-                    return CreatePatient(deceased: true);
-                }
-
-                case ErrorMessages.InvalidServicesCard:
-                {
-                    return commonNameExists == false ? CreatePatient(commonNameExists: false, legalNameExists: false) : CreatePatient(string.Empty, string.Empty);
-                }
-
-                case ErrorMessages.PhnInvalid:
-                {
-                    return CreatePatient();
-                }
-
-                case ErrorMessages.ClientRegistryRecordsNotFound:
-                {
-                    return null;
-                }
-
-                default:
-                {
-                    return CreatePatient(commonNameExists: commonNameExists, legalNameExists: legalNameExists);
-                }
-            }
+                ErrorMessages.ClientRegistryReturnedDeceasedPerson => CreatePatient(deceased: true),
+                ErrorMessages.InvalidServicesCard => commonNameExists == false ? CreatePatient(commonNameExists: false, legalNameExists: false) : CreatePatient(string.Empty, string.Empty),
+                ErrorMessages.PhnInvalid => CreatePatient(),
+                ErrorMessages.ClientRegistryRecordsNotFound => null,
+                _ => CreatePatient(commonNameExists: commonNameExists, legalNameExists: legalNameExists),
+            };
 
             static PatientModel CreatePatient(string hdid = Hdid, string phn = Phn, bool commonNameExists = true, bool legalNameExists = true, bool deceased = false)
             {


### PR DESCRIPTION
# Implements [AB#16663](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16663)

## Description

Increase code coverage for Patient. Note discussed with @MikeLyttle  ignored IPatientDataService records
Increate code coverage for Medication
Fixed sonar cloud code smells for Patient
Fixed sonar cloud code smells for Medication

Patient: https://sonarcloud.io/code?id=bcgov_healthgateway&selected=bcgov_healthgateway%3AApps%2FPatient
Medication: https://sonarcloud.io/code?id=bcgov_healthgateway&selected=bcgov_healthgateway%3AApps%2FMedication

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
