### PR TITLE
Fix sonar code smells for AB#16670

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         /// <inheritdoc/>
         public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
-            PatientModel? patient = request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Phn, ct) : null;
+            PatientModel? patient = request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null;
 
             if (patient == null)
             {

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -61,8 +61,15 @@ namespace AccountDataAccessTest.Strategy
             // Act
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
-            // Verify
+            // Assert
             mock.Expected.ShouldDeepEqual(actual);
+
+            // Verify
+            mock.CacheProvider.Verify(
+                v => v.GetItemAsync<PatientModel>(
+                    It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{mock.PatientRequest.Identifier}"),
+                    It.IsAny<CancellationToken>()),
+                useCache ? Times.AtLeastOnce : Times.Never);
         }
 
         /// <summary>
@@ -78,7 +85,7 @@ namespace AccountDataAccessTest.Strategy
             // Act
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
-            // Verify
+            // Assert
             mock.Expected.ShouldDeepEqual(actual);
         }
 
@@ -134,10 +141,20 @@ namespace AccountDataAccessTest.Strategy
             PatientModel? cachedPatient = useCache ? patient : null;
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(
+                    s => s.GetItemAsync<PatientModel>(
+                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(
+                    s => s.GetDemographicsAsync(
+                        It.Is<OidType>(x => x == OidType.Hdid),
+                        It.Is<string>(x => x == Hdid),
+                        It.Is<bool>(x => x == false),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(patient);
 
             HdidAllStrategy hdidAllStrategy = new(
                 GetConfiguration(),
@@ -147,7 +164,7 @@ namespace AccountDataAccessTest.Strategy
                 new Mock<ILogger<HdidAllStrategy>>().Object,
                 Mapper);
 
-            return new(hdidAllStrategy, patient, patientRequest);
+            return new(hdidAllStrategy, cacheProvider, patient, patientRequest);
         }
 
         private static GetPatientIdentityMock SetupGetPatientIdentityMock()
@@ -178,14 +195,27 @@ namespace AccountDataAccessTest.Strategy
             };
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(
+                    s => s.GetItemAsync<PatientModel>(
+                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdid, false, It.IsAny<CancellationToken>()))
+            clientRegistriesDelegate.Setup(
+                    s => s.GetDemographicsAsync(
+                        It.Is<OidType>(x => x == OidType.Hdid),
+                        It.Is<string>(x => x == PhsaHdid),
+                        It.Is<bool>(x => x == false),
+                        It.IsAny<CancellationToken>()))
                 .Throws(new CommunicationException("Unit test PHSA get patient identity."));
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdid, It.IsAny<CancellationToken>()))!.ReturnsAsync(patientIdentity);
+            patientIdentityApi.Setup(
+                    s => s.GetPatientIdentityAsync(
+                        It.Is<string>(x => x == PhsaHdid),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(patientIdentity);
 
             HdidAllStrategy hdidAllStrategy = new(
                 GetConfiguration(),
@@ -205,25 +235,48 @@ namespace AccountDataAccessTest.Strategy
             PatientModel? cachedPatient = null;
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(
+                    s => s.GetItemAsync<PatientModel>(
+                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, PhsaHdidNotFound, false, It.IsAny<CancellationToken>()))
+            clientRegistriesDelegate.Setup(
+                    s => s.GetDemographicsAsync(
+                        It.Is<OidType>(x => x == OidType.Hdid),
+                        It.Is<string>(x => x == PhsaHdidNotFound),
+                        It.Is<bool>(x => x == false),
+                        It.IsAny<CancellationToken>()))
                 .Throws(new CommunicationException("Unit test PHSA get patient identity. NotFound"));
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdidNotFound, It.IsAny<CancellationToken>()))!.Throws(
-                RefitExceptionUtil.CreateApiException(HttpStatusCode.NotFound).Result);
+            patientIdentityApi.Setup(
+                    s => s.GetPatientIdentityAsync(
+                        It.Is<string>(x => x == PhsaHdidNotFound),
+                        It.IsAny<CancellationToken>()))
+                .Throws(
+                    RefitExceptionUtil.CreateApiException(HttpStatusCode.NotFound).Result);
 
             HdidAllStrategy hdidAllStrategy = GetHdidAllStrategy(cacheProvider, clientRegistriesDelegate, patientIdentityApi);
 
             return new(hdidAllStrategy, typeof(NotFoundException), patientRequest);
         }
 
-        private sealed record GetPatientMock(HdidAllStrategy Strategy, PatientModel Expected, PatientRequest PatientRequest);
+        private sealed record GetPatientMock(
+            HdidAllStrategy Strategy,
+            Mock<ICacheProvider> CacheProvider,
+            PatientModel Expected,
+            PatientRequest PatientRequest);
 
-        private sealed record GetPatientIdentityMock(HdidAllStrategy Strategy, PatientModel Expected, PatientRequest PatientRequest);
+        private sealed record GetPatientIdentityMock(
+            HdidAllStrategy Strategy,
+            PatientModel Expected,
+            PatientRequest PatientRequest);
 
-        private sealed record GetPatientHandlesExceptionMock(HdidAllStrategy Strategy, Type ExpectedExceptionType, PatientRequest PatientRequest);
+        private sealed record GetPatientHandlesExceptionMock(
+            HdidAllStrategy Strategy,
+            Type ExpectedExceptionType,
+            PatientRequest PatientRequest);
     }
 }

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
@@ -50,8 +50,15 @@ namespace AccountDataAccessTest.Strategy
             // Act
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
-            // Verify
+            // Assert
             mock.Expected.ShouldDeepEqual(actual);
+
+            // Verify
+            mock.CacheProvider.Verify(
+                v => v.GetItemAsync<PatientModel>(
+                    It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{mock.PatientRequest.Identifier}"),
+                    It.IsAny<CancellationToken>()),
+                useCache ? Times.AtLeastOnce : Times.Never);
         }
 
         private static IConfigurationRoot GetConfiguration()
@@ -79,10 +86,20 @@ namespace AccountDataAccessTest.Strategy
             PatientModel? cachedPatient = useCache ? patient : null;
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(
+                    s => s.GetItemAsync<PatientModel>(
+                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedPatient);
 
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
-            clientRegistriesDelegate.Setup(p => p.GetDemographicsAsync(OidType.Hdid, Hdid, false, It.IsAny<CancellationToken>())).ReturnsAsync(patient);
+            clientRegistriesDelegate.Setup(
+                    s => s.GetDemographicsAsync(
+                        It.Is<OidType>(x => x == OidType.Hdid),
+                        It.Is<string>(x => x == Hdid),
+                        It.Is<bool>(x => x == false),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(patient);
 
             HdidEmpiStrategy hdidEmpiStrategy = new(
                 GetConfiguration(),
@@ -90,9 +107,13 @@ namespace AccountDataAccessTest.Strategy
                 clientRegistriesDelegate.Object,
                 new Mock<ILogger<HdidEmpiStrategy>>().Object);
 
-            return new(hdidEmpiStrategy, patient, patientRequest);
+            return new(hdidEmpiStrategy, cacheProvider, patient, patientRequest);
         }
 
-        private sealed record GetPatientMock(HdidEmpiStrategy Strategy, PatientModel Expected, PatientRequest PatientRequest);
+        private sealed record GetPatientMock(
+            HdidEmpiStrategy Strategy,
+            Mock<ICacheProvider> CacheProvider,
+            PatientModel Expected,
+            PatientRequest PatientRequest);
     }
 }

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -60,6 +60,13 @@ namespace AccountDataAccessTest.Strategy
 
             // Assert
             mock.Expected.ShouldDeepEqual(actual);
+
+            // Verify
+            mock.CacheProvider.Verify(
+                v => v.GetItemAsync<PatientModel>(
+                    It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{mock.PatientRequest.Identifier}"),
+                    It.IsAny<CancellationToken>()),
+                useCache ? Times.AtLeastOnce : Times.Never);
         }
 
         /// <summary>
