### PR TITLE
Add coverage to remaining admin services for AB#16674.

### DIFF
--- a/Apps/Admin/Server/Services/UserFeedbackService.cs
+++ b/Apps/Admin/Server/Services/UserFeedbackService.cs
@@ -187,7 +187,7 @@ namespace HealthGateway.Admin.Server.Services
                 if (savedUserFeedbackResult.Status == DbStatusCode.Updated)
                 {
                     string email = await this.GetUserEmailAsync(userFeedback.UserProfileId, ct);
-                    result.ResourcePayload = mappingService.MapToUserFeedbackView(userFeedback, email);
+                    result.ResourcePayload = mappingService.MapToUserFeedbackView(savedUserFeedbackResult.Payload, email);
                     result.ResultStatus = ResultType.Success;
                 }
                 else

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -224,10 +224,10 @@ namespace HealthGateway.Admin.Tests.Services
             return new(service, expected);
         }
 
-        private record GetProtectedDependentReportMock(IAdminReportService Service, IList<string> ExpectedHdids, IList<string> ExpectedPhns);
+        private sealed record GetProtectedDependentReportMock(IAdminReportService Service, IList<string> ExpectedHdids, IList<string> ExpectedPhns);
 
-        private record GetProtectedDependentReportHandlesExceptionMock(IAdminReportService Service, IList<string> ExpectedHdids);
+        private sealed record GetProtectedDependentReportHandlesExceptionMock(IAdminReportService Service, IList<string> ExpectedHdids);
 
-        private record GetBlockedAccessReportMock(IAdminReportService Service, HashSet<DataSource> Expected);
+        private sealed record GetBlockedAccessReportMock(IAdminReportService Service, HashSet<DataSource> Expected);
     }
 }

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -127,8 +127,6 @@ namespace HealthGateway.Admin.Tests.Services
                 Hdid2,
             ];
 
-            (IList<string> hdidList, int hdidCount) = (hdids, hdids.Count);
-
             Mock<IDelegationDelegate> delegationDelegateMock = new();
             delegationDelegateMock.Setup(
                     s => s.GetProtectedDependentHdidsAsync(
@@ -136,7 +134,7 @@ namespace HealthGateway.Admin.Tests.Services
                         It.IsAny<int>(),
                         It.IsAny<SortDirection>(),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int _, int _, SortDirection _, CancellationToken _) => (hdidList, hdidCount));
+                .ReturnsAsync((int _, int _, SortDirection _, CancellationToken _) => (hdids, hdids.Count));
 
             PatientQuery query1 = new PatientDetailsQuery(Hdid: Hdid1, Source: PatientDetailSource.All);
             PatientQuery query2 = new PatientDetailsQuery(Hdid: Hdid2, Source: PatientDetailSource.All);
@@ -177,8 +175,6 @@ namespace HealthGateway.Admin.Tests.Services
                 Hdid2,
             ];
 
-            (IList<string> hdidList, int hdidCount) = (hdids, hdids.Count);
-
             Mock<IDelegationDelegate> delegationDelegateMock = new();
             delegationDelegateMock.Setup(
                     s => s.GetProtectedDependentHdidsAsync(
@@ -186,7 +182,7 @@ namespace HealthGateway.Admin.Tests.Services
                         It.IsAny<int>(),
                         It.IsAny<SortDirection>(),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync((int _, int _, SortDirection _, CancellationToken _) => (hdidList, hdidCount));
+                .ReturnsAsync((int _, int _, SortDirection _, CancellationToken _) => (hdids, hdids.Count));
 
             PatientQuery query1 = new PatientDetailsQuery(Hdid: Hdid1, Source: PatientDetailSource.All);
             PatientQuery query2 = new PatientDetailsQuery(Hdid: Hdid2, Source: PatientDetailSource.All);

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -1,0 +1,233 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Services
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using HealthGateway.AccountDataAccess.Patient;
+    using HealthGateway.Admin.Common.Models.AdminReports;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using Moq;
+    using Serilog;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the AdminReportService class.
+    /// </summary>
+    public class AdminReportServiceTests
+    {
+        private const string Hdid1 = "DEV4FPEGCXG2NB5K2USBL52S66SC3GOUHWRP3GTXR2BTY5HEC4YA";
+        private const string Hdid2 = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
+        private const string Phn1 = "9735350000";
+        private const string Phn2 = "9735360000";
+
+        /// <summary>
+        /// GetProtectedDependentsReportAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetProtectedDependentsReport()
+        {
+            // Arrange
+            GetProtectedDependentReportMock mock = SetupGetProtectedDependentReportMock();
+
+            // Act
+            ProtectedDependentReport actual = await mock.Service.GetProtectedDependentsReportAsync(0, 25, SortDirection.Ascending);
+
+            // Assert
+            Assert.Equal(mock.ExpectedHdids.Count, actual.Records.Count);
+            Assert.Equal(mock.ExpectedHdids[0], actual.Records[0].Hdid);
+            Assert.Equal(mock.ExpectedPhns[0], actual.Records[0].Phn);
+            Assert.Equal(mock.ExpectedHdids[1], actual.Records[1].Hdid);
+            Assert.Equal(mock.ExpectedPhns[1], actual.Records[1].Phn);
+        }
+
+        /// <summary>
+        /// GetProtectedDependentsReportAsync handles not found exception.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetProtectedDependentsReportHandlesException()
+        {
+            // Arrange
+            GetProtectedDependentReportHandlesExceptionMock mock = SetupGetProtectedDependentReportHandlesExceptionMock();
+
+            // Act
+            ProtectedDependentReport actual = await mock.Service.GetProtectedDependentsReportAsync(0, 25, SortDirection.Ascending);
+
+            // Assert
+            Assert.Equal(mock.ExpectedHdids.Count, actual.Records.Count);
+            Assert.Equal(mock.ExpectedHdids[0], actual.Records[0].Hdid);
+            Assert.Null(actual.Records[0].Phn); // NotFoundException occurred so cannot get PHN
+            Assert.Equal(mock.ExpectedHdids[1], actual.Records[1].Hdid);
+            Assert.Null(actual.Records[1].Phn); // NotFoundException occurred so cannot get PHN
+        }
+
+        /// <summary>
+        /// GetBlockedAccessReportAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetBlockedAccessReport()
+        {
+            // Arrange
+            GetBlockedAccessReportMock mock = SetupGetBlockedAccessReportMock();
+
+            // Act
+            IEnumerable<BlockedAccessRecord> enumerable = await mock.Service.GetBlockedAccessReportAsync();
+            IEnumerable<BlockedAccessRecord> actual = enumerable.ToList();
+
+            // Assert
+            Assert.Single(actual);
+            Assert.Equal(Hdid1, actual.First().Hdid);
+            mock.Expected.ShouldDeepEqual(actual.First().BlockedSources);
+        }
+
+        private static IAdminReportService GetAdminReportService(
+            Mock<IDelegationDelegate>? delegationDelegateMock = null,
+            Mock<IBlockedAccessDelegate>? blockedAccessDelegateMock = null,
+            Mock<IPatientRepository>? patientRepositoryMock = null)
+        {
+            delegationDelegateMock = delegationDelegateMock ?? new();
+            blockedAccessDelegateMock = blockedAccessDelegateMock ?? new();
+            patientRepositoryMock = patientRepositoryMock ?? new();
+
+            return new AdminReportService(
+                delegationDelegateMock.Object,
+                blockedAccessDelegateMock.Object,
+                patientRepositoryMock.Object,
+                new Mock<ILogger>().Object);
+        }
+
+        private static GetProtectedDependentReportMock SetupGetProtectedDependentReportMock()
+        {
+            IList<string> hdids =
+            [
+                Hdid1,
+                Hdid2,
+            ];
+
+            (IList<string> hdidList, int hdidCount) = (hdids, hdids.Count);
+
+            Mock<IDelegationDelegate> delegationDelegateMock = new();
+            delegationDelegateMock.Setup(
+                    s => s.GetProtectedDependentHdidsAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<int>(),
+                        It.IsAny<SortDirection>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int _, int _, SortDirection _, CancellationToken _) => (hdidList, hdidCount));
+
+            PatientQuery query1 = new PatientDetailsQuery(Hdid: Hdid1, Source: PatientDetailSource.All);
+            PatientQuery query2 = new PatientDetailsQuery(Hdid: Hdid2, Source: PatientDetailSource.All);
+
+            PatientModel patient1 = new()
+            {
+                Hdid = Hdid1,
+                Phn = Phn1,
+            };
+
+            PatientModel patient2 = new()
+            {
+                Hdid = Hdid2,
+                Phn = Phn2,
+            };
+
+            IList<string> expectedPhns =
+            [
+                Phn1, Phn2,
+            ];
+
+            PatientQueryResult patientQueryResult1 = new([patient1]);
+            PatientQueryResult patientQueryResult2 = new([patient2]);
+
+            Mock<IPatientRepository> patientRepositoryMock = new();
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query1), It.IsAny<CancellationToken>())).ReturnsAsync(patientQueryResult1);
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query2), It.IsAny<CancellationToken>())).ReturnsAsync(patientQueryResult2);
+
+            IAdminReportService service = GetAdminReportService(delegationDelegateMock, patientRepositoryMock: patientRepositoryMock);
+            return new(service, hdids, expectedPhns);
+        }
+
+        private static GetProtectedDependentReportHandlesExceptionMock SetupGetProtectedDependentReportHandlesExceptionMock()
+        {
+            IList<string> hdids =
+            [
+                Hdid1,
+                Hdid2,
+            ];
+
+            (IList<string> hdidList, int hdidCount) = (hdids, hdids.Count);
+
+            Mock<IDelegationDelegate> delegationDelegateMock = new();
+            delegationDelegateMock.Setup(
+                    s => s.GetProtectedDependentHdidsAsync(
+                        It.IsAny<int>(),
+                        It.IsAny<int>(),
+                        It.IsAny<SortDirection>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync((int _, int _, SortDirection _, CancellationToken _) => (hdidList, hdidCount));
+
+            PatientQuery query1 = new PatientDetailsQuery(Hdid: Hdid1, Source: PatientDetailSource.All);
+            PatientQuery query2 = new PatientDetailsQuery(Hdid: Hdid2, Source: PatientDetailSource.All);
+
+            Mock<IPatientRepository> patientRepositoryMock = new();
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query1), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query2), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
+
+            IAdminReportService service = GetAdminReportService(delegationDelegateMock, patientRepositoryMock: patientRepositoryMock);
+            return new(service, hdids);
+        }
+
+        private static GetBlockedAccessReportMock SetupGetBlockedAccessReportMock()
+        {
+            HashSet<DataSource> expected =
+            [
+                DataSource.Immunization,
+                DataSource.Medication,
+                DataSource.Note,
+            ];
+
+            IList<BlockedAccess> records =
+            [
+                new()
+                {
+                    Hdid = Hdid1,
+                    DataSources = expected,
+                },
+            ];
+
+            Mock<IBlockedAccessDelegate> blockedAccessDelegateMock = new();
+            blockedAccessDelegateMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(records);
+
+            IAdminReportService service = GetAdminReportService(blockedAccessDelegateMock: blockedAccessDelegateMock);
+            return new(service, expected);
+        }
+
+        private record GetProtectedDependentReportMock(IAdminReportService Service, IList<string> ExpectedHdids, IList<string> ExpectedPhns);
+
+        private record GetProtectedDependentReportHandlesExceptionMock(IAdminReportService Service, IList<string> ExpectedHdids);
+
+        private record GetBlockedAccessReportMock(IAdminReportService Service, HashSet<DataSource> Expected);
+    }
+}

