### PR TITLE
Increase code coverage for AccountDataAccess for AB#16673.

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -299,12 +299,6 @@ namespace HealthGateway.AccountDataAccess.Patient
                     patientModel.ResponseCode = responseCode;
                 }
 
-                if (responseCode.Contains("BCHCIM.GD.2.0018", StringComparison.InvariantCulture))
-                {
-                    this.logger.LogDebug("Return null for patient as response code is BCHCIM.GD.2.0018");
-                    patientModel = null;
-                }
-
                 return patientModel;
             }
         }

--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -63,7 +63,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         private static ActivitySource Source { get; } = new(nameof(ClientRegistriesDelegate));
 
         /// <inheritdoc/>
-        public async Task<PatientModel?> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false, CancellationToken ct = default)
+        public async Task<PatientModel> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false, CancellationToken ct = default)
         {
             this.logger.LogDebug("Getting patient for type: {Type} and value: {Identifier} started", type, identifier);
             using Activity? activity = Source.StartActivity();
@@ -253,7 +253,7 @@ namespace HealthGateway.AccountDataAccess.Patient
 
         [SuppressMessage("Minor Code Smell", "S6602:\"Find\" method should be used instead of the \"FirstOrDefault\" extension", Justification = "Team decision")]
         [SuppressMessage("Minor Code Smell", "S6605:Collection-specific \"Exists\" method should be used instead of the \"Any\" extension", Justification = "Team decision")]
-        private PatientModel? ParseResponse(HCIM_IN_GetDemographicsResponse1 reply, bool disableIdValidation)
+        private PatientModel ParseResponse(HCIM_IN_GetDemographicsResponse1 reply, bool disableIdValidation)
         {
             using (Source.StartActivity())
             {
@@ -273,7 +273,7 @@ namespace HealthGateway.AccountDataAccess.Patient
                 }
 
                 // Initialize model
-                PatientModel? patientModel = new()
+                PatientModel patientModel = new()
                 {
                     Birthdate = dob,
                     Gender = retrievedPerson.identifiedPerson.administrativeGenderCode.code switch

--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -36,6 +36,7 @@ namespace HealthGateway.AccountDataAccess.Patient
     /// </summary>
     internal class ClientRegistriesDelegate : IClientRegistriesDelegate
     {
+        private const string Instance = "INSTANCE";
         private static readonly List<string> WarningResponseCodes =
         [
             "BCHCIM.GD.0.0015", "BCHCIM.GD.1.0015", "BCHCIM.GD.0.0019", "BCHCIM.GD.1.0019", "BCHCIM.GD.0.0020", "BCHCIM.GD.1.0020", "BCHCIM.GD.0.0021", "BCHCIM.GD.1.0021", "BCHCIM.GD.0.0022",
@@ -93,12 +94,12 @@ namespace HealthGateway.AccountDataAccess.Patient
                         typeCode = "RCV",
                         device = new MCCI_MT000100Device
                         {
-                            determinerCode = "INSTANCE", classCode = "DEV",
+                            determinerCode = Instance, classCode = "DEV",
                             id = new II { root = "2.16.840.1.113883.3.51.1.1.4", extension = "192.168.0.1" },
                             asAgent = new MCCI_MT000100Agent
                             {
                                 classCode = "AGNT",
-                                representedOrganization = new MCCI_MT000100Organization { determinerCode = "INSTANCE", classCode = "ORG" },
+                                representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" },
                             },
                         },
                     },
@@ -106,7 +107,7 @@ namespace HealthGateway.AccountDataAccess.Patient
 
                 request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization
                 {
-                    determinerCode = "INSTANCE", classCode = "ORG",
+                    determinerCode = Instance, classCode = "ORG",
                     id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HCIM" },
                 };
 
@@ -115,18 +116,18 @@ namespace HealthGateway.AccountDataAccess.Patient
                     typeCode = "SND",
                     device = new MCCI_MT000100Device
                     {
-                        determinerCode = "INSTANCE", classCode = "DEV",
+                        determinerCode = Instance, classCode = "DEV",
                         id = new II { root = "2.16.840.1.113883.3.51.1.1.5", extension = "MOH_CRS" },
                         asAgent = new MCCI_MT000100Agent
                         {
                             classCode = "AGNT",
-                            representedOrganization = new MCCI_MT000100Organization { determinerCode = "INSTANCE", classCode = "ORG" },
+                            representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" },
                         },
                     },
                 };
                 request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization
                 {
-                    determinerCode = "INSTANCE", classCode = "ORG",
+                    determinerCode = Instance, classCode = "ORG",
                     id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HGWAY" },
                 };
 

--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -225,6 +225,12 @@ namespace HealthGateway.AccountDataAccess.Patient
 
         private void CheckResponseCode(string responseCode)
         {
+            if (responseCode.Contains("BCHCIM.GD.2.0018", StringComparison.InvariantCulture))
+            {
+                this.logger.LogDebug("Return patient not found as response code is BCHCIM.GD.2.0018");
+                throw new NotFoundException(ErrorMessages.ClientRegistryRecordsNotFound);
+            }
+
             if (responseCode.Contains("BCHCIM.GD.2.0006", StringComparison.InvariantCulture))
             {
                 // Returned BCHCIM.GD.2.0006 Invalid PHN

--- a/Apps/AccountDataAccess/src/Patient/IClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/IClientRegistriesDelegate.cs
@@ -17,7 +17,9 @@ namespace HealthGateway.AccountDataAccess.Patient
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using FluentValidation;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
 
     /// <summary>
     /// The Patient data service.
@@ -31,7 +33,9 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="identifier">The associated oid type's identifier to retrieve the patient demographics information.</param>
         /// <param name="disableIdValidation">Disables the validation on HDID/PHN when true.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <exception cref="NotFoundException">No patient could be found matching the provided criteria.</exception>
+        /// <exception cref="ValidationException">The provided PHN identifier is invalid.</exception>
         /// <returns>The patient model wrapped in an api result object.</returns>
-        Task<PatientModel?> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false, CancellationToken ct = default);
+        Task<PatientModel> GetDemographicsAsync(OidType type, string identifier, bool disableIdValidation = false, CancellationToken ct = default);
     }
 }

--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -18,7 +18,9 @@ namespace HealthGateway.AccountDataAccess.Patient
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using FluentValidation;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
     using HealthGateway.Database.Models;
 
     /// <summary>
@@ -52,6 +54,8 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// </summary>
         /// <param name="query">The query.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <exception cref="NotFoundException">No patient could be found matching the provided criteria.</exception>
+        /// <exception cref="ValidationException">The provided PHN identifier is invalid.</exception>
         /// <returns>The patient model wrapped in a patient query result object.</returns>
         Task<PatientQueryResult> QueryAsync(PatientQuery query, CancellationToken ct = default);
 
@@ -97,8 +101,8 @@ namespace HealthGateway.AccountDataAccess.Patient
     /// <summary>
     /// The query result.
     /// </summary>
-    /// <param name="Items">The result.</param>
-    public record PatientQueryResult(IEnumerable<PatientModel> Items);
+    /// <param name="Item">The result.</param>
+    public record PatientQueryResult(PatientModel Item);
 
     /// <summary>
     /// The patient details query.

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -214,8 +214,8 @@ namespace HealthGateway.AccountDataAccess.Patient
             // Get the appropriate strategy from factory to query patient
             PatientQueryStrategy patientQueryStrategy = this.patientQueryFactory.GetPatientQueryStrategy(strategy);
             PatientQueryContext context = new(patientQueryStrategy);
-            PatientModel? patient = await context.GetPatientAsync(patientRequest, ct);
-            return new PatientQueryResult(new[] { patient! });
+            PatientModel patient = await context.GetPatientAsync(patientRequest, ct);
+            return new PatientQueryResult(patient);
         }
     }
 }

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     using HealthGateway.AccountDataAccess.Patient.Api;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Refit;
@@ -60,7 +61,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         }
 
         /// <inheritdoc/>
-        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
+        public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
             PatientModel? patient = request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null;
 
@@ -80,6 +81,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
                 {
                     this.GetLogger().LogInformation(e, "PHSA could not find patient identity for {Hdid}", request.Identifier);
+                    throw new NotFoundException(ErrorMessages.PatientIdentityNotFound);
                 }
             }
 

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidAllStrategy.cs
@@ -70,7 +70,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
             }
             catch (CommunicationException ce)
             {
-                this.GetLogger().LogError("Will call PHSA for patient due to EMPI Communication Exception when trying to retrieve patient information: {Exception}", ce);
+                this.GetLogger().LogError(ce, "Will call PHSA for patient due to EMPI Communication Exception when trying to retrieve patient information: {Message}", ce.Message);
 
                 try
                 {
@@ -79,7 +79,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
                 }
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
                 {
-                    this.GetLogger().LogInformation("PHSA could not find patient identity for {Hdid}", request.Identifier);
+                    this.GetLogger().LogInformation(e, "PHSA could not find patient identity for {Hdid}", request.Identifier);
                 }
             }
 

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidEmpiStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidEmpiStrategy.cs
@@ -47,10 +47,10 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         }
 
         /// <inheritdoc/>
-        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
+        public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
-            PatientModel? patient = (request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null) ??
-                                    await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation, ct);
+            PatientModel patient = (request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null) ??
+                                   await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation, ct);
 
             await this.CachePatientAsync(patient, request.DisabledValidation, ct);
             return patient;

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
@@ -68,7 +68,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
                 }
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
                 {
-                    this.GetLogger().LogInformation("PHSA could not find patient identity for {Hdid}", request.Identifier);
+                    this.GetLogger().LogInformation(e, "PHSA could not find patient identity for {Hdid}", request.Identifier);
                 }
             }
 

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     using HealthGateway.AccountDataAccess.Patient.Api;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Refit;
@@ -55,7 +56,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         }
 
         /// <inheritdoc/>
-        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
+        public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
             PatientModel? patient = request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Phn, ct) : null;
 
@@ -69,6 +70,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
                 {
                     this.GetLogger().LogInformation(e, "PHSA could not find patient identity for {Hdid}", request.Identifier);
+                    throw new NotFoundException(ErrorMessages.PatientIdentityNotFound);
                 }
             }
 

