### PR TITLE
Show exception for print vaccine card in patient details admin for AB#16703.

### DIFF
--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor
@@ -4,6 +4,7 @@
 @using HealthGateway.Admin.Client.Components.Details
 @using HealthGateway.Admin.Client.Store.PatientDetails
 @using HealthGateway.Admin.Client.Store.PatientSupport
+@using HealthGateway.Admin.Client.Store.VaccineCard
 @inherits Fluxor.Blazor.Web.Components.FluxorComponent
 
 <PageTitle>Health Gateway Admin Patient Details</PageTitle>
@@ -30,6 +31,15 @@
     DataTestId="user-banner-feedback-error-message"
     Class="mb-4">
     @PatientSupportState.Value.Error?.Message
+</HgBannerFeedback>
+
+<HgBannerFeedback
+    Severity="Severity.Error"
+    IsEnabled="HasPrintVaccineCardError"
+    TResetAction="VaccineCardActions.ResetStateAction"
+    DataTestId="user-banner-print-vaccine-card-error-message"
+    Class="mb-4">
+    @VaccineCardState.Value.PrintVaccineCard.Error?.Message
 </HgBannerFeedback>
 
 <HgBannerFeedback

--- a/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/PatientDetailsPage.razor.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Admin.Client.Pages
     using HealthGateway.Admin.Client.Authorization;
     using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Client.Store.PatientSupport;
+    using HealthGateway.Admin.Client.Store.VaccineCard;
     using HealthGateway.Admin.Client.Utils;
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Admin.Common.Models;
@@ -48,6 +49,9 @@ namespace HealthGateway.Admin.Client.Pages
         private IState<PatientSupportState> PatientSupportState { get; set; } = default!;
 
         [Inject]
+        private IState<VaccineCardState> VaccineCardState { get; set; } = default!;
+
+        [Inject]
         private NavigationManager NavigationManager { get; set; } = default!;
 
         [Inject]
@@ -58,6 +62,8 @@ namespace HealthGateway.Admin.Client.Pages
         private bool HasPatientSupportDetailsError => this.PatientDetailsState.Value.Error is { Message.Length: > 0 };
 
         private bool HasPatientsError => this.PatientSupportState.Value.Error is { Message.Length: > 0 };
+
+        private bool HasPrintVaccineCardError => this.VaccineCardState.Value.PrintVaccineCard.Error is { Message.Length: > 0 };
 
         private bool HasPatientsWarning => this.PatientSupportState.Value.WarningMessages.Any();
 

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
@@ -216,6 +216,20 @@ describe("Patient details as admin", () => {
             .should("be.visible")
             .click();
     });
+
+    it("Verify print vaccine card shows error message", () => {
+        cy.intercept("GET", `**/Document?phn=${phn}`, {
+            statusCode: 500,
+        });
+    
+        performSearch("PHN", phn);
+        selectPatientTab("Profile");
+        cy.scrollTo("bottom", { ensureScrollable: false });
+        cy.get("[data-testid=print-button]").should("be.visible").click();
+        cy.scrollTo("top", { ensureScrollable: false });
+        cy.get("[data-testid=user-banner-print-vaccine-card-error-message]")
+            .should("be.visible");
+    });
 });
 
 describe("Patient details as support", () => {


### PR DESCRIPTION
# Fixes [AB#16703](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16703)

## Description

- When exception occurs while printing vaccine card, show exception message to user.
- Added functional test.

**Error Message:**

<img width="1393" alt="Screenshot 2024-03-19 at 4 00 34 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/ddc50f7e-2e23-44b1-adcd-dd2bda14d55e">

**Functional Test:**

<img width="2515" alt="Screenshot 2024-03-20 at 11 08 05 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/80d18913-d151-4757-998c-91272e541c7c">

<img width="1013" alt="Screenshot 2024-03-20 at 11 10 24 AM" src="https://github.com/bcgov/healthgateway/assets/58790456/cf8e9b72-214d-4ed2-913c-f9e8df09d671">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

Yes

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