--- a/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
@@ -368,9 +368,9 @@ namespace HealthGateway.Admin.Tests.Services
             return new(service, expected, adminAgent);
         }
 
-        private record GetAgentsMock(IAgentAccessService Service, AdminAgent Expected, string SearchString);
+        private sealed record GetAgentsMock(IAgentAccessService Service, AdminAgent Expected, string SearchString);
 
-        private record ProvisionAgentAccessMock(
+        private sealed record ProvisionAgentAccessMock(
             IAgentAccessService Service,
             Mock<IKeycloakAdminApi> KeycloakAdminApiMock,
             AdminAgent Expected,
@@ -379,12 +379,12 @@ namespace HealthGateway.Admin.Tests.Services
             Guid AgentId,
             string Username);
 
-        private record ProvisionAgentAccessThrowsExceptionMock(
+        private sealed record ProvisionAgentAccessThrowsExceptionMock(
             IAgentAccessService Service,
             string ExpectedErrorMessage,
             AdminAgent AdminAgent);
 
-        private record UpdateAgentAccessMock(
+        private sealed record UpdateAgentAccessMock(
             IAgentAccessService Service,
             AdminAgent Expected,
             AdminAgent AdminAgent);

--- a/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
@@ -1,0 +1,392 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using HealthGateway.Admin.Common.Constants;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Admin.Tests.Utils;
+    using HealthGateway.Common.AccessManagement.Administration.Models;
+    using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.AccessManagement.Authentication.Models;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.Utils;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Refit;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the AgentAccessService class.
+    /// </summary>
+    public class AgentAccessServiceTests
+    {
+        private const string IdentityProviderName = "idir";
+
+        private static readonly string AdminAnalystRoleId = Guid.NewGuid().ToString();
+        private static readonly string AdminReviewerRoleId = Guid.NewGuid().ToString();
+        private static readonly string AdminUserRoleId = Guid.NewGuid().ToString();
+        private static readonly KeycloakIdentityProvider IdentityProvider = EnumUtility.ToEnumOrDefault<KeycloakIdentityProvider>(IdentityProviderName, true);
+
+        /// <summary>
+        /// GetAgentsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetAgents()
+        {
+            // Arrange
+            GetAgentsMock mock = SetupGetAgentsMock();
+
+            // Act
+            IEnumerable<AdminAgent> adminAgents = await mock.Service.GetAgentsAsync(mock.SearchString);
+            IEnumerable<AdminAgent> actual = adminAgents.ToList();
+
+            // Assert
+            Assert.Single(actual);
+            mock.Expected.ShouldDeepEqual(actual.First());
+        }
+
+        /// <summary>
+        /// ProvisionAgentAccessAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldProvisionAgentAccess()
+        {
+            // Arrange
+            ProvisionAgentAccessMock mock = SetupProvisionAgentAccessMock();
+
+            // Act
+            AdminAgent actual = await mock.Service.ProvisionAgentAccessAsync(mock.AdminAgent);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+            mock.KeycloakAdminApiMock.Verify(
+                v => v.AddUserAsync(
+                    It.Is<UserRepresentation>(x => x.Username == mock.Username),
+                    mock.Jwt.AccessToken,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+            mock.KeycloakAdminApiMock.Verify(
+                v => v.AddUserRolesAsync(
+                    It.Is<Guid>(x => x == mock.AgentId),
+                    It.Is<IEnumerable<RoleRepresentation>>(x => x.Any(y => y.Name == IdentityAccessRole.AdminReviewer.ToString())),
+                    mock.Jwt.AccessToken,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// ProvisionAgentAccessAsync.
+        /// </summary>
+        /// <param name="expectedExceptionType">The exception type to be thrown.</param>
+        /// <param name="expectedErrorMessage">The associated error message for the exception.</param>
+        /// <param name="httpStatusCode">The http status code to return for keycloak add user async call.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(typeof(AlreadyExistsException), ErrorMessages.KeycloakUserAlreadyExists, HttpStatusCode.Conflict)]
+        [InlineData(typeof(InvalidDataException), "Username admin is not in the expected format", HttpStatusCode.OK)]
+        [InlineData(typeof(ApiException), "Unknown Error.", HttpStatusCode.BadRequest)]
+        public async Task ProvisionAgentAccessThrowsException(Type expectedExceptionType, string expectedErrorMessage, HttpStatusCode httpStatusCode)
+        {
+            // Arrange
+            ProvisionAgentAccessThrowsExceptionMock mock = await SetupProvisionAgentAccessThrowsExceptionMock(httpStatusCode, expectedErrorMessage);
+
+            // Act & Verify
+            Exception exception = await Assert.ThrowsAsync(
+                expectedExceptionType,
+                async () => { await mock.Service.ProvisionAgentAccessAsync(mock.AdminAgent); });
+
+            // Assert
+            Assert.Equal(mock.ExpectedErrorMessage, exception.Message);
+        }
+
+        /// <summary>
+        /// RemoveAgentAccessAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldRemoveAgentAccess()
+        {
+            // Arrange
+            Guid agentId = Guid.NewGuid();
+            JwtModel jwt = GenerateJwt();
+
+            Mock<IAuthenticationDelegate> authenticationDelegateMock = new();
+            authenticationDelegateMock.Setup(s => s.AuthenticateAsSystemAsync(It.IsAny<ClientCredentialsRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(jwt);
+
+            Mock<IKeycloakAdminApi> keycloakAdminApiMock = new();
+            IAgentAccessService service = GetAgentAccessService(authenticationDelegateMock, keycloakAdminApiMock);
+
+            // Act
+            await service.RemoveAgentAccessAsync(agentId);
+
+            // Assert
+            keycloakAdminApiMock.Verify(
+                v => v.DeleteUserAsync(
+                    It.Is<Guid>(x => x == agentId),
+                    jwt.AccessToken,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// UpdateAgentAccessAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldUpdateAgentAccess()
+        {
+            // Arrange
+            UpdateAgentAccessMock mock = SetupUpdateAgentAccessMock();
+
+            // Act
+            AdminAgent actual = await mock.Service.UpdateAgentAccessAsync(mock.AdminAgent);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        private static AdminAgent GenerateAdminAgent(Guid id, string username, ISet<IdentityAccessRole> roles)
+        {
+            return new()
+            {
+                Id = id,
+                Username = username,
+                Roles = roles,
+                IdentityProvider = IdentityProvider,
+            };
+        }
+
+        private static JwtModel GenerateJwt()
+        {
+            return new()
+            {
+                AccessToken = "AccessToken",
+            };
+        }
+
+        private static RoleRepresentation GenerateRoleRepresentation(string id, string name)
+        {
+            return new()
+            {
+                Id = id,
+                Name = name,
+            };
+        }
+
+        private static UserRepresentation GenerateUserRepresentation(Guid userId, string username, string? role = null)
+        {
+            return new()
+            {
+                Username = username,
+                UserId = userId,
+                RealmRoles = role,
+                Enabled = true,
+            };
+        }
+
+        private static IAgentAccessService GetAgentAccessService(
+            Mock<IAuthenticationDelegate>? authenticationDelegateMock = null,
+            Mock<IKeycloakAdminApi>? keycloakAdminApiMock = null)
+        {
+            authenticationDelegateMock = authenticationDelegateMock ?? new();
+            keycloakAdminApiMock = keycloakAdminApiMock ?? new();
+
+            return new AgentAccessService(
+                authenticationDelegateMock.Object,
+                keycloakAdminApiMock.Object,
+                new Mock<ILogger<AgentAccessService>>().Object);
+        }
+
+        private static GetAgentsMock SetupGetAgentsMock()
+        {
+            const string searchString = "admin";
+            const string agentName1 = "admin@idir";
+            const string agentName2 = "admin";
+            Guid agentId1 = Guid.NewGuid();
+            Guid agentId2 = Guid.NewGuid();
+            ISet<IdentityAccessRole> roles = new HashSet<IdentityAccessRole> { IdentityAccessRole.AdminUser };
+            AdminAgent expected = GenerateAdminAgent(agentId1, searchString, roles);
+
+            List<UserRepresentation> users =
+            [
+                GenerateUserRepresentation(agentId1, agentName1, IdentityAccessRole.AdminUser.ToString()),
+                GenerateUserRepresentation(agentId2, agentName2, IdentityAccessRole.AdminUser.ToString()),
+            ];
+
+            List<RoleRepresentation> userRoles =
+            [
+                GenerateRoleRepresentation(AdminUserRoleId, IdentityAccessRole.AdminUser.ToString()),
+            ];
+
+            JwtModel jwt = GenerateJwt();
+
+            Mock<IAuthenticationDelegate> authenticationDelegateMock = new();
+            authenticationDelegateMock.Setup(s => s.AuthenticateAsSystemAsync(It.IsAny<ClientCredentialsRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(jwt);
+
+            Mock<IKeycloakAdminApi> keycloakAdminApiMock = new();
+            keycloakAdminApiMock.Setup(s => s.GetUsersSearchAsync(searchString, It.IsAny<int>(), It.IsAny<int>(), jwt.AccessToken, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(users);
+            keycloakAdminApiMock.Setup(s => s.GetUserRolesAsync(agentId1, jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(userRoles);
+
+            IAgentAccessService service = GetAgentAccessService(authenticationDelegateMock, keycloakAdminApiMock);
+            return new(service, expected, searchString);
+        }
+
+        private static ProvisionAgentAccessMock SetupProvisionAgentAccessMock()
+        {
+            const string agentUsername = "admin";
+            string username = agentUsername + "@" + EnumUtility.ToEnumString(IdentityProvider, true);
+            Guid agentId = Guid.NewGuid();
+            ISet<IdentityAccessRole> roles = new HashSet<IdentityAccessRole> { IdentityAccessRole.AdminReviewer };
+            AdminAgent adminAgent = GenerateAdminAgent(agentId, agentUsername, roles);
+            AdminAgent expected = GenerateAdminAgent(agentId, agentUsername, roles);
+
+            List<RoleRepresentation> realmRoles =
+            [
+                GenerateRoleRepresentation(AdminUserRoleId, IdentityAccessRole.AdminUser.ToString()),
+                GenerateRoleRepresentation(AdminReviewerRoleId, IdentityAccessRole.AdminReviewer.ToString()),
+            ];
+
+            List<UserRepresentation> users =
+            [
+                GenerateUserRepresentation(agentId, username),
+            ];
+
+            JwtModel jwt = GenerateJwt();
+
+            Mock<IAuthenticationDelegate> authenticationDelegateMock = new();
+            authenticationDelegateMock.Setup(s => s.AuthenticateAsSystemAsync(It.IsAny<ClientCredentialsRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(jwt);
+
+            Mock<IKeycloakAdminApi> keycloakAdminApiMock = new();
+            keycloakAdminApiMock.Setup(s => s.GetRealmRolesAsync(jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(realmRoles);
+            keycloakAdminApiMock.Setup(s => s.GetUsersByUsernameAsync(username, jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(users);
+
+            IAgentAccessService service = GetAgentAccessService(authenticationDelegateMock, keycloakAdminApiMock);
+            return new(service, keycloakAdminApiMock, expected, adminAgent, jwt, agentId, username);
+        }
+
+        private static async Task<ProvisionAgentAccessThrowsExceptionMock> SetupProvisionAgentAccessThrowsExceptionMock(HttpStatusCode httpStatusCode, string expectedErrorMessage)
+        {
+            const string agentUsername = "admin";
+            string username = agentUsername + "@" + EnumUtility.ToEnumString(IdentityProvider, true);
+            Guid agentId = Guid.NewGuid();
+            ISet<IdentityAccessRole> roles = new HashSet<IdentityAccessRole> { IdentityAccessRole.AdminReviewer };
+            AdminAgent adminAgent = GenerateAdminAgent(agentId, agentUsername, roles);
+
+            List<RoleRepresentation> realmRoles =
+            [
+                GenerateRoleRepresentation(AdminUserRoleId, IdentityAccessRole.AdminUser.ToString()),
+                GenerateRoleRepresentation(AdminReviewerRoleId, IdentityAccessRole.AdminReviewer.ToString()),
+            ];
+
+            List<UserRepresentation> users =
+            [
+                GenerateUserRepresentation(agentId, agentUsername), // agentUsername is an invalid username as there is no @ and Identity Provider
+            ];
+
+            JwtModel jwt = GenerateJwt();
+
+            Mock<IAuthenticationDelegate> authenticationDelegateMock = new();
+            authenticationDelegateMock.Setup(s => s.AuthenticateAsSystemAsync(It.IsAny<ClientCredentialsRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(jwt);
+
+            Mock<IKeycloakAdminApi> keycloakAdminApiMock = new();
+            keycloakAdminApiMock.Setup(s => s.GetRealmRolesAsync(jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(realmRoles);
+            keycloakAdminApiMock.Setup(s => s.GetUsersByUsernameAsync(username, jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(users);
+
+            if (httpStatusCode != HttpStatusCode.OK)
+            {
+                Exception apiException = await RefitExceptionUtil.CreateApiException(httpStatusCode, expectedErrorMessage);
+
+                keycloakAdminApiMock.Setup(
+                        s =>
+                            s.AddUserAsync(
+                                It.Is<UserRepresentation>(x => x.Username == username),
+                                jwt.AccessToken,
+                                It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(apiException);
+            }
+
+            IAgentAccessService service = GetAgentAccessService(authenticationDelegateMock, keycloakAdminApiMock);
+            return new(service, expectedErrorMessage, adminAgent);
+        }
+
+        private static UpdateAgentAccessMock SetupUpdateAgentAccessMock()
+        {
+            const string agentUsername1 = "admin";
+            Guid agentId1 = Guid.NewGuid();
+            ISet<IdentityAccessRole> roles = new HashSet<IdentityAccessRole> { IdentityAccessRole.AdminReviewer, IdentityAccessRole.AdminAnalyst };
+            AdminAgent adminAgent = GenerateAdminAgent(agentId1, agentUsername1, roles);
+            AdminAgent expected = GenerateAdminAgent(agentId1, agentUsername1, roles);
+
+            List<RoleRepresentation> realmRoles =
+            [
+                GenerateRoleRepresentation(AdminUserRoleId, IdentityAccessRole.AdminUser.ToString()),
+                GenerateRoleRepresentation(AdminAnalystRoleId, IdentityAccessRole.AdminAnalyst.ToString()),
+                GenerateRoleRepresentation(AdminReviewerRoleId, IdentityAccessRole.AdminReviewer.ToString()),
+            ];
+
+            List<RoleRepresentation> userRoles =
+            [
+                GenerateRoleRepresentation(AdminUserRoleId, IdentityAccessRole.AdminUser.ToString()),
+            ];
+
+            JwtModel jwt = GenerateJwt();
+
+            Mock<IAuthenticationDelegate> authenticationDelegateMock = new();
+            authenticationDelegateMock.Setup(s => s.AuthenticateAsSystemAsync(It.IsAny<ClientCredentialsRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(jwt);
+
+            Mock<IKeycloakAdminApi> keycloakAdminApiMock = new();
+            keycloakAdminApiMock.Setup(s => s.GetRealmRolesAsync(jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(realmRoles);
+            keycloakAdminApiMock.Setup(s => s.GetUserRolesAsync(agentId1, jwt.AccessToken, It.IsAny<CancellationToken>())).ReturnsAsync(userRoles);
+
+            IAgentAccessService service = GetAgentAccessService(authenticationDelegateMock, keycloakAdminApiMock);
+            return new(service, expected, adminAgent);
+        }
+
+        private record GetAgentsMock(IAgentAccessService Service, AdminAgent Expected, string SearchString);
+
+        private record ProvisionAgentAccessMock(
+            IAgentAccessService Service,
+            Mock<IKeycloakAdminApi> KeycloakAdminApiMock,
+            AdminAgent Expected,
+            AdminAgent AdminAgent,
+            JwtModel Jwt,
+            Guid AgentId,
+            string Username);
+
+        private record ProvisionAgentAccessThrowsExceptionMock(
+            IAgentAccessService Service,
+            string ExpectedErrorMessage,
+            AdminAgent AdminAgent);
+
+        private record UpdateAgentAccessMock(
+            IAgentAccessService Service,
+            AdminAgent Expected,
+            AdminAgent AdminAgent);
+    }
+}

--- a/Apps/Admin/Tests/Services/DashboardServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DashboardServiceTests.cs
@@ -156,9 +156,9 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IUserProfileDelegate>? userProfileDelegateMock = null,
             Mock<IRatingDelegate>? ratingDelegateMock = null)
         {
-            dependentDelegateMock = dependentDelegateMock ?? new();
-            userProfileDelegateMock = userProfileDelegateMock ?? new();
-            ratingDelegateMock = ratingDelegateMock ?? new();
+            dependentDelegateMock ??= new();
+            userProfileDelegateMock ??= new();
+            ratingDelegateMock ??= new();
 
             return new DashboardService(
                 Configuration,

--- a/Apps/Admin/Tests/Services/DashboardServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DashboardServiceTests.cs
@@ -324,16 +324,16 @@ namespace HealthGateway.Admin.Tests.Services
             return new(service, expected, startDate, endDate);
         }
 
-        private record GetAllTimeCountsMock(IDashboardService Service, AllTimeCounts Expected);
+        private sealed record GetAllTimeCountsMock(IDashboardService Service, AllTimeCounts Expected);
 
-        private record GetDailyUsageCountsMock(IDashboardService Service, DailyUsageCounts Expected, DateOnly StartDate, DateOnly EndDate);
+        private sealed record GetDailyUsageCountsMock(IDashboardService Service, DailyUsageCounts Expected, DateOnly StartDate, DateOnly EndDate);
 
-        private record GetRecurringUserCountMock(IDashboardService Service, int Expected, DateOnly StartDate, DateOnly EndDate, int DayCount);
+        private sealed record GetRecurringUserCountMock(IDashboardService Service, int Expected, DateOnly StartDate, DateOnly EndDate, int DayCount);
 
-        private record GetAgeCountsMock(IDashboardService Service, IDictionary<int, int> Expected, DateOnly StartDate, DateOnly EndDate);
+        private sealed record GetAgeCountsMock(IDashboardService Service, IDictionary<int, int> Expected, DateOnly StartDate, DateOnly EndDate);
 
-        private record GetAppLoginCountsMock(IDashboardService Service, AppLoginCounts Expected, DateOnly StartDate, DateOnly EndDate);
+        private sealed record GetAppLoginCountsMock(IDashboardService Service, AppLoginCounts Expected, DateOnly StartDate, DateOnly EndDate);
 
-        private record GetRatingsSummaryMock(IDashboardService Service, IDictionary<string, int> Expected, DateOnly StartDate, DateOnly EndDate);
+        private sealed record GetRatingsSummaryMock(IDashboardService Service, IDictionary<string, int> Expected, DateOnly StartDate, DateOnly EndDate);
     }
 }

--- a/Apps/Admin/Tests/Services/DashboardServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DashboardServiceTests.cs
@@ -1,0 +1,339 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Database.Delegates;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the DashboardService class.
+    /// </summary>
+    public class DashboardServiceTests
+    {
+        private static readonly IConfiguration Configuration = GetIConfigurationRoot();
+
+        /// <summary>
+        /// GetAllTimeCountsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetAllTimeCounts()
+        {
+            // Arrange
+            GetAllTimeCountsMock mock = SetupGetAllTimeCountsMock();
+
+            // Act
+            AllTimeCounts actual = await mock.Service.GetAllTimeCountsAsync();
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// GetDailyUsageCountsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetDailyUsageCounts()
+        {
+            // Arrange
+            GetDailyUsageCountsMock mock = SetupDailyUsageCountsMock();
+
+            // Act
+            DailyUsageCounts actual = await mock.Service.GetDailyUsageCountsAsync(mock.StartDate, mock.EndDate);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// GetRecurringUserCountAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetRecurringUserCount()
+        {
+            // Arrange
+            GetRecurringUserCountMock mock = SetupGetRecurringUserCountMock();
+
+            // Act
+            int actual = await mock.Service.GetRecurringUserCountAsync(mock.DayCount, mock.StartDate, mock.EndDate);
+
+            // Assert
+            Assert.Equal(mock.Expected, actual);
+        }
+
+        /// <summary>
+        /// GetAppLoginCountsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetAppLoginCounts()
+        {
+            // Arrange
+            GetAppLoginCountsMock mock = SetupGetAppLoginCountsMock();
+
+            // Act
+            AppLoginCounts actual = await mock.Service.GetAppLoginCountsAsync(mock.StartDate, mock.EndDate);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// GetRatingsSummaryAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetRatingsSummary()
+        {
+            // Arrange
+            GetRatingsSummaryMock mock = SetupGetRatingsSummaryMock();
+
+            // Act
+            IDictionary<string, int> actual = await mock.Service.GetRatingsSummaryAsync(mock.StartDate, mock.EndDate);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// GetAgeCountsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetAgeCounts()
+        {
+            // Arrange
+            GetAgeCountsMock mock = SetupGetAgeCountsMock();
+
+            // Act
+            IDictionary<int, int> actual = await mock.Service.GetAgeCountsAsync(mock.StartDate, mock.EndDate);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        private static IConfigurationRoot GetIConfigurationRoot()
+        {
+            Dictionary<string, string?> myConfiguration = new()
+            {
+                { "TimeZone:UnixTimeZoneId", "America/Vancouver" },
+                { "TimeZone:WindowsTimeZoneId", "Pacific Standard Time" },
+            };
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration.ToList())
+                .Build();
+        }
+
+        private static IDashboardService GetDashboardService(
+            Mock<IResourceDelegateDelegate>? dependentDelegateMock = null,
+            Mock<IUserProfileDelegate>? userProfileDelegateMock = null,
+            Mock<IRatingDelegate>? ratingDelegateMock = null)
+        {
+            dependentDelegateMock = dependentDelegateMock ?? new();
+            userProfileDelegateMock = userProfileDelegateMock ?? new();
+            ratingDelegateMock = ratingDelegateMock ?? new();
+
+            return new DashboardService(
+                Configuration,
+                dependentDelegateMock.Object,
+                userProfileDelegateMock.Object,
+                ratingDelegateMock.Object);
+        }
+
+        private static GetAllTimeCountsMock SetupGetAllTimeCountsMock()
+        {
+            const int userProfileCount = 5;
+            const int dependentCount = 2;
+            const int closedUserProfileCount = 2;
+
+            AllTimeCounts expected = new()
+            {
+                RegisteredUsers = userProfileCount,
+                Dependents = dependentCount,
+                ClosedAccounts = closedUserProfileCount,
+            };
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetUserProfileCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(userProfileCount);
+            userProfileDelegateMock.Setup(s => s.GetClosedUserProfileCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(closedUserProfileCount);
+
+            Mock<IResourceDelegateDelegate> dependentDelegateMock = new();
+            dependentDelegateMock.Setup(s => s.GetDependentCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dependentCount);
+
+            IDashboardService service = GetDashboardService(dependentDelegateMock, userProfileDelegateMock);
+            return new(service, expected);
+        }
+
+        private static GetDailyUsageCountsMock SetupDailyUsageCountsMock()
+        {
+            DateOnly endDate = DateOnly.FromDateTime(DateTime.Now);
+            DateOnly startDate = endDate.AddDays(-1);
+
+            const int userRegistrationCount = 5;
+            const int userLoginCount = 2;
+            const int dependentRegistrationCount = 2;
+
+            IDictionary<DateOnly, int> userRegistrationCounts = new Dictionary<DateOnly, int>();
+            userRegistrationCounts.Add(endDate, userRegistrationCount);
+            userRegistrationCounts.Add(startDate, userRegistrationCount);
+
+            IDictionary<DateOnly, int> userLoginCounts = new Dictionary<DateOnly, int>();
+            userLoginCounts.Add(endDate, userLoginCount);
+            userLoginCounts.Add(startDate, userLoginCount);
+
+            IDictionary<DateOnly, int> dependentRegistrationCounts = new Dictionary<DateOnly, int>();
+            dependentRegistrationCounts.Add(endDate, dependentRegistrationCount);
+            dependentRegistrationCounts.Add(startDate, dependentRegistrationCount);
+
+            DailyUsageCounts expected = new()
+            {
+                UserRegistrations = new SortedDictionary<DateOnly, int>(userRegistrationCounts),
+                UserLogins = new SortedDictionary<DateOnly, int>(userLoginCounts),
+                DependentRegistrations = new SortedDictionary<DateOnly, int>(dependentRegistrationCounts),
+            };
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetDailyUserRegistrationCountsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(userRegistrationCounts);
+            userProfileDelegateMock.Setup(s => s.GetDailyUniqueLoginCountsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>())).ReturnsAsync(userLoginCounts);
+
+            Mock<IResourceDelegateDelegate> dependentDelegateMock = new();
+            dependentDelegateMock.Setup(s => s.GetDailyDependentRegistrationCountsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dependentRegistrationCounts);
+
+            IDashboardService service = GetDashboardService(dependentDelegateMock, userProfileDelegateMock);
+            return new(service, expected, startDate, endDate);
+        }
+
+        private static GetRecurringUserCountMock SetupGetRecurringUserCountMock()
+        {
+            DateOnly endDate = DateOnly.FromDateTime(DateTime.Now);
+            DateOnly startDate = endDate.AddDays(-1);
+
+            const int dayCount = 5;
+            const int userCount = 10;
+            const int expected = 10;
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetRecurringUserCountAsync(dayCount, It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(userCount);
+
+            IDashboardService service = GetDashboardService(userProfileDelegateMock: userProfileDelegateMock);
+            return new(service, expected, startDate, endDate, dayCount);
+        }
+
+        private static GetAppLoginCountsMock SetupGetAppLoginCountsMock()
+        {
+            DateOnly endDate = DateOnly.FromDateTime(DateTime.Now);
+            DateOnly startDate = endDate.AddDays(-1);
+
+            const int webCount = 5;
+            const int mobileCount = 2;
+            const int salesforceCount = 2;
+
+            IDictionary<UserLoginClientType, int> lastLoginClientCounts = new Dictionary<UserLoginClientType, int>();
+            lastLoginClientCounts.Add(UserLoginClientType.Web, webCount);
+            lastLoginClientCounts.Add(UserLoginClientType.Mobile, mobileCount);
+            lastLoginClientCounts.Add(UserLoginClientType.Salesforce, salesforceCount);
+
+            AppLoginCounts expected = new(webCount, mobileCount, salesforceCount);
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetLoginClientCountsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(lastLoginClientCounts);
+
+            IDashboardService service = GetDashboardService(userProfileDelegateMock: userProfileDelegateMock);
+            return new(service, expected, startDate, endDate);
+        }
+
+        private static GetRatingsSummaryMock SetupGetRatingsSummaryMock()
+        {
+            DateOnly endDate = DateOnly.FromDateTime(DateTime.Now);
+            DateOnly startDate = endDate.AddDays(-1);
+
+            const int fiveStarCount = 5;
+            const int threeStarCount = 1;
+
+            IDictionary<string, int> summary = new Dictionary<string, int>();
+            summary.Add("3", threeStarCount);
+            summary.Add("5", fiveStarCount);
+
+            IDictionary<string, int> expected = new Dictionary<string, int>();
+            expected.Add("3", threeStarCount);
+            expected.Add("5", fiveStarCount);
+
+            Mock<IRatingDelegate> ratingsDelegateMock = new();
+            ratingsDelegateMock.Setup(s => s.GetRatingsSummaryAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(summary);
+
+            IDashboardService service = GetDashboardService(ratingDelegateMock: ratingsDelegateMock);
+            return new(service, expected, startDate, endDate);
+        }
+
+        private static GetAgeCountsMock SetupGetAgeCountsMock()
+        {
+            DateOnly startDate = new(2010, 1, 15);
+            DateOnly startDatePlus5Years = startDate.AddYears(5);
+            DateOnly endDate = new(2024, 1, 15);
+
+            const int startDateAge = 14;
+            const int startDatePlus5YearsAge = 9;
+            const int startDateAgeCount = 5;
+            const int startDatePlus5YearsAgeCount = 1;
+
+            IDictionary<int, int> yearOfBirthCounts = new Dictionary<int, int>();
+            yearOfBirthCounts.Add(startDate.Year, startDateAgeCount);
+            yearOfBirthCounts.Add(startDatePlus5Years.Year, startDatePlus5YearsAgeCount);
+
+            IDictionary<int, int> expected = new Dictionary<int, int>();
+            expected.Add(startDateAge, startDateAgeCount);
+            expected.Add(startDatePlus5YearsAge, startDatePlus5YearsAgeCount);
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetLoggedInUserYearOfBirthCountsAsync(It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(yearOfBirthCounts);
+
+            IDashboardService service = GetDashboardService(userProfileDelegateMock: userProfileDelegateMock);
+            return new(service, expected, startDate, endDate);
+        }
+
+        private record GetAllTimeCountsMock(IDashboardService Service, AllTimeCounts Expected);
+
+        private record GetDailyUsageCountsMock(IDashboardService Service, DailyUsageCounts Expected, DateOnly StartDate, DateOnly EndDate);
+
+        private record GetRecurringUserCountMock(IDashboardService Service, int Expected, DateOnly StartDate, DateOnly EndDate, int DayCount);
+
+        private record GetAgeCountsMock(IDashboardService Service, IDictionary<int, int> Expected, DateOnly StartDate, DateOnly EndDate);
+
+        private record GetAppLoginCountsMock(IDashboardService Service, AppLoginCounts Expected, DateOnly StartDate, DateOnly EndDate);
+
+        private record GetRatingsSummaryMock(IDashboardService Service, IDictionary<string, int> Expected, DateOnly StartDate, DateOnly EndDate);
+    }
+}

--- a/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
+++ b/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
@@ -65,8 +65,8 @@ namespace HealthGateway.Admin.Tests.Services
         /// <summary>
         /// GetInactiveUsersAsync.
         /// </summary>
-        /// <param name="adminUserErrorExists">The exception type to be thrown.</param>
-        /// <param name="supportUserErrorExists">Value to determine whether there is .</param>
+        /// <param name="adminUserErrorExists">Value to determine whether admin user error exists.</param>
+        /// <param name="supportUserErrorExists">Value to determine whether support user error exists.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [InlineData(false, false)]
         [InlineData(true, false)]

--- a/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
+++ b/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
@@ -75,7 +75,7 @@ namespace HealthGateway.Admin.Tests.Services
         public async Task ShouldGetInactiveUsers(bool adminUserErrorExists, bool supportUserErrorExists)
         {
             // Arrange
-            GetInactiveUsersMock mock = await this.SetupGetInactiveUsersMock(adminUserErrorExists, supportUserErrorExists);
+            GetInactiveUsersMock mock = await SetupGetInactiveUsersMock(adminUserErrorExists, supportUserErrorExists);
 
             // Act
             RequestResult<List<AdminUserProfileView>> actual = await mock.Service.GetInactiveUsersAsync(mock.InactiveDays);
@@ -150,7 +150,7 @@ namespace HealthGateway.Admin.Tests.Services
                 .Build();
         }
 
-        private async Task<GetInactiveUsersMock> SetupGetInactiveUsersMock(bool adminUserErrorExists, bool supportUserErrorExists)
+        private static async Task<GetInactiveUsersMock> SetupGetInactiveUsersMock(bool adminUserErrorExists, bool supportUserErrorExists)
         {
             const int inactiveDays = 3;
 
@@ -268,6 +268,6 @@ namespace HealthGateway.Admin.Tests.Services
             return new(service, expected, inactiveDays);
         }
 
-        private record GetInactiveUsersMock(IInactiveUserService Service, RequestResult<List<AdminUserProfileView>> Expected, int InactiveDays);
+        private sealed record GetInactiveUsersMock(IInactiveUserService Service, RequestResult<List<AdminUserProfileView>> Expected, int InactiveDays);
     }
 }

--- a/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
+++ b/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
@@ -1,0 +1,273 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using HealthGateway.Admin.Server.Models;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Admin.Tests.Utils;
+    using HealthGateway.Common.AccessManagement.Administration.Models;
+    using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.AccessManagement.Authentication.Models;
+    using HealthGateway.Common.Api;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Data.Utils;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the InactiveUserServiceTests class.
+    /// </summary>
+    public class InactiveUserServiceTests
+    {
+        private const string Email1 = "user@gmail.com";
+        private const string Email2 = "user@outlook.com";
+        private const string Email3 = "user@yahoo.com";
+        private const string Email4 = "user@hotmail.com";
+        private const string NoProfileKeycloakUsername = "turner.stevenson";
+        private const string AdminUsername1 = "john.smith";
+        private const string AdminUsername2 = "darwin.lewis";
+        private const string SupportUsername1 = "Jill.Paulus";
+        private const string SupportUsername2 = "Barry.Alonso";
+        private static readonly Guid AdminUserId1 = Guid.NewGuid();
+        private static readonly Guid AdminUserId2 = Guid.NewGuid();
+        private static readonly Guid SupportUserId1 = Guid.NewGuid();
+        private static readonly Guid SupportUserId2 = Guid.NewGuid();
+        private static readonly Guid NoProfileKeycloakUserId = Guid.NewGuid();
+
+        private static readonly IConfiguration Configuration = GetIConfigurationRoot();
+        private static readonly IAdminServerMappingService MappingService = new AdminServerMappingService(MapperUtil.InitializeAutoMapper(), Configuration);
+
+        /// <summary>
+        /// GetInactiveUsersAsync.
+        /// </summary>
+        /// <param name="adminUserErrorExists">The exception type to be thrown.</param>
+        /// <param name="supportUserErrorExists">Value to determine whether there is .</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [InlineData(false, false)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [Theory]
+        public async Task ShouldGetInactiveUsers(bool adminUserErrorExists, bool supportUserErrorExists)
+        {
+            // Arrange
+            GetInactiveUsersMock mock = await this.SetupGetInactiveUsersMock(adminUserErrorExists, supportUserErrorExists);
+
+            // Act
+            RequestResult<List<AdminUserProfileView>> actual = await mock.Service.GetInactiveUsersAsync(mock.InactiveDays);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        private static JwtModel GenerateJwt()
+        {
+            return new()
+            {
+                AccessToken = "AccessToken",
+            };
+        }
+
+        private static AdminUserProfile GenerateAdminUserProfile(string username, DateTime lastLoginDateTime)
+        {
+            return new()
+            {
+                Username = username,
+                LastLoginDateTime = lastLoginDateTime,
+            };
+        }
+
+        private static AdminUserProfileView GenerateAdminUserProfileView(
+            Guid userId,
+            string username,
+            string firstName,
+            string lastName,
+            string email,
+            string roles,
+            DateTime? lastLoginDateTime = null,
+            Guid? adminUserProfileId = null)
+        {
+            return new()
+            {
+                AdminUserProfileId = adminUserProfileId,
+                UserId = userId,
+                Username = username,
+                FirstName = firstName,
+                LastName = lastName,
+                Email = email,
+                RealmRoles = roles,
+                LastLoginDateTime = lastLoginDateTime,
+            };
+        }
+
+        private static UserRepresentation GenerateUserRepresentation(Guid userId, string username, string firstName, string lastName, string email, string roles)
+        {
+            return new()
+            {
+                UserId = userId,
+                Username = username,
+                FirstName = firstName,
+                LastName = lastName,
+                Email = email,
+                RealmRoles = roles,
+            };
+        }
+
+        private static IConfigurationRoot GetIConfigurationRoot()
+        {
+            Dictionary<string, string?> myConfiguration = new()
+            {
+                { "TimeZone:UnixTimeZoneId", "America/Vancouver" },
+                { "TimeZone:WindowsTimeZoneId", "Pacific Standard Time" },
+            };
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration.ToList())
+                .Build();
+        }
+
+        private async Task<GetInactiveUsersMock> SetupGetInactiveUsersMock(bool adminUserErrorExists, bool supportUserErrorExists)
+        {
+            const int inactiveDays = 3;
+
+            JwtModel jwt = GenerateJwt();
+            DateTime today = DateTime.UtcNow;
+
+            IList<AdminUserProfile> activeUserProfiles =
+            [
+                GenerateAdminUserProfile(AdminUsername1, today.AddDays(-1)),
+                GenerateAdminUserProfile(SupportUsername1, today.AddDays(-2)),
+            ];
+
+            IList<AdminUserProfile> inactiveUserProfiles =
+            [
+                GenerateAdminUserProfile(AdminUsername2, today.AddDays(-3)),
+                GenerateAdminUserProfile(SupportUsername2, today.AddDays(-4)),
+            ];
+
+            List<UserRepresentation> keycloakAdminUsers =
+            [
+                GenerateUserRepresentation(AdminUserId1, AdminUsername1, "john", "Smith", Email1, "AdminUser"),
+                GenerateUserRepresentation(AdminUserId2, AdminUsername2, "Darwin", "Lewis", Email2, "AdminUser"),
+                GenerateUserRepresentation(NoProfileKeycloakUserId, NoProfileKeycloakUsername, "Turner", "Stevenson", "user@rocketmail.com", "AdminUser"),
+            ];
+
+            List<UserRepresentation> keycloakSupportUsers =
+            [
+                GenerateUserRepresentation(SupportUserId1, SupportUsername1, "Jill", "Paulus", Email3, "SupportUser"),
+                GenerateUserRepresentation(SupportUserId2, SupportUsername2, "Barry", "Alonso", Email4, "SupportUser"),
+            ];
+
+            TimeSpan localTimeOffset = DateFormatter.GetLocalTimeOffset(Configuration, DateTime.UtcNow);
+            List<AdminUserProfileView> expectedInactiveUsers =
+            [
+                GenerateAdminUserProfileView(
+                    AdminUserId2,
+                    AdminUsername2,
+                    keycloakAdminUsers[1].FirstName,
+                    keycloakAdminUsers[1].LastName,
+                    keycloakAdminUsers[1].Email,
+                    keycloakAdminUsers[1].RealmRoles,
+                    inactiveUserProfiles[0].LastLoginDateTime.AddMinutes(localTimeOffset.TotalMinutes),
+                    Guid.Empty),
+                GenerateAdminUserProfileView(
+                    SupportUserId2,
+                    SupportUsername2,
+                    keycloakSupportUsers[1].FirstName,
+                    keycloakSupportUsers[1].LastName,
+                    keycloakSupportUsers[1].Email,
+                    keycloakSupportUsers[1].RealmRoles,
+                    inactiveUserProfiles[1].LastLoginDateTime.AddMinutes(localTimeOffset.TotalMinutes),
+                    Guid.Empty),
+                GenerateAdminUserProfileView(
+                    NoProfileKeycloakUserId,
+                    NoProfileKeycloakUsername,
+                    keycloakAdminUsers[2].FirstName,
+                    keycloakAdminUsers[2].LastName,
+                    keycloakAdminUsers[2].Email,
+                    keycloakAdminUsers[2].RealmRoles),
+            ];
+
+            RequestResult<List<AdminUserProfileView>> expected = new()
+            {
+                ResultStatus = adminUserErrorExists || supportUserErrorExists ? ResultType.Error : ResultType.Success,
+                ResourcePayload = adminUserErrorExists || supportUserErrorExists ? new() : expectedInactiveUsers,
+                TotalResultCount = adminUserErrorExists || supportUserErrorExists ? 0 : expectedInactiveUsers.Count,
+                ResultError = adminUserErrorExists || supportUserErrorExists
+                    ? new()
+                    {
+                        ResultMessage = "Error communicating with Keycloak",
+                    }
+                    : null,
+            };
+
+            Mock<IAuthenticationDelegate> authenticationDelegateMock = new();
+            authenticationDelegateMock.Setup(s => s.AuthenticateAsSystemAsync(It.IsAny<ClientCredentialsRequest>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(jwt);
+
+            Mock<IAdminUserProfileDelegate> adminUserProfileDelegateMock = new();
+            adminUserProfileDelegateMock.Setup(s => s.GetActiveAdminUserProfilesAsync(inactiveDays, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).ReturnsAsync(activeUserProfiles);
+            adminUserProfileDelegateMock.Setup(s => s.GetInactiveAdminUserProfilesAsync(inactiveDays, It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>())).ReturnsAsync(inactiveUserProfiles);
+
+            Mock<IKeycloakAdminApi> keycloakAdminApiMock = new();
+            Exception apiException = await RefitExceptionUtil.CreateApiException(HttpStatusCode.BadRequest);
+
+            if (adminUserErrorExists)
+            {
+                keycloakAdminApiMock.Setup(s => s.GetUsersByRoleAsync(It.Is<string>(x => x == "AdminUser"), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(apiException);
+            }
+            else
+            {
+                keycloakAdminApiMock.Setup(s => s.GetUsersByRoleAsync(It.Is<string>(x => x == "AdminUser"), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(keycloakAdminUsers);
+            }
+
+            if (supportUserErrorExists)
+            {
+                keycloakAdminApiMock.Setup(s => s.GetUsersByRoleAsync(It.Is<string>(x => x == "SupportUser"), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(apiException);
+            }
+            else
+            {
+                keycloakAdminApiMock.Setup(s => s.GetUsersByRoleAsync(It.Is<string>(x => x == "SupportUser"), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(keycloakSupportUsers);
+            }
+
+            IInactiveUserService service = new InactiveUserService(
+                authenticationDelegateMock.Object,
+                adminUserProfileDelegateMock.Object,
+                keycloakAdminApiMock.Object,
+                new Mock<ILogger<InactiveUserService>>().Object,
+                Configuration,
+                MappingService);
+
+            return new(service, expected, inactiveDays);
+        }
+
+        private record GetInactiveUsersMock(IInactiveUserService Service, RequestResult<List<AdminUserProfileView>> Expected, int InactiveDays);
+    }
+}

--- a/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
+++ b/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
@@ -1,0 +1,639 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using HealthGateway.Admin.Common.Models;
+    using HealthGateway.Admin.Server.Services;
+    using HealthGateway.Admin.Tests.Utils;
+    using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Models;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the UserFeedbackService class.
+    /// </summary>
+    public class UserFeedbackServiceTests
+    {
+        private const string Hdid1 = "DEV4FPEGCXG2NB5K2USBL52S66SC3GOUHWRP3GTXR2BTY5HEC4YA";
+        private const string Hdid2 = "C3GOUHWRP3GTXR2BTY5HEC4YADEV4FPEGCXG2NB5K2USBL52S66S";
+        private const string Email1 = "user@gmail.com";
+        private const string Email2 = "user@outlook.com";
+        private const string DbErrorMessage = "DB Error";
+        private static readonly IConfiguration Configuration = GetIConfigurationRoot();
+        private static readonly IAdminServerMappingService MappingService = new AdminServerMappingService(MapperUtil.InitializeAutoMapper(), Configuration);
+
+        /// <summary>
+        /// AssociateFeedbackTagsAsync.
+        /// </summary>
+        /// <param name="feedbackDbStatusCode">The db status code for getting user feedback with feedback tags.</param>
+        /// <param name="updateFeedbackDbStatusCode">The db status code for updating user feedback with tag associations.</param>
+        /// <param name="resultType">The result type returned for calling AssociateFeedbackTagsAsync.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(DbStatusCode.Read, DbStatusCode.Updated, ResultType.Success)]
+        [InlineData(DbStatusCode.Read, DbStatusCode.Error, ResultType.Error)]
+        [InlineData(DbStatusCode.NotFound, DbStatusCode.Error, ResultType.Error)]
+        public async Task ShouldAssociateFeedbackTags(DbStatusCode feedbackDbStatusCode, DbStatusCode updateFeedbackDbStatusCode, ResultType resultType)
+        {
+            // Arrange
+            const string tagName1 = "Poor";
+            const string tagName2 = "Average";
+            Guid userFeedbackId = Guid.NewGuid();
+            Guid adminTagId1 = Guid.NewGuid();
+            Guid adminTagId2 = Guid.NewGuid();
+
+            IList<Tag> adminTags =
+            [
+                new(adminTagId1, tagName1),
+                new(adminTagId2, tagName2),
+            ];
+
+            AssociateFeedbackTagMock mock = SetupAssociateFeedbackMock(
+                userFeedbackId,
+                adminTags,
+                feedbackDbStatusCode,
+                updateFeedbackDbStatusCode,
+                resultType);
+
+            // Act
+            RequestResult<UserFeedbackView> actual = await mock.Service.AssociateFeedbackTagsAsync(userFeedbackId, adminTags.Select(x => x.AdminTagId).ToList());
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// CreateTagAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldCreateTag()
+        {
+            // Arrange
+            CreateUserFeedbackMock mock = SetupCreateUserFeedbackMock(false);
+
+            // Act
+            RequestResult<AdminTagView> actual = await mock.Service.CreateTagAsync(mock.TagName);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// CreateTagAsync handles error.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task CreateTagHandlesDbError()
+        {
+            // Arrange
+            CreateUserFeedbackMock mock = SetupCreateUserFeedbackMock(true);
+
+            // Act
+            RequestResult<AdminTagView> actual = await mock.Service.CreateTagAsync(mock.TagName);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// DeleteTagAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldDeleteTag()
+        {
+            // Arrange
+            DeleteUserFeedbackMock mock = SetupDeleteUserFeedbackMock(false);
+
+            // Act
+            RequestResult<AdminTagView> actual = await mock.Service.DeleteTagAsync(new() { Id = mock.AdminTagId, Name = mock.TagName });
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// DeleteTagAsync handles db error.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task DeleteTagHandlesDbError()
+        {
+            // Arrange
+            DeleteUserFeedbackMock mock = SetupDeleteUserFeedbackMock(true);
+
+            // Act
+            RequestResult<AdminTagView> actual = await mock.Service.DeleteTagAsync(new() { Id = mock.AdminTagId, Name = mock.TagName });
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// GetAllTagsAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetAllTags()
+        {
+            // Arrange
+            GetAllFeedbackMock mock = SetupGetAllFeedbackMock();
+
+            // Act
+            RequestResult<IList<AdminTagView>> actual = await mock.Service.GetAllTagsAsync();
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// GetUserFeedbackAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetUserFeedback()
+        {
+            // Arrange
+            GetUserFeedbackMock mock = SetupGetUserFeedbackMock();
+
+            // Act
+            RequestResult<IList<UserFeedbackView>> actual = await mock.Service.GetUserFeedbackAsync();
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+        }
+
+        /// <summary>
+        /// UpdateFeedbackReviewAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldUpdateFeedbackReview()
+        {
+            // Arrange
+            Mock<IFeedbackDelegate> feedbackDelegateMock = new();
+            UpdateFeedbackMock mock = SetupUpdateFeedbackMock(feedbackDelegateMock);
+
+            // Act
+            RequestResult<UserFeedbackView> actual = await mock.Service.UpdateFeedbackReviewAsync(mock.Update);
+
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual);
+
+            feedbackDelegateMock.Verify(
+                v => v.UpdateUserFeedbackAsync(
+                    It.Is<UserFeedback>(x => x.UserProfileId == mock.Update.UserProfileId && x.Id == mock.Update.Id && x.Comment == mock.Update.Comment),
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        private static AdminTag GenerateAdminTag(Guid adminTagId, string name)
+        {
+            return new()
+            {
+                AdminTagId = adminTagId,
+                Name = name,
+            };
+        }
+
+        private static AdminTagView GenerateAdminTagView(Guid id, string name)
+        {
+            return new()
+            {
+                Id = id,
+                Name = name,
+            };
+        }
+
+        private static UserFeedback GenerateUserFeedback(Guid id, string userProfileId, string comment, ICollection<UserFeedbackTag>? tags = null)
+        {
+            return new()
+            {
+                Id = id,
+                UserProfileId = userProfileId,
+                Comment = comment,
+                ClientCode = UserLoginClientType.Web,
+                Tags = tags ?? [],
+            };
+        }
+
+        private static UserFeedbackView GenerateUserFeedbackView(Guid id, string userProfileId, string comment, string? email = null)
+        {
+            return new()
+            {
+                Id = id,
+                UserProfileId = userProfileId,
+                Comment = comment,
+                ClientType = UserLoginClientType.Web,
+                Email = email ?? string.Empty,
+            };
+        }
+
+        private static UserFeedbackTag GenerateUserFeedbackTag(Guid userFeedbackId, Guid adminTagId)
+        {
+            return new()
+            {
+                UserFeedbackId = userFeedbackId,
+                AdminTagId = adminTagId,
+            };
+        }
+
+        private static UserFeedbackTagView GenerateUserFeedbackTagView(Guid userFeedbackId, Guid adminTagId)
+        {
+            return new()
+            {
+                Id = Guid.Empty,
+                FeedbackId = userFeedbackId,
+                TagId = adminTagId,
+            };
+        }
+
+        private static UserProfile GenerateUserProfile(string hdid, string email)
+        {
+            return new()
+            {
+                HdId = hdid,
+                Email = email,
+            };
+        }
+
+        private static IConfigurationRoot GetIConfigurationRoot()
+        {
+            Dictionary<string, string?> myConfiguration = new()
+            {
+                { "TimeZone:UnixTimeZoneId", "America/Vancouver" },
+                { "TimeZone:WindowsTimeZoneId", "Pacific Standard Time" },
+            };
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration.ToList())
+                .Build();
+        }
+
+        private static IUserFeedbackService GetUserFeedbackService(
+            Mock<IFeedbackDelegate>? feedbackDelegateMock = null,
+            Mock<IAdminTagDelegate>? adminTagDelegateMock = null,
+            Mock<IUserProfileDelegate>? userProfileDelegateMock = null)
+        {
+            feedbackDelegateMock = feedbackDelegateMock ?? new();
+            adminTagDelegateMock = adminTagDelegateMock ?? new();
+            userProfileDelegateMock = userProfileDelegateMock ?? new();
+
+            return new UserFeedbackService(
+                new Mock<ILogger<UserFeedbackService>>().Object,
+                feedbackDelegateMock.Object,
+                adminTagDelegateMock.Object,
+                userProfileDelegateMock.Object,
+                MappingService);
+        }
+
+        private static AssociateFeedbackTagMock SetupAssociateFeedbackMock(
+            Guid userFeedbackId,
+            IList<Tag> tags,
+            DbStatusCode feedbackDbStatusCode,
+            DbStatusCode updateFeedbackDbStatusCode,
+            ResultType resultType)
+        {
+            const string comment = "Great";
+
+            IList<FeedbackTag> feedbackTags =
+            [
+                new(userFeedbackId, tags[0].AdminTagId),
+                new(userFeedbackId, tags[1].AdminTagId),
+            ];
+
+            RequestResult<UserFeedbackView> expected = new()
+            {
+                ResultStatus = resultType,
+                ResourcePayload = resultType == ResultType.Success
+                    ? new()
+                    {
+                        Id = userFeedbackId,
+                        UserProfileId = Hdid1,
+                        Comment = comment,
+                        ClientType = UserLoginClientType.Web,
+                        Email = Email1,
+                        Tags =
+                        [
+                            GenerateUserFeedbackTagView(userFeedbackId, feedbackTags[0].AdminTagId),
+                            GenerateUserFeedbackTagView(userFeedbackId, feedbackTags[1].AdminTagId),
+                        ],
+                    }
+                    : null,
+                ResultError = resultType == ResultType.Error
+                    ? new()
+                    {
+                        ResultMessage = DbErrorMessage,
+                    }
+                    : null,
+            };
+
+            IList<Guid> adminTagIds = tags.Select(x => x.AdminTagId).ToList();
+
+            ICollection<UserFeedbackTag> userFeedbackTags =
+            [
+                GenerateUserFeedbackTag(feedbackTags[0].UserFeedbackId, feedbackTags[0].AdminTagId),
+                GenerateUserFeedbackTag(feedbackTags[1].UserFeedbackId, feedbackTags[1].AdminTagId),
+            ];
+
+            DbResult<UserFeedback> userFeedbackDbResult = new()
+            {
+                Status = feedbackDbStatusCode,
+                Payload = feedbackDbStatusCode == DbStatusCode.Read ? GenerateUserFeedback(userFeedbackId, Hdid1, comment) : null!,
+                Message = feedbackDbStatusCode == DbStatusCode.NotFound ? DbErrorMessage : string.Empty,
+            };
+
+            DbResult<UserFeedback> updateUserFeedbackDbResult = new()
+            {
+                Status = updateFeedbackDbStatusCode,
+                Payload = updateFeedbackDbStatusCode == DbStatusCode.Updated ? GenerateUserFeedback(userFeedbackId, Hdid1, comment, userFeedbackTags) : null!,
+                Message = updateFeedbackDbStatusCode == DbStatusCode.Error ? DbErrorMessage : string.Empty,
+            };
+
+            IList<AdminTag> adminTags =
+            [
+                GenerateAdminTag(tags[0].AdminTagId, tags[0].TagName),
+                GenerateAdminTag(tags[1].AdminTagId, tags[1].TagName),
+            ];
+
+            DbResult<IEnumerable<AdminTag>> adminTagDbResult = new()
+            {
+                Status = DbStatusCode.Read,
+                Payload = adminTags,
+            };
+
+            UserProfile userProfile = GenerateUserProfile(Hdid1, Email1);
+
+            Mock<IFeedbackDelegate> feedbackDelegateMock = new();
+            feedbackDelegateMock.Setup(s => s.GetUserFeedbackWithFeedbackTagsAsync(userFeedbackId, It.IsAny<CancellationToken>())).ReturnsAsync(userFeedbackDbResult);
+            feedbackDelegateMock
+                .Setup(s => s.UpdateUserFeedbackWithTagAssociationsAsync(It.Is<UserFeedback>(x => x.Id == userFeedbackId && x.Tags.Count == adminTags.Count()), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(updateUserFeedbackDbResult);
+
+            Mock<IAdminTagDelegate> adminTagDelegateMock = new();
+            adminTagDelegateMock.Setup(s => s.GetAdminTagsAsync(adminTagIds, It.IsAny<CancellationToken>())).ReturnsAsync(adminTagDbResult);
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetUserProfileAsync(Hdid1, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
+
+            IUserFeedbackService service = GetUserFeedbackService(
+                adminTagDelegateMock: adminTagDelegateMock,
+                userProfileDelegateMock: userProfileDelegateMock,
+                feedbackDelegateMock: feedbackDelegateMock);
+
+            return new(service, expected);
+        }
+
+        private static CreateUserFeedbackMock SetupCreateUserFeedbackMock(bool dbErrorExists)
+        {
+            const string tagName = "Great";
+
+            RequestResult<AdminTagView> expected = new()
+            {
+                ResultStatus = dbErrorExists ? ResultType.Error : ResultType.Success,
+                ResultError = dbErrorExists
+                    ? new()
+                    {
+                        ResultMessage = DbErrorMessage,
+                    }
+                    : null,
+                ResourcePayload = dbErrorExists ? null : new() { Name = tagName },
+            };
+
+            DbResult<AdminTag?> adminTagDbResult = new()
+            {
+                Status = dbErrorExists ? DbStatusCode.Error : DbStatusCode.Created,
+                Payload = dbErrorExists ? null : new() { Name = tagName },
+                Message = dbErrorExists ? DbErrorMessage : string.Empty,
+            };
+
+            Mock<IAdminTagDelegate> adminTagDelegateMock = new();
+            adminTagDelegateMock.Setup(s => s.AddAsync(It.Is<AdminTag>(x => x.Name == tagName), true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adminTagDbResult!);
+
+            IUserFeedbackService service = GetUserFeedbackService(adminTagDelegateMock: adminTagDelegateMock);
+            return new(service, expected, tagName);
+        }
+
+        private static DeleteUserFeedbackMock SetupDeleteUserFeedbackMock(bool dbErrorExists)
+        {
+            Guid adminTagId = Guid.NewGuid();
+            const string tagName = "Great";
+
+            RequestResult<AdminTagView> expected = new()
+            {
+                ResourcePayload = dbErrorExists
+                    ? null
+                    : new()
+                    {
+                        Id = adminTagId,
+                        Name = tagName,
+                    },
+                ResultError = dbErrorExists
+                    ? new()
+                    {
+                        ResultMessage = DbErrorMessage,
+                    }
+                    : null,
+                ResultStatus = dbErrorExists ? ResultType.Error : ResultType.Success,
+            };
+
+            DbResult<AdminTag?> adminTagDbResult = new()
+            {
+                Status = dbErrorExists ? DbStatusCode.Error : DbStatusCode.Deleted,
+                Payload = dbErrorExists
+                    ? null
+                    : new()
+                    {
+                        AdminTagId = adminTagId,
+                        Name = tagName,
+                    },
+                Message = dbErrorExists ? DbErrorMessage : string.Empty,
+            };
+
+            Mock<IAdminTagDelegate> adminTagDelegateMock = new();
+            adminTagDelegateMock.Setup(
+                    s => s.DeleteAsync(It.Is<AdminTag>(x => x.AdminTagId == adminTagId && x.Name == tagName), true, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(adminTagDbResult!);
+
+            IUserFeedbackService service = GetUserFeedbackService(adminTagDelegateMock: adminTagDelegateMock);
+            return new(service, expected, adminTagId, tagName);
+        }
+
+        private static GetUserFeedbackMock SetupGetUserFeedbackMock()
+        {
+            const string comment1 = "ABC";
+            const string comment2 = "123";
+            Guid feedbackId1 = Guid.NewGuid();
+            Guid feedbackId2 = Guid.NewGuid();
+            Guid feedbackId3 = Guid.NewGuid();
+
+            IList<Profile> profiles =
+            [
+                new(Hdid1, Email1),
+                new(Hdid2, Email2),
+            ];
+
+            IList<Feedback> feedbacks =
+            [
+                new(feedbackId1, Hdid1, comment1),
+                new(feedbackId2, Hdid1, comment2),
+                new(feedbackId3, Hdid2, comment1),
+            ];
+
+            RequestResult<IList<UserFeedbackView>> expected = new()
+            {
+                ResourcePayload =
+                [
+                    GenerateUserFeedbackView(feedbackId1, Hdid1, comment1, Email1),
+                    GenerateUserFeedbackView(feedbackId2, Hdid1, comment2, Email1),
+                    GenerateUserFeedbackView(feedbackId3, Hdid2, comment1, Email2),
+                ],
+                ResultStatus = ResultType.Success,
+                TotalResultCount = feedbacks.Count,
+            };
+
+            IList<string> userProfileIds = profiles.Select(x => x.Hdid).ToList();
+
+            IList<UserFeedback> userFeedbacks =
+            [
+                GenerateUserFeedback(feedbacks[0].FeedbackId, feedbacks[0].Hdid, feedbacks[0].Comment),
+                GenerateUserFeedback(feedbacks[1].FeedbackId, feedbacks[1].Hdid, feedbacks[1].Comment),
+                GenerateUserFeedback(feedbacks[2].FeedbackId, feedbacks[2].Hdid, feedbacks[2].Comment),
+            ];
+
+            IList<UserProfile> userProfiles =
+            [
+                GenerateUserProfile(profiles[0].Hdid, profiles[0].Email),
+                GenerateUserProfile(profiles[1].Hdid, profiles[1].Email),
+            ];
+
+            Mock<IFeedbackDelegate> feedbackDelegateMock = new();
+            feedbackDelegateMock.Setup(s => s.GetAllUserFeedbackEntriesAsync(false, It.IsAny<CancellationToken>())).ReturnsAsync(userFeedbacks);
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetUserProfilesAsync(userProfileIds, It.IsAny<CancellationToken>())).ReturnsAsync(userProfiles);
+
+            IUserFeedbackService service = GetUserFeedbackService(feedbackDelegateMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            return new(service, expected);
+        }
+
+        private static UpdateFeedbackMock SetupUpdateFeedbackMock(Mock<IFeedbackDelegate> feedbackDelegateMock)
+        {
+            const string comment = "ABC";
+            Guid feedbackId = Guid.NewGuid();
+
+            UserFeedbackView update = GenerateUserFeedbackView(feedbackId, Hdid1, comment);
+
+            RequestResult<UserFeedbackView> expected = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = GenerateUserFeedbackView(feedbackId, Hdid1, comment, Email1),
+            };
+            DbResult<UserFeedback> dbResult = new()
+            {
+                Status = DbStatusCode.Read,
+                Payload = GenerateUserFeedback(feedbackId, Hdid1, comment),
+            };
+
+            UserProfile userProfile = GenerateUserProfile(Hdid1, Email1);
+
+            feedbackDelegateMock.Setup(s => s.GetUserFeedbackWithFeedbackTagsAsync(feedbackId, It.IsAny<CancellationToken>())).ReturnsAsync(dbResult);
+
+            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
+            userProfileDelegateMock.Setup(s => s.GetUserProfileAsync(Hdid1, It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
+
+            IUserFeedbackService service = GetUserFeedbackService(feedbackDelegateMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            return new(service, expected, update);
+        }
+
+        private static GetAllFeedbackMock SetupGetAllFeedbackMock()
+        {
+            Guid adminTagId1 = Guid.NewGuid();
+            Guid adminTagId2 = Guid.NewGuid();
+            const string tagName1 = "Test1";
+            const string tagName2 = "Test2";
+
+            IList<Dictionary<Guid, string>> tags =
+            [
+                new()
+                {
+                    { adminTagId1, tagName1 },
+                },
+                new()
+                {
+                    { adminTagId2, tagName2 },
+                },
+            ];
+
+            RequestResult<IList<AdminTagView>> expected = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload =
+                [
+                    GenerateAdminTagView(adminTagId1, tagName1),
+                    GenerateAdminTagView(adminTagId2, tagName2),
+                ],
+                TotalResultCount = tags.Count,
+            };
+
+            IEnumerable<AdminTag> adminTags = tags
+                .SelectMany(dict => dict.Select(kv => GenerateAdminTag(kv.Key, kv.Value)));
+
+            Mock<IAdminTagDelegate> adminTagDelegateMock = new();
+            adminTagDelegateMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(adminTags);
+
+            IUserFeedbackService service = GetUserFeedbackService(adminTagDelegateMock: adminTagDelegateMock);
+            return new(service, expected);
+        }
+
+        private record Tag(Guid AdminTagId, string TagName);
+
+        private record Profile(string Hdid, string Email);
+
+        private record Feedback(Guid FeedbackId, string Hdid, string Comment);
+
+        private record FeedbackTag(Guid UserFeedbackId, Guid AdminTagId);
+
+        private record AssociateFeedbackTagMock(IUserFeedbackService Service, RequestResult<UserFeedbackView> Expected);
+
+        private record CreateUserFeedbackMock(IUserFeedbackService Service, RequestResult<AdminTagView> Expected, string TagName);
+
+        private record DeleteUserFeedbackMock(IUserFeedbackService Service, RequestResult<AdminTagView> Expected, Guid AdminTagId, string TagName);
+
+        private record GetAllFeedbackMock(IUserFeedbackService Service, RequestResult<IList<AdminTagView>> Expected);
+
+        private record GetUserFeedbackMock(IUserFeedbackService Service, RequestResult<IList<UserFeedbackView>> Expected);
+
+        private record UpdateFeedbackMock(IUserFeedbackService Service, RequestResult<UserFeedbackView> Expected, UserFeedbackView Update);
+    }
+}

--- a/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
+++ b/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
@@ -616,24 +616,24 @@ namespace HealthGateway.Admin.Tests.Services
             return new(service, expected);
         }
 
-        private record Tag(Guid AdminTagId, string TagName);
+        private sealed record Tag(Guid AdminTagId, string TagName);
 
-        private record Profile(string Hdid, string Email);
+        private sealed record Profile(string Hdid, string Email);
 
-        private record Feedback(Guid FeedbackId, string Hdid, string Comment);
+        private sealed record Feedback(Guid FeedbackId, string Hdid, string Comment);
 
-        private record FeedbackTag(Guid UserFeedbackId, Guid AdminTagId);
+        private sealed record FeedbackTag(Guid UserFeedbackId, Guid AdminTagId);
 
-        private record AssociateFeedbackTagMock(IUserFeedbackService Service, RequestResult<UserFeedbackView> Expected);
+        private sealed record AssociateFeedbackTagMock(IUserFeedbackService Service, RequestResult<UserFeedbackView> Expected);
 
-        private record CreateUserFeedbackMock(IUserFeedbackService Service, RequestResult<AdminTagView> Expected, string TagName);
+        private sealed record CreateUserFeedbackMock(IUserFeedbackService Service, RequestResult<AdminTagView> Expected, string TagName);
 
-        private record DeleteUserFeedbackMock(IUserFeedbackService Service, RequestResult<AdminTagView> Expected, Guid AdminTagId, string TagName);
+        private sealed record DeleteUserFeedbackMock(IUserFeedbackService Service, RequestResult<AdminTagView> Expected, Guid AdminTagId, string TagName);
 
-        private record GetAllFeedbackMock(IUserFeedbackService Service, RequestResult<IList<AdminTagView>> Expected);
+        private sealed record GetAllFeedbackMock(IUserFeedbackService Service, RequestResult<IList<AdminTagView>> Expected);
 
-        private record GetUserFeedbackMock(IUserFeedbackService Service, RequestResult<IList<UserFeedbackView>> Expected);
+        private sealed record GetUserFeedbackMock(IUserFeedbackService Service, RequestResult<IList<UserFeedbackView>> Expected);
 
-        private record UpdateFeedbackMock(IUserFeedbackService Service, RequestResult<UserFeedbackView> Expected, UserFeedbackView Update);
+        private sealed record UpdateFeedbackMock(IUserFeedbackService Service, RequestResult<UserFeedbackView> Expected, UserFeedbackView Update);
     }
 }

--- a/Apps/Admin/Tests/Utils/MapperUtil.cs
+++ b/Apps/Admin/Tests/Utils/MapperUtil.cs
@@ -36,7 +36,9 @@ namespace HealthGateway.Admin.Tests.Utils
                 {
                     cfg.AddProfile(new AddressProfile());
                     cfg.AddProfile(new AgentActionProfile());
+                    cfg.AddProfile(new AdminTagProfile());
                     cfg.AddProfile(new AdminUserProfileViewProfile());
+                    cfg.AddProfile(new UserFeedbackProfile());
                     cfg.AddProfile(new BroadcastProfile());
                     cfg.AddProfile(new DelegateInfoProfile());
                     cfg.AddProfile(new DependentInfoProfile());

--- a/Apps/Admin/Tests/Utils/RefitExceptionUtil.cs
+++ b/Apps/Admin/Tests/Utils/RefitExceptionUtil.cs
@@ -1,0 +1,46 @@
+﻿//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Admin.Tests.Utils
+{
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Refit;
+
+    /// <summary>
+    /// Exception utilities class to assist in mocking Refit exceptions.
+    /// </summary>
+    public static class RefitExceptionUtil
+    {
+        /// <summary>
+        /// Creates a Refit exception with the given status code and reason phrase.
+        /// </summary>
+        /// <param name="statusCode">The desired exception status code.</param>
+        /// <param name="message">The message associated with the exception.</param>
+        /// <returns>Refit ApiException</returns>
+        public static async Task<ApiException> CreateApiException(HttpStatusCode statusCode, string? message = null)
+        {
+            RefitSettings rfSettings = new();
+            using HttpResponseMessage response = new(statusCode);
+            return await ApiException.Create(
+                message,
+                null!,
+                null!,
+                response,
+                rfSettings);
+        }
+    }
+}


### PR DESCRIPTION
# Implements [AB#16674](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16674)

## Description

- Added comments to InactiveUserService
- Updated logger error statement in InactiveUserService to avoid code smell
- Simplify catch statement to catch only ApiException in InactiveUserService
- Removed ErrorCode in ResultErrror in InactiveUserService as that is not needed
- Updated update call in UserFeedbackService to use userFeedbackResult.Payload as Feedback is being passed back after changes in delegate
- Added AdminResportServiceTests
- Added AgentAccessServiceTests
- Added DashboardServiceTests
- Added InactiveUserServiceTests
- Added UserFeedbackServiceTests

<img width="663" alt="Screenshot 2024-03-28 at 6 32 59 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/3f98faa2-7738-4778-9d5a-6a36c831dd00">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