--- a/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryContext.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryContext.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         /// <param name="patientRequest">The patient request parameters to use.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The patient model.</returns>
-        public async Task<PatientModel?> GetPatientAsync(PatientRequest patientRequest, CancellationToken ct = default)
+        public async Task<PatientModel> GetPatientAsync(PatientRequest patientRequest, CancellationToken ct = default)
         {
             return await this.patientQueryStrategy.GetPatientAsync(patientRequest, ct);
         }

--- a/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryStrategy.cs
@@ -19,8 +19,10 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
+    using FluentValidation;
     using HealthGateway.Common.CacheProviders;
     using HealthGateway.Common.Constants;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -61,8 +63,10 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         /// </summary>
         /// <param name="request">The request parameter values to use in the query..</param>
         /// <param name="ct">The cancellation token.</param>
+        /// <exception cref="NotFoundException">No patient could be found matching the provided criteria.</exception>
+        /// <exception cref="ValidationException">The provided PHN identifier is invalid.</exception>
         /// <returns>A <see cref="PatientQueryStrategy"/> class.</returns>
-        public abstract Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default);
+        public abstract Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default);
 
         /// <summary>
         /// Returns the logger.

--- a/Apps/AccountDataAccess/src/Patient/Strategy/PhnEmpiStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PhnEmpiStrategy.cs
@@ -49,7 +49,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         }
 
         /// <inheritdoc/>
-        public override async Task<PatientModel?> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
+        public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
             await new PhnValidator(ErrorMessages.PhnInvalid).ValidateAndThrowAsync(request.Identifier, ct);
 

--- a/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
+++ b/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
@@ -41,33 +41,46 @@ namespace AccountDataAccessTest
         /// <summary>
         /// Client registry get demographics by hdid - Happy Path.
         /// </summary>
+        /// <param name="addressExists">Value to determine whether address exists or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetDemographics()
+        [InlineData(true)]
+        [InlineData(false)]
+        [Theory]
+        public async Task ShouldGetDemographics(bool addressExists)
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.0.0013";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
-            string expectedGender = "Female";
-            Address expectedPhysicalAddr = new()
-            {
-                StreetLines = ["Line 1", "Line 2", "Physical"],
-                City = "city",
-                Country = "CA",
-                PostalCode = "N0N0N0",
-                State = "BC",
-            };
-            Address expectedPostalAddr = new()
-            {
-                StreetLines = ["Line 1", "Line 2", "Postal"],
-                City = "city",
-                Country = "CA",
-                PostalCode = "N0N0N0",
-                State = "BC",
-            };
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.0.0013";
+            const string expectedFirstName = "Jane";
+            const string expectedLastName = "Doe";
+            const string expectedGender = "Female";
+            Address? expectedPhysicalAddr = addressExists
+                ? new()
+                {
+                    StreetLines = ["Line 1", "Line 2", "Physical"],
+                    City = "city",
+                    Country = "CA",
+                    PostalCode = "N0N0N0",
+                    State = "BC",
+                }
+                : null;
+            Address? expectedPostalAddr = addressExists
+                ? new()
+                {
+                    StreetLines = ["Line 1", "Line 2", "Postal"],
+                    City = "city",
+                    Country = "CA",
+                    PostalCode = "N0N0N0",
+                    State = "BC",
+                }
+                : null;
+
+            IEnumerable<ClientRegistryAddress> clientRegistryAddresses = addressExists
+                ? [new ClientRegistryAddress(expectedPhysicalAddr, cs_PostalAddressUse.PHYS), new ClientRegistryAddress(expectedPostalAddr, cs_PostalAddressUse.PST)]
+                : [];
+            IEnumerable<AD> addresses = GenerateAddresses(clientRegistryAddresses);
+
             DateTime expectedBirthDate = DateTime.ParseExact("20001231", "yyyyMMdd", CultureInfo.InvariantCulture);
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
@@ -81,93 +94,7 @@ namespace AccountDataAccessTest
                         displayable = true,
                     },
                 ],
-                addr =
-                [
-                    new()
-                    {
-                        use =
-                        [
-                            cs_PostalAddressUse.PHYS,
-                        ],
-                        Items =
-                        [
-                            new ADStreetAddressLine
-                            {
-                                Text = expectedPhysicalAddr.StreetLines.ToArray(),
-                            },
-                            new ADCity
-                            {
-                                Text =
-                                [
-                                    expectedPhysicalAddr.City,
-                                ],
-                            },
-                            new ADState
-                            {
-                                Text =
-                                [
-                                    expectedPhysicalAddr.State,
-                                ],
-                            },
-                            new ADPostalCode
-                            {
-                                Text =
-                                [
-                                    expectedPhysicalAddr.PostalCode,
-                                ],
-                            },
-                            new ADCountry
-                            {
-                                Text =
-                                [
-                                    expectedPhysicalAddr.Country,
-                                ],
-                            },
-                        ],
-                    },
-                    new()
-                    {
-                        use =
-                        [
-                            cs_PostalAddressUse.PST,
-                        ],
-                        Items =
-                        [
-                            new ADStreetAddressLine
-                            {
-                                Text = expectedPostalAddr.StreetLines.ToArray(),
-                            },
-                            new ADCity
-                            {
-                                Text =
-                                [
-                                    expectedPostalAddr.City,
-                                ],
-                            },
-                            new ADState
-                            {
-                                Text =
-                                [
-                                    expectedPostalAddr.State,
-                                ],
-                            },
-                            new ADPostalCode
-                            {
-                                Text =
-                                [
-                                    expectedPostalAddr.PostalCode,
-                                ],
-                            },
-                            new ADCountry
-                            {
-                                Text =
-                                [
-                                    expectedPostalAddr.Country,
-                                ],
-                            },
-                        ],
-                    },
-                ],
+                addr = addresses.ToArray(),
                 identifiedPerson = new HCIM_IN_GetDemographicsResponsePerson
                 {
                     id =
@@ -255,17 +182,29 @@ namespace AccountDataAccessTest
         /// <summary>
         /// Client registry get demographics - Happy Path (Validate Multiple Names).
         /// </summary>
+        /// <param name="nameExists">Value to determine whether name exists or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetDemographicsGivenCorrectNameSection()
+        [InlineData(true)]
+        [InlineData(false)]
+        [Theory]
+        public async Task ShouldGetDemographicsGivenCorrectNameSection(bool nameExists)
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.0.0013";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
-            string expectedGender = "Female";
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.0.0013";
+            const string? firstName1 = "Jane";
+            const string? firstName2 = "Ann";
+            const string? lastName1 = "Lee";
+            const string? lastName2 = "Curtis";
+            const string expectedGender = "Female";
+            string? expectedFirstName = nameExists ? $"{firstName1} {firstName2}" : null;
+            string? expectedLastName = nameExists ? $"{lastName1} {lastName2}" : null;
+            IEnumerable<string> givenNames = [firstName1, firstName2];
+            IEnumerable<string> familyNames = [lastName1, lastName2];
+            IEnumerable<ClientRegistryName> clientRegistryNames =
+                nameExists ? [new ClientRegistryName(["Wrong given name"], ["Wrong family name"]), new ClientRegistryName(givenNames, familyNames, cs_EntityNameUse.C)] : [];
+            IEnumerable<PN> names = GenerateNames(clientRegistryNames);
             DateTime expectedBirthDate = DateTime.ParseExact("20001231", "yyyyMMdd", CultureInfo.InvariantCulture);
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
@@ -289,39 +228,7 @@ namespace AccountDataAccessTest
                             extension = expectedPhn,
                         },
                     ],
-                    name =
-                    [
-                        new PN
-                        {
-                            Items =
-                            [
-                                new engiven
-                                {
-                                    Text = ["Wrong Given Name"],
-                                },
-                                new enfamily
-                                {
-                                    Text = ["Wrong Family Name"],
-                                },
-                            ],
-                            use = [cs_EntityNameUse.L],
-                        },
-                        new PN
-                        {
-                            Items =
-                            [
-                                new engiven
-                                {
-                                    Text = [expectedFirstName],
-                                },
-                                new enfamily
-                                {
-                                    Text = [expectedLastName],
-                                },
-                            ],
-                            use = [cs_EntityNameUse.C],
-                        },
-                    ],
+                    name = names.ToArray(),
                     birthTime = new TS
                     {
                         value = "20001231",
@@ -370,8 +277,8 @@ namespace AccountDataAccessTest
             // Verify
             Assert.Equal(expectedHdId, actual?.Hdid);
             Assert.Equal(expectedPhn, actual?.Phn);
-            Assert.Equal(expectedFirstName, actual?.PreferredName.GivenName);
-            Assert.Equal(expectedLastName, actual?.PreferredName.Surname);
+            Assert.Equal(expectedFirstName, actual?.PreferredName?.GivenName);
+            Assert.Equal(expectedLastName, actual?.PreferredName?.Surname);
             Assert.Equal(expectedBirthDate, actual?.Birthdate);
             Assert.Equal(expectedGender, actual?.Gender);
         }
