### PR TITLE
Increase code coverage in Common project AB#16659

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -844,6 +844,12 @@ dotnet_diagnostic.ca1859.severity = none
 # CA1869: Cache and reuse 'JsonSerializerOptions' instances
 dotnet_diagnostic.ca1869.severity = none
 
+# CA2201: Do not raise reserved exception types
+dotnet_diagnostic.ca2201.severity = none
+
+# CA2254: Template should be a static expression
+dotnet_diagnostic.ca2254.severity = none
+
 # CS1591: Missing XML comment for publicly visible type or member
 dotnet_diagnostic.cs1591.severity = none
 

--- a/Apps/AccountDataAccess/src/Patient/Address.cs
+++ b/Apps/AccountDataAccess/src/Patient/Address.cs
@@ -13,10 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //-------------------------------------------------------------------------
-using System.Runtime.CompilerServices;
-
-[assembly: InternalsVisibleTo("PatientTests")]
-
 namespace HealthGateway.AccountDataAccess.Patient
 {
     using System.Collections.Generic;

--- a/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
+++ b/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
@@ -29,10 +29,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <InternalsVisibleTo Include="AccountDataAccessTests" />
-    </ItemGroup>
-
-    <ItemGroup>
       <ProjectReference Include="..\..\src\AccountDataAccess.csproj" />
     </ItemGroup>
 

--- a/Apps/Admin/Client/Layouts/MainLayout.razor
+++ b/Apps/Admin/Client/Layouts/MainLayout.razor
@@ -15,9 +15,9 @@
         </MudTooltip>
         <AuthorizeView>
             <Authorized>
-                <MudMenu Direction="Direction.Left" OffsetX="true" Dense="true" Class="mt-1 ml-4">
+                <MudMenu AnchorOrigin="@Origin.BottomRight" TransformOrigin="@Origin.TopRight" Dense="true" Class="mt-1 ml-4">
                     <ActivatorContent>
-                        <MudIcon Icon="fas fa-user" Color="Color.Inherit" Edge="Edge.End" data-testid="user-account-icon" />
+                        <MudIconButton Icon="fas fa-user" Color="Color.Inherit" Edge="@Edge.End" data-testid="user-account-icon" />
                     </ActivatorContent>
                     <ChildContent>
                         <MudNavLink href="user-info" Typo="Typo.h6" Underline="Underline.None" align="center" Disabled="@UserInfoDisabled" data-testid="user-info-link">

--- a/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
@@ -310,5 +310,6 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
     /// </summary>
     /// <param name="Enabled">Enable or disable request logging</param>
     /// <param name="ExcludedPaths">Optional request paths to exclude, can handle * wildcard in prefix or postfix</param>
+    [ExcludeFromCodeCoverage]
     public record RequestLoggingSettings(bool Enabled = true, IEnumerable<string>? ExcludedPaths = null);
 }

--- a/Apps/Common/src/AssemblyInfo.cs
+++ b/Apps/Common/src/AssemblyInfo.cs
@@ -14,7 +14,5 @@
 // limitations under the License.
 //-------------------------------------------------------------------------
 using System;
-using System.Runtime.CompilerServices;
 
 [assembly: CLSCompliant(false)]
-[assembly: InternalsVisibleTo("CommonTests")]

--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -29,8 +29,6 @@ namespace HealthGateway.Common.Auditing
     using Microsoft.AspNetCore.Routing;
     using Microsoft.Extensions.Primitives;
 
-#pragma warning disable CA1303 // Do not pass literals as localized parameters
-
     /// <summary>
     /// The Abstract Audit Logger service.
     /// </summary>
@@ -80,26 +78,13 @@ namespace HealthGateway.Common.Auditing
         /// <returns>The mapped transaction result.</returns>
         private static AuditTransactionResult GetTransactionResultType(int statusCode)
         {
-            // Success codes (1xx, 2xx, 3xx)
-            if (statusCode < 400)
+            return statusCode switch
             {
-                return AuditTransactionResult.Success;
-            }
-
-            // Unauthorized and forbidden (401, 403)
-            if (statusCode == 401 || statusCode == 403)
-            {
-                return AuditTransactionResult.Unauthorized;
-            }
-
-            // Client/Request errors codes other than unauthorized and forbidden (4xx)
-            if (statusCode < 500)
-            {
-                return AuditTransactionResult.Failure;
-            }
-
-            // System error codes (5xx)
-            return AuditTransactionResult.SystemError;
+                < 400 => AuditTransactionResult.Success, // Success codes (1xx, 2xx, 3xx)
+                401 or 403 => AuditTransactionResult.Unauthorized, // Unauthorized and forbidden (401, 403)
+                < 500 => AuditTransactionResult.Failure, // Client/Request errors codes other than unauthorized and forbidden (4xx)
+                _ => AuditTransactionResult.SystemError, // System error codes (5xx)
+            };
         }
 
         /// <summary>
@@ -110,37 +95,20 @@ namespace HealthGateway.Common.Auditing
         private static string GetApplicationType()
         {
             AssemblyName assemblyName = Assembly.GetEntryAssembly()!.GetName();
-            switch (assemblyName.Name)
+            return assemblyName.Name switch
             {
-                case "Configuration":
-                    return ApplicationType.Configuration;
-                case "GatewayApi":
-                case "WebClient":
-                    return ApplicationType.WebClient;
-                case "Immunization":
-                    return ApplicationType.Immunization;
-                case "Patient":
-                    return ApplicationType.Patient;
-                case "Medication":
-                    return ApplicationType.Medication;
-                case "Admin.Server":
-                    return ApplicationType.Admin;
-                case "Laboratory":
-                    return ApplicationType.Laboratory;
-                case "Encounter":
-                    return ApplicationType.Encounter;
-                case "ClinicalDocument":
-                    return ApplicationType.ClinicalDocument;
-                case "ReSharperTestRunner":
-                case "ReSharperTestRunner64":
-                case "ReSharperTestRunnerArm64":
-                case "testhost":
-                    return ApplicationType.Configuration;
-                default:
-                    throw new NotSupportedException($"Audit Error: Invalid application name '{assemblyName.Name}'");
-            }
+                "Configuration" => ApplicationType.Configuration,
+                "GatewayApi" or "WebClient" => ApplicationType.WebClient,
+                "Immunization" => ApplicationType.Immunization,
+                "Patient" => ApplicationType.Patient,
+                "Medication" => ApplicationType.Medication,
+                "Admin.Server" => ApplicationType.Admin,
+                "Laboratory" => ApplicationType.Laboratory,
+                "Encounter" => ApplicationType.Encounter,
+                "ClinicalDocument" => ApplicationType.ClinicalDocument,
+                "ReSharperTestRunner" or "ReSharperTestRunner64" or "ReSharperTestRunnerArm64" or "testhost" => ApplicationType.Configuration,
+                _ => throw new NotSupportedException($"Audit Error: Invalid application name '{assemblyName.Name}'"),
+            };
         }
     }