@@ -127,14 +134,22 @@ namespace AccountDataAccessTest.Strategy
             PatientRequest patientRequest = new(Hdid, useCache);
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(
+                    p => p.GetItemAsync<PatientModel>(
+                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedPatient);
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(Hdid, It.IsAny<CancellationToken>()))!.ReturnsAsync(patientIdentity);
+            patientIdentityApi.Setup(
+                    p => p.GetPatientIdentityAsync(
+                        It.Is<string>(x => x == Hdid),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(patientIdentity);
 
             HdidPhsaStrategy hdidPhsaStrategy = GetHdidPhsaStrategy(cacheProvider, patientIdentityApi);
 
-            return new(hdidPhsaStrategy, patient, patientRequest);
+            return new(hdidPhsaStrategy, cacheProvider, patient, patientRequest);
         }
 
         private static GetPatientHandlesPhsaApiExceptionMock SetupGetPatientHandlesPhsaApiExceptionMock()
@@ -143,19 +158,33 @@ namespace AccountDataAccessTest.Strategy
             PatientRequest patientRequest = new(PhsaHdidNotFound, false);
 
             Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(p => p.GetItem<PatientModel>($"{PatientCacheDomain}:HDID:{Hdid}")).Returns(cachedPatient);
+            cacheProvider.Setup(
+                    s => s.GetItemAsync<PatientModel>(
+                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(cachedPatient);
 
             Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(p => p.GetPatientIdentityAsync(PhsaHdidNotFound, It.IsAny<CancellationToken>()))!.Throws(
-                RefitExceptionUtil.CreateApiException(HttpStatusCode.NotFound).Result);
+            patientIdentityApi.Setup(
+                    s => s.GetPatientIdentityAsync(
+                        It.Is<string>(x => x == PhsaHdidNotFound),
+                        It.IsAny<CancellationToken>()))
+                .Throws(RefitExceptionUtil.CreateApiException(HttpStatusCode.NotFound).Result);
 
             HdidPhsaStrategy hdidPhsaStrategy = GetHdidPhsaStrategy(cacheProvider, patientIdentityApi);
 
             return new(hdidPhsaStrategy, typeof(NotFoundException), patientRequest);
         }
 
-        private sealed record GetPatientMock(HdidPhsaStrategy Strategy, PatientModel Expected, PatientRequest PatientRequest);
+        private sealed record GetPatientMock(
+            HdidPhsaStrategy Strategy,
+            Mock<ICacheProvider> CacheProvider,
+            PatientModel Expected,
+            PatientRequest PatientRequest);
 
-        private sealed record GetPatientHandlesPhsaApiExceptionMock(HdidPhsaStrategy Strategy, Type ExpectedExceptionType, PatientRequest PatientRequest);
+        private sealed record GetPatientHandlesPhsaApiExceptionMock(
+            HdidPhsaStrategy Strategy,
+            Type ExpectedExceptionType,
+            PatientRequest PatientRequest);
     }
 }

--- a/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
+++ b/Apps/Admin/Client/Store/AdminReport/AdminReportEffects.cs
@@ -40,7 +40,7 @@ namespace HealthGateway.Admin.Client.Store.AdminReport
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                logger.LogError("Error retrieving users with blocked data sources: {Exception}", e.ToString());
+                logger.LogError(e, "Error retrieving users with blocked data sources: {Message}", e.Message);
                 RequestError error = StoreUtility.FormatRequestError(e);
                 dispatcher.Dispatch(new AdminReportActions.GetProtectedDependentsFailureAction { Error = error });
             }

--- a/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
+++ b/Apps/Admin/Client/Store/AgentAccess/AgentAccessEffects.cs
@@ -42,13 +42,13 @@ public class AgentAccessEffects(ILogger<AgentAccessEffects> logger, IAgentAccess
         catch (ApiException e) when (e.StatusCode == HttpStatusCode.Conflict)
         {
             RequestError error = new() { Message = "User already exists" };
-            logger.LogInformation("Agent already exists");
+            logger.LogInformation(e, "Agent already exists");
             dispatcher.Dispatch(new AgentAccessActions.AddFailureAction { Error = error });
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error adding agent, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error adding agent, reason: {Message}", e.Message);
             dispatcher.Dispatch(new AgentAccessActions.AddFailureAction { Error = error });
         }
     }
@@ -66,7 +66,7 @@ public class AgentAccessEffects(ILogger<AgentAccessEffects> logger, IAgentAccess
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError(e, "Error retrieving agents, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error retrieving agents, reason: {Message}", e.Message);
             dispatcher.Dispatch(new AgentAccessActions.SearchFailureAction { Error = error });
         }
     }
@@ -84,7 +84,7 @@ public class AgentAccessEffects(ILogger<AgentAccessEffects> logger, IAgentAccess
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error updating agent access, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error updating agent access, reason: {Message}", e.Message);
             dispatcher.Dispatch(new AgentAccessActions.UpdateFailureAction { Error = error });
         }
     }
@@ -102,7 +102,7 @@ public class AgentAccessEffects(ILogger<AgentAccessEffects> logger, IAgentAccess
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error removing agent access, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error removing agent access, reason: {Message}", e.Message);
             dispatcher.Dispatch(new AgentAccessActions.DeleteFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/Analytics/AnalyticsEffects.cs
+++ b/Apps/Admin/Client/Store/Analytics/AnalyticsEffects.cs
@@ -23,6 +23,8 @@ using Microsoft.Extensions.Logging;
 
 public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi analyticsApi)
 {
+    private const string ErrorMessage = "{ErrorMessage}";
+
     [EffectMethod(typeof(AnalyticsActions.LoadUserProfilesAction))]
     public async Task HandleLoadUserProfilesAction(IDispatcher dispatcher)
     {
@@ -41,7 +43,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting user profile report",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 
@@ -63,7 +65,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting comments report.",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 
@@ -85,7 +87,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting notes report.",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 
@@ -107,7 +109,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting rating report.",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 
@@ -129,7 +131,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting inactive users report.",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 
@@ -151,7 +153,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting user feedback report.",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 
@@ -173,7 +175,7 @@ public class AnalyticsEffects(ILogger<AnalyticsEffects> logger, IAnalyticsApi an
             Message = "Error exporting year of birth counts report.",
         };
 
-        logger.LogError("{ErrorMessage}", error.Message);
+        logger.LogError(ErrorMessage, error.Message);
         dispatcher.Dispatch(new AnalyticsActions.LoadFailureAction { Error = error });
     }
 }

--- a/Apps/Admin/Client/Store/BetaAccess/BetaAccessEffects.cs
+++ b/Apps/Admin/Client/Store/BetaAccess/BetaAccessEffects.cs
@@ -42,7 +42,7 @@ public class BetaAccessEffects(ILogger<BetaAccessEffects> logger, IBetaFeatureAp
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error setting user access, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error setting user access, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BetaAccessActions.SetUserAccessFailureAction { Error = error });
         }
     }
@@ -60,13 +60,13 @@ public class BetaAccessEffects(ILogger<BetaAccessEffects> logger, IBetaFeatureAp
         catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
         {
             RequestError error = new() { Message = $"No users found matching the supplied email address ({action.Email})" };
-            logger.LogInformation("No users found matching the supplied email address");
+            logger.LogError(e, "No users found matching the supplied email address");
             dispatcher.Dispatch(new BetaAccessActions.GetUserAccessFailureAction { Error = error });
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError(e, "Error retrieving user access, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error retrieving user access, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BetaAccessActions.GetUserAccessFailureAction { Error = error });
         }
     }
@@ -84,7 +84,7 @@ public class BetaAccessEffects(ILogger<BetaAccessEffects> logger, IBetaFeatureAp
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error retrieving all user access, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error retrieving all user access, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BetaAccessActions.GetAllUserAccessFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
+++ b/Apps/Admin/Client/Store/Broadcasts/BroadcastsEffects.cs
@@ -51,7 +51,7 @@ public class BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error adding broadcast, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error adding broadcast, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BroadcastsActions.AddFailureAction { Error = error });
         }
     }