@@ -384,12 +291,12 @@ namespace AccountDataAccessTest
         public async Task ShouldGetDemographicsGivenCorrectNameQualifier()
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.0.0013";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
-            string expectedGender = "Female";
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.0.0013";
+            const string expectedFirstName = "Jane";
+            const string expectedLastName = "Doe";
+            const string expectedGender = "Female";
             DateTime expectedBirthDate = DateTime.ParseExact("20001231", "yyyyMMdd", CultureInfo.InvariantCulture);
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
@@ -532,11 +439,11 @@ namespace AccountDataAccessTest
         public async Task ShouldGetDemographicsGivenSubjectOfOverlay()
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.1.0019";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.1.0019";
+            const string expectedFirstName = "Jane";
+            const string expectedLastName = "Doe";
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
@@ -634,11 +541,11 @@ namespace AccountDataAccessTest
         public async Task ShouldGetDemographicsGivenSubjectOfPotentialDuplicate()
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.1.0021";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.1.0021";
+            const string expectedFirstName = "Jane";
+            const string expectedLastName = "Doe";
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
@@ -736,11 +643,11 @@ namespace AccountDataAccessTest
         public async Task ShouldGetDemographicsGivenSubjectOfPotentialLinkage()
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.1.0022";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.1.0022";
+            const string expectedFirstName = "Jane";
+            const string expectedLastName = "Doe";
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
@@ -838,11 +745,11 @@ namespace AccountDataAccessTest
         public async Task ShouldGetDemographicsGivenSubjectOfReviewIdentifier()
         {
             // Setup
-            string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
-            string expectedPhn = "0009735353315";
-            string expectedResponseCode = "BCHCIM.GD.1.0023";
-            string expectedFirstName = "Jane";
-            string expectedLastName = "Doe";
+            const string expectedHdId = "EXTRIOYFPNX35TWEBUAJ3DNFDFXSYTBC6J4M76GYE3HC5ER2NKWQ";
+            const string expectedPhn = "0009735353315";
+            const string expectedResponseCode = "BCHCIM.GD.1.0023";
+            const string expectedFirstName = "Jane";
+            const string expectedLastName = "Doe";
 
             HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = new()
             {
@@ -951,6 +858,22 @@ namespace AccountDataAccessTest
         }
 
         /// <summary>
+        /// Client registry get demographics throws not found exception given invalid birthdate.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetDemographicsThrowsNotFoundExceptionGivenInvalidBirthDate()
+        {
+            // Setup
+            const string expectedResponseCode = "BCHCIM.GD.0.0013";
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode, invalidBirthdate: true);
+
+            // Act and Assert
+            NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(() => clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn));
+            Assert.Equal(ErrorMessages.InvalidServicesCard, exception.Message);
+        }
+
+        /// <summary>
         /// Client registry get demographics throws api patient exception given client registry not returning person.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -958,17 +881,11 @@ namespace AccountDataAccessTest
         public async Task GetDemographicsThrowsProblemDetailsExceptionGivenClientRegistryDoesNotReturnPerson()
         {
             // Setup
-            string expectedResponseCode = "BCHCIM.GD.0.0099";
+            const string expectedResponseCode = "BCHCIM.GD.0.0099";
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode);
 
-            // Act
-            async Task Actual()
-            {
-                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn);
-            }
-
-            // Verify
-            NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(Actual);
+            // Act and Assert
+            NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(() => clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn));
             Assert.Equal(ErrorMessages.ClientRegistryDoesNotReturnPerson, exception.Message);
         }
 
@@ -980,17 +897,11 @@ namespace AccountDataAccessTest
         public async Task GetDemographicsThrowsProblemDetailsExceptionGivenClientRegistryPhnInvalid()
         {
             // Setup
-            string expectedResponseCode = "BCHCIM.GD.2.0006";
+            const string expectedResponseCode = "BCHCIM.GD.2.0006";
             IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode, false, true);
 
-            // Act
-            async Task Actual()
-            {
-                await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn);
-            }
-
-            // Verify
-            ValidationException exception = await Assert.ThrowsAsync<ValidationException>(Actual);
+            // Act and Assert
+            ValidationException exception = await Assert.ThrowsAsync<ValidationException>(() => clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn));
             Assert.Equal(ErrorMessages.PhnInvalid, exception.Message);
         }
 
@@ -1013,9 +924,10 @@ namespace AccountDataAccessTest
             bool deceasedInd = false,
             bool noNames = false,
             bool noIds = false,
-            bool throwsException = false)
+            bool throwsException = false,
+            bool invalidBirthdate = false)
         {
-            HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = GetSubjectTarget(deceasedInd, noNames, noIds);
+            HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = GetSubjectTarget(deceasedInd, noNames, noIds, invalidBirthdate);
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
 
@@ -1035,7 +947,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
         }
 
-        private static HCIM_IN_GetDemographicsResponseIdentifiedPerson GetSubjectTarget(bool deceasedInd = false, bool noNames = false, bool noIds = false)
+        private static HCIM_IN_GetDemographicsResponseIdentifiedPerson GetSubjectTarget(bool deceasedInd = false, bool noNames = false, bool noIds = false, bool invalidBirthdate = false)
         {
             return new HCIM_IN_GetDemographicsResponseIdentifiedPerson
             {
@@ -1052,10 +964,10 @@ namespace AccountDataAccessTest
                     deceasedInd = new BL
                         { value = deceasedInd },
                     id = GetIds(noIds),
-                    name = GetNames(noNames),
+                    name = GenerateNames([new ClientRegistryName([FirstName], [LastName], cs_EntityNameUse.C)]).ToArray(),
                     birthTime = new TS
                     {
-                        value = "20001231",
+                        value = invalidBirthdate ? "yyyyMMdd" : "20001231",
                     },
                     administrativeGenderCode = new CE
                     {
@@ -1078,33 +990,6 @@ namespace AccountDataAccessTest
                 {
                     root = "01010101010",
                     extension = Phn,
-                },
-            ];
-        }
-
-        private static PN[] GetNames(bool noNames = false)
-        {
-            if (noNames)
-            {
-                return Array.Empty<PN>();
-            }
-
-            return
-            [
-                new PN
-                {
-                    Items =
-                    [
-                        new engiven
-                        {
-                            Text = [FirstName],
-                        },
-                        new enfamily
-                        {
-                            Text = [LastName],
-                        },
-                    ],
-                    use = [cs_EntityNameUse.C],
                 },
             ];
         }
@@ -1137,5 +1022,80 @@ namespace AccountDataAccessTest
                 },
             };
         }
+
+        private static IEnumerable<AD> GenerateAddresses(IEnumerable<ClientRegistryAddress> addresses)
+        {
+            return addresses.Select(GenerateAddress);
+        }
+
+        private static AD GenerateAddress(ClientRegistryAddress address)
+        {
+            return new()
+            {
+                use =
+                [
+                    address.AddressUse,
+                ],
+                Items =
+                [
+                    new ADStreetAddressLine
+                    {
+                        Text = address.Address.StreetLines.ToArray(),
+                    },
+                    new ADCity
+                    {
+                        Text =
+                        [
+                            address.Address.City,
+                        ],
+                    },
+                    new ADState
+                    {
+                        Text =
+                        [
+                            address.Address.State,
+                        ],
+                    },
+                    new ADPostalCode
+                    {
+                        Text =
+                        [
+                            address.Address.PostalCode,
+                        ],
+                    },
+                    new ADCountry
+                    {
+                        Text =
+                        [
+                            address.Address.Country,
+                        ],
+                    },
+                ],
+            };
+        }
+
+        private static IEnumerable<PN> GenerateNames(IEnumerable<ClientRegistryName>? names = null)
+        {
+            return names.Select(GenerateName) ?? Enumerable.Empty<PN>();
+        }
+
+        private static PN GenerateName(ClientRegistryName name)
+        {
+            return new()
+            {
+                Items = GenerateItemNames(name.GivenNames, name.FamilyNames).ToArray(),
+                use = [name.NameUse],
+            };
+        }
+
+        private static IEnumerable<ENXP> GenerateItemNames(IEnumerable<string> givenNames, IEnumerable<string> familyNames)
+        {
+            return givenNames.Select(x => new engiven { Text = [x] })
+                .Concat<ENXP>(familyNames.Select(x => new enfamily { Text = [x] }));
+        }
+
+        private sealed record ClientRegistryAddress(Address Address, cs_PostalAddressUse AddressUse);
+
+        private sealed record ClientRegistryName(IEnumerable<string> GivenNames, IEnumerable<string> FamilyNames, cs_EntityNameUse NameUse = cs_EntityNameUse.L);
     }
 }

--- a/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
+++ b/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
@@ -277,8 +277,8 @@ namespace AccountDataAccessTest
             // Verify
             Assert.Equal(expectedHdId, actual?.Hdid);
             Assert.Equal(expectedPhn, actual?.Phn);
-            Assert.Equal(expectedFirstName, actual?.PreferredName?.GivenName);
-            Assert.Equal(expectedLastName, actual?.PreferredName?.Surname);
+            Assert.Equal(expectedFirstName, actual?.CommonName?.GivenName);
+            Assert.Equal(expectedLastName, actual?.CommonName?.Surname);
             Assert.Equal(expectedBirthDate, actual?.Birthdate);
             Assert.Equal(expectedGender, actual?.Gender);
         }
@@ -848,7 +848,7 @@ namespace AccountDataAccessTest
         public async Task ShouldGetDemographicsGivenDisabledIdValidationIsTrue()
         {
             // Setup
-            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, false, true);
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(false, true);
 
             // Act
             PatientModel? actual = await clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn, true);
@@ -907,14 +907,12 @@ namespace AccountDataAccessTest
 
         private static IClientRegistriesDelegate GetClientRegistriesDelegate(
             bool deceasedInd = false,
-            bool noNames = false,
             bool noIds = false,
             bool throwsException = false)
         {
             return GetClientRegistriesDelegate(
                 ResponseCode,
                 deceasedInd,
-                noNames,
                 noIds,
                 throwsException);
         }
@@ -922,12 +920,11 @@ namespace AccountDataAccessTest
         private static IClientRegistriesDelegate GetClientRegistriesDelegate(
             string expectedResponseCode = ResponseCode,
             bool deceasedInd = false,
-            bool noNames = false,
             bool noIds = false,
             bool throwsException = false,
             bool invalidBirthdate = false)
         {
-            HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = GetSubjectTarget(deceasedInd, noNames, noIds, invalidBirthdate);
+            HCIM_IN_GetDemographicsResponseIdentifiedPerson subjectTarget = GetSubjectTarget(deceasedInd, noIds, invalidBirthdate);
 
             Mock<QUPA_AR101102_PortType> clientMock = new();
 
@@ -947,7 +944,7 @@ namespace AccountDataAccessTest
                 clientMock.Object);
         }
 
-        private static HCIM_IN_GetDemographicsResponseIdentifiedPerson GetSubjectTarget(bool deceasedInd = false, bool noNames = false, bool noIds = false, bool invalidBirthdate = false)
+        private static HCIM_IN_GetDemographicsResponseIdentifiedPerson GetSubjectTarget(bool deceasedInd = false, bool noIds = false, bool invalidBirthdate = false)
         {
             return new HCIM_IN_GetDemographicsResponseIdentifiedPerson
             {
@@ -1076,7 +1073,7 @@ namespace AccountDataAccessTest
 
         private static IEnumerable<PN> GenerateNames(IEnumerable<ClientRegistryName>? names = null)
         {
-            return names.Select(GenerateName) ?? Enumerable.Empty<PN>();
+            return names.Select(GenerateName);
         }
 
         private static PN GenerateName(ClientRegistryName name)

--- a/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
+++ b/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
@@ -874,11 +874,27 @@ namespace AccountDataAccessTest
         }
 
         /// <summary>
-        /// Client registry get demographics throws api patient exception given client registry not returning person.
+        /// Client registry get demographics throws not found exception given client registry not returning person.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task GetDemographicsThrowsProblemDetailsExceptionGivenClientRegistryDoesNotReturnPerson()
+        public async Task GetDemographicsThrowsNotFoundExceptionGivenClientRegistryRecordNotFound()
+        {
+            // Setup
+            const string expectedResponseCode = "BCHCIM.GD.2.0018";
+            IClientRegistriesDelegate clientRegistryDelegate = GetClientRegistriesDelegate(expectedResponseCode);
+
+            // Act and Assert
+            NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(() => clientRegistryDelegate.GetDemographicsAsync(OidType.Phn, Phn));
+            Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.Message);
+        }
+
+        /// <summary>
+        /// Client registry get demographics throws not found exception given client registry not returning person.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task GetDemographicsThrowsNotFoundExceptionGivenClientRegistryDoesNotReturnPerson()
         {
             // Setup
             const string expectedResponseCode = "BCHCIM.GD.0.0099";
@@ -890,11 +906,11 @@ namespace AccountDataAccessTest
         }
 
         /// <summary>