-
-#pragma warning restore CA1303 // Do not pass literals as localized parameters
 }

--- a/Apps/Common/src/Common.csproj
+++ b/Apps/Common/src/Common.csproj
@@ -71,6 +71,8 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <InternalsVisibleTo Include="CommonTests" />
     <InternalsVisibleTo Include="IntegrationTests" />
+    <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
   </ItemGroup>
 </Project>

--- a/Apps/Common/src/ErrorHandling/Exceptions/AlreadyExistsException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/AlreadyExistsException.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     /// The default status code is <see cref="HttpStatusCode.Conflict"/> (409).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
+    [ExcludeFromCodeCoverage]
     public class AlreadyExistsException : HealthGatewayException
     {
         private const HttpStatusCode DefaultStatusCode = HttpStatusCode.Conflict;

--- a/Apps/Common/src/ErrorHandling/Exceptions/DatabaseException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/DatabaseException.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     /// The default status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
+    [ExcludeFromCodeCoverage]
     public class DatabaseException : HealthGatewayException
     {
         private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;

--- a/Apps/Common/src/ErrorHandling/Exceptions/HealthGatewayException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/HealthGatewayException.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     /// Abstract exception class for Health Gateway.
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
+    [ExcludeFromCodeCoverage]
     public abstract class HealthGatewayException : Exception
     {
         private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;

--- a/Apps/Common/src/ErrorHandling/Exceptions/InvalidDataException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/InvalidDataException.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     /// The default status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
+    [ExcludeFromCodeCoverage]
     public class InvalidDataException : HealthGatewayException
     {
         private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;

--- a/Apps/Common/src/ErrorHandling/Exceptions/NotFoundException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/NotFoundException.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     /// The default status code is <see cref="HttpStatusCode.NotFound"/> (404).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
+    [ExcludeFromCodeCoverage]
     public class NotFoundException : HealthGatewayException
     {
         private const HttpStatusCode DefaultStatusCode = HttpStatusCode.NotFound;

--- a/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     /// The default status code is <see cref="HttpStatusCode.BadGateway"/> (502).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
+    [ExcludeFromCodeCoverage]
     public class UpstreamServiceException : HealthGatewayException
     {
         private const HttpStatusCode DefaultStatusCode = HttpStatusCode.BadGateway;

--- a/Apps/Common/src/Messaging/AzureServiceBus.cs
+++ b/Apps/Common/src/Messaging/AzureServiceBus.cs
@@ -180,5 +180,5 @@ internal class AzureServiceBus : IMessageSender, IMessageReceiver, IAsyncDisposa
         }
     }
 
-    private sealed record SessionState(bool IsFaulted);
+    internal sealed record SessionState(bool IsFaulted);
 }

--- a/Apps/Common/src/Messaging/ConfigurationExtensions.cs
+++ b/Apps/Common/src/Messaging/ConfigurationExtensions.cs
@@ -84,11 +84,13 @@ namespace HealthGateway.Common.Messaging
     /// <summary>
     /// Base class for Messaging configuration settings.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public abstract record MessagingSettings;
 
     /// <summary>
     /// Configuration settings for service bus.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record AzureServiceBusSettings : MessagingSettings
     {
         /// <summary>

--- a/Apps/Common/src/Messaging/MessageBase.cs
+++ b/Apps/Common/src/Messaging/MessageBase.cs
@@ -17,6 +17,7 @@
 namespace HealthGateway.Common.Messaging;
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using HealthGateway.Common.Utils;
 
@@ -24,6 +25,7 @@ using HealthGateway.Common.Utils;
 /// Base record for messages
 /// It uses PolymorphicJsonConverter to ensure the type is always serialized in the payload.
 /// </summary>
+[ExcludeFromCodeCoverage]
 [JsonConverter(typeof(PolymorphicJsonConverter<MessageBase>))]
 public abstract record MessageBase;
 
@@ -32,6 +34,7 @@ public abstract record MessageBase;
 /// </summary>
 /// <param name="SessionId">The session id to manage FIFO.</param>
 /// <param name="Content">The message.</param>
+[ExcludeFromCodeCoverage]
 public record MessageEnvelope(MessageBase Content, string SessionId)
 {
     /// <summary>
@@ -45,7 +48,7 @@ public record MessageEnvelope(MessageBase Content, string SessionId)
     public string MessageType => this.Content.GetType().Name;
 
     /// <summary>
-    /// Gets the creation time timestamp as as string.
+    /// Gets the creation time timestamp as a string.
     /// </summary>
     public string CreatedOnTimestamp => this.CreatedOn.ToString("o");
 }

--- a/Apps/Common/src/Services/IPatientService.cs
+++ b/Apps/Common/src/Services/IPatientService.cs
@@ -35,14 +35,6 @@ namespace HealthGateway.Common.Services
         Task<RequestResult<string>> GetPatientPhnAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
-        /// Gets the patient HDID by PHN.
-        /// </summary>
-        /// <param name="phn">The patient PHN.</param>
-        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>The patient HDID.</returns>
-        Task<string> GetPatientHdidAsync(string phn, CancellationToken ct = default);
-
-        /// <summary>
         /// Gets the patient record.
         /// </summary>
         /// <param name="identifier">The patient identifier.</param>

--- a/Apps/Common/src/Services/PatientService.cs
+++ b/Apps/Common/src/Services/PatientService.cs
@@ -97,19 +97,6 @@ namespace HealthGateway.Common.Services
         }
 
         /// <inheritdoc/>
-        public async Task<string> GetPatientHdidAsync(string phn, CancellationToken ct = default)
-        {
-            using Activity? activity = Source.StartActivity();
-            RequestResult<PatientModel> patientResult = await this.GetPatientAsync(phn, PatientIdentifierType.Phn, ct: ct);
-            if (patientResult.ResultStatus != ResultType.Success || patientResult.ResourcePayload == null)
-            {
-                throw new NotFoundException(patientResult.ResultError?.ResultMessage ?? "Unspecified error");
-            }
-
-            return patientResult.ResourcePayload.HdId;
-        }
-
-        /// <inheritdoc/>
         public async Task<RequestResult<PatientModel>> GetPatientAsync(
             string identifier,
             PatientIdentifierType identifierType = PatientIdentifierType.Hdid,

--- a/Apps/Common/src/Services/PatientService.cs
+++ b/Apps/Common/src/Services/PatientService.cs
@@ -27,7 +27,6 @@ namespace HealthGateway.Common.Services
     using HealthGateway.Common.Data.Validations;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.ErrorHandling;
-    using HealthGateway.Common.ErrorHandling.Exceptions;
     using HealthGateway.Common.Factories;
     using HealthGateway.Common.Models;
     using Microsoft.Extensions.Configuration;

--- a/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
+++ b/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.Utils
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Text.Json;
     using System.Text.Json.Nodes;
     using System.Text.Json.Serialization;
@@ -65,6 +66,7 @@ namespace HealthGateway.Common.Utils
         /// <param name="typeToConvert">The type to convert to.</param>
         /// <param name="actualType">The type parsed from the json payload.</param>
         /// <returns>True if actual type can be converted.</returns>
+        [ExcludeFromCodeCoverage]
         protected virtual bool CanConvert(Type typeToConvert, Type actualType)
         {
             return typeToConvert.IsAssignableFrom(actualType);
@@ -75,6 +77,7 @@ namespace HealthGateway.Common.Utils
         /// </summary>
         /// <param name="discriminatorValue">The discovered discriminator value.</param>
         /// <returns>Type to use for deserialization, null if type not found.</returns>
+        [ExcludeFromCodeCoverage]
         protected virtual Type? ResolveType(string? discriminatorValue)
         {
             return string.IsNullOrEmpty(discriminatorValue)
@@ -87,6 +90,7 @@ namespace HealthGateway.Common.Utils
         /// </summary>
         /// <param name="value">The serialized value.</param>
         /// <returns>The discriminator value.</returns>
+        [ExcludeFromCodeCoverage]
         protected virtual string ResolveDiscriminatorValue(T value)
         {
             return value!.GetType().AssemblyQualifiedName!;

--- a/Apps/Common/test/unit/ErrorHandling/ExceptionHandlerTests.cs
+++ b/Apps/Common/test/unit/ErrorHandling/ExceptionHandlerTests.cs
@@ -1,0 +1,216 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.ErrorHandling
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.ServiceModel;
+    using System.Threading.Tasks;
+    using FluentValidation.Results;
+    using HealthGateway.Common.ErrorHandling.ExceptionHandlers;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
+    using HealthGateway.Common.Utils;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for all exception handler classes.
+    /// </summary>
+    public class ExceptionHandlerTests
+    {
+        /// <summary>
+        /// Gets parameters for DefaultExceptionHandler unit test(s).
+        /// </summary>
+        public static TheoryData<Exception> DefaultExceptionHandlerTheoryData =>
+            new()
+            {
+                new UnauthorizedAccessException(),
+                new CommunicationException(),
+                new AlreadyExistsException(),
+                new DatabaseException(),
+                new InvalidDataException(),
+                new NotFoundException(),
+                new UpstreamServiceException(),
+                new Exception("e", new("e", new("e", new("e", new("e", new("e", new("e", new("e", new("e", new("e")))))))))),
+            };
+
+        /// <summary>
+        /// DefaultExceptionHandler TryHandleAsync - Happy Path.
+        /// </summary>
+        /// <param name="exception">The exception to be handled.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(DefaultExceptionHandlerTheoryData))]
+        public async Task ValidateDefaultExceptionHandlerTryHandleAsync(Exception exception)
+        {
+            // Arrange
+            HttpContext httpContext = new DefaultHttpContext();
+
+            DefaultExceptionHandlerSetup setup = GetDefaultExceptionHandlerSetup(true);
+
+            // Act
+            bool actual = await setup.ExceptionHandler.TryHandleAsync(httpContext, exception, default);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        /// <summary>
+        /// ApiExceptionHandler TryHandleAsync - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateApiExceptionHandlerTryHandleAsync()
+        {
+            // Arrange
+            HttpContext httpContext = new DefaultHttpContext();
+            using StringContent httpContent = new("content");
+            Exception exception = MockRefitExceptionHelper.CreateApiException(HttpStatusCode.InternalServerError, HttpMethod.Get, httpContent);
+
+            ApiExceptionHandlerSetup setup = GetApiExceptionHandlerSetup(true);
+
+            // Act
+            bool actual = await setup.ExceptionHandler.TryHandleAsync(httpContext, exception, default);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        /// <summary>
+        /// ApiExceptionHandler TryHandleAsync - Unsupported Exception Type.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateApiExceptionHandlerTryHandleAsyncUnsupportedException()
+        {
+            // Arrange
+            HttpContext httpContext = new DefaultHttpContext();
+            Exception exception = new InvalidOperationException();
+
+            ApiExceptionHandlerSetup setup = GetApiExceptionHandlerSetup(true);
+
+            // Act
+            bool actual = await setup.ExceptionHandler.TryHandleAsync(httpContext, exception, default);
+
+            // Assert
+            Assert.False(actual);
+        }
+
+        /// <summary>
+        /// ValidationExceptionHandler TryHandleAsync - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateValidationExceptionHandlerTryHandleAsync()
+        {
+            // Arrange
+            HttpContext httpContext = new DefaultHttpContext();
+            Exception exception = new FluentValidation.ValidationException([new ValidationFailure("hdid", "required"), new ValidationFailure("hdid", "malformed")]);
+
+            ValidationExceptionHandlerSetup setup = GetValidationExceptionHandlerSetup(true);
+
+            // Act
+            bool actual = await setup.ExceptionHandler.TryHandleAsync(httpContext, exception, default);
+
+            // Assert
+            Assert.True(actual);
+        }
+
+        /// <summary>
+        /// ValidationExceptionHandler TryHandleAsync - Unsupported Exception Type.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateValidationExceptionHandlerTryHandleAsyncUnsupportedException()
+        {
+            // Arrange
+            HttpContext httpContext = new DefaultHttpContext();
+            Exception exception = new InvalidOperationException();
+
+            ValidationExceptionHandlerSetup setup = GetValidationExceptionHandlerSetup(true);
+
+            // Act
+            bool actual = await setup.ExceptionHandler.TryHandleAsync(httpContext, exception, default);
+
+            // Assert
+            Assert.False(actual);
+        }
+
+        private static ApiExceptionHandlerSetup GetApiExceptionHandlerSetup(bool includeExceptionDetailsInResponse)
+        {
+            ApiExceptionHandlerMocks mocks = new(new());
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                [
+                    new("IncludeExceptionDetailsInResponse", includeExceptionDetailsInResponse.ToString()),
+                ])
+                .Build();
+
+            return new(GetApiExceptionHandler(mocks, configuration), mocks);
+        }
+
+        private static DefaultExceptionHandlerSetup GetDefaultExceptionHandlerSetup(bool includeExceptionDetailsInResponse)
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                [
+                    new("IncludeExceptionDetailsInResponse", includeExceptionDetailsInResponse.ToString()),
+                ])
+                .Build();
+
+            return new(GetDefaultExceptionHandler(configuration));
+        }
+
+        private static ValidationExceptionHandlerSetup GetValidationExceptionHandlerSetup(bool includeExceptionDetailsInResponse)
+        {
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(
+                [
+                    new("IncludeExceptionDetailsInResponse", includeExceptionDetailsInResponse.ToString()),
+                ])
+                .Build();
+
+            return new(GetValidationExceptionHandler(configuration));
+        }
+
+        private static ApiExceptionHandler GetApiExceptionHandler(ApiExceptionHandlerMocks mocks, IConfiguration configuration)
+        {
+            return new(configuration, mocks.Logger.Object);
+        }
+
+        private static DefaultExceptionHandler GetDefaultExceptionHandler(IConfiguration configuration)
+        {
+            return new(configuration);
+        }
+
+        private static ValidationExceptionHandler GetValidationExceptionHandler(IConfiguration configuration)
+        {
+            return new(configuration);
+        }
+
+        private sealed record ApiExceptionHandlerSetup(ApiExceptionHandler ExceptionHandler, ApiExceptionHandlerMocks Mocks);
+
+        private sealed record DefaultExceptionHandlerSetup(DefaultExceptionHandler ExceptionHandler);
+
+        private sealed record ValidationExceptionHandlerSetup(ValidationExceptionHandler ExceptionHandler);
+
+        private sealed record ApiExceptionHandlerMocks(Mock<ILogger<ApiExceptionHandler>> Logger);
+    }
+}

--- a/Apps/Common/test/unit/Messaging/AzureServiceBusTests.cs
+++ b/Apps/Common/test/unit/Messaging/AzureServiceBusTests.cs
@@ -46,8 +46,6 @@ namespace HealthGateway.CommonTests.Messaging
         private static readonly AccountClosedEvent AccountClosedEvent = new(Hdid2, DateTime);
         private static readonly DependentAddedEvent DependentAddedEvent = new(Hdid1, Hdid2);
 
-        // private AccountCreatedEvent Event1 = new(Hdid1, DateTime), Hdid1) { CreatedOn = DateTime };
-
         /// <summary>
         /// SendAsync - Happy Path.
         /// </summary>

--- a/Apps/Common/test/unit/Messaging/AzureServiceBusTests.cs
+++ b/Apps/Common/test/unit/Messaging/AzureServiceBusTests.cs
@@ -1,0 +1,314 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Messaging
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Messaging.ServiceBus;
+    using DeepEqual.Syntax;
+    using HealthGateway.Common.Messaging;
+    using HealthGateway.Common.Models.Events;
+    using HealthGateway.Common.Utils;
+    using Microsoft.Extensions.Azure;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Moq;
+    using Moq.Language;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for AzureServiceBus.
+    /// </summary>
+    public class AzureServiceBusTests
+    {
+        private const string Hdid1 = "123";
+        private const string Hdid2 = "456";
+        private const string QueueName = "TestQueue";
+
+        private static readonly DateTime DateTime = new(2020, 1, 30, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly AccountCreatedEvent AccountCreatedEvent = new(Hdid1, DateTime);
+        private static readonly AccountClosedEvent AccountClosedEvent = new(Hdid2, DateTime);
+        private static readonly DependentAddedEvent DependentAddedEvent = new(Hdid1, Hdid2);
+
+        // private AccountCreatedEvent Event1 = new(Hdid1, DateTime), Hdid1) { CreatedOn = DateTime };
+
+        /// <summary>
+        /// SendAsync - Happy Path.
+        /// </summary>
+        /// <param name="messageCount">Total number of messages to send.</param>
+        /// <param name="batchSize">Number of messages to send per batch.</param>
+        /// <param name="expectedBatchCount">Expected number of batches to be sent.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(1, 1, 1)]
+        [InlineData(2, 1, 2)]
+        [InlineData(2, 2, 1)]
+        [InlineData(3, 1, 3)]
+        [InlineData(3, 2, 2)]
+        [InlineData(3, 3, 1)]
+        public async Task ValidateSendAsync(int messageCount, int batchSize, int expectedBatchCount)
+        {
+            // Arrange
+            IEnumerable<MessageEnvelope> allMessages =
+            [
+                new MessageEnvelope(AccountCreatedEvent, AccountCreatedEvent.Hdid) { CreatedOn = DateTime },
+                new MessageEnvelope(AccountClosedEvent, AccountClosedEvent.Hdid) { CreatedOn = DateTime },
+                new MessageEnvelope(DependentAddedEvent, DependentAddedEvent.DelegateHdid) { CreatedOn = DateTime },
+            ];
+            IList<MessageEnvelope> messages = allMessages.Take(messageCount).ToList();
+            IList<ServiceBusMessage> expectedMessages = messages.Select(m => new ServiceBusMessage { SessionId = m.SessionId, Body = new(m.Content.Serialize(false)) }).ToList();
+
+            SendAsyncSetup setup = GetSendAsyncSetup(messageCount, batchSize);
+
+            // Act
+            await setup.AzureServiceBus.SendAsync(messages);
+
+            // Assert
+            setup.Mocks.ServiceBusSender.Verify(m => m.CreateMessageBatchAsync(It.IsAny<CancellationToken>()), Times.Exactly(expectedBatchCount));
+
+            IList<ServiceBusMessage> actualMessages = setup.AttemptedAddMessageCollections.SelectMany(p => p).Where(t => t.Added).Select(t => t.Message).ToList();
+            Assert.Equal(expectedMessages.Count, actualMessages.Count);
+            Assert.Equal<ServiceBusMessage>(
+                expectedMessages,
+                actualMessages,
+                (e, a) => e.WithDeepEqual(a).IgnoreSourceProperty(s => s.ContentType).IgnoreSourceProperty(s => s.ApplicationProperties).Compare());
+
+            Assert.Equal(expectedBatchCount, setup.SentBatchCollection.Count);
+
+            for (int batchIndex = 0; batchIndex < expectedBatchCount; batchIndex++)
+            {
+                int remainingMessageCount = messageCount - (batchIndex * batchSize);
+                int expectedMessagesInBatch = remainingMessageCount >= batchSize ? batchSize : remainingMessageCount;
+                Assert.Equal(expectedMessagesInBatch, setup.SentBatchCollection.ElementAt(batchIndex).Count);
+            }
+        }
+
+        /// <summary>
+        /// DisposeAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateDisposeAsync()
+        {
+            // Arrange
+            DisposeAsyncSetup setup = GetDisposeAsyncSetup();
+
+            // Act
+            await setup.AzureServiceBus.DisposeAsync();
+
+            // Assert
+            setup.Mocks.ServiceBusSender.Verify(m => m.DisposeAsync(), Times.Once);
+        }
+
+        /// <summary>
+        /// HandleProcessMessageAsync - Happy Path.
+        /// </summary>
+        /// <param name="receiveHandlerResponse">Boolean value returned from the receive message handler indicating whether the message was processed successfully.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ValidateHandleProcessMessageAsync(bool receiveHandlerResponse)
+        {
+            // Arrange
+            ServiceBusReceivedMessage message = GenerateServiceBusReceivedMessage(BinaryData.FromObjectAsJson(AccountCreatedEvent), AccountCreatedEvent.GetType());
+            HandleProcessMessageAsyncSetup setup = GetHandleProcessMessageAsyncSetup(new AzureServiceBus.SessionState(false), message, receiveHandlerResponse);
+
+            // Act
+            await setup.AzureServiceBus.HandleProcessMessageAsync(setup.Args, setup.ParameterMocks.ReceiveHandler.Object, setup.ParameterMocks.ErrorHandler.Object);
+
+            // Assert
+            setup.ParameterMocks.ReceiveHandler.Verify(m => m(It.IsAny<string>(), It.IsAny<IEnumerable<MessageEnvelope>>()), Times.Once);
+        }
+
+        /// <summary>
+        /// HandleProcessMessageAsync - Empty Message.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateHandleProcessMessageAsyncEmptyMessage()
+        {
+            // Arrange
+            ServiceBusReceivedMessage message = GenerateServiceBusReceivedMessage(BinaryData.FromBytes([]), AccountCreatedEvent.GetType());
+            HandleProcessMessageAsyncSetup setup = GetHandleProcessMessageAsyncSetup(new AzureServiceBus.SessionState(false), message, true);
+
+            // Act
+            await setup.AzureServiceBus.HandleProcessMessageAsync(setup.Args, setup.ParameterMocks.ReceiveHandler.Object, setup.ParameterMocks.ErrorHandler.Object);
+
+            // Assert
+            setup.ParameterMocks.ReceiveHandler.Verify(m => m(It.IsAny<string>(), It.IsAny<IEnumerable<MessageEnvelope>>()), Times.Never);
+            setup.ParameterMocks.ErrorHandler.Verify(m => m(It.IsAny<Exception>()), Times.Once);
+        }
+
+        /// <summary>
+        /// HandleProcessMessageAsync - Unsupported Message Type.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateHandleProcessMessageAsyncUnsupportedMessageType()
+        {
+            // Arrange
+            int[] unsupportedObject = [5]; // only types that derive from MessageBase can be processed
+            ServiceBusReceivedMessage message = GenerateServiceBusReceivedMessage(BinaryData.FromObjectAsJson(unsupportedObject), unsupportedObject.GetType());
+            HandleProcessMessageAsyncSetup setup = GetHandleProcessMessageAsyncSetup(new AzureServiceBus.SessionState(false), message, true);
+
+            // Act
+            await setup.AzureServiceBus.HandleProcessMessageAsync(setup.Args, setup.ParameterMocks.ReceiveHandler.Object, setup.ParameterMocks.ErrorHandler.Object);
+
+            // Assert
+            setup.ParameterMocks.ReceiveHandler.Verify(m => m(It.IsAny<string>(), It.IsAny<IEnumerable<MessageEnvelope>>()), Times.Never);
+            setup.ParameterMocks.ErrorHandler.Verify(m => m(It.IsAny<Exception>()), Times.Once);
+        }
+
+        /// <summary>
+        /// HandleProcessMessageAsync - Missing Type.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateHandleProcessMessageAsyncMissingType()
+        {
+            // Arrange
+            ServiceBusReceivedMessage message = GenerateServiceBusReceivedMessage(BinaryData.FromObjectAsJson(AccountCreatedEvent), null);
+            HandleProcessMessageAsyncSetup setup = GetHandleProcessMessageAsyncSetup(new AzureServiceBus.SessionState(false), message, true);
+
+            // Act
+            await setup.AzureServiceBus.HandleProcessMessageAsync(setup.Args, setup.ParameterMocks.ReceiveHandler.Object, setup.ParameterMocks.ErrorHandler.Object);
+
+            // Assert
+            setup.ParameterMocks.ReceiveHandler.Verify(m => m(It.IsAny<string>(), It.IsAny<IEnumerable<MessageEnvelope>>()), Times.Never);
+            setup.ParameterMocks.ErrorHandler.Verify(m => m(It.IsAny<Exception>()), Times.Once);
+        }
+
+        /// <summary>
+        /// HandleProcessMessageAsync - SessionBlocked.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateHandleProcessMessageAsyncSessionBlocked()
+        {
+            // Arrange
+            ServiceBusReceivedMessage message = GenerateServiceBusReceivedMessage(BinaryData.FromObjectAsJson(AccountCreatedEvent), AccountCreatedEvent.GetType());
+            HandleProcessMessageAsyncSetup setup = GetHandleProcessMessageAsyncSetup(new AzureServiceBus.SessionState(true), message, true);
+
+            // Act
+            await setup.AzureServiceBus.HandleProcessMessageAsync(setup.Args, setup.ParameterMocks.ReceiveHandler.Object, setup.ParameterMocks.ErrorHandler.Object);
+
+            // Assert
+            setup.ParameterMocks.ReceiveHandler.Verify(m => m(It.IsAny<string>(), It.IsAny<IEnumerable<MessageEnvelope>>()), Times.Never);
+            setup.ParameterMocks.ErrorHandler.Verify(m => m(It.IsAny<Exception>()), Times.Once);
+        }
+
+        private static SendAsyncSetup GetSendAsyncSetup(int messageCount, int batchSize)
+        {
+            int expectedBatchCount = ((messageCount - 1) / batchSize) + 1;
+            Mocks mocks = new(new(), new(), new());
+
+            ICollection<ServiceBusMessageBatch> sentMessagesCollection = [];
+            mocks.ServiceBusSender.Setup(m => m.SendMessagesAsync(Capture.In(sentMessagesCollection), It.IsAny<CancellationToken>()));
+
+            // manually capture ServiceBusMessageBatch.TryAddAsync() calls since ServiceBusMessageBatch can't be mocked
+            ISetupSequentialResult<ValueTask<ServiceBusMessageBatch>> setupSequentialResult =
+                mocks.ServiceBusSender.SetupSequence(m => m.CreateMessageBatchAsync(It.IsAny<CancellationToken>()));
+
+            IList<ICollection<(ServiceBusMessage, bool)>> attemptedAddMessageCollections = new List<ICollection<(ServiceBusMessage, bool)>>(expectedBatchCount);
+            for (int i = 0; i < expectedBatchCount; i++)
+            {
+                ICollection<(ServiceBusMessage, bool)> attemptedAddMessageCollection = [];
+                attemptedAddMessageCollections.Add(attemptedAddMessageCollection);
+
+                int callCount = 0;
+                Func<ServiceBusMessage, bool> tryAddFunc = message =>
+                {
+                    bool added = callCount++ < batchSize;
+                    attemptedAddMessageCollection.Add((message, added));
+                    return added;
+                };
+
+                setupSequentialResult = setupSequentialResult.ReturnsAsync(ServiceBusModelFactory.ServiceBusMessageBatch(0, [], null, tryAddFunc));
+            }
+
+            setupSequentialResult.ThrowsAsync(new InvalidOperationException("More batches were created than expected."));
+
+            return new(GetAzureServiceBus(mocks), mocks, attemptedAddMessageCollections, sentMessagesCollection);
+        }
+
+        private static ServiceBusReceivedMessage GenerateServiceBusReceivedMessage(BinaryData serializedObject, Type? supposedType)
+        {
+            return ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: serializedObject,
+                properties: new Dictionary<string, object>
+                {
+                    ["$type"] = supposedType?.Name ?? string.Empty,
+                    ["$aqn"] = supposedType?.AssemblyQualifiedName ?? string.Empty,
+                });
+        }
+
+        private static DisposeAsyncSetup GetDisposeAsyncSetup()
+        {
+            Mocks mocks = new(new(), new(), new());
+            return new(GetAzureServiceBus(mocks), mocks);
+        }
+
+        private static HandleProcessMessageAsyncSetup GetHandleProcessMessageAsyncSetup(AzureServiceBus.SessionState? sessionState, ServiceBusReceivedMessage message, bool receiveResponse)
+        {
+            Mocks mocks = new(new(), new(), new());
+            HandleProcessMessageAsyncParameterMocks parameterMocks = new(new(), new(), new());
+
+            parameterMocks.ServiceBusSessionReceiver.Setup(m => m.GetSessionStateAsync(It.IsAny<CancellationToken>())).ReturnsAsync(BinaryData.FromObjectAsJson(sessionState));
+            ProcessSessionMessageEventArgs args = new(message, parameterMocks.ServiceBusSessionReceiver.Object, default);
+
+            parameterMocks.ReceiveHandler.Setup(m => m(It.IsAny<string>(), It.IsAny<IEnumerable<MessageEnvelope>>())).ReturnsAsync(receiveResponse);
+
+            return new(GetAzureServiceBus(mocks), mocks, parameterMocks, args);
+        }
+
+        private static AzureServiceBus GetAzureServiceBus(Mocks mocks)
+        {
+            Mock<ServiceBusClient> mockServiceBusClient = new();
+            mockServiceBusClient.Setup(m => m.CreateSender(It.IsAny<string>())).Returns(mocks.ServiceBusSender.Object);
+            mockServiceBusClient.Setup(m => m.CreateSessionProcessor(It.IsAny<string>(), It.IsAny<ServiceBusSessionProcessorOptions?>())).Returns(mocks.ServiceBusSessionProcessor.Object);
+
+            Mock<IAzureClientFactory<ServiceBusClient>> mockServiceBusClientFactory = new();
+            mockServiceBusClientFactory.Setup(m => m.CreateClient(It.IsAny<string>())).Returns(mockServiceBusClient.Object);
+
+            IOptions<AzureServiceBusSettings> azureServiceBusSettingsOptions = Options.Create(new AzureServiceBusSettings { QueueName = QueueName });
+            return new(mockServiceBusClientFactory.Object, azureServiceBusSettingsOptions, mocks.Logger.Object);
+        }
+
+        private sealed record SendAsyncSetup(
+            AzureServiceBus AzureServiceBus,
+            Mocks Mocks,
+            IList<ICollection<(ServiceBusMessage Message, bool Added)>> AttemptedAddMessageCollections,
+            ICollection<ServiceBusMessageBatch> SentBatchCollection);
+
+        private sealed record DisposeAsyncSetup(AzureServiceBus AzureServiceBus, Mocks Mocks);
+
+        private sealed record HandleProcessMessageAsyncSetup(AzureServiceBus AzureServiceBus, Mocks Mocks, HandleProcessMessageAsyncParameterMocks ParameterMocks, ProcessSessionMessageEventArgs Args);
+
+        private sealed record Mocks(
+            Mock<ServiceBusSender> ServiceBusSender,
+            Mock<ServiceBusSessionProcessor> ServiceBusSessionProcessor,
+            Mock<ILogger<AzureServiceBus>> Logger);
+
+        private sealed record HandleProcessMessageAsyncParameterMocks(
+            Mock<ServiceBusSessionReceiver> ServiceBusSessionReceiver,
+            Mock<Func<string, IEnumerable<MessageEnvelope>, Task<bool>>> ReceiveHandler,
+            Mock<Func<Exception, Task>> ErrorHandler);
+    }
+}

--- a/Apps/Common/test/unit/Messaging/DbOutboxStoreTests.cs
+++ b/Apps/Common/test/unit/Messaging/DbOutboxStoreTests.cs
@@ -1,0 +1,221 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Messaging
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using Hangfire;
+    using HealthGateway.Common.Messaging;
+    using HealthGateway.Common.Models.Events;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for DbOutboxStore.
+    /// </summary>
+    public class DbOutboxStoreTests
+    {
+        private const string Hdid1 = "123";
+        private const string Hdid2 = "456";
+
+        private static readonly DateTime DateTime = new(2020, 1, 30, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly AccountCreatedEvent AccountCreatedEvent = new(Hdid1, DateTime);
+        private static readonly AccountClosedEvent AccountClosedEvent = new(Hdid2, DateTime);
+
+        /// <summary>
+        /// StoreAsync - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateStoreAsync()
+        {
+            // Arrange
+            IEnumerable<MessageEnvelope> messages =
+            [
+                new MessageEnvelope(AccountCreatedEvent, AccountCreatedEvent.Hdid) { CreatedOn = DateTime },
+                new MessageEnvelope(AccountClosedEvent, AccountClosedEvent.Hdid) { CreatedOn = DateTime },
+            ];
+
+            IEnumerable<OutboxItem> expectedEnqueuedItems =
+            [
+                new()
+                {
+                    Content = """{"Hdid":"123","RegistrationDate":"2020-01-30T00:00:00Z"}""",
+                    Metadata = new OutboxItemMetadata
+                    {
+                        CreatedOn = DateTime,
+                        Type = "AccountCreatedEvent",
+                        SessionId = Hdid1,
+                        AssemblyQualifiedName = "HealthGateway.Common.Models.Events.AccountCreatedEvent, Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    },
+                },
+                new()
+                {
+                    Content = """{"Hdid":"456","ClosedDate":"2020-01-30T00:00:00Z"}""",
+                    Metadata = new OutboxItemMetadata
+                    {
+                        CreatedOn = DateTime,
+                        Type = "AccountClosedEvent",
+                        SessionId = Hdid2,
+                        AssemblyQualifiedName = "HealthGateway.Common.Models.Events.AccountClosedEvent, Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    },
+                },
+            ];
+
+            StoreAsyncSetup setup = GetStoreAsyncSetup();
+
+            // Act
+            await setup.DbOutboxStore.StoreAsync(messages);
+
+            // Assert
+            Assert.NotEmpty(setup.EnqueuedItemsCollection);
+            Assert.Equal<OutboxItem>(
+                expectedEnqueuedItems,
+                setup.EnqueuedItemsCollection.First(),
+                (e, a) => e.WithDeepEqual(a).IgnoreSourceProperty(s => s.CreatedOn).Compare());
+        }
+
+        /// <summary>
+        /// DispatchOutboxItemsAsync - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateDispatchOutboxItemsAsync()
+        {
+            // Arrange
+            IEnumerable<OutboxItem> dequeuedItems =
+            [
+                new()
+                {
+                    Content = """{"Hdid":"123","RegistrationDate":"2020-01-30T00:00:00Z"}""",
+                    Metadata = new OutboxItemMetadata
+                    {
+                        SessionId = Hdid1,
+                        AssemblyQualifiedName = "HealthGateway.Common.Models.Events.AccountCreatedEvent, Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    },
+                },
+                new()
+                {
+                    Content = """{"Hdid":"456","ClosedDate":"2020-01-30T00:00:00Z"}""",
+                    Metadata = new OutboxItemMetadata
+                    {
+                        SessionId = Hdid2,
+                        AssemblyQualifiedName = "HealthGateway.Common.Models.Events.AccountClosedEvent, Common, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null",
+                    },
+                },
+            ];
+
+            IEnumerable<MessageEnvelope> expectedSentMessages =
+            [
+                new MessageEnvelope(AccountCreatedEvent, AccountCreatedEvent.Hdid) { CreatedOn = DateTime },
+                new MessageEnvelope(AccountClosedEvent, AccountClosedEvent.Hdid) { CreatedOn = DateTime },
+            ];
+
+            DispatchOutboxItemsAsyncSetup setup = GetDispatchOutboxItemsAsyncSetup(dequeuedItems);
+
+            // Act
+            await setup.DbOutboxStore.DispatchOutboxItemsAsync();
+
+            // Assert
+            Assert.NotEmpty(setup.SentMessagesCollection);
+            Assert.Equal<MessageEnvelope>(
+                expectedSentMessages,
+                setup.SentMessagesCollection.First(),
+                (e, a) => e.WithDeepEqual(a).IgnoreSourceProperty(s => s.CreatedOn).IgnoreSourceProperty(s => s.CreatedOnTimestamp).Compare());
+        }
+
+        /// <summary>
+        /// DispatchOutboxItemsAsync - Exception.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateDispatchOutboxItemsAsyncThrowsException()
+        {
+            // Arrange
+            DbUpdateException exception = new("Mysterious db error");
+            DispatchOutboxItemsAsyncThrowsExceptionSetup setup = GetDispatchOutboxItemsAsyncThrowsExceptionSetup(exception);
+
+            // Act
+            await Assert.ThrowsAsync<DbUpdateException>(async () => await setup.DbOutboxStore.DispatchOutboxItemsAsync());
+
+            // Assert
+            setup.Mocks.Logger.Verify(
+                m => m.Log(
+                    It.Is<LogLevel>(l => l == LogLevel.Error),
+                    It.IsAny<EventId>(),
+                    It.IsAny<It.IsAnyType>(),
+                    It.Is<Exception?>(e => e is DbUpdateException),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once());
+        }
+
+        private static StoreAsyncSetup GetStoreAsyncSetup()
+        {
+            Mocks mocks = new(new(), new(), new(), new());
+
+            ICollection<IEnumerable<OutboxItem>> enqueuedItemsCollection = [];
+            mocks.OutboxQueueDelegate.Setup(m => m.Enqueue(Capture.In(enqueuedItemsCollection)));
+
+            return new(GetDbOutboxStore(mocks), mocks, enqueuedItemsCollection);
+        }
+
+        private static DispatchOutboxItemsAsyncSetup GetDispatchOutboxItemsAsyncSetup(IEnumerable<OutboxItem> dequeuedItems)
+        {
+            Mocks mocks = new(new(), new(), new(), new());
+
+            mocks.OutboxQueueDelegate.Setup(m => m.DequeueAsync(It.IsAny<CancellationToken>())).ReturnsAsync(dequeuedItems);
+
+            ICollection<IEnumerable<MessageEnvelope>> sentMessagesCollection = [];
+            mocks.MessageSender.Setup(m => m.SendAsync(Capture.In(sentMessagesCollection), It.IsAny<CancellationToken>()));
+
+            return new(GetDbOutboxStore(mocks), mocks, sentMessagesCollection);
+        }
+
+        private static DispatchOutboxItemsAsyncThrowsExceptionSetup GetDispatchOutboxItemsAsyncThrowsExceptionSetup(Exception exception)
+        {
+            Mocks mocks = new(new(), new(), new(), new());
+
+            mocks.OutboxQueueDelegate.Setup(m => m.DequeueAsync(It.IsAny<CancellationToken>())).ThrowsAsync(exception);
+
+            return new(GetDbOutboxStore(mocks), mocks);
+        }
+
+        private static DbOutboxStore GetDbOutboxStore(Mocks mocks)
+        {
+            return new(mocks.OutboxQueueDelegate.Object, mocks.BackgroundJobClient.Object, mocks.MessageSender.Object, mocks.Logger.Object);
+        }
+
+        private sealed record StoreAsyncSetup(DbOutboxStore DbOutboxStore, Mocks Mocks, ICollection<IEnumerable<OutboxItem>> EnqueuedItemsCollection);
+
+        private sealed record DispatchOutboxItemsAsyncSetup(DbOutboxStore DbOutboxStore, Mocks Mocks, ICollection<IEnumerable<MessageEnvelope>> SentMessagesCollection);
+
+        private sealed record DispatchOutboxItemsAsyncThrowsExceptionSetup(DbOutboxStore DbOutboxStore, Mocks Mocks);
+
+        private sealed record Mocks(
+            Mock<IOutboxQueueDelegate> OutboxQueueDelegate,
+            Mock<IBackgroundJobClient> BackgroundJobClient,
+            Mock<IMessageSender> MessageSender,
+            Mock<ILogger<DbOutboxStore>> Logger);
+    }
+}

--- a/Apps/Common/test/unit/Messaging/OutboxMessageSenderTests.cs
+++ b/Apps/Common/test/unit/Messaging/OutboxMessageSenderTests.cs
@@ -1,0 +1,88 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Messaging
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using HealthGateway.Common.Messaging;
+    using HealthGateway.Common.Models.Events;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for OutboxMessageSender.
+    /// </summary>
+    public class OutboxMessageSenderTests
+    {
+        private const string Hdid1 = "123";
+        private const string Hdid2 = "456";
+
+        private DateTime DateTime { get; } = new(2020, 1, 30, 0, 0, 0, DateTimeKind.Utc);
+
+        /// <summary>
+        /// SendAsync - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateSendAsync()
+        {
+            // Arrange
+            IList<MessageEnvelope> messages =
+            [
+                new MessageEnvelope(new AccountCreatedEvent(Hdid1, this.DateTime), Hdid1) { CreatedOn = this.DateTime },
+                new MessageEnvelope(new AccountClosedEvent(Hdid2, this.DateTime), Hdid2) { CreatedOn = this.DateTime },
+            ];
+
+            StoreAsyncSetup setup = GetStoreAsyncSetup();
+
+            // Act
+            await setup.OutboxMessageSender.SendAsync(messages);
+
+            // Assert
+            Assert.NotEmpty(setup.StoredMessagesCollection);
+            Assert.Equal<MessageEnvelope>(
+                messages,
+                setup.StoredMessagesCollection.First(),
+                (e, a) => e.IsDeepEqual(a));
+        }
+
+        private static StoreAsyncSetup GetStoreAsyncSetup()
+        {
+            Mocks mocks = new(new(), new());
+
+            ICollection<IEnumerable<MessageEnvelope>> storedMessagesCollection = [];
+            mocks.OutboxStore.Setup(m => m.StoreAsync(Capture.In(storedMessagesCollection), It.IsAny<CancellationToken>()));
+
+            return new StoreAsyncSetup(GetOutboxMessageSender(mocks), mocks, storedMessagesCollection);
+        }
+
+        private static OutboxMessageSender GetOutboxMessageSender(Mocks mocks)
+        {
+            return new(mocks.OutboxStore.Object, mocks.Logger.Object);
+        }
+
+        private sealed record StoreAsyncSetup(OutboxMessageSender OutboxMessageSender, Mocks Mocks, ICollection<IEnumerable<MessageEnvelope>> StoredMessagesCollection);
+
+        private sealed record Mocks(
+            Mock<IOutboxStore> OutboxStore,
+            Mock<ILogger<OutboxMessageSender>> Logger);
+    }
+}

--- a/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
+++ b/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
@@ -161,7 +161,7 @@ namespace HealthGateway.CommonTests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetActiveCommunicationFromDbException()
+        public async Task GetActiveCommunicationDbExceptionShouldReturnError()
         {
             Mock<ICommunicationDelegate> communicationDelegateMock = new();
             communicationDelegateMock.Setup(s => s.GetNextAsync(It.IsAny<CommunicationType>(), It.IsAny<CancellationToken>())).ThrowsAsync(new NpgsqlException());

--- a/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
+++ b/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
@@ -32,6 +32,7 @@ namespace HealthGateway.CommonTests.Services
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using Moq;
+    using Npgsql;
     using Xunit;
 
     /// <summary>
@@ -153,6 +154,27 @@ namespace HealthGateway.CommonTests.Services
             {
                 Assert.Equal(0, actualResult.TotalResultCount);
             }
+        }
+
+        /// <summary>
+        /// GetActiveCommunicationAsync - DB Exception.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetActiveCommunicationFromDbException()
+        {
+            Mock<ICommunicationDelegate> communicationDelegateMock = new();
+            communicationDelegateMock.Setup(s => s.GetNextAsync(It.IsAny<CommunicationType>(), It.IsAny<CancellationToken>())).ThrowsAsync(new NpgsqlException());
+
+            ICommunicationService service = new CommunicationService(
+                new Mock<ILogger<CommunicationService>>().Object,
+                communicationDelegateMock.Object,
+                this.cacheProvider);
+
+            RequestResult<Communication?> actualResult = await service.GetActiveCommunicationAsync(CommunicationType.Banner);
+
+            Assert.NotNull(actualResult);
+            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
         }
 
         // ReSharper disable once CognitiveComplexity
@@ -278,6 +300,32 @@ namespace HealthGateway.CommonTests.Services
                 new Mock<ICommunicationDelegate>().Object,
                 new Mock<ICacheProvider>().Object);
             await Assert.ThrowsAsync<NotImplementedException>(() => service.GetActiveCommunicationAsync(CommunicationType.Email));
+        }
+
+        /// <summary>
+        /// ClearCache - Happy Path.
+        /// </summary>
+        [Fact]
+        public void ValidateClearCache()
+        {
+            // Arrange
+            ICommunicationService service = new CommunicationService(
+                new Mock<ILogger<CommunicationService>>().Object,
+                new Mock<ICommunicationDelegate>().Object,
+                this.cacheProvider);
+
+            Communication communication = new();
+            this.cacheProvider.AddItem(CommunicationService.BannerCacheKey, communication);
+            this.cacheProvider.AddItem(CommunicationService.InAppCacheKey, communication);
+            this.cacheProvider.AddItem(CommunicationService.MobileCacheKey, communication);
+
+            // Act
+            service.ClearCache();
+
+            // Assert
+            Assert.Null(this.cacheProvider.GetItem<Communication>(CommunicationService.BannerCacheKey));
+            Assert.Null(this.cacheProvider.GetItem<Communication>(CommunicationService.InAppCacheKey));
+            Assert.Null(this.cacheProvider.GetItem<Communication>(CommunicationService.MobileCacheKey));
         }
 
         private static RequestResult<Communication?> GetCommResult(Communication? communication, ResultType resultStatus)

--- a/Apps/Common/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PatientServiceTests.cs
@@ -245,7 +245,7 @@ namespace HealthGateway.CommonTests.Services
             patientDelegateMock.Setup(p => p.GetDemographicsByHdidAsync(It.IsAny<string>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(requestResult);
 
             Mock<ICacheProvider> cacheProviderMock = new();
-            cacheProviderMock.Setup(p => p.GetItem<PatientModel>(It.IsAny<string>())).Returns(returnNullPatientResult ? null : requestResult.ResourcePayload);
+            cacheProviderMock.Setup(p => p.GetItemAsync<PatientModel>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(returnNullPatientResult ? null : requestResult.ResourcePayload);
 
             IPatientService service = new PatientService(
                 new Mock<ILogger<PatientService>>().Object,
@@ -285,7 +285,7 @@ namespace HealthGateway.CommonTests.Services
             Mock<ICacheProvider> cacheProviderMock = new();
             if (returnValidCache)
             {
-                cacheProviderMock.Setup(p => p.GetItem<PatientModel>(It.IsAny<string>())).Returns(requestResult.ResourcePayload);
+                cacheProviderMock.Setup(p => p.GetItemAsync<PatientModel>(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(requestResult.ResourcePayload);
             }
 
             IPatientService service = new PatientService(

--- a/Apps/Patient/src/Patient.csproj
+++ b/Apps/Patient/src/Patient.csproj
@@ -18,6 +18,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="PatientTests" />
+        <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Implements [AB#16659](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16659)

## Description

- fixes MudBlazor error in Admin.Client
- adds InternalsVisibleTo DynamicProxyGenAssembly2 (for Moq)
  - this allows mocking of types in the affected projects that have internal visibility
  - this also standardizes our placement of InternalsVisibleTo within .csproj files instead of AssemblyInfo.cs files
- excludes models from code coverage
- splits SubscribeAsync into two methods to reduce complexity and enable easier testing
- simplifies AuditLogger using switch expressions
- removes unused method
- updates unit tests in Common

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