@@ -77,7 +77,7 @@ public class BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error loading broadcasts, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error loading broadcasts, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BroadcastsActions.LoadFailureAction { Error = error });
         }
     }
@@ -103,7 +103,7 @@ public class BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error updating broadcasts, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error updating broadcasts, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BroadcastsActions.UpdateFailureAction { Error = error });
         }
     }
@@ -129,7 +129,7 @@ public class BroadcastsEffects(ILogger<BroadcastsEffects> logger, IBroadcastsApi
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error deleting broadcast, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error deleting broadcast, reason: {Message}", e.Message);
             dispatcher.Dispatch(new BroadcastsActions.DeleteFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/Communications/CommunicationsEffects.cs
+++ b/Apps/Admin/Client/Store/Communications/CommunicationsEffects.cs
@@ -53,9 +53,8 @@ public class CommunicationsEffects(ILogger<CommunicationsEffects> logger, ICommu
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
-            logger.LogError("Error adding communication...{Error}", e);
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error adding communication, reason: {ErrorMessage}", error.Message);
+            logger.LogError(e, "Error adding communication, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new CommunicationsActions.AddFailureAction { Error = error });
         }
     }
@@ -82,9 +81,8 @@ public class CommunicationsEffects(ILogger<CommunicationsEffects> logger, ICommu
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
-            logger.LogError("Error loading communications...{Error}", e);
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error loading communications, reason: {ErrorMessage}", error.Message);
+            logger.LogError(e, "Error loading communications, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new CommunicationsActions.LoadFailureAction { Error = error });
         }
     }
@@ -111,9 +109,8 @@ public class CommunicationsEffects(ILogger<CommunicationsEffects> logger, ICommu
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
-            logger.LogError("Error updating communication...{Error}", e);
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error updating communication, reason: {ErrorMessage}", error.Message);
+            logger.LogError(e, "Error updating communication, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new CommunicationsActions.UpdateFailureAction { Error = error });
         }
     }
@@ -140,9 +137,8 @@ public class CommunicationsEffects(ILogger<CommunicationsEffects> logger, ICommu
         }
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
-            logger.LogError("Error deleting communication...{Error}", e);
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error deleting communication, reason: {ErrorMessage}", error.Message);
+            logger.LogError(e, "Error deleting communication, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new CommunicationsActions.DeleteFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
+++ b/Apps/Admin/Client/Store/Configuration/ConfigurationEffects.cs
@@ -39,7 +39,7 @@ namespace HealthGateway.Admin.Client.Store.Configuration
             catch (ApiException ex)
             {
                 RequestError error = StoreUtility.FormatRequestError(ex);
-                logger.LogError("Error loading external configuration, reason: {ErrorMessage}", error.Message);
+                logger.LogError(ex, "Error loading external configuration, reason: {ErrorMessage}", error.Message);
                 dispatcher.Dispatch(new ConfigurationActions.LoadFailureAction { Error = error });
             }
         }

--- a/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
+++ b/Apps/Admin/Client/Store/Dashboard/DashboardEffects.cs
@@ -40,7 +40,7 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving all-time counts, reason: {ErrorMessage}", error.Message);
+            logger.LogError(ex, "Error retrieving all-time counts, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new DashboardActions.GetAllTimeCountsFailureAction { Error = error });
         }
     }
@@ -59,7 +59,7 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving daily usage counts, reason: {ErrorMessage}", error.Message);
+            logger.LogError(ex, "Error retrieving daily usage counts, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new DashboardActions.GetDailyUsageCountsFailureAction { Error = error });
         }
     }
@@ -78,7 +78,7 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving recurring user count, reason: {ErrorMessage}", error.Message);
+            logger.LogError(ex, "Error retrieving recurring user count, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new DashboardActions.GetRecurringUserCountFailureAction { Error = error });
         }
     }
@@ -97,7 +97,7 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving recurring app login counts, reason: {ErrorMessage}", error.Message);
+            logger.LogError(ex, "Error retrieving recurring app login counts, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new DashboardActions.GetAppLoginCountsFailureAction { Error = error });
         }
     }
@@ -116,7 +116,7 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving ratings summary, reason: {ErrorMessage}", error.Message);
+            logger.LogError(ex, "Error retrieving ratings summary, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new DashboardActions.GetRatingsSummaryFailureAction { Error = error });
         }
     }
@@ -135,7 +135,7 @@ public class DashboardEffects(ILogger<DashboardEffects> logger, IDashboardApi da
         catch (ApiException ex)
         {
             RequestError error = StoreUtility.FormatRequestError(ex);
-            logger.LogError("Error retrieving age counts, reason: {ErrorMessage}", error.Message);
+            logger.LogError(ex, "Error retrieving age counts, reason: {ErrorMessage}", error.Message);
             dispatcher.Dispatch(new DashboardActions.GetAgeCountsFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
+++ b/Apps/Admin/Client/Store/Delegation/DelegationEffects.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     _ => StoreUtility.FormatRequestError(e),
                 };
 
-                logger.LogError(e, "Error retrieving delegation info, reason: {Exception}", e.ToString());
+                logger.LogError(e, "Error retrieving delegation info, reason: {Message}", e.Message);
                 dispatcher.Dispatch(new DelegationActions.SearchFailureAction { Error = error });
             }
         }
@@ -80,7 +80,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
                     _ => StoreUtility.FormatRequestError(e),
                 };
 
-                logger.LogError(e, "Error retrieving delegate info, reason: {Exception}", e.ToString());
+                logger.LogError(e, "Error retrieving delegate info, reason: {Message}", e.Message);
                 dispatcher.Dispatch(new DelegationActions.DelegateSearchFailureAction { Error = error });
             }
         }
@@ -112,7 +112,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
                 RequestError error = StoreUtility.FormatRequestError(e);
-                logger.LogError("Error protecting dependent, reason: {Exception}", e.ToString());
+                logger.LogError(e, "Error protecting dependent, reason: {Message}", e.Message);
                 dispatcher.Dispatch(new DelegationActions.ProtectDependentFailureAction { Error = error });
             }
         }
@@ -140,7 +140,7 @@ namespace HealthGateway.Admin.Client.Store.Delegation
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
                 RequestError error = StoreUtility.FormatRequestError(e);
-                logger.LogError("Error unprotecting dependent, reason: {Exception}", e.ToString());
+                logger.LogError(e, "Error unprotecting dependent, reason: {Message}", e.Message);
                 dispatcher.Dispatch(new DelegationActions.UnprotectDependentFailureAction { Error = error });
             }
         }

--- a/Apps/Admin/Client/Store/PatientDetails/PatientDetailsEffects.cs
+++ b/Apps/Admin/Client/Store/PatientDetails/PatientDetailsEffects.cs
@@ -42,9 +42,8 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                logger.LogError("Error loading patient details...{Error}", e);
                 RequestError error = StoreUtility.FormatRequestError(e);
-                logger.LogError("Error loading patient details, reason: {ErrorMessage}", error.Message);
+                logger.LogError(e, "Error loading patient details, reason: {ErrorMessage}", error.Message);
                 dispatcher.Dispatch(new PatientDetailsActions.LoadFailureAction { Error = error });
             }
         }
@@ -61,7 +60,7 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                logger.LogError("Error blocking access: {Exception}", e.ToString());
+                logger.LogError(e, "Error blocking access: {Message}", e.Message);
                 RequestError error = StoreUtility.FormatRequestError(e);
                 dispatcher.Dispatch(new PatientDetailsActions.BlockAccessFailureAction { Error = error });
             }
@@ -92,7 +91,7 @@ namespace HealthGateway.Admin.Client.Store.PatientDetails
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                logger.LogError("Error submitting COVID-19 treatment assessment: {Exception}", e.ToString());
+                logger.LogError(e, "Error submitting COVID-19 treatment assessment: {Message}", e.Message);
                 RequestError error = StoreUtility.FormatRequestError(e);
                 dispatcher.Dispatch(new PatientDetailsActions.SubmitCovid19TreatmentAssessmentFailureAction { Error = error });
             }

