### PR TITLE
Add functional tests for beta site alert AB#16695

### DIFF
--- a/Apps/Admin/Client/Pages/BetaAccessPage.razor.cs
+++ b/Apps/Admin/Client/Pages/BetaAccessPage.razor.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.Admin.Client.Pages
             this.BetaAccessState.Value.SearchResult == null ? [] : [this.BetaAccessState.Value.SearchResult];
 
         private IEnumerable<UserBetaAccess> AllUserBetaAccess =>
-            this.BetaAccessState.Value.AllUserAccess?.Select(d => d.Value) ?? [];
+            this.BetaAccessState.Value.AllUserAccess?.OrderBy(d => d.Key).Select(d => d.Value) ?? [];
 
         /// <inheritdoc/>
         protected override void OnInitialized()

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
@@ -1,3 +1,5 @@
+import { selectTab } from "../../utilities/sharedUtilities";
+
 const validEmail = "nobody@healthgateway.gov.bc.ca";
 const notFoundEmail = "nobody@salesforce.gov.bc.ca";
 const invalidEmail = "nobody@";
@@ -13,17 +15,13 @@ describe("Beta feature access", () => {
 
     it("Verify View tab is empty due to no seed data.", () => {
         cy.log("Verify view tab has no data.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "View")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "View");
         cy.get("[data-testid=beta-access-table]").should("not.exist");
     });
 
     it("Verify error when search with invalid email", () => {
         cy.log("Verify search fails with invalid email.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "Search")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "Search");
         cy.get("[data-testid=query-input]").clear().type(invalidEmail);
         cy.get(".d-flex").contains("Invalid email format").should("be.visible");
         cy.get("[data-testid=beta-access-table]").should("not.exist");
@@ -31,14 +29,14 @@ describe("Beta feature access", () => {
 
     it("Verify error when search with not found email", () => {
         cy.log("Verify search fails with not found email.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "Search")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "Search");
         cy.get("[data-testid=query-input]").clear().type(notFoundEmail);
         cy.get(".d-flex").contains("Invalid email format").should("not.exist");
         cy.get("[data-testid=search-button]").click();
 
-        cy.get("[data-testid=get-user-access-error-message]").should("be.visible");
+        cy.get("[data-testid=get-user-access-error-message]").should(
+            "be.visible"
+        );
         cy.get("[data-testid=beta-access-table]").should("not.exist");
         cy.get("[data-testid=beta-email]").should("not.exist");
     });
@@ -46,16 +44,18 @@ describe("Beta feature access", () => {
     it("Verify successful assign/un-assign feature access", () => {
         // Tab to Search and search with a valid email
         cy.log("Verify search with valid email.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "Search")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "Search");
         cy.get("[data-testid=query-input]").clear().type(validEmail);
         cy.get(".d-flex").contains("Invalid email format").should("not.exist");
         cy.get("[data-testid=search-button]").click();
 
-        cy.get("[data-testid=get-user-access-error-message]").should("not.exist");
+        cy.get("[data-testid=get-user-access-error-message]").should(
+            "not.exist"
+        );
         cy.get("[data-testid=beta-access-table]").should("be.visible");
-        cy.get("[data-testid=salesforce-access-switch]").should("not.be.checked");
+        cy.get("[data-testid=salesforce-access-switch]").should(
+            "not.be.checked"
+        );
 
         // Assign salesforce feature
         cy.log("Verify assign salesforce feature on Search.");
@@ -63,75 +63,67 @@ describe("Beta feature access", () => {
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
         // Search and verify results again
-        cy.log("After assigning salesforce access, search and verify assigning of salesforce feature again.");
+        cy.log(
+            "After assigning salesforce access, search and verify assigning of salesforce feature again."
+        );
         cy.get("[data-testid=query-input]").clear().type(validEmail);
         cy.get("[data-testid=search-button]").click();
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
         // Tab to View and verify assigned feature(s)
         cy.log("Verify assigned feature(s) on View tab.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "View")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "View");
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
-        
+
         // Tab back to Search and verify salesforce is still assigned
         cy.log("Tab back to search to verify salesforce is still assigned.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "Search")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "Search");
         cy.get("[data-testid=email]").contains(validEmail);
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
         // Tab back to View and salesforce is still assigned
         cy.log("Tab back to view to validate salesforce still assigned.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "View")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "View");
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
-                
+
         // Un-assign salesforce feature on View
         cy.log("Verify un-assign salesforce feature access on View tab.");
         cy.get("[data-testid=salesforce-access-switch]").click();
         cy.get("[data-testid=beta-access-table]").should("not.exist");
-        
+
         // Tab back to Search and verify salesforce is un-assigned
         cy.log("Verify salesforce feature un-assigned on Search tab.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "Search")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "Search");
         cy.get("[data-testid=email]").contains(validEmail);
-        cy.get("[data-testid=salesforce-access-switch]").should("not.be.checked");
-        
+        cy.get("[data-testid=salesforce-access-switch]").should(
+            "not.be.checked"
+        );
+
         // Assign salesforce feature again on Search
         cy.log("Verify re-assign salesforce feature access on Search tab.");
         cy.get("[data-testid=salesforce-access-switch]").click();
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
-                
+
         // Tab back to View and verify salesforce is assigned
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "View")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "View");
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
         // Tab back to Search and un-assign salesforce feature
         cy.log("Verify salesforce feature still assigned on Search tab.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "Search")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "Search");
         cy.get("[data-testid=email]").contains(validEmail);
-        cy.get("[data-testid=salesforce-access-switch]").should("be.checked");    
-        
+        cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
+
         // Un-assign salesforce on Search
         cy.log("Verify un-assign salesforce feature on Search tab.");
         cy.get("[data-testid=salesforce-access-switch]").click();
-        cy.get("[data-testid=salesforce-access-switch]").should("not.be.checked");
-        
+        cy.get("[data-testid=salesforce-access-switch]").should(
+            "not.be.checked"
+        );
+
         // Tab back to View and verify salesforce is un-assigned
         cy.log("Tab back to View to verify salesforce still un-assigned.");
-        cy.get("[data-testid=beta-access-tabs]")
-            .contains(".mud-tab", "View")
-            .click();
+        selectTab("[data-testid=beta-access-tabs]", "View");
         cy.get("[data-testid=beta-access-table]").should("not.exist");
     });
 });

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
@@ -1,5 +1,6 @@
-import { selectTab } from "../../utilities/sharedUtilities";
+import { getTableRows, selectTab } from "../../utilities/sharedUtilities";
 
+const existingEmail = "somebody@healthgateway.gov.bc.ca";
 const validEmail = "nobody@healthgateway.gov.bc.ca";
 const notFoundEmail = "nobody@salesforce.gov.bc.ca";
 const invalidEmail = "nobody@";
@@ -13,10 +14,18 @@ describe("Beta feature access", () => {
         );
     });
 
-    it("Verify View tab is empty due to no seed data.", () => {
-        cy.log("Verify view tab has no data.");
+    it("Verify View tab has seed data.", () => {
+        cy.log("Verify view tab has 1 entry.");
         selectTab("[data-testid=beta-access-tabs]", "View");
-        cy.get("[data-testid=beta-access-table]").should("not.exist");
+        getTableRows("[data-testid=beta-access-table]")
+            .should("have.length", 1)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=email]").contains(existingEmail);
+                cy.get("[data-testid=salesforce-access-switch]").should(
+                    "be.checked"
+                );
+            });
     });
 
     it("Verify error when search with invalid email", () => {
@@ -73,7 +82,15 @@ describe("Beta feature access", () => {
         // Tab to View and verify assigned feature(s)
         cy.log("Verify assigned feature(s) on View tab.");
         selectTab("[data-testid=beta-access-tabs]", "View");
-        cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
+        getTableRows("[data-testid=beta-access-table]")
+            .should("have.length", 2)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=email]").contains(validEmail);
+                cy.get("[data-testid=salesforce-access-switch]").should(
+                    "be.checked"
+                );
+            });
 
         // Tab back to Search and verify salesforce is still assigned
         cy.log("Tab back to search to verify salesforce is still assigned.");
@@ -81,15 +98,25 @@ describe("Beta feature access", () => {
         cy.get("[data-testid=email]").contains(validEmail);
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
-        // Tab back to View and salesforce is still assigned
-        cy.log("Tab back to view to validate salesforce still assigned.");
+        // Tab back to View and verify salesforce is still assigned, then unassign
+        cy.log("Validate salesforce still assigned on View tab then unassign.");
         selectTab("[data-testid=beta-access-tabs]", "View");
-        cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
+        getTableRows("[data-testid=beta-access-table]")
+            .should("have.length", 2)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=email]").contains(validEmail);
+                cy.get("[data-testid=salesforce-access-switch]").should(
+                    "be.checked"
+                );
+                cy.get("[data-testid=salesforce-access-switch]").click();
+            });
 
-        // Un-assign salesforce feature on View
-        cy.log("Verify un-assign salesforce feature access on View tab.");
-        cy.get("[data-testid=salesforce-access-switch]").click();
-        cy.get("[data-testid=beta-access-table]").should("not.exist");
+        // Verify no longer present on View tab
+        getTableRows("[data-testid=beta-access-table]").should(
+            "have.length",
+            1
+        );
 
         // Tab back to Search and verify salesforce is un-assigned
         cy.log("Verify salesforce feature un-assigned on Search tab.");
@@ -106,7 +133,15 @@ describe("Beta feature access", () => {
 
         // Tab back to View and verify salesforce is assigned
         selectTab("[data-testid=beta-access-tabs]", "View");
-        cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
+        getTableRows("[data-testid=beta-access-table]")
+            .should("have.length", 2)
+            .first()
+            .within(() => {
+                cy.get("[data-testid=email]").contains(validEmail);
+                cy.get("[data-testid=salesforce-access-switch]").should(
+                    "be.checked"
+                );
+            });
 
         // Tab back to Search and un-assign salesforce feature
         cy.log("Verify salesforce feature still assigned on Search tab.");
@@ -124,6 +159,9 @@ describe("Beta feature access", () => {
         // Tab back to View and verify salesforce is un-assigned
         cy.log("Tab back to View to verify salesforce still un-assigned.");
         selectTab("[data-testid=beta-access-tabs]", "View");
-        cy.get("[data-testid=beta-access-table]").should("not.exist");
+        getTableRows("[data-testid=beta-access-table]").should(
+            "have.length",
+            1
+        );
     });
 });

--- a/Apps/Database/src/Delegates/DbProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbProfileDelegate.cs
@@ -77,7 +77,7 @@ namespace HealthGateway.Database.Delegates
         public async Task<DbResult<UserProfile>> UpdateAsync(UserProfile profile, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating user profile in DB");
-            UserProfile? userProfile = await this.GetUserProfileAsync(profile.HdId, ct: ct);
+            UserProfile? userProfile = await this.GetUserProfileAsync(profile.HdId, true, ct: ct);
             DbResult<UserProfile> result = new();
 
             if (userProfile != null)
@@ -89,6 +89,7 @@ namespace HealthGateway.Database.Delegates
                 userProfile.Version = profile.Version;
                 userProfile.YearOfBirth = profile.YearOfBirth;
                 userProfile.LastLoginClientCode = profile.LastLoginClientCode;
+                userProfile.BetaFeatureCodes = profile.BetaFeatureCodes;
                 result.Status = DbStatusCode.Deferred;
                 result.Payload = userProfile;
                 this.dbContext.UserProfile.Update(userProfile);

--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -196,7 +196,7 @@ namespace HealthGateway.GatewayApi.Services
         {
             this.logger.LogTrace("Updating user email...");
 
-            UserProfile userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, ct: ct) ??
+            UserProfile userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, true, ct: ct) ??
                                       throw new NotFoundException($"User profile not found for hdid {hdid}");
 
             bool result = string.IsNullOrWhiteSpace(emailAddress)
@@ -207,8 +207,9 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             this.logger.LogInformation("Removing email from user {Hdid}", hdid);
-            await this.profileDelegate.UpdateAsync(userProfile, ct: ct);
             userProfile.Email = null;
+            userProfile.BetaFeatureCodes = [];
+            await this.profileDelegate.UpdateAsync(userProfile, ct: ct);
 
             // Update the notification settings
             await this.notificationSettingsService.QueueNotificationSettingsAsync(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber), ct);

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -76,7 +76,7 @@ VALUES (
 	'System', 
 	current_timestamp, 
 	'2fab66e7-37c9-4b03-ba25-e8fad604dc7f', 
-	null,
+	'somebody@healthgateway.gov.bc.ca',
 	null,
 	null,
 	current_timestamp, 
@@ -611,6 +611,21 @@ VALUES (
     '1994',
     'Web'
 );
+
+INSERT INTO gateway."BetaFeatureAccess" (
+    "UserProfileId",
+    "BetaFeatureCode",
+    "CreatedBy",
+    "CreatedDateTime",
+    "UpdatedBy",
+    "UpdatedDateTime")
+VALUES (
+    'RD33Y2LJEUZCY2TCMOIECUTKS3E62MEQ62CSUL6Q553IHHBI3AWQ',
+    'Salesforce',
+    'System',
+    current_timestamp - INTERVAL '1 day',
+    'System',
+    current_timestamp - INTERVAL '1 day');
 
 INSERT INTO gateway."Rating"(
 	"RatingId", 

--- a/Testing/functional/tests/cypress/integration/e2e/user/betaFeatures.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/betaFeatures.js
@@ -1,0 +1,29 @@
+const { AuthMethod } = require("../../../support/constants");
+const homeUrl = "/home";
+
+describe("Beta Features", () => {
+    beforeEach(() => {
+        cy.configureSettings({});
+    });
+
+    it("Link to Beta Site on Home Page for Approved User", () => {
+        cy.login(
+            Cypress.env("keycloak.protected.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homeUrl
+        );
+        cy.get("[data-testid=beta-alert]").should("be.visible");
+    });
+
+    it("No Link to Beta Site on Home Page for Unapproved User", () => {
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homeUrl
+        );
+        cy.get("[data-testid=add-quick-link-button]").should("be.visible");
+        cy.get("[data-testid=beta-alert]").should("not.exist");
+    });
+});


### PR DESCRIPTION
# Implements [AB#16695](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16695)

## Description

- removes access to beta features when clearing email address
- uses shared utilities in admin beta access functional tests
- sorts rows in admin beta access table by email address
- updates seed data to pre-populate beta access
- updates admin beta feature tests to reflect updated seed data
- adds functional tests for link to beta site

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
