### PR TITLE
Update beta site link to open in same tab AB#16713

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -413,7 +413,7 @@ watch(vaccineRecordState, () => {
         <span class="text-body-1">
             You are invited to try the new beta version of Health Gateway and
             provide your feedback.
-            <a :href="betaUrl" target="_blank" rel="noopener" class="text-link">
+            <a :href="betaUrl" target="_self" class="text-link">
                 Try the beta version now.
             </a>
         </span>


### PR DESCRIPTION
# Implements [AB#16713](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16713)

## Description

Modifies the link for the beta site to open in the same tab instead of a new tab, to reflect updated requirements.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