--- a/Apps/Admin/Client/Store/PatientSupport/PatientSupportEffects.cs
+++ b/Apps/Admin/Client/Store/PatientSupport/PatientSupportEffects.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.Admin.Client.Store.PatientSupport
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
                 RequestError error = StoreUtility.FormatRequestError(e);
-                logger.LogError("Error loading patients, reason: {ErrorMessage}", error.Message);
+                logger.LogError(e, "Error loading patients, reason: {ErrorMessage}", error.Message);
                 dispatcher.Dispatch(new PatientSupportActions.LoadFailureAction { Error = error });
             }
         }

--- a/Apps/Admin/Client/Store/Tag/TagEffects.cs
+++ b/Apps/Admin/Client/Store/Tag/TagEffects.cs
@@ -44,7 +44,7 @@ public class TagEffects(ILogger<TagEffects> logger, ITagApi api)
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error adding tag, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error adding tag, reason: {Message}", e.Message);
             dispatcher.Dispatch(new TagActions.AddFailureAction { Error = error });
         }
     }
@@ -63,7 +63,7 @@ public class TagEffects(ILogger<TagEffects> logger, ITagApi api)
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error loading Tag, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error loading Tag, reason: {Message}", e.Message);
             dispatcher.Dispatch(new TagActions.LoadFailureAction { Error = error });
         }
     }
@@ -82,7 +82,7 @@ public class TagEffects(ILogger<TagEffects> logger, ITagApi api)
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error deleting tag, reason: {ErrorMessage}", e.ToString());
+            logger.LogError(e, "Error deleting tag, reason: {ErrorMessage}", e.Message);
             dispatcher.Dispatch(new TagActions.DeleteFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/UserFeedback/UserFeedbackEffects.cs
+++ b/Apps/Admin/Client/Store/UserFeedback/UserFeedbackEffects.cs
@@ -58,7 +58,7 @@ public class UserFeedbackEffects(ILogger<UserFeedbackEffects> logger, IUserFeedb
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error loading user feedback, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error loading user feedback, reason: {Message}", e.Message);
             dispatcher.Dispatch(new UserFeedbackActions.LoadFailureAction { Error = error });
         }
     }
@@ -89,7 +89,7 @@ public class UserFeedbackEffects(ILogger<UserFeedbackEffects> logger, IUserFeedb
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error updating user feedback, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error updating user feedback, reason: {Message}", e.Message);
             dispatcher.Dispatch(new UserFeedbackActions.UpdateFailureAction { Error = error });
         }
     }
@@ -121,7 +121,7 @@ public class UserFeedbackEffects(ILogger<UserFeedbackEffects> logger, IUserFeedb
         catch (Exception e) when (e is ApiException or HttpRequestException)
         {
             RequestError error = StoreUtility.FormatRequestError(e);
-            logger.LogError("Error associating tags to user feedback, reason: {Exception}", e.ToString());
+            logger.LogError(e, "Error associating tags to user feedback, reason: {Message}", e.Message);
             dispatcher.Dispatch(new UserFeedbackActions.SaveAssociatedTagsFailureAction { Error = error });
         }
     }

--- a/Apps/Admin/Client/Store/VaccineCard/VaccineCardEffects.cs
+++ b/Apps/Admin/Client/Store/VaccineCard/VaccineCardEffects.cs
@@ -46,7 +46,7 @@ namespace HealthGateway.Admin.Client.Store.VaccineCard
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                logger.LogError("Error requesting to mail vaccine card: {Exception}", e.ToString());
+                logger.LogError(e, "Error requesting to mail vaccine card: {Message}", e.Message);
                 RequestError error = StoreUtility.FormatRequestError(e);
                 dispatcher.Dispatch(new VaccineCardActions.MailVaccineCardFailureAction { Error = error });
             }
@@ -63,7 +63,7 @@ namespace HealthGateway.Admin.Client.Store.VaccineCard
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                logger.LogError("Error retrieving vaccine card record: {Exception}", e.ToString());
+                logger.LogError(e, "Error retrieving vaccine card record: {Message}", e.Message);
                 RequestError error = StoreUtility.FormatRequestError(e);
                 dispatcher.Dispatch(new VaccineCardActions.PrintVaccineCardFailureAction { Error = error });
             }

