### PR TITLE
Update test to download attachments from specific card AB#16701

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/diagnosticImaging.js
@@ -63,7 +63,8 @@ describe("Diagnostic Imaging", () => {
     });
 
     it("Validate file download", () => {
-        cy.get("[data-testid=timelineCard")
+        cy.contains("[data-testid=entryCardDate]", "2022-Oct-08")
+            .parents("[data-testid=timelineCard]")
             .filter(":has([data-testid=attachment-button])")
             .first()
             .within(() => {
@@ -74,7 +75,8 @@ describe("Diagnostic Imaging", () => {
     });
 
     it("Validate attachment download", () => {
-        cy.get("[data-testid=timelineCard")
+        cy.contains("[data-testid=entryCardDate]", "2022-Oct-08")
+            .parents("[data-testid=timelineCard]")
             .filter(":has([data-testid=attachment-button])")
             .first()
             .within(() => {


### PR DESCRIPTION
# Fixes [AB#16701](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16701)

## Description

Updates diagnostic imaging file download tests to target a record that is known to have a valid attachment, since new records have been added which do not have valid attachments associated with them.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
