### PR TITLE
Add ApiExceptionHandler for uncaught Refit exceptions AB#16705

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/ExceptionHandling.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/ExceptionHandling.cs
@@ -16,7 +16,7 @@
 namespace HealthGateway.Common.AspNetConfiguration.Modules
 {
     using System.Diagnostics.CodeAnalysis;
-    using HealthGateway.Common.ErrorHandling;
+    using HealthGateway.Common.ErrorHandling.ExceptionHandlers;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.Extensions.DependencyInjection;
 
@@ -32,6 +32,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// <param name="services">The service collection to add forward proxies into.</param>
         public static void ConfigureProblemDetails(IServiceCollection services)
         {
+            services.AddExceptionHandler<ApiExceptionHandler>();
             services.AddExceptionHandler<ValidationExceptionHandler>();
             services.AddExceptionHandler<DefaultExceptionHandler>();
             services.AddProblemDetails();

--- a/Apps/Common/src/ErrorHandling/ExceptionHandlers/ApiExceptionHandler.cs
+++ b/Apps/Common/src/ErrorHandling/ExceptionHandlers/ApiExceptionHandler.cs
@@ -1,0 +1,71 @@
+﻿// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.Common.ErrorHandling.ExceptionHandlers
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
+    using Microsoft.AspNetCore.Diagnostics;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+
+    /// <inheritdoc/>
+    /// <summary>
+    /// Transform Refit <see cref="Refit.ApiException"/> into a problem details response.
+    /// </summary>
+    internal sealed class ApiExceptionHandler(IConfiguration configuration, ILogger<ApiExceptionHandler> logger) : IExceptionHandler
+    {
+        /// <inheritdoc/>
+        public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
+        {
+            if (exception is not Refit.ApiException apiException)
+            {
+                return false;
+            }
+
+            this.LogException(apiException);
+
+            bool includeException = configuration.GetValue("IncludeExceptionDetailsInResponse", false);
+
+            ProblemDetails problemDetails = ExceptionUtilities.ToProblemDetails(WrapException(apiException), httpContext, includeException);
+
+            httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status502BadGateway;
+            await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
+
+            return true;
+        }
+
+        private static UpstreamServiceException WrapException(Refit.ApiException apiException)
+        {
+            // include HTTP method, URI, and response content in message for easier debugging
+            string message = $"Unexpected response ({(int)apiException.StatusCode}) from API call {apiException.HttpMethod} {apiException.Uri}";
+            if (!string.IsNullOrEmpty(apiException.Content))
+            {
+                message += $"{Environment.NewLine}{Environment.NewLine}Content:{Environment.NewLine}{apiException.Content}";
+            }
+
+            return new(message, apiException);
+        }
+
+        private void LogException(Refit.ApiException apiException)
+        {
+            logger.LogError(apiException, "Unexpected response ({ResponseCode}) from API call {Method} {Uri}", (int)apiException.StatusCode, apiException.HttpMethod, apiException.Uri);
+        }
+    }
+}

--- a/Apps/Common/src/ErrorHandling/ExceptionHandlers/ValidationExceptionHandler.cs
+++ b/Apps/Common/src/ErrorHandling/ExceptionHandlers/ValidationExceptionHandler.cs
@@ -13,30 +13,36 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 // -------------------------------------------------------------------------
-namespace HealthGateway.Common.ErrorHandling
+namespace HealthGateway.Common.ErrorHandling.ExceptionHandlers
 {
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using FluentValidation;
     using Microsoft.AspNetCore.Diagnostics;
     using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Configuration;
-    using ProblemDetails = Microsoft.AspNetCore.Mvc.ProblemDetails;
 
     /// <inheritdoc/>
     /// <summary>
-    /// Transforms any exception into the appropriate problem details response.
+    /// Transform validation exceptions into a problem details response.
     /// </summary>
-    internal sealed class DefaultExceptionHandler(IConfiguration configuration) : IExceptionHandler
+    internal sealed class ValidationExceptionHandler(IConfiguration configuration) : IExceptionHandler
     {
         /// <inheritdoc/>
         public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception exception, CancellationToken cancellationToken)
         {
+            if (exception is not ValidationException validationException)
+            {
+                return false;
+            }
+
             bool includeException = configuration.GetValue("IncludeExceptionDetailsInResponse", false);
 
-            ProblemDetails problemDetails = ExceptionUtilities.ToProblemDetails(exception, httpContext, includeException);
+            ValidationProblemDetails problemDetails = (ValidationProblemDetails)ExceptionUtilities.ToProblemDetails(validationException, httpContext, includeException);
 
-            httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status500InternalServerError;
+            httpContext.Response.StatusCode = problemDetails.Status ?? StatusCodes.Status400BadRequest;
             await httpContext.Response.WriteAsJsonAsync(problemDetails, cancellationToken);
 
             return true;


### PR DESCRIPTION
# Implements [AB#16705](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16705) ([AB#16709](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16709))

## Description

Adds exception handler for ApiExceptions thrown by Refit that aren't caught by the calling code.

These exceptions will now be transformed into UpstreamServiceExceptions for better handling when generating the problem details response.  This enables more accurate feedback to be returned in all cases, and for specific debug information to be included when returning exception details is enabled in the dev environment.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

### Example problem details response

```
{
    "type": "UpstreamError",
    "title": "An error occurred with an upstream service.",
    "status": 502,
    "instance": "/Notification/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A",
    "traceId": "0HN2K86BANG7T:00000008",
    "exception": {
        "message": "Unexpected response (404) from API call GET https://phsa-ccd-dev.azure-api.net/healthgateways/personal-accounts/hdid/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A\r\n\r\nContent:\r\n{ \"statusCode\": 404, \"message\": \"Resource not found\" }",
        "stackTrace": null,
        "innerException": {
            "message": "Response status code does not indicate success: 404 (Resource Not Found).",
            "stackTrace": "<omitted for the purposes of this example>",
            "innerException": null
        }
    }
}
```

The important new part is the first exception's message, which expands to this when formatted:

```
Unexpected response (404) from API call GET https://phsa-ccd-dev.azure-api.net/healthgateways/personal-accounts/hdid/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A

Content:
{ "statusCode": 404, "message": "Resource not found" }
```

### Example log message

The first part of that additional info will be logged now as well:

```
[17:53:28 ERR] Unexpected response (404) from API call GET https://phsa-ccd-dev.azure-api.net/healthgateways/personal-accounts/hdid/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A
Refit.ApiException: Response status code does not indicate success: 404 (Resource Not Found).
   at Refit.RequestBuilderImplementation.<>c__DisplayClass14_0`2.<<BuildCancellableTaskFuncForMethod>b__0>d.MoveNext() in /_/Refit/RequestBuilderImplementation.cs:line 288
--- End of stack trace from previous location ---
   at HealthGateway.Common.Services.PersonalAccountsService.GetPatientAccountAsync(String hdid, CancellationToken ct) in D:\Dev\Work\healthgateway\Apps\Common\src\Services\PersonalAccountsService.cs:line 80
   at <etc.>
```

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