--- a/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
@@ -110,7 +110,7 @@ namespace HealthGateway.ClinicalDocument.Services
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogCritical("Error while retrieving Clinical Documents ... {Error}", e.ToString());
+                this.logger.LogCritical(e, "Error while retrieving Clinical Documents ... {Message}", e.Message);
                 requestResult.ResultError = new()
                 {
                     ResultMessage = "Error while retrieving Clinical Documents",
@@ -161,7 +161,7 @@ namespace HealthGateway.ClinicalDocument.Services
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogCritical("Error while retrieving Clinical Document file ... {Error}", e.ToString());
+                this.logger.LogCritical(e, "Error while retrieving Clinical Document file ... {Message}", e.Message);
                 requestResult.ResultError = new()
                 {
                     ResultMessage = "Error while retrieving Clinical Document file",

--- a/Apps/DBMaintainer/Apps/BCPProvDrugDBApp.cs
+++ b/Apps/DBMaintainer/Apps/BCPProvDrugDBApp.cs
@@ -193,10 +193,10 @@ namespace HealthGateway.DBMaintainer.Apps
             // Add new pharmacy assessment file download to database
             await this.AddFileToDbAsync(pharmacyAssessmentFileDownload, ct);
 
-            this.Logger.LogInformation("Parsing Provincial PharmaCare Drug file");
+            // Parse Provincial PharmaCare Drug file
             IList<PharmaCareDrug> pharmaCareDrugs = await this.Parser.ParsePharmaCareDrugFileAsync(pharmaCareDrugFile, pharmaCareDrugFileDownload, ct);
 
-            this.Logger.LogInformation("Parsing Pharmacy Assessment file");
+            // Parse Pharmacy Assessment file
             IEnumerable<PharmacyAssessment> pharmacyAssessments = this.pharmacyAssessmentParser.ParsePharmacyAssessmentFile(pharmacyAssessmentFile, pharmacyAssessmentFileDownload);
 
             // If required, modify pharma care drug with pharmacy assessment

--- a/Apps/DBMaintainer/Apps/FedDrugDBApp.cs
+++ b/Apps/DBMaintainer/Apps/FedDrugDBApp.cs
@@ -50,10 +50,11 @@ namespace HealthGateway.DBMaintainer.Apps
         /// <inheritdoc/>
         protected override async Task ProcessDownloadAsync(string sourceFolder, FileDownload downloadedFile, CancellationToken ct = default)
         {
-            this.Logger.LogInformation("Parsing Drug File and adding to DB Context");
+            // Parse Drug File and add to DB Context
             IList<DrugProduct> drugProducts = this.Parser.ParseDrugFile(sourceFolder, downloadedFile);
             await this.DrugDbContext.DrugProduct.AddRangeAsync(drugProducts, ct);
-            this.Logger.LogInformation("Parsing Other files and adding to DB Context");
+
+            // Parse other drug files and add to DB Context
             await this.DrugDbContext.ActiveIngredient.AddRangeAsync(this.Parser.ParseActiveIngredientFile(sourceFolder, drugProducts), ct);
             await this.DrugDbContext.Company.AddRangeAsync(this.Parser.ParseCompanyFile(sourceFolder, drugProducts), ct);
             await this.DrugDbContext.Status.AddRangeAsync(this.Parser.ParseStatusFile(sourceFolder, drugProducts), ct);

--- a/Apps/DBMaintainer/FileDownload/FileDownloadService.cs
+++ b/Apps/DBMaintainer/FileDownload/FileDownloadService.cs
@@ -80,7 +80,7 @@ namespace HealthGateway.DBMaintainer.FileDownload
             }
             catch (Exception exception)
             {
-                this.logger.LogCritical("{Exception}", exception.ToString());
+                this.logger.LogCritical(exception, "{Message}", exception.Message);
                 File.Delete(filePath);
                 fd.Name = string.Empty;
                 fd.LocalFilePath = string.Empty;

--- a/Apps/Database/src/Context/GatewayDbContext.cs
+++ b/Apps/Database/src/Context/GatewayDbContext.cs
@@ -37,6 +37,10 @@ namespace HealthGateway.Database.Context
     [ExcludeFromCodeCoverage]
     public class GatewayDbContext : BaseDbContext
     {
+        private const string HgDoNotReply = "HG_Donotreply@gov.bc.ca";
+        private const string DateFormat = "MM/dd/yyyy";
+        private const string TimezoneDateFormat = "MM/dd/yyyy K";
+
         /// <summary>
         /// Initializes a new instance of the <see cref="GatewayDbContext"/> class.
         /// </summary>
@@ -772,7 +776,7 @@ namespace HealthGateway.Database.Context
                     {
                         Id = Guid.Parse("040c2ec3-d6c0-4199-9e4b-ebe6da48d52a"),
                         Name = "Registration",
-                        From = "HG_Donotreply@gov.bc.ca",
+                        From = HgDoNotReply,
                         Subject = "Health Gateway Email Verification ${Environment}",
                         Body = ReadResource("HealthGateway.Database.Assets.docs.EmailValidationTemplate.html"),
                         Priority = EmailPriority.Standard,
@@ -787,7 +791,7 @@ namespace HealthGateway.Database.Context
                     {
                         Id = Guid.Parse("79503a38-c14a-4992-b2fe-5586629f552e"),
                         Name = "AccountClosed",
-                        From = "HG_Donotreply@gov.bc.ca",
+                        From = HgDoNotReply,
                         Subject = "Health Gateway Account Closed ",
                         Body = ReadResource("HealthGateway.Database.Assets.docs.EmailAccountClosed.html"),
                         Priority = EmailPriority.Low,
@@ -802,7 +806,7 @@ namespace HealthGateway.Database.Context
                     {
                         Id = Guid.Parse("2fe8c825-d4de-4884-be6a-01a97b466425"),
                         Name = "AccountRecovered",
-                        From = "HG_Donotreply@gov.bc.ca",
+                        From = HgDoNotReply,
                         Subject = "Health Gateway Account Recovered",
                         Body = ReadResource("HealthGateway.Database.Assets.docs.EmailAccountRecovered.html"),
                         Priority = EmailPriority.Low,
@@ -817,7 +821,7 @@ namespace HealthGateway.Database.Context
                     {
                         Id = Guid.Parse("d9898318-4e53-4074-9979-5d24bd370055"),
                         Name = "AccountRemoved",
-                        From = "HG_Donotreply@gov.bc.ca",
+                        From = HgDoNotReply,
                         Subject = "Health Gateway Account Closure Complete",
                         Body = ReadResource("HealthGateway.Database.Assets.docs.EmailAccountRemoved.html"),
                         Priority = EmailPriority.Low,
@@ -832,7 +836,7 @@ namespace HealthGateway.Database.Context
                     {
                         Id = Guid.Parse("75c79b3e-1a61-403b-82ee-fddcda7144af"),
                         Name = "AdminFeedback",
-                        From = "HG_Donotreply@gov.bc.ca",
+                        From = HgDoNotReply,
                         Subject = "Health Gateway Feedback Received",
                         Body = ReadResource("HealthGateway.Database.Assets.docs.AdminFeedback.html"),
                         Priority = EmailPriority.Low,
@@ -880,55 +884,55 @@ namespace HealthGateway.Database.Context
                         Id = Guid.Parse("ec438d12-f8e2-4719-8444-28e35d34674c"),
                         LegalAgreementCode = LegalAgreementType.TermsOfService,
                         LegalText = ReadResource("HealthGateway.Database.Assets.Legal.TermsOfService.20200317.html"),
-                        EffectiveDate = DateTime.ParseExact("03/18/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        EffectiveDate = DateTime.ParseExact("03/18/2020", DateFormat, CultureInfo.InvariantCulture),
                         CreatedBy = UserId.DefaultUser,
-                        CreatedDateTime = DateTime.ParseExact("03/18/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        CreatedDateTime = DateTime.ParseExact("03/18/2020", DateFormat, CultureInfo.InvariantCulture),
                         UpdatedBy = UserId.DefaultUser,
-                        UpdatedDateTime = DateTime.ParseExact("03/18/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        UpdatedDateTime = DateTime.ParseExact("03/18/2020", DateFormat, CultureInfo.InvariantCulture),
                     },
                     new LegalAgreement // Updated Terms of Service for Lab/Covid Update
                     {
                         Id = Guid.Parse("1d94c170-5118-4aa6-ba31-e3e07274ccbd"),
                         LegalAgreementCode = LegalAgreementType.TermsOfService,
                         LegalText = ReadResource("HealthGateway.Database.Assets.Legal.TermsOfService.20200511.html"),
-                        EffectiveDate = DateTime.ParseExact("07/31/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        EffectiveDate = DateTime.ParseExact("07/31/2020", DateFormat, CultureInfo.InvariantCulture),
                         CreatedBy = UserId.DefaultUser,
-                        CreatedDateTime = DateTime.ParseExact("06/22/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        CreatedDateTime = DateTime.ParseExact("06/22/2020", DateFormat, CultureInfo.InvariantCulture),
                         UpdatedBy = UserId.DefaultUser,
-                        UpdatedDateTime = DateTime.ParseExact("06/22/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        UpdatedDateTime = DateTime.ParseExact("06/22/2020", DateFormat, CultureInfo.InvariantCulture),
                     },
                     new LegalAgreement // Updated Terms of Service for Dependents
                     {
                         Id = Guid.Parse("c99fd839-b4a2-40f9-b103-529efccd0dcd"),
                         LegalAgreementCode = LegalAgreementType.TermsOfService,
                         LegalText = ReadResource("HealthGateway.Database.Assets.Legal.TermsOfService.20201224.html"),
-                        EffectiveDate = DateTime.ParseExact("01/07/2021", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        EffectiveDate = DateTime.ParseExact("01/07/2021", DateFormat, CultureInfo.InvariantCulture),
                         CreatedBy = UserId.DefaultUser,
-                        CreatedDateTime = DateTime.ParseExact("12/24/2020", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        CreatedDateTime = DateTime.ParseExact("12/24/2020", DateFormat, CultureInfo.InvariantCulture),
                         UpdatedBy = UserId.DefaultUser,
-                        UpdatedDateTime = DateTime.ParseExact("01/06/2021", "MM/dd/yyyy", CultureInfo.InvariantCulture),
+                        UpdatedDateTime = DateTime.ParseExact("01/06/2021", DateFormat, CultureInfo.InvariantCulture),
                     },
                     new LegalAgreement // Updated Terms of Service Fix Contact
                     {
                         Id = Guid.Parse("eafeee76-8a64-49ee-81ba-ddfe2c01deb8"),
                         LegalAgreementCode = LegalAgreementType.TermsOfService,
                         LegalText = ReadResource("HealthGateway.Database.Assets.Legal.TermsOfService.20220519.html"),
-                        EffectiveDate = DateTime.ParseExact("05/19/2022 Z", "MM/dd/yyyy K", CultureInfo.InvariantCulture).ToUniversalTime(),
+                        EffectiveDate = DateTime.ParseExact("05/19/2022 Z", TimezoneDateFormat, CultureInfo.InvariantCulture).ToUniversalTime(),
                         CreatedBy = UserId.DefaultUser,
-                        CreatedDateTime = DateTime.ParseExact("05/19/2022 Z", "MM/dd/yyyy K", CultureInfo.InvariantCulture).ToUniversalTime(),
+                        CreatedDateTime = DateTime.ParseExact("05/19/2022 Z", TimezoneDateFormat, CultureInfo.InvariantCulture).ToUniversalTime(),
                         UpdatedBy = UserId.DefaultUser,
-                        UpdatedDateTime = DateTime.ParseExact("05/19/2022 Z", "MM/dd/yyyy K", CultureInfo.InvariantCulture).ToUniversalTime(),
+                        UpdatedDateTime = DateTime.ParseExact("05/19/2022 Z", TimezoneDateFormat, CultureInfo.InvariantCulture).ToUniversalTime(),
                     },
                     new LegalAgreement // Revamped Terms of Service
                     {
                         Id = Guid.Parse("2fab66e7-37c9-4b03-ba25-e8fad604dc7f"),
                         LegalAgreementCode = LegalAgreementType.TermsOfService,
                         LegalText = ReadResource("HealthGateway.Database.Assets.Legal.TermsOfService.20220607.html"),
-                        EffectiveDate = DateTime.ParseExact("06/07/2022 Z", "MM/dd/yyyy K", CultureInfo.InvariantCulture).ToUniversalTime(),
+                        EffectiveDate = DateTime.ParseExact("06/07/2022 Z", TimezoneDateFormat, CultureInfo.InvariantCulture).ToUniversalTime(),
                         CreatedBy = UserId.DefaultUser,
-                        CreatedDateTime = DateTime.ParseExact("06/07/2022 Z", "MM/dd/yyyy K", CultureInfo.InvariantCulture).ToUniversalTime(),
+                        CreatedDateTime = DateTime.ParseExact("06/07/2022 Z", TimezoneDateFormat, CultureInfo.InvariantCulture).ToUniversalTime(),
                         UpdatedBy = UserId.DefaultUser,
-                        UpdatedDateTime = DateTime.ParseExact("06/07/2022 Z", "MM/dd/yyyy K", CultureInfo.InvariantCulture).ToUniversalTime(),
+                        UpdatedDateTime = DateTime.ParseExact("06/07/2022 Z", TimezoneDateFormat, CultureInfo.InvariantCulture).ToUniversalTime(),
                     });
         }
 

--- a/Apps/Database/src/Delegates/DbAdminTagDelegate.cs
+++ b/Apps/Database/src/Delegates/DbAdminTagDelegate.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to save AdminTag to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to save AdminTag to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = e.Message;
                 }

--- a/Apps/Database/src/Delegates/DbCommentDelegate.cs
+++ b/Apps/Database/src/Delegates/DbCommentDelegate.cs
@@ -81,7 +81,7 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to save Comment to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to save Comment to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = e.Message;
                 }

--- a/Apps/Database/src/Delegates/DbCommunicationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbCommunicationDelegate.cs
@@ -84,7 +84,7 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to save Communication to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to save Communication to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = IsUniqueConstraintDbError(e) ? BannerCommunicationOverlapMessage : e.Message;
                 }
@@ -122,13 +122,13 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateConcurrencyException e)
                 {
-                    this.logger.LogError("Unable to update Communication to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to update Communication to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Concurrency;
                     result.Message = e.Message;
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to update Communication to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to update Communication to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = IsUniqueConstraintDbError(e) ? BannerCommunicationOverlapMessage : e.Message;
                 }

--- a/Apps/Database/src/Delegates/DbNoteDelegate.cs
+++ b/Apps/Database/src/Delegates/DbNoteDelegate.cs
@@ -83,7 +83,7 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to save note to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to save note to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = e.Message;
                 }

--- a/Apps/Database/src/Delegates/DbProfileDelegate.cs
+++ b/Apps/Database/src/Delegates/DbProfileDelegate.cs
@@ -77,7 +77,7 @@ namespace HealthGateway.Database.Delegates
         public async Task<DbResult<UserProfile>> UpdateAsync(UserProfile profile, bool commit = true, CancellationToken ct = default)
         {
             this.logger.LogTrace("Updating user profile in DB");
-            UserProfile? userProfile = await this.GetUserProfileAsync(profile.HdId, true, ct: ct);
+            UserProfile? userProfile = await this.GetUserProfileAsync(profile.HdId, true, ct);
             DbResult<UserProfile> result = new();
 
             if (userProfile != null)
@@ -108,7 +108,7 @@ namespace HealthGateway.Database.Delegates
                     }
                     catch (DbUpdateException e)
                     {
-                        this.logger.LogError("Unable to update UserProfile to DB {Exception}", e.ToString());
+                        this.logger.LogError(e, "Unable to update UserProfile to DB {Message}", e.Message);
                         result.Status = DbStatusCode.Error;
                         result.Message = e.Message;
                     }
@@ -138,7 +138,7 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IList<UserProfile>> GetUserProfilesAsync(string email, bool includeBetaFeatureCodes, CancellationToken ct = default)
+        public async Task<IList<UserProfile>> GetUserProfilesAsync(string email, bool includeBetaFeatureCodes = false, CancellationToken ct = default)
         {
             IQueryable<UserProfile> query = this.dbContext.UserProfile;
             query = query.Where(p => EF.Functions.ILike(p.Email, email));

--- a/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
+++ b/Apps/Database/src/Delegates/DbResourceDelegateDelegate.cs
@@ -77,7 +77,7 @@ namespace HealthGateway.Database.Delegates
                     }
                     else
                     {
-                        this.logger.LogError("Error inserting resource delegate to DB with exception {Exception}", e.ToString());
+                        this.logger.LogError(e, "Error inserting resource delegate to DB with exception {Message}", e.Message);
                         result.Message = e.Message;
                     }
                 }

--- a/Apps/Database/src/Delegates/DbUserPreferenceDelegate.cs
+++ b/Apps/Database/src/Delegates/DbUserPreferenceDelegate.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to create UserPreference to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to create UserPreference to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = e.Message;
                 }
@@ -107,7 +107,7 @@ namespace HealthGateway.Database.Delegates
                 }
                 catch (DbUpdateException e)
                 {
-                    this.logger.LogError("Unable to update UserPreference to DB {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unable to update UserPreference to DB {Message}", e.Message);
                     result.Status = DbStatusCode.Error;
                     result.Message = e.Message;
                 }

--- a/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
+++ b/Apps/Encounter/src/Delegates/RestHospitalVisitDelegate.cs
@@ -88,7 +88,7 @@ namespace HealthGateway.Encounter.Delegates
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogError("Error while retrieving Hospital Visits... {Error}", e);
+                this.logger.LogError(e, "Error while retrieving Hospital Visits... {Message}", e.Message);
                 return RequestResultFactory.ServiceError<PhsaResult<IEnumerable<HospitalVisit>>>(ErrorType.CommunicationExternal, ServiceType.Phsa, "Error while retrieving Hospital Visits");
             }
         }

--- a/Apps/Encounter/src/Delegates/RestMspVisitDelegate.cs
+++ b/Apps/Encounter/src/Delegates/RestMspVisitDelegate.cs
@@ -82,7 +82,7 @@ namespace HealthGateway.Encounter.Delegates
                 }
                 catch (Exception e) when (e is ApiException or HttpRequestException)
                 {
-                    this.logger.LogError("Error while retrieving Msp Visits... {Error}", e);
+                    this.logger.LogError(e, "Error while retrieving Msp Visits... {Message}", e.Message);
                     HttpStatusCode? statusCode = (e as ApiException)?.StatusCode ?? ((HttpRequestException)e).StatusCode;
                     retVal.ResultError = new()
                     {

--- a/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
@@ -115,7 +115,7 @@ namespace HealthGateway.Immunization.Delegates
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogCritical("Get Immunizations unexpected Exception {Error}", e.ToString());
+                this.logger.LogCritical(e, "Get Immunizations unexpected Exception {Message}", e.Message);
                 requestResult.ResultError = new()
                 {
                     ResultMessage = "Error with Get Immunization Request",

--- a/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestImmunizationDelegate.cs
@@ -85,7 +85,7 @@ namespace HealthGateway.Immunization.Delegates
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogCritical("Get Immunization unexpected Exception {Error}", e.ToString());
+                this.logger.LogCritical(e, "Get Immunization unexpected Exception {Message}", e.Message);
                 requestResult.ResultError = new()
                 {
                     ResultMessage = "Error with Get Immunization Request",

--- a/Apps/Immunization/src/Delegates/RestVaccineStatusDelegate.cs
+++ b/Apps/Immunization/src/Delegates/RestVaccineStatusDelegate.cs
@@ -78,7 +78,7 @@ namespace HealthGateway.Immunization.Delegates
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogError("Unexpected exception in GetVaccineStatus {Exception}", e);
+                this.logger.LogError(e, "Unexpected exception in GetVaccineStatus {Message}", e.Message);
             }
 
             if (retVal.ResourcePayload == null)
@@ -123,7 +123,7 @@ namespace HealthGateway.Immunization.Delegates
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogError("Unexpected exception in GetVaccineStatusPublic {Exception}", e);
+                this.logger.LogError(e, "Unexpected exception in GetVaccineStatusPublic {Message}", e.Message);
             }
 
             if (retVal.ResourcePayload == null)

--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -45,6 +45,7 @@ namespace HealthGateway.Immunization.Services
     {
         private const string PhsaConfigSectionKey = "PHSA";
         private const string AuthConfigSectionName = "PublicAuthentication";
+        private const string VaccineProofDocumentNotAvailable = "Vaccine Proof document is not available.";
         private readonly IAuthenticationDelegate authDelegate;
         private readonly IImmunizationMappingService mappingService;
         private readonly IHttpContextAccessor? httpContextAccessor;
@@ -125,7 +126,7 @@ namespace HealthGateway.Immunization.Services
                 {
                     this.logger.LogDebug("Vaccine Proof document is not available (not found)");
                     retVal.ResultStatus = ResultType.ActionRequired;
-                    retVal.ResultError = ErrorTranslator.ActionRequired("Vaccine Proof document is not available.", ActionType.Invalid);
+                    retVal.ResultError = ErrorTranslator.ActionRequired(VaccineProofDocumentNotAvailable, ActionType.Invalid);
                 }
                 else if (payload.Loaded && string.IsNullOrEmpty(payload.FederalVaccineProof?.Data))
                 {
@@ -133,7 +134,7 @@ namespace HealthGateway.Immunization.Services
                     retVal.ResultStatus = ResultType.Error;
                     retVal.ResultError = new RequestResultError
                     {
-                        ResultMessage = "Vaccine Proof document is not available.",
+                        ResultMessage = VaccineProofDocumentNotAvailable,
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Phsa),
                     };
                 }
@@ -168,9 +169,9 @@ namespace HealthGateway.Immunization.Services
             {
                 if (payload.State == VaccineState.NotFound)
                 {
-                    this.logger.LogDebug("Vaccine Proof document is not available (not found)");
+                    this.logger.LogDebug(VaccineProofDocumentNotAvailable);
                     retVal.ResultStatus = ResultType.ActionRequired;
-                    retVal.ResultError = ErrorTranslator.ActionRequired("Vaccine Proof document is not available.", ActionType.Invalid);
+                    retVal.ResultError = ErrorTranslator.ActionRequired(VaccineProofDocumentNotAvailable, ActionType.Invalid);
                 }
                 else if (payload.Loaded && string.IsNullOrEmpty(payload.FederalVaccineProof?.Data))
                 {
@@ -178,7 +179,7 @@ namespace HealthGateway.Immunization.Services
                     retVal.ResultStatus = ResultType.Error;
                     retVal.ResultError = new RequestResultError
                     {
-                        ResultMessage = "Vaccine Proof document is not available.",
+                        ResultMessage = VaccineProofDocumentNotAvailable,
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.InvalidState, ServiceType.Phsa),
                     };
                 }

--- a/Apps/JobScheduler/src/Jobs/AdminFeedbackJob.cs
+++ b/Apps/JobScheduler/src/Jobs/AdminFeedbackJob.cs
@@ -93,7 +93,7 @@ namespace HealthGateway.JobScheduler.Jobs
             EmailTemplate? template = await this.emailService.GetEmailTemplateAsync(FeedbackTemplateName, ct);
             if (template == null)
             {
-                this.logger.LogCritical($"Email template {FeedbackTemplateName} is null");
+                this.logger.LogCritical("Email template {FeedbackTemplateName} is null", FeedbackTemplateName);
                 throw new InvalidOperationException($"Email template {FeedbackTemplateName} is null");
             }
 

--- a/Apps/JobScheduler/src/Jobs/CloseAccountJob.cs
+++ b/Apps/JobScheduler/src/Jobs/CloseAccountJob.cs
@@ -146,9 +146,10 @@ namespace HealthGateway.JobScheduler.Jobs
                     catch (Exception e) when (e is ApiException or HttpRequestException)
                     {
                         this.logger.LogError(
-                            "Error deleting {Id} from Keycloak with exception: {Exception}",
+                            e,
+                            "Error deleting {Id} from Keycloak with exception: {Message}",
                             profile.IdentityManagementId,
-                            e.ToString());
+                            e.Message);
                     }
                 }
 

--- a/Apps/JobScheduler/src/Jobs/OneTimeJob.cs
+++ b/Apps/JobScheduler/src/Jobs/OneTimeJob.cs
@@ -102,7 +102,7 @@ namespace HealthGateway.JobScheduler.Jobs
                             Value = true.ToString(),
                         };
                         this.applicationSettingsDelegate.AddApplicationSetting(hasRunAppSetting);
-                        this.logger.LogInformation("OneTimeJob is commiting DB changes");
+                        this.logger.LogDebug("OneTimeJob is commiting DB changes");
                         await this.dbContext.SaveChangesAsync(ct);
                     }
                     else

--- a/Apps/JobScheduler/src/Listeners/AuditQueueListener.cs
+++ b/Apps/JobScheduler/src/Listeners/AuditQueueListener.cs
@@ -115,7 +115,7 @@ namespace HealthGateway.JobScheduler.Listeners
                 }
                 catch (DataException e)
                 {
-                    this.logger.LogError("Error writing to DB:\n{@Exception}", e);
+                    this.logger.LogError(e, "Error writing to DB:\n{Message}", e.Message);
                 }
             }
 

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -102,14 +102,14 @@ namespace HealthGateway.JobScheduler.Listeners
                 }
                 catch (NpgsqlException e)
                 {
-                    this.logger.LogError("DB Error encountered in WaitChannelNotification: {Channel}\n{Exception}", Channel, e.ToString());
+                    this.logger.LogError(e, "DB Error encountered in WaitChannelNotification: {Channel}\n{Message}", Channel, e.Message);
                     if (!stoppingToken.IsCancellationRequested)
                     {
                         await Task.Delay(SleepDuration, stoppingToken);
                     }
                 }
 