-        /// Client registry get demographics throws api patient exception given client registry finds phn is invalid.
+        /// Client registry get demographics throws validation exception given client registry finds phn is invalid.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task GetDemographicsThrowsProblemDetailsExceptionGivenClientRegistryPhnInvalid()
+        public async Task GetDemographicsThrowsValidationExceptionGivenClientRegistryPhnInvalid()
         {
             // Setup
             const string expectedResponseCode = "BCHCIM.GD.2.0006";

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -71,7 +71,7 @@ namespace AccountDataAccessTest
             PatientQueryResult actual = await mock.PatientRepository.QueryAsync(mock.PatientDetailsQuery, CancellationToken.None);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual.Items.SingleOrDefault());
+            mock.Expected.ShouldDeepEqual(actual.Item);
         }
 
         /// <summary>

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -16,24 +16,18 @@
 namespace AccountDataAccessTest
 {
     // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
-    using System.Globalization;
-    using System.Net;
-    using System.ServiceModel;
     using AccountDataAccessTest.Utils;
     using AutoMapper;
     using DeepEqual.Syntax;
-    using FluentValidation;
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.AccountDataAccess.Patient.Api;
     using HealthGateway.AccountDataAccess.Patient.Strategy;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.CacheProviders;
-    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Messaging;
     using HealthGateway.Common.Models.Events;
-    using HealthGateway.Common.Utils;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using Microsoft.Extensions.Configuration;
@@ -47,280 +41,106 @@ namespace AccountDataAccessTest
     /// </summary>
     public class PatientRepositoryTests
     {
-        private const string PatientCacheDomain = "PatientV2";
         private const string Hdid = "abc123";
-        private const string PhsaHdid = "phsa123";
-        private const string PhsaHdidNotFound = "phsa123NotFound";
         private const string Phn = "9735353315";
-        private const string Gender = "Male";
-
         private static readonly IMapper Mapper = MapperUtil.InitializeAutoMapper();
-
-        /// <summary>
-        /// GetDemographics by PHN - happy path.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetDemographicsByPhn()
-        {
-            // Arrange
-            PatientDetailsQuery patientDetailsQuery = new(Phn, Source: PatientDetailSource.Empi, UseCache: false);
-
-            PatientModel patient = new()
-            {
-                Phn = Phn,
-                Hdid = Hdid,
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery);
-
-            // Act
-            PatientQueryResult result = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
-
-            // Verify
-            Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
-        }
 
         /// <summary>
         /// GetDemographics by Hdid - happy path.
         /// </summary>
+        /// <param name="source">The patient detail source to determine where to query.</param>
+        /// <param name="useHdid">The value indicates whether hdid should be used/ If false, then phn is used.</param>
+        /// <param name="useCache">The value indicates whether cache should be used or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetDemographicsByHdid()
+        [Theory]
+        [InlineData(PatientDetailSource.Empi, true, true)]
+        [InlineData(PatientDetailSource.Empi, true, false)]
+        [InlineData(PatientDetailSource.Phsa, true, true)]
+        [InlineData(PatientDetailSource.Phsa, true, false)]
+        [InlineData(PatientDetailSource.All, true, true)]
+        [InlineData(PatientDetailSource.All, true, false)]
+        [InlineData(PatientDetailSource.Empi, false, true)]
+        [InlineData(PatientDetailSource.Empi, false, false)]
+        public async Task ShouldQueryAsync(PatientDetailSource source, bool useHdid, bool useCache)
         {
             // Arrange
-            PatientDetailsQuery patientDetailsQuery = new(Hdid: Hdid, Source: PatientDetailSource.Empi, UseCache: false);
-
-            PatientModel patient = new()
-            {
-                Phn = Phn,
-                Hdid = Hdid,
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery);
+            QueryMock mock = SetupQueryMock(source, useHdid, useCache);
 
             // Act
-            PatientQueryResult result = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
+            PatientQueryResult actual = await mock.PatientRepository.QueryAsync(mock.PatientDetailsQuery, CancellationToken.None);
 
-            // Verify
-            Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
-        }
-
-        /// <summary>
-        /// GetDemographics by Hdid - using cache.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetDemographicsByHdidUsingCache()
-        {
-            // Arrange
-            PatientDetailsQuery patientDetailsQuery = new(Hdid: Hdid, Source: PatientDetailSource.Empi, UseCache: true);
-
-            PatientModel? patient = null;
-
-            PatientModel cachedPatient = new()
-            {
-                Phn = Phn,
-                Hdid = Hdid,
-            };
-
-            PatientIdentity? patientResult = null;
-
-            PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientResult, cachedPatient);
-
-            // Act
-            PatientQueryResult result = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
-
-            // Verify
-            Assert.Equal(Phn, result.Items.SingleOrDefault()?.Phn);
-        }
-
-        /// <summary>
-        /// Get patient identity by hdid.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetPatientIdentityByHdid()
-        {
-            // Arrange
-            PatientModel expectedPatient = new()
-            {
-                Phn = Phn,
-                Hdid = PhsaHdid,
-                Gender = Gender,
-                ResponseCode = string.Empty,
-                IsDeceased = false,
-                CommonName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
-                LegalName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
-            };
-
-            PatientDetailsQuery patientDetailsQuery = new(Hdid: PhsaHdid, Source: PatientDetailSource.All);
-
-            PatientModel? patient = null;
-            PatientModel? cachedPatient = null;
-
-            PatientIdentity patientIdentity = new()
-            {
-                Phn = Phn,
-                HdId = PhsaHdid,
-                Gender = Gender,
-                HasDeathIndicator = false,
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientIdentity, cachedPatient);
-
-            // Act
-            PatientQueryResult actual = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
-
-            // Verify
-            expectedPatient.ShouldDeepEqual(actual.Items.SingleOrDefault());
-        }
-
-        /// <summary>
-        /// Get patient identity by hdid throws not found api exception.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetPatientIdentityThrowsNotFoundApiException()
-        {
-            // Arrange
-            PatientDetailsQuery patientDetailsQuery = new(Hdid: PhsaHdidNotFound, Source: PatientDetailSource.All);
-
-            PatientModel? patient = null;
-            PatientModel? cachedPatient = null;
-            PatientIdentity? patientIdentity = null;
-
-            PatientRepository patientRepository = GetPatientRepository(patient, patientDetailsQuery, patientIdentity, cachedPatient);
-
-            // Act
-            PatientQueryResult actual = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
-
-            // Verify
-            Assert.Null(actual.Items.SingleOrDefault());
-        }
-
-        /// <summary>
-        /// Client registry get demographics throws problem details exception given an invalid phn.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task GetDemographicsThrowsProblemDetailsExceptionGivenClientRegistryPhnNotValid()
-        {
-            // Arrange
-            const string invalidPhn = "abc123";
-            PatientDetailsQuery patientQuery = new(invalidPhn, Source: PatientDetailSource.Empi);
-
-            PatientModel patient = new()
-            {
-                Phn = Phn,
-                Hdid = Hdid,
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(patient, patientQuery);
-
-            // Act
-            async Task Actual()
-            {
-                await patientRepository.QueryAsync(patientQuery, CancellationToken.None);
-            }
-
-            // Verify
-            ValidationException exception = await Assert.ThrowsAsync<ValidationException>(Actual);
-            Assert.Contains(ErrorMessages.PhnInvalid, exception.Message, StringComparison.OrdinalIgnoreCase);
+            // Assert
+            mock.Expected.ShouldDeepEqual(actual.Items.SingleOrDefault());
         }
 
         /// <summary>
         /// Block access.
         /// </summary>
-        /// <param name="blockedDataSourcesEnabled">
+        /// <param name="changeFeedEnabled">
         /// The value indicates whether blocked data sources change feed should be enabled
         /// or not.
         /// </param>
+        /// <param name="datasourceExist">
+        /// The value indicates whether datasource(s) exist or not.
+        /// </param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ShouldBlockAccess(bool blockedDataSourcesEnabled)
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        public async Task ShouldBlockAccessAsync(bool changeFeedEnabled, bool datasourceExist)
         {
             // Arrange
-            const string reason = "Unit Test Block Access";
-            bool commit = !blockedDataSourcesEnabled;
-
-            Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
-            Mock<IMessageSender> messageSender = new();
-            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
-
-            BlockedAccess blockedAccess = new()
-            {
-                Hdid = Hdid,
-                DataSources = dataSources,
-            };
-
-            AgentAudit audit = new()
-            {
-                Hdid = Hdid,
-                Reason = reason,
-                OperationCode = AuditOperation.ChangeDataSourceAccess,
-                GroupCode = AuditGroup.BlockedAccess,
-            };
-
-            BlockAccessCommand command = new(Hdid, dataSources, reason);
-            PatientRepository patientRepository = GetPatientRepository(blockedAccess, blockedAccessDelegate, blockedDataSourcesEnabled, messageSender);
+            BlockAccessMock mock = SetupBlockAccessMock(changeFeedEnabled, datasourceExist);
 
             // Act
-            await patientRepository.BlockAccessAsync(command);
+            await mock.PatientRepository.BlockAccessAsync(mock.Command);
 
             // Verify
-            blockedAccessDelegate.Verify(
+            mock.BlockedAccessDelegate.Verify(
                 d => d.UpdateBlockedAccessAsync(
-                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(blockedAccess, ba)),
-                    It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa)),
-                    commit,
-                    It.IsAny<CancellationToken>()));
+                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(mock.BlockedAccess, ba)),
+                    It.Is<AgentAudit>(aa => AssertAgentAudit(mock.Audit, aa)),
+                    mock.Commit,
+                    It.IsAny<CancellationToken>()),
+                datasourceExist ? Times.Once : Times.Never);
 