-                this.logger.LogWarning($"Banner Listener on {Channel} exiting...");
+                this.logger.LogWarning("Banner Listener on {Channel} exiting...", Channel);
             }
         }
 

--- a/Apps/JobScheduler/src/Tasks/CopyEmailToMessagingVerification.cs
+++ b/Apps/JobScheduler/src/Tasks/CopyEmailToMessagingVerification.cs
@@ -56,7 +56,7 @@ namespace HealthGateway.JobScheduler.Tasks
         /// <inheritdoc/>
         public async Task RunAsync(CancellationToken ct = default)
         {
-            this.logger.LogInformation("Performing Task {Name} started", this.GetType().Name);
+            this.logger.LogDebug("Performing Task {Name} started", this.GetType().Name);
 
             IQueryable<Email> query = this.dbContext.Email.Where(
                 email => this.dbContext.MessagingVerification.Any(msgVerification => msgVerification.EmailId == email.Id && msgVerification.EmailAddress == null));
@@ -81,13 +81,15 @@ namespace HealthGateway.JobScheduler.Tasks
                 await Task.WhenAll(tasks);
 
                 await this.dbContext.SaveChangesAsync(ct);
-                this.logger.LogInformation("Saved message verification changes after {Processed} email(s) processed", processed);
 
                 emails = await query.Take(this.batchSize).ToListAsync(ct);
-                this.logger.LogInformation("The number of emails to copy from Email.To to MessagingVerification.EmailAddress: {Emails}", emails.Count);
+                this.logger.LogInformation(
+                    "Saved message verification changes after {Processed} email(s) processed. \n The number of emails copied from Email.To to MessagingVerification.EmailAddress: {Emails}",
+                    processed,
+                    emails.Count);
             }
 
-            this.logger.LogInformation("Performing Task {Name} finished", this.GetType().Name);
+            this.logger.LogDebug("Performing Task {Name} finished", this.GetType().Name);
         }
     }
 }

--- a/Apps/JobScheduler/src/Tasks/SendValidatedUsersToPhsa.cs
+++ b/Apps/JobScheduler/src/Tasks/SendValidatedUsersToPhsa.cs
@@ -55,7 +55,7 @@ namespace HealthGateway.JobScheduler.Tasks
         /// <inheritdoc/>
         public async Task RunAsync(CancellationToken ct = default)
         {
-            this.logger.LogInformation("Performing Task {Name}", this.GetType().Name);
+            this.logger.LogDebug("Performing Task {Name}", this.GetType().Name);
             IEnumerable<UserProfile> users = await this.dbContext.UserProfile.Where(q => !string.IsNullOrEmpty(q.Email)).ToListAsync(ct);
             this.logger.LogInformation("Queueing NotificationSettings for {Count} users", users.Count());
             foreach (UserProfile user in users)
@@ -71,7 +71,7 @@ namespace HealthGateway.JobScheduler.Tasks
                 await this.notificationSettingsService.QueueNotificationSettingsAsync(nsr, ct);
             }
 
-            this.logger.LogInformation("Task {Name} has completed", this.GetType().Name);
+            this.logger.LogDebug("Task {Name} has completed", this.GetType().Name);
         }
     }
 }