-            if (blockedDataSourcesEnabled)
-            {
-                messageSender.Verify(
-                    s => s.SendAsync(
-                        It.Is<IEnumerable<MessageEnvelope>>(
-                            me => AssertDataSourcesBlockedEvent(
-                                blockedAccess,
-                                me.Select(envelope => envelope.Content as DataSourcesBlockedEvent).First())),
-                        It.IsAny<CancellationToken>()));
-            }
+            mock.BlockedAccessDelegate.Verify(
+                d => d.DeleteBlockedAccessAsync(
+                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(mock.BlockedAccess, ba)),
+                    It.Is<AgentAudit>(aa => AssertAgentAudit(mock.Audit, aa)),
+                    mock.Commit,
+                    It.IsAny<CancellationToken>()),
+                !datasourceExist ? Times.Once : Times.Never);
+
+            mock.MessageSender.Verify(
+                s => s.SendAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(
+                        me => AssertDataSourcesBlockedEvent(
+                            mock.BlockedAccess,
+                            me.Select(envelope => envelope.Content as DataSourcesBlockedEvent).First())),
+                    It.IsAny<CancellationToken>()),
+                changeFeedEnabled ? Times.Once : Times.Never);
         }
 
         /// <summary>
         /// Can access data source.
         /// </summary>
         /// <param name="dataSource">The data source to check for access.</param>
-        /// <param name="canAccessDataSource">The value indicates whether the data source can be accessed or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(DataSource.Note, true)]
-        [InlineData(DataSource.Medication, false)]
-        public async Task CanAccessDataSource(DataSource dataSource, bool canAccessDataSource)
+        [InlineData(DataSource.Note)]
+        [InlineData(DataSource.Medication)]
+        public async Task CanAccessDataSourceAsync(DataSource dataSource)
         {
             // Arrange
-            string hdid = Hdid;
-
-            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
-
-            BlockedAccess blockedAccess = new()
-            {
-                Hdid = hdid,
-                DataSources = dataSources,
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(blockedAccess);
+            CanAccessDatasourceMock mock = SetupCanAccessDatasourceMock(dataSource);
 
             // Act
-            bool actual = await patientRepository.CanAccessDataSourceAsync(hdid, dataSource);
+            bool actual = await mock.PatientRepository.CanAccessDataSourceAsync(Hdid, mock.DataSource);
 
-            // Verify
-            Assert.Equal(canAccessDataSource, actual);
+            // Assert
+            Assert.Equal(mock.Expected, actual);
         }
 
         /// <summary>
@@ -328,24 +148,16 @@ namespace AccountDataAccessTest
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetBlockedAccessByHdid()
+        public async Task ShouldGetBlockedAccessAsync()
         {
             // Arrange
-            string hdid = Hdid;
-
-            BlockedAccess blockedAccess = new()
-            {
-                Hdid = hdid,
-                DataSources = [DataSource.Immunization, DataSource.Medication],
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(blockedAccess);
+            GetBlockedAccessMock mock = SetupGetBlockedAccessMock();
 
             // Act
-            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecordsAsync(hdid);
+            BlockedAccess? actual = await mock.PatientRepository.GetBlockedAccessRecordsAsync(mock.Hdid);
 
             // Verify
-            blockedAccess.ShouldDeepEqual(actual);
+            mock.Expected.ShouldDeepEqual(actual);
         }
 
         /// <summary>
@@ -353,26 +165,16 @@ namespace AccountDataAccessTest
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDataSourcesByHdid()
+        public async Task ShouldGetDataSourcesAsync()
         {
             // Arrange
-            string hdid = Hdid;
-
-            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
-
-            BlockedAccess blockedAccess = new()
-            {
-                Hdid = hdid,
-                DataSources = dataSources,
-            };
-
-            PatientRepository patientRepository = GetPatientRepository(blockedAccess);
+            GetDataSourcesMock mock = SetupGetDataSourcesMock();
 
             // Act
-            IEnumerable<DataSource> actual = await patientRepository.GetDataSourcesAsync(hdid);
+            IEnumerable<DataSource> actual = await mock.PatientRepository.GetDataSourcesAsync(mock.Hdid);
 
             // Verify
-            dataSources.ShouldDeepEqual(actual);
+            mock.Expected.ShouldDeepEqual(actual);
         }
 
         private static IConfigurationRoot GetConfiguration()
@@ -423,18 +225,37 @@ namespace AccountDataAccessTest
                 .Build();
         }
 
-        private static PatientRepository GetPatientRepository(
-            BlockedAccess blockedAccess,
-            Mock<IBlockedAccessDelegate>? blockedAccessDelegate = null,
-            bool? blockedDataSourcesEnabled = null,
-            Mock<IMessageSender>? messageSender = null)
+        private static IEnumerable<string> GetDataSourceValues(HashSet<DataSource> dataSources)
         {
-            blockedAccessDelegate ??= new();
+            return dataSources.Select(ds => EnumUtility.ToEnumString(ds));
+        }
+
+        private static BlockAccessMock SetupBlockAccessMock(bool changeFeedEnabled, bool datasourceExist)
+        {
+            const string reason = "Unit Test Block Access";
+            bool commit = !changeFeedEnabled;
+            HashSet<DataSource> dataSources = datasourceExist ? [DataSource.Immunization, DataSource.Medication] : [];
+
+            BlockedAccess blockedAccess = new()
+            {
+                Hdid = Hdid,
+                DataSources = dataSources,
+            };
+
+            AgentAudit audit = new()
+            {
+                Hdid = Hdid,
+                Reason = reason,
+                OperationCode = AuditOperation.ChangeDataSourceAccess,
+                GroupCode = AuditGroup.BlockedAccess,
+            };
+
+            Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
             blockedAccessDelegate.Setup(p => p.GetBlockedAccessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockedAccess);
             blockedAccessDelegate.Setup(p => p.GetDataSourcesAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockedAccess.DataSources);
 
-            bool changeFeedEnabled = blockedDataSourcesEnabled ?? false;
-            messageSender ??= new();
+            BlockAccessCommand command = new(Hdid, dataSources, reason);
+            Mock<IMessageSender> messageSender = new();
 
             if (changeFeedEnabled)
             {
@@ -445,106 +266,164 @@ namespace AccountDataAccessTest
                 messageSender.Setup(ms => ms.SendAsync(events, It.IsAny<CancellationToken>()));
             }
 
-            string blockedAccessCacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, blockedAccess.Hdid);
-            Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(
-                    p => p.GetOrSetAsync(
-                        blockedAccessCacheKey,
-                        It.IsAny<Func<Task<IEnumerable<DataSource>>>>(),
-                        It.IsAny<TimeSpan>(),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync(blockedAccess.DataSources);
+            PatientRepository patientRepository = new(
+                new Mock<ILogger<PatientRepository>>().Object,
+                blockedAccessDelegate.Object,
+                new Mock<IAuthenticationDelegate>().Object,
+                new Mock<ICacheProvider>().Object,
+                GetIConfigurationRoot(changeFeedEnabled),
+                new PatientQueryFactory(new Mock<IServiceProvider>().Object),
+                messageSender.Object);
+
+            return new(patientRepository, blockedAccessDelegate, messageSender, blockedAccess, audit, commit, command);
+        }
+
+        private static CanAccessDatasourceMock SetupCanAccessDatasourceMock(DataSource dataSource)
+        {
+            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
+            Mock<ICacheProvider> cacheProviderMock = new();
+            cacheProviderMock.Setup(
+                    p =>
+                        p.GetOrSetAsync(It.IsAny<string>(), It.IsAny<Func<Task<IEnumerable<DataSource>>>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dataSources);
+
+            PatientRepository patientRepository = new(
+                new Mock<ILogger<PatientRepository>>().Object,
+                new Mock<IBlockedAccessDelegate>().Object,
+                new Mock<IAuthenticationDelegate>().Object,
+                cacheProviderMock.Object,
+                GetIConfigurationRoot(),
+                new PatientQueryFactory(new Mock<IServiceProvider>().Object),
+                new Mock<IMessageSender>().Object);
+
+            return new(patientRepository, !dataSources.Contains(dataSource), dataSource);
+        }
+
+        private static GetBlockedAccessMock SetupGetBlockedAccessMock()
+        {
+            BlockedAccess blockedAccess = new()
+            {
+                Hdid = Hdid,
+                DataSources = [DataSource.Immunization, DataSource.Medication],
+            };
+
+            Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
+            blockedAccessDelegate.Setup(p => p.GetBlockedAccessAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(blockedAccess);
 
             PatientRepository patientRepository = new(
                 new Mock<ILogger<PatientRepository>>().Object,
                 blockedAccessDelegate.Object,
                 new Mock<IAuthenticationDelegate>().Object,
-                cacheProvider.Object,
-                GetIConfigurationRoot(blockedDataSourcesEnabled ?? false),
-                GetPatientQueryFactory(
-                    new PatientModel(),
-                    new PatientDetailsQuery(Hdid: Hdid, Source: PatientDetailSource.All, UseCache: false)),
-                messageSender.Object);
-            return patientRepository;
+                new Mock<ICacheProvider>().Object,
+                GetIConfigurationRoot(),
+                new PatientQueryFactory(new Mock<IServiceProvider>().Object),
+                new Mock<IMessageSender>().Object);
+
+            return new(patientRepository, blockedAccess, Hdid);
         }
 
-        private static PatientRepository GetPatientRepository(
-            PatientModel patient,
-            PatientDetailsQuery patientDetailsQuery,
-            PatientIdentity? patientIdentity = null,
-            PatientModel? cachedPatient = null)
+        private static GetDataSourcesMock SetupGetDataSourcesMock()
         {
+            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
+            Mock<ICacheProvider> cacheProviderMock = new();
+            cacheProviderMock.Setup(
+                    p =>
+                        p.GetOrSetAsync(It.IsAny<string>(), It.IsAny<Func<Task<IEnumerable<DataSource>>>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dataSources);
+
+            PatientRepository patientRepository = new(
+                new Mock<ILogger<PatientRepository>>().Object,
+                new Mock<IBlockedAccessDelegate>().Object,
+                new Mock<IAuthenticationDelegate>().Object,
+                cacheProviderMock.Object,
+                GetIConfigurationRoot(),
+                new PatientQueryFactory(new Mock<IServiceProvider>().Object),
+                new Mock<IMessageSender>().Object);
+
+            return new(patientRepository, dataSources, Hdid);
+        }
+
+        private static QueryMock SetupQueryMock(PatientDetailSource source, bool useHdid, bool useCache)
+        {
+            PatientDetailsQuery patientDetailsQuery = new(Hdid: useHdid ? Hdid : null, Phn: !useHdid ? Phn : null, Source: source, UseCache: useCache);
+
+            PatientRequest patientRequest = new(useHdid ? Hdid : Phn, useCache);
+
+            PatientModel patient = new()
+            {
+                Phn = Phn,
+                Hdid = Hdid,
+            };
+
+            ServiceCollection serviceCollection = [];
+
+            Mock<HdidEmpiStrategy> hdidEmpiStrategyMock = new(
+                GetConfiguration(),
+                new Mock<ICacheProvider>().Object,
+                new Mock<IClientRegistriesDelegate>().Object,
+                new Mock<ILogger<HdidEmpiStrategy>>().Object);
+            hdidEmpiStrategyMock.Setup(s => s.GetPatientAsync(It.Is<PatientRequest>(x => x == patientRequest), It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+
+            Mock<PhnEmpiStrategy> phnEmpiStrategyMock = new(
+                GetConfiguration(),
+                new Mock<ICacheProvider>().Object,
+                new Mock<IClientRegistriesDelegate>().Object,
+                new Mock<ILogger<PhnEmpiStrategy>>().Object);
+            phnEmpiStrategyMock.Setup(s => s.GetPatientAsync(It.Is<PatientRequest>(x => x == patientRequest), It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+
+            Mock<HdidAllStrategy> hdidAllStrategyMock = new(
+                GetConfiguration(),
+                new Mock<ICacheProvider>().Object,
+                new Mock<IClientRegistriesDelegate>().Object,
+                new Mock<IPatientIdentityApi>().Object,
+                new Mock<ILogger<HdidAllStrategy>>().Object,
+                Mapper);
+            hdidAllStrategyMock.Setup(s => s.GetPatientAsync(It.Is<PatientRequest>(x => x == patientRequest), It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+
+            Mock<HdidPhsaStrategy> hdidPhsaStrategyMock = new(
+                GetConfiguration(),
+                new Mock<ICacheProvider>().Object,
+                new Mock<IPatientIdentityApi>().Object,
+                new Mock<ILogger<HdidPhsaStrategy>>().Object,
+                Mapper);
+            hdidPhsaStrategyMock.Setup(s => s.GetPatientAsync(It.Is<PatientRequest>(x => x == patientRequest), It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+
+            serviceCollection.AddScoped<HdidEmpiStrategy>(_ => hdidEmpiStrategyMock.Object);
+            serviceCollection.AddScoped<PhnEmpiStrategy>(_ => phnEmpiStrategyMock.Object);
+            serviceCollection.AddScoped<HdidAllStrategy>(_ => hdidAllStrategyMock.Object);
+            serviceCollection.AddScoped<HdidPhsaStrategy>(_ => hdidPhsaStrategyMock.Object);
+            ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
+
             PatientRepository patientRepository = new(
                 new Mock<ILogger<PatientRepository>>().Object,
                 new Mock<IBlockedAccessDelegate>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 new Mock<ICacheProvider>().Object,
                 GetIConfigurationRoot(),
-                GetPatientQueryFactory(patient, patientDetailsQuery, patientIdentity, cachedPatient),
+                new PatientQueryFactory(serviceProvider),
                 new Mock<IMessageSender>().Object);
-            return patientRepository;
+
+            return new(patientRepository, patient, patientDetailsQuery);
         }
 
-        private static PatientQueryFactory GetPatientQueryFactory(
-            PatientModel patient,
-            PatientDetailsQuery patientDetailsQuery,
-            PatientIdentity? patientIdentity = null,
-            PatientModel? cachedPatient = null)
-        {
-            ServiceCollection serviceCollection = new();
+        private sealed record BlockAccessMock(
+            PatientRepository PatientRepository,
+            Mock<IBlockedAccessDelegate> BlockedAccessDelegate,
+            Mock<IMessageSender> MessageSender,
+            BlockedAccess BlockedAccess,
+            AgentAudit Audit,
+            bool Commit,
+            BlockAccessCommand Command);
 
-            Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItemAsync<PatientModel>($"{PatientCacheDomain}:HDID:{patientDetailsQuery.Hdid}", It.IsAny<CancellationToken>())).ReturnsAsync(cachedPatient);
+        private sealed record CanAccessDatasourceMock(PatientRepository PatientRepository, bool Expected, DataSource DataSource);
 
-            Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, patientDetailsQuery.Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Phn, patientDetailsQuery.Phn, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdid, false, It.IsAny<CancellationToken>()))
-                .Throws(new CommunicationException("Unit test PHSA get patient identity."));
+        private sealed record GetBlockedAccessMock(PatientRepository PatientRepository, BlockedAccess Expected, string Hdid);
 
-            HdidEmpiStrategy hdidEmpiStrategy = new(
-                GetConfiguration(),
-                cacheProvider.Object,
-                clientRegistriesDelegate.Object,
-                new Mock<ILogger<HdidEmpiStrategy>>().Object);
-            serviceCollection.AddScoped<HdidEmpiStrategy>(_ => hdidEmpiStrategy);
+        private sealed record GetDataSourcesMock(PatientRepository PatientRepository, IEnumerable<DataSource> Expected, string Hdid);
 
-            PhnEmpiStrategy phnEmpiStrategy = new(
-                GetConfiguration(),
-                cacheProvider.Object,
-                clientRegistriesDelegate.Object,
-                new Mock<ILogger<PhnEmpiStrategy>>().Object);
-            serviceCollection.AddScoped<PhnEmpiStrategy>(_ => phnEmpiStrategy);
-
-            Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdid, It.IsAny<CancellationToken>()))!.ReturnsAsync(patientIdentity);
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdidNotFound, It.IsAny<CancellationToken>()))
-                .Throws(MockRefitExceptionHelper.CreateApiException(HttpStatusCode.NotFound, HttpMethod.Get));
-
-            HdidAllStrategy hdidAllStrategy = new(
-                GetConfiguration(),
-                cacheProvider.Object,
-                clientRegistriesDelegate.Object,
-                patientIdentityApi.Object,
-                new Mock<ILogger<HdidAllStrategy>>().Object,
-                Mapper);
-            serviceCollection.AddScoped<HdidAllStrategy>(_ => hdidAllStrategy);
-
-            HdidPhsaStrategy hdidPhsaStrategy = new(
-                GetConfiguration(),
-                cacheProvider.Object,
-                patientIdentityApi.Object,
-                new Mock<ILogger<HdidPhsaStrategy>>().Object,
-                Mapper);
-            serviceCollection.AddScoped<HdidPhsaStrategy>(_ => hdidPhsaStrategy);
-
-            ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
-            return new(serviceProvider);
-        }
-
-        private static IEnumerable<string> GetDataSourceValues(HashSet<DataSource> dataSources)
-        {
-            return dataSources.Select(ds => EnumUtility.ToEnumString(ds));
-        }
+        private sealed record QueryMock(
+            PatientRepository PatientRepository,
+            PatientModel Expected,
+            PatientDetailsQuery PatientDetailsQuery);
     }
 }

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -16,6 +16,7 @@
 namespace AccountDataAccessTest
 {
     // ReSharper disable ParameterOnlyUsedForPreconditionCheck.Local
+    using System.Globalization;
     using AccountDataAccessTest.Utils;
     using AutoMapper;
     using DeepEqual.Syntax;
@@ -352,11 +353,12 @@ namespace AccountDataAccessTest
 
         private static GetDataSourcesMock SetupGetDataSourcesMock()
         {
+            string cacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, Hdid);
             HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
             Mock<ICacheProvider> cacheProviderMock = new();
             cacheProviderMock.Setup(
-                    p =>
-                        p.GetOrSetAsync(It.IsAny<string>(), It.IsAny<Func<Task<IEnumerable<DataSource>>>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
+                    s =>
+                        s.GetOrSetAsync(It.Is<string>(x => x.Contains(cacheKey)), It.IsAny<Func<Task<IEnumerable<DataSource>>>>(), It.IsAny<TimeSpan>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dataSources);
 
             PatientRepository patientRepository = new(
@@ -437,7 +439,7 @@ namespace AccountDataAccessTest
         private static QueryThrowsInvalidOperationExceptionMock SetupQueryThrowsInvalidOperationExceptionMock(string? hdid, string? phn, CancellationToken ct)
         {
             PatientDetailsQuery patientDetailsQuery = new(Hdid: hdid, Phn: phn, Source: PatientDetailSource.Empi, UseCache: true);
-            string? expected = string.Empty;
+            string expected = string.Empty;
 
             if (string.IsNullOrEmpty(hdid))
             {

--- a/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
@@ -26,39 +26,48 @@ namespace AccountDataAccessTest.Strategy
     using Xunit;
 
     /// <summary>
-    /// Hdid Empi Strategy Unit Tests.
+    /// Cache Provider used in Strategy Unit Tests.
     /// </summary>
-    public class HdidEmpiStrategyTests
+    public class CacheProviderTests
     {
         private const string PatientCacheDomain = "PatientV2";
         private const string Hdid = "abc123";
         private const string Phn = "9735353315";
 
         /// <summary>
-        /// GetPatientAsync by hdid - happy path.
+        /// Cache patient when calling get patient.
         /// </summary>
         /// <param name="useCache">The value indicates whether cache should be used or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ShouldGetPatientByHdid(bool useCache)
+        public async Task ShouldCachePatientAsync(bool useCache)
         {
             // Arrange
-            GetPatientMock mock = SetupGetPatientMock(useCache);
+            CachePatientMock mock = SetupCachePatientMock(useCache);
 
             // Act
             PatientModel? actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
-            // Verify
+            // Assert
             mock.Expected.ShouldDeepEqual(actual);
+
+            // Verify
+            mock.CacheProvider.Verify(
+                v => v.AddItemAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<PatientModel>(),
+                    It.IsAny<TimeSpan?>(),
+                    It.IsAny<CancellationToken>()),
+                useCache ? Times.AtLeastOnce : Times.Never);
         }
 
-        private static IConfigurationRoot GetConfiguration()
+        private static IConfigurationRoot GetConfiguration(bool useCache)
         {
             Dictionary<string, string?> myConfiguration = new()
             {
-                { "PatientService:CacheTTL", "90" },
+                { "PatientService:CacheTTL", useCache ? "90" : "0" },
             };
 
             return new ConfigurationBuilder()
@@ -66,7 +75,7 @@ namespace AccountDataAccessTest.Strategy
                 .Build();
         }
 
-        private static GetPatientMock SetupGetPatientMock(bool useCache)
+        private static CachePatientMock SetupCachePatientMock(bool useCache)
         {
             PatientRequest patientRequest = new(Hdid, useCache);
 
@@ -85,14 +94,14 @@ namespace AccountDataAccessTest.Strategy
             clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
 
             HdidEmpiStrategy hdidEmpiStrategy = new(
-                GetConfiguration(),
+                GetConfiguration(useCache),
                 cacheProvider.Object,
                 clientRegistriesDelegate.Object,
                 new Mock<ILogger<HdidEmpiStrategy>>().Object);
 
-            return new(hdidEmpiStrategy, patient, patientRequest);
+            return new(hdidEmpiStrategy, cacheProvider, patient, patientRequest);
         }
 
-        private sealed record GetPatientMock(HdidEmpiStrategy Strategy, PatientModel Expected, PatientRequest PatientRequest);
+        private sealed record CachePatientMock(HdidEmpiStrategy Strategy, Mock<ICacheProvider> CacheProvider, PatientModel Expected, PatientRequest PatientRequest);
     }
 }

--- a/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
@@ -48,7 +48,7 @@ namespace AccountDataAccessTest.Strategy
             CachePatientMock mock = SetupCachePatientMock(useCache);
 
             // Act
-            PatientModel? actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
+            PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
             mock.Expected.ShouldDeepEqual(actual);

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
@@ -48,7 +48,7 @@ namespace AccountDataAccessTest.Strategy
             GetPatientMock mock = SetupGetPatientMock(useCache);
 
             // Act
-            PatientModel? actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
+            PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Verify
             mock.Expected.ShouldDeepEqual(actual);

--- a/Apps/AccountDataAccess/test/unit/Strategy/PatientQueryFactoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PatientQueryFactoryTests.cs
@@ -26,7 +26,7 @@ namespace AccountDataAccessTest.Strategy
         {
             PatientQueryFactory patientQueryFactory = new(new Mock<IServiceProvider>().Object);
 
-            string strategyType = "Not.A.Strategy.Type";
+            const string strategyType = "Not.A.Strategy.Type";
 
             Assert.Throws<ArgumentException>(() => patientQueryFactory.GetPatientQueryStrategy(strategyType));
         }

--- a/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
@@ -50,7 +50,7 @@ namespace AccountDataAccessTest.Strategy
             GetPatientMock mock = SetupGetPatientMock(useCache);
 
             // Act
-            PatientModel? actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
+            PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Verify
             mock.Expected.ShouldDeepEqual(actual);

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -44,17 +44,17 @@ namespace HealthGateway.Admin.Server.Services
                     async hdid =>
                     {
                         PatientQuery query = new PatientDetailsQuery(Hdid: hdid, Source: PatientDetailSource.All);
-                        PatientQueryResult? patient = null;
+                        PatientModel? patient = null;
                         try
                         {
-                            patient = await patientRepository.QueryAsync(query, ct);
+                            patient = (await patientRepository.QueryAsync(query, ct)).Item;
                         }
                         catch (NotFoundException e)
                         {
                             logger.Error(e, "Error retrieving patient details for hdid {Hdid}: {EMessage}", hdid, e.Message);
                         }
 
-                        return new ProtectedDependentRecord(hdid, patient?.Items.SingleOrDefault()?.Phn);
+                        return new ProtectedDependentRecord(hdid, patient?.Phn);
                     });
 
             return new(await Task.WhenAll(tasks), new(totalHdids, page, pageSize));

--- a/Apps/Admin/Server/Services/CovidSupportService.cs
+++ b/Apps/Admin/Server/Services/CovidSupportService.cs
@@ -102,13 +102,7 @@ namespace HealthGateway.Admin.Server.Services
         private async Task<PatientModel> GetPatientAsync(string phn, CancellationToken ct)
         {
             PatientDetailsQuery query = new(phn, Source: PatientDetailSource.Empi, UseCache: true);
-            PatientModel? patient = (await patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
-            if (patient == null)
-            {
-                throw new NotFoundException(ErrorMessages.ClientRegistryRecordsNotFound);
-            }
-
-            return patient;
+            return (await patientRepository.QueryAsync(query, ct)).Item;
         }
 
         private async Task<VaccineStatusResult> GetVaccineStatusResultAsync(string phn, DateTime birthdate, string accessToken, CancellationToken ct)

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -150,8 +150,7 @@ namespace HealthGateway.Admin.Server.Services
 
         private async Task<PatientModel> GetPatientAsync(PatientDetailsQuery query, CancellationToken ct = default)
         {
-            PatientModel? patient = (await patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
-            return patient ?? throw new NotFoundException(ErrorMessages.ClientRegistryRecordsNotFound);
+            return (await patientRepository.QueryAsync(query, ct)).Item;
         }
 
         private async Task<PatientModel?> TryGetPatientAsync(PatientIdentifierType identifierType, string queryString, CancellationToken ct)

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
@@ -90,6 +90,7 @@ describe("Beta feature access", () => {
         cy.get("[data-testid=query-input]")
             .should("be.visible")
             .should("be.enabled")
+            .click()
             .clear()
             .should("be.empty")
             .type(validEmail);

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -156,8 +156,8 @@ namespace HealthGateway.Admin.Tests.Services
                 Phn1, Phn2,
             ];
 
-            PatientQueryResult patientQueryResult1 = new([patient1]);
-            PatientQueryResult patientQueryResult2 = new([patient2]);
+            PatientQueryResult patientQueryResult1 = new(patient1);
+            PatientQueryResult patientQueryResult2 = new(patient2);
 
             Mock<IPatientRepository> patientRepositoryMock = new();
             patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query1), It.IsAny<CancellationToken>())).ReturnsAsync(patientQueryResult1);

--- a/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
@@ -56,32 +56,6 @@ namespace HealthGateway.Admin.Tests.Services
         private static readonly IConfiguration Configuration = GetIConfigurationRoot();
 
         /// <summary>
-        /// Retrieve vaccine record async throws exception given client registry records not found.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task RetrieveVaccineRecordAsyncThrowsClientRegistryRecordsNotFound()
-        {
-            // Arrange
-            PatientDetailsQuery query = new() { Phn = Phn, Source = PatientDetailSource.Empi, UseCache = true };
-            PatientModel? patient = null; // Client registry not found
-
-            ICovidSupportService service = CreateCovidSupportService(
-                GetPatientRepositoryMock((query, patient)),
-                GetAuthenticationDelegateMock(AccessToken));
-
-            // Act and Assert
-            NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(Actual);
-            Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.Message);
-            return;
-
-            async Task Actual()
-            {
-                await service.RetrieveVaccineRecordAsync(Phn);
-            }
-        }
-
-        /// <summary>
         /// Retrieve vaccine record async throws exception given BC Mail Plus returns empty payload for report.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -98,8 +72,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult();
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             // BC Mail Plus returns status success but empty payload - CannotGetVaccineProofPdf
@@ -148,8 +121,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult();
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             // Report has result error
@@ -202,8 +174,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult();
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             ICovidSupportService service = CreateCovidSupportService(
@@ -238,8 +209,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult();
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             // Vaccine proof response has an error
@@ -284,8 +254,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult(status);
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             ICovidSupportService service = CreateCovidSupportService(
@@ -315,8 +284,7 @@ namespace HealthGateway.Admin.Tests.Services
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
                 Result = null,
-                LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             ICovidSupportService service = CreateCovidSupportService(
@@ -377,8 +345,7 @@ namespace HealthGateway.Admin.Tests.Services
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
                 Result = null,
-                LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             ICovidSupportService service = CreateCovidSupportService(
@@ -391,34 +358,6 @@ namespace HealthGateway.Admin.Tests.Services
             // Act and Assert
             NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(Actual);
             Assert.Equal(ErrorMessages.CannotGetVaccineStatus, exception.Message);
-            return;
-
-            async Task Actual()
-            {
-                await service.MailVaccineCardAsync(request);
-            }
-        }
-
-        /// <summary>
-        /// Mail vaccine card async throws exception given client registry records not found.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task MailVaccineCardAsyncThrowsClientRegistryRecordsNotFound()
-        {
-            // Arrange
-            PatientDetailsQuery query = new() { Phn = Phn, Source = PatientDetailSource.Empi, UseCache = true };
-            PatientModel? patient = null;
-
-            ICovidSupportService service = CreateCovidSupportService(
-                GetPatientRepositoryMock((query, patient)),
-                GetAuthenticationDelegateMock(AccessToken));
-
-            MailDocumentRequest request = GenerateMailDocumentRequest();
-
-            // Act and Assert
-            NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(Actual);
-            Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.Message);
             return;
 
             async Task Actual()
@@ -441,8 +380,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult();
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             // BC Mail Plus vaccine proof response has error.
@@ -486,8 +424,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult(status);
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             ICovidSupportService service = CreateCovidSupportService(
@@ -540,16 +477,13 @@ namespace HealthGateway.Admin.Tests.Services
         /// <summary>
         /// Should mail vaccine card async successfully.
         /// </summary>
-        /// <param name="patientExists">bool indicating whether patient exists or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Theory]
-        [InlineData(true)]
-        [InlineData(false)]
-        public async Task ShouldMailVaccineCardAsync(bool patientExists)
+        [Fact]
+        public async Task ShouldMailVaccineCardAsync()
         {
             // Arrange
             PatientDetailsQuery query = new() { Phn = Phn, Source = PatientDetailSource.Empi, UseCache = true };
-            PatientModel? patient = patientExists ? GeneratePatientModel(Phn, Hdid, Birthdate) : null;
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate);
 
             VaccineProofResponse vaccineProof = GenerateVaccineProofResponse();
             RequestResult<VaccineProofResponse> vaccineProofResult = new() { ResultStatus = ResultType.Success, ResourcePayload = vaccineProof };
@@ -557,8 +491,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult();
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             Guid covidAssessmentId = Guid.NewGuid();
@@ -573,49 +506,32 @@ namespace HealthGateway.Admin.Tests.Services
 
             MailDocumentRequest request = GenerateMailDocumentRequest();
 
-            if (patientExists)
+            // Act
+            async Task Action()
             {
-                // Act
-                async Task Action()
-                {
-                    await service.MailVaccineCardAsync(request);
-                }
-
-                Exception? exception = await Record.ExceptionAsync(Action);
-
-                // Assert
-                Assert.Null(exception);
+                await service.MailVaccineCardAsync(request);
             }
-            else
-            {
-                // Act
-                async Task Actual()
-                {
-                    await service.MailVaccineCardAsync(request);
-                }
 
-                // Assert
-                NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(Actual);
-                Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.Message);
-            }
+            Exception? exception = await Record.ExceptionAsync(Action);
+
+            // Assert
+            Assert.Null(exception);
         }
 
         /// <summary>
         /// Should mail vaccine card async successfully.
         /// </summary>
-        /// <param name="patientExists">bool indicating whether patient exists or not.</param>
         /// <param name="status">Value to parse into VaccineState.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(true, "Exempt")]
-        [InlineData(true, "AllDosesReceived")]
-        [InlineData(true, "PartialDosesReceived")]
-        [InlineData(false, "AllDosesReceived")]
-        public async Task ShouldRetrieveVaccineRecordAsync(bool patientExists, string status)
+        [InlineData("Exempt")]
+        [InlineData("AllDosesReceived")]
+        [InlineData("PartialDosesReceived")]
+        public async Task ShouldRetrieveVaccineRecordAsync(string status)
         {
             // Arrange
             PatientDetailsQuery query = new() { Phn = Phn, Source = PatientDetailSource.Empi, UseCache = true };
-            PatientModel? patient = patientExists ? GeneratePatientModel(Phn, Hdid, Birthdate) : null;
+            PatientModel patient = GeneratePatientModel(Phn, Hdid, Birthdate);
 
             VaccineProofResponse vaccineProof = GenerateVaccineProofResponse();
             RequestResult<VaccineProofResponse> vaccineProofResult = new() { ResultStatus = ResultType.Success, ResourcePayload = vaccineProof };
@@ -623,8 +539,7 @@ namespace HealthGateway.Admin.Tests.Services
             VaccineStatusResult vaccineStatus = GenerateVaccineStatusResult(status);
             PhsaResult<VaccineStatusResult> vaccineStatusResult = new()
             {
-                Result = vaccineStatus, LoadState = new PhsaLoadState
-                    { Queued = false, RefreshInProgress = false },
+                Result = vaccineStatus, LoadState = new PhsaLoadState { Queued = false, RefreshInProgress = false },
             };
 
             RequestResult<ReportModel> expected = new()
@@ -647,26 +562,11 @@ namespace HealthGateway.Admin.Tests.Services
                 GetVaccineProofDelegateMock(vaccineProofResult, expected),
                 GetImmunizationAdminApiMock(covidAssessmentResponse));
 
-            if (patientExists)
-            {
-                // Act
-                ReportModel actual = await service.RetrieveVaccineRecordAsync(Phn);
+            // Act
+            ReportModel actual = await service.RetrieveVaccineRecordAsync(Phn);
 
-                // Assert
-                Assert.Equal(expected.ResourcePayload, actual);
-            }
-            else
-            {
-                // Act
-                async Task Actual()
-                {
-                    await service.RetrieveVaccineRecordAsync(Phn);
-                }
-
-                // Assert
-                NotFoundException exception = await Assert.ThrowsAsync<NotFoundException>(Actual);
-                Assert.Equal(ErrorMessages.ClientRegistryRecordsNotFound, exception.Message);
-            }
+            // Assert
+            Assert.Equal(expected.ResourcePayload, actual);
         }
 
         /// <summary>
@@ -832,7 +732,7 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IPatientRepository> mock = new();
             foreach ((PatientDetailsQuery query, PatientModel? patient) in pairs)
             {
-                PatientQueryResult result = new(patient == null ? [] : [patient]);
+                PatientQueryResult result = new(patient);
                 mock.Setup(p => p.QueryAsync(query, It.IsAny<CancellationToken>())).ReturnsAsync(result);
             }
 

--- a/Apps/Common/src/Constants/ErrorMessages.cs
+++ b/Apps/Common/src/Constants/ErrorMessages.cs
@@ -66,6 +66,11 @@ namespace HealthGateway.Common.Constants
         public const string PhnNotFoundErrorMessage = "PHN could not be retrieved";
 
         /// <summary>
+        /// Error message to return when patient identity can't be found.
+        /// </summary>
+        public const string PatientIdentityNotFound = "Patient identity could not be found";
+
+        /// <summary>
         /// Error message to return when client registry did not find any records.
         /// </summary>
         public const string ClientRegistryRecordsNotFound = "Client Registry did not find any records";

--- a/Apps/GatewayApi/src/Services/IUserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileService.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.GatewayApi.Services
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Data.Models;

--- a/Apps/GatewayApi/src/Services/PatientDetailsService.cs
+++ b/Apps/GatewayApi/src/Services/PatientDetailsService.cs
@@ -22,7 +22,6 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
-    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.ErrorHandling.Exceptions;
     using HealthGateway.GatewayApi.Models;
     using Microsoft.Extensions.Logging;
@@ -67,14 +66,7 @@ namespace HealthGateway.GatewayApi.Services
 
             this.logger.LogDebug("Starting GetPatient for identifier type: {IdentifierType} and patient data source: {Source}", identifierType, query.Source);
 
-            PatientModel? patientModel = (await this.patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
-
-            if (patientModel == null)
-            {
-                // BCHCIM.GD.2.0018 Not found
-                this.logger.LogWarning("Client Registry did not find any records. Returned message code: {ResponseCode}", "Not found");
-                throw new NotFoundException(ErrorMessages.ClientRegistryRecordsNotFound, ErrorCodes.UpstreamError);
-            }
+            PatientModel patientModel = (await this.patientRepository.QueryAsync(query, ct)).Item;
 
             if (patientModel.LegalName == null && patientModel.CommonName == null)
             {

--- a/Apps/Patient/src/Services/PatientService.cs
+++ b/Apps/Patient/src/Services/PatientService.cs
@@ -65,14 +65,7 @@ namespace HealthGateway.Patient.Services
 
             this.logger.LogDebug("Starting GetPatient for identifier type: {IdentifierType} and patient data source: {Source}", identifierType, query.Source);
 
-            PatientModel? patientDetails = (await this.patientRepository.QueryAsync(query, ct)).Items.SingleOrDefault();
-
-            if (patientDetails == null)
-            {
-                // BCHCIM.GD.2.0018 Not found
-                this.logger.LogWarning("Client Registry did not find any records. Returned message code: {ResponseCode}", "Not found");
-                throw new NotFoundException(ErrorMessages.ClientRegistryRecordsNotFound);
-            }
+            PatientModel patientDetails = (await this.patientRepository.QueryAsync(query, ct)).Item;
 
             if (patientDetails.IsDeceased == true)
             {

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -87,7 +87,6 @@ namespace HealthGateway.PatientTests.Services
         [InlineData(Phn, typeof(InvalidDataException), ErrorMessages.ClientRegistryReturnedDeceasedPerson, true)]
         [InlineData(Phn, typeof(InvalidDataException), ErrorMessages.InvalidServicesCard, true)]
         [InlineData(Phn, typeof(InvalidDataException), ErrorMessages.InvalidServicesCard, false)]
-        [InlineData(Phn, typeof(NotFoundException), ErrorMessages.ClientRegistryRecordsNotFound, true)]
         [InlineData(InvalidPhn, typeof(ValidationException), ErrorMessages.PhnInvalid, true)]
         public async Task GetPatientThrowsException(string phn, Type expectedExceptionType, string expectedErrorMessage, bool commonNameExists)
         {
@@ -106,7 +105,7 @@ namespace HealthGateway.PatientTests.Services
 
         private static IPatientService GetPatientService(PatientModel? patient = null)
         {
-            PatientQueryResult patientQueryResult = new(patient != null ? [patient] : []);
+            PatientQueryResult patientQueryResult = new(patient);
 
             Mock<IPatientRepository> patientRepository = new();
             patientRepository.Setup(p => p.QueryAsync(new PatientDetailsQuery(InvalidPhn, null, PatientDetailSource.All, true), It.IsAny<CancellationToken>()))
@@ -129,7 +128,6 @@ namespace HealthGateway.PatientTests.Services
                 ErrorMessages.ClientRegistryReturnedDeceasedPerson => CreatePatient(deceased: true),
                 ErrorMessages.InvalidServicesCard => commonNameExists == false ? CreatePatient(commonNameExists: false, legalNameExists: false) : CreatePatient(string.Empty, string.Empty),
                 ErrorMessages.PhnInvalid => CreatePatient(),
-                ErrorMessages.ClientRegistryRecordsNotFound => null,
                 _ => CreatePatient(commonNameExists: commonNameExists, legalNameExists: legalNameExists),
             };
 


### PR DESCRIPTION
# Implements [AB#16673](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16673)

## Description

Increase code coverage for AccountDataAccess project:

- Refactored patient repository tests to increase coverage and remove unnecessary tests as some are being covered by Strategy test
- Fixed code smells
- Added coverage for client registry delegate 
- Removed lines 301 to 306 because this code will never execute.  This was added in #5046 - [commit](https://github.com/bcgov/healthgateway/pull/5046/commits/aab216c8161960eb778a1e9e1b9313c626155a2a)  Line 226 to 231 was removed. However line 241 in current file will fire and will by pass lines 301 to 306.

Also address failing admin beta-access functional test:

- Added additional click to set focus before clearing and entering email value.  There is a trigger on that input field so want to set focus first before clearing and entering input.

**Sonar:**

https://sonarcloud.io/code?id=bcgov_healthgateway&selected=bcgov_healthgateway%3AApps%2FAccountDataAccess

<img width="2156" alt="Screenshot 2024-04-11 at 6 52 46 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/b29770dc-cc31-4d70-94e2-054f34edda6d">

Cypress:

Ran twice without issue.

https://cloud.cypress.io/projects/rccf87/branches/16673/overview

## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