--- a/Apps/Laboratory/src/Delegates/RestLaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/RestLaboratoryDelegate.cs
@@ -95,7 +95,7 @@ namespace HealthGateway.Laboratory.Delegates
                     }
                     else
                     {
-                        this.logger.LogError("Error while retrieving Covid19 Orders... {Error}", e);
+                        this.logger.LogError(e, "Error while retrieving Covid19 Orders... {Message}", e.Message);
                         HttpStatusCode? statusCode = (e as ApiException)?.StatusCode ?? ((HttpRequestException)e).StatusCode;
 
                         retVal.ResultError = new()
@@ -140,7 +140,7 @@ namespace HealthGateway.Laboratory.Delegates
                 }
                 catch (Exception e) when (e is ApiException or HttpRequestException)
                 {
-                    this.logger.LogError("Error retrieving Laboratory Report...{Error}", e);
+                    this.logger.LogError(e, "Error retrieving Laboratory Report...{Message}", e.Message);
                     HttpStatusCode? statusCode = (e as ApiException)?.StatusCode ?? ((HttpRequestException)e).StatusCode;
 
                     retVal.ResultError = new()
@@ -186,7 +186,7 @@ namespace HealthGateway.Laboratory.Delegates
                 }
                 else
                 {
-                    this.logger.LogError("Error while retrieving Laboratory Summary... {Error}", e);
+                    this.logger.LogError(e, "Error while retrieving Laboratory Summary... {Message}", e.Message);
                     HttpStatusCode? statusCode = (e as ApiException)?.StatusCode ?? ((HttpRequestException)e).StatusCode;
 
                     retVal.ResultError = new()

--- a/Apps/Laboratory/src/Services/LabTestKitService.cs
+++ b/Apps/Laboratory/src/Services/LabTestKitService.cs
@@ -91,7 +91,7 @@ namespace HealthGateway.Laboratory.Services
             }
             catch (HttpRequestException e)
             {
-                this.logger.LogCritical("HTTP Request Exception {Exception}", e.ToString());
+                this.logger.LogCritical(e, "HTTP Request Exception {Message}", e.Message);
                 return RequestResultFactory.ServiceError<PublicLabTestKit>(ErrorType.CommunicationExternal, ServiceType.Phsa, "Error with HTTP Request");
             }
         }
@@ -108,7 +108,7 @@ namespace HealthGateway.Laboratory.Services
             }
             catch (HttpRequestException e)
             {
-                this.logger.LogCritical("HTTP Request Exception {Exception}", e.ToString());
+                this.logger.LogCritical(e, "HTTP Request Exception {Message}", e.Message);
                 return RequestResultFactory.ServiceError<LabTestKit>(ErrorType.CommunicationExternal, ServiceType.Phsa, "Error with HTTP Request");
             }
         }

--- a/Apps/Medication/src/Delegates/RestMedicationStatementDelegate.cs
+++ b/Apps/Medication/src/Delegates/RestMedicationStatementDelegate.cs
@@ -125,7 +125,7 @@ namespace HealthGateway.Medication.Delegates
                         ResultMessage = "An error occured with the Medication History Provider",
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.OdrRecords),
                     };
-                    this.logger.LogError("Error with Medication Service: {Exception}", e.ToString());
+                    this.logger.LogError(e, "Error with Medication Service: {Message}", e.Message);
                 }
 
                 return retVal;

--- a/Apps/Medication/src/Delegates/SalesforceMedicationRequestDelegate.cs
+++ b/Apps/Medication/src/Delegates/SalesforceMedicationRequestDelegate.cs
@@ -112,7 +112,7 @@ namespace HealthGateway.Medication.Delegates
                         ResultMessage = "Error while retrieving Medication Requests",
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.Sf),
                     };
-                    this.logger.LogError("Unexpected exception in GetMedicationRequestsAsync {Exception}", e.ToString());
+                    this.logger.LogError(e, "Unexpected exception in GetMedicationRequestsAsync {Message}", e.Message);
                 }
 
                 this.logger.LogDebug("Finished getting Medication Requests");

--- a/Apps/Medication/src/Services/RestMedicationStatementService.cs
+++ b/Apps/Medication/src/Services/RestMedicationStatementService.cs
@@ -152,8 +152,7 @@ namespace HealthGateway.Medication.Services
             {
                 List<string> medicationIdentifiers = medSummaries.Select(s => s.Din.PadLeft(8, '0')).ToList();
 
-                this.logger.LogDebug("Getting drugs from DB");
-                this.logger.LogTrace("Identifiers: {MedicationIdentifiers}", string.Join(",", medicationIdentifiers));
+                this.logger.LogTrace("Getting drugs from DB - Identifiers: {MedicationIdentifiers}", string.Join(",", medicationIdentifiers));
                 List<string> uniqueDrugIdentifiers = medicationIdentifiers.Distinct().ToList();
                 this.logger.LogDebug(
                     "Total DrugIdentifiers: {MedicationIdentifiersCount} | Unique identifiers: {UniqueDrugIdentifiersCount}",
@@ -174,8 +173,7 @@ namespace HealthGateway.Medication.Services
                     provincialDict = pharmaCareDrugs.ToDictionary(dp => dp.DinPin, dp => dp);
                 }
 
-                this.logger.LogDebug("Finished getting drugs from DB");
-                this.logger.LogTrace("Populating medication summary... {Count} records", medSummaries.Count);
+                this.logger.LogTrace("Finished getting drugs from DB - Populating medication summary... {Count} records", medSummaries.Count);
                 foreach (MedicationSummary mdSummary in medSummaries)
                 {
                     string din = mdSummary.Din.PadLeft(8, '0');


### PR DESCRIPTION
# Implements AB#16670

## Description

Fix sonar code smells:

1. Fix sonar code smell for DependentServerTests
2. Fix sonar code smell for PatientRepositoryTests
3. Fix sonar code smell regarding logger statements that require exception argument to be passed in when in an exception block
4. Fix sonar code smell regarding reducing the number logger statements in a code block - addressed this by either merging statements into one or removing them and adding a comment instead of a logged statement
5. Fixed a bug in Strategy where the incorrect cache parameter was being passed.   As a result, the cache was not used.
6. Fixed use of cache in Strategy tests

Remaining code smells are either in non C# code or something that can be discussed further:

https://sonarcloud.io/code?id=bcgov_healthgateway&selected=bcgov_healthgateway%3AApps



## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
