### PR TITLE
Exclude records from Code coverage for AB#16719

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryStrategy.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
 {
     using System;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using FluentValidation;
@@ -163,6 +164,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     /// <summary>
     /// The patient request.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     internal record PatientRequest(
         string Identifier,
         bool UseCache,

--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -254,7 +254,7 @@ namespace HealthGateway.Common.AccessManagement.Authentication
             }
             catch (Exception e) when (e is HttpRequestException or InvalidOperationException or JsonException)
             {
-                this.logger.LogError("Error Message {Message}", e.Message);
+                this.logger.LogError(e, "Error Message {Message}", e.Message);
             }
 
             return authModel;

--- a/Apps/Common/src/Delegates/CDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/CDogsDelegate.cs
@@ -95,7 +95,7 @@ namespace HealthGateway.Common.Delegates
                         ResultMessage = $"Exception generating report: {e}",
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.CDogs),
                     };
-                    this.logger.LogError("Unexpected exception in GenerateReport {Exception}", e);
+                    this.logger.LogError(e, "Unexpected exception in GenerateReport {Message}", e.Message);
                 }
 
                 return retVal;

--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -38,6 +38,8 @@ namespace HealthGateway.Common.Delegates
     /// </summary>
     public class ClientRegistriesDelegate : IClientRegistriesDelegate
     {
+        private const string Instance = "INSTANCE";
+
         private static readonly List<string> WarningResponseCodes =
         [
             "BCHCIM.GD.0.0015", "BCHCIM.GD.1.0015", "BCHCIM.GD.0.0019", "BCHCIM.GD.1.0019", "BCHCIM.GD.0.0020", "BCHCIM.GD.1.0020", "BCHCIM.GD.0.0021", "BCHCIM.GD.1.0021", "BCHCIM.GD.0.0022",
@@ -84,7 +86,7 @@ namespace HealthGateway.Common.Delegates
                 }
                 catch (CommunicationException e)
                 {
-                    this.logger.LogError("{Exception}", e.ToString());
+                    this.logger.LogError(e, "{Message}", e.Message);
                     return new RequestResult<PatientModel>
                     {
                         ResultStatus = ResultType.Error,
@@ -113,7 +115,7 @@ namespace HealthGateway.Common.Delegates
                 }
                 catch (CommunicationException e)
                 {
-                    this.logger.LogError("{Exception}", e.ToString());
+                    this.logger.LogError(e, "{Message}", e.Message);
                     return new RequestResult<PatientModel>
                     {
                         ResultStatus = ResultType.Error,
@@ -141,19 +143,19 @@ namespace HealthGateway.Common.Delegates
                 request.acceptAckCode = new CS { code = "NE" };
 
                 request.receiver = new MCCI_MT000100Receiver { typeCode = "RCV" };
-                request.receiver.device = new MCCI_MT000100Device { determinerCode = "INSTANCE", classCode = "DEV" };
+                request.receiver.device = new MCCI_MT000100Device { determinerCode = Instance, classCode = "DEV" };
                 request.receiver.device.id = new II { root = "2.16.840.1.113883.3.51.1.1.4", extension = clientIp };
                 request.receiver.device.asAgent = new MCCI_MT000100Agent { classCode = "AGNT" };
-                request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = "INSTANCE", classCode = "ORG" };
-                request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = "INSTANCE", classCode = "ORG" };
+                request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
+                request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
                 request.receiver.device.asAgent.representedOrganization.id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HCIM" };
 
                 request.sender = new MCCI_MT000100Sender { typeCode = "SND" };
-                request.sender.device = new MCCI_MT000100Device { determinerCode = "INSTANCE", classCode = "DEV" };
+                request.sender.device = new MCCI_MT000100Device { determinerCode = Instance, classCode = "DEV" };
                 request.sender.device.id = new II { root = "2.16.840.1.113883.3.51.1.1.5", extension = "MOH_CRS" };
                 request.sender.device.asAgent = new MCCI_MT000100Agent { classCode = "AGNT" };
-                request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = "INSTANCE", classCode = "ORG" };
-                request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = "INSTANCE", classCode = "ORG" };
+                request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
+                request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
                 request.sender.device.asAgent.representedOrganization.id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HGWAY" };
 
                 request.controlActProcess = new HCIM_IN_GetDemographicsQUQI_MT020001ControlActProcess { classCode = "ACCM", moodCode = "EVN" };

--- a/Apps/Common/src/Delegates/PHSA/RestNotificationSettingsDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestNotificationSettingsDelegate.cs
@@ -89,7 +89,7 @@ namespace HealthGateway.Common.Delegates.PHSA
                     ResultMessage = "Error while sending notification settings to PHSA",
                     ErrorCode = errorCode,
                 };
-                this.logger.LogError("Unexpected exception in SetNotificationSettings {Exception}", e);
+                this.logger.LogError(e, "Unexpected exception in SetNotificationSettings {Message}", e.Message);
             }
 
             this.logger.LogDebug("Finished sending notification settings to PHSA");

--- a/Apps/Common/src/Delegates/PHSA/RestTokenSwapDelegate.cs
+++ b/Apps/Common/src/Delegates/PHSA/RestTokenSwapDelegate.cs
@@ -86,7 +86,7 @@ namespace HealthGateway.Common.Delegates.PHSA
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogCritical("TokenSwap API Exception {Exception}", e.ToString());
+                this.logger.LogCritical(e, "TokenSwap API Exception {Message}", e.Message);
                 requestResult.ResultError = new()
                 {
                     ResultMessage = "Error with Token Swap API",

--- a/Apps/Common/src/Delegates/VaccineProofDelegate.cs
+++ b/Apps/Common/src/Delegates/VaccineProofDelegate.cs
@@ -245,7 +245,7 @@ namespace HealthGateway.Common.Delegates
                     ResultMessage = $"Exception while fetching Vaccine Proof: {e}",
                     ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.Bcmp),
                 };
-                this.logger.LogError("Unexpected exception while fetching Vaccine Proof {Exception}", e);
+                this.logger.LogError(e, "Unexpected exception while fetching Vaccine Proof {Message}", e.Message);
             }
 
             return retVal;
@@ -322,7 +322,7 @@ namespace HealthGateway.Common.Delegates
                     ResultMessage = $"Exception while sending HTTP request to BC Mail Plus: {e}",
                     ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationExternal, ServiceType.Bcmp),
                 };
-                this.logger.LogError("Unexpected exception while sending HTTP request to BC Mail Plus {Exception}", e);
+                this.logger.LogError(e, "Unexpected exception while sending HTTP request to BC Mail Plus {Message}", e.Message);
             }
 
             return retVal;

--- a/Apps/Common/src/Services/CommunicationService.cs
+++ b/Apps/Common/src/Services/CommunicationService.cs
@@ -81,7 +81,7 @@ namespace HealthGateway.Common.Services
                 }
                 catch (Exception e)
                 {
-                    this.logger.LogError("Error getting Communication from DB {Error}", e.ToString());
+                    this.logger.LogError(e, "Error getting Communication from DB {Message}", e.Message);
                     cacheEntry = new()
                     {
                         ResultStatus = ResultType.Error,

--- a/Apps/Common/src/Services/PersonalAccountsService.cs
+++ b/Apps/Common/src/Services/PersonalAccountsService.cs
@@ -99,7 +99,7 @@ namespace HealthGateway.Common.Services
             }
             catch (Exception e) when (e is ApiException or HttpRequestException)
             {
-                this.logger.LogCritical("Request Exception {Error}", e.ToString());
+                this.logger.LogCritical(e, "Request Exception {Message}", e.Message);
                 requestResult.ResultError = new()
                 {
                     ResultMessage = "Error with request for Personal Accounts",

--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Patient.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Runtime.Serialization;
     using System.Text.Json.Serialization;
     using System.Threading;
@@ -52,12 +53,14 @@ namespace HealthGateway.Patient.Services
     /// </summary>
     /// <param name="Hdid">The patient hdid.</param>
     /// <param name="PatientDataTypes">The data types to query.</param>
+    [ExcludeFromCodeCoverage]
     public record PatientDataQuery(string Hdid, IEnumerable<PatientDataType> PatientDataTypes);
 
     /// <summary>
     /// Response message with patient data.
     /// </summary>
     /// <param name="Items">list of patient data information.</param>
+    [ExcludeFromCodeCoverage]
     public record PatientDataResponse(IEnumerable<PatientData> Items);
 
     /// <summary>
@@ -67,6 +70,7 @@ namespace HealthGateway.Patient.Services
     [KnownType(typeof(OrganDonorRegistration))]
     [KnownType(typeof(DiagnosticImagingExam))]
     [KnownType(typeof(BcCancerScreening))]
+    [ExcludeFromCodeCoverage]
     public abstract record PatientData
     {
         /// <summary>
@@ -83,6 +87,7 @@ namespace HealthGateway.Patient.Services
     /// <summary>
     /// Organ donor patient data.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record OrganDonorRegistration : PatientData
     {
         /// <summary>
@@ -112,6 +117,7 @@ namespace HealthGateway.Patient.Services
     /// <summary>
     /// Diagnostic imaging exam patient data.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record DiagnosticImagingExam : PatientData
     {
         /// <summary>
@@ -166,6 +172,7 @@ namespace HealthGateway.Patient.Services
     /// <summary>
     /// BC Cancer screening exam patient data.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record BcCancerScreening : PatientData
     {
         /// <summary>
@@ -202,6 +209,7 @@ namespace HealthGateway.Patient.Services
     /// </summary>
     /// <param name="Hdid">Patient's hdid.</param>
     /// <param name="FileId">File id.</param>
+    [ExcludeFromCodeCoverage]
     public record PatientFileQuery(string Hdid, string FileId);
 
     /// <summary>
@@ -209,6 +217,7 @@ namespace HealthGateway.Patient.Services
     /// </summary>
     /// <param name="Content">The file content.</param>
     /// <param name="ContentType">The file content type.</param>
+    [ExcludeFromCodeCoverage]
     public record PatientFileResponse(IEnumerable<byte> Content, string ContentType);
 
 // Disable documentation for internal class.

--- a/Apps/PatientDataAccess/src/Api/HealthDataEntry.cs
+++ b/Apps/PatientDataAccess/src/Api/HealthDataEntry.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.PatientDataAccess.Api
     using System.Text.Json.Serialization;
 
     [JsonConverter(typeof(HealthDataJsonConverter))]
+    [ExcludeFromCodeCoverage]
     internal abstract record HealthDataEntry
     {
         public string? HealthDataId { get; set; }
@@ -107,6 +108,7 @@ namespace HealthGateway.PatientDataAccess.Api
         public string? ResultLink { get; set; }
     }
 
+    [ExcludeFromCodeCoverage]
     internal record DiagnosticImagingExam : HealthDataEntry
     {
         public string? ProcedureDescription { get; set; }
@@ -126,6 +128,7 @@ namespace HealthGateway.PatientDataAccess.Api
         public bool? IsUpdated { get; set; }
     }
 
+    [ExcludeFromCodeCoverage]
     internal record BcCancerScreening : HealthDataEntry
     {
         public CancerScreeningType EventType { get; set; }

--- a/Apps/PatientDataAccess/src/Api/HealthOptionsData.cs
+++ b/Apps/PatientDataAccess/src/Api/HealthOptionsData.cs
@@ -17,11 +17,14 @@ namespace HealthGateway.PatientDataAccess.Api
 {
 #pragma warning disable SA1600 // Disables documentation for internal class.
 #pragma warning disable SA1602 // Disables documentation for internal class.
+    using System.Diagnostics.CodeAnalysis;
     using System.Text.Json.Serialization;
 
     [JsonConverter(typeof(HealthOptionDataJsonConverter))]
+    [ExcludeFromCodeCoverage]
     internal abstract record HealthOptionsData;
 
+    [ExcludeFromCodeCoverage]
     internal record OrganDonorRegistration : HealthOptionsData
     {
         public string? HealthOptionsId { get; set; }

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.PatientDataAccess.Api
 #pragma warning disable SA1602 // Disables documentation for internal class.
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Refit;
@@ -68,14 +69,19 @@ namespace HealthGateway.PatientDataAccess.Api
         Task<HealthDataResult?> GetHealthDataAsync(Guid pid, [Query(CollectionFormat.Multi)] string[] categories, CancellationToken ct = default);
     }
 
+    [ExcludeFromCodeCoverage]
     internal record FileResult(string? MediaType, string? Data, string? Encoding);
 
+    [ExcludeFromCodeCoverage]
     internal record HealthOptionsResult(HealthOptionsMetadata Metadata, IEnumerable<HealthOptionsData> Data);
 
+    [ExcludeFromCodeCoverage]
     internal record HealthDataResult(HealthDataMetadata Metadata, IEnumerable<HealthDataEntry> Data);
 
+    [ExcludeFromCodeCoverage]
     internal record HealthOptionsMetadata;
 
+    [ExcludeFromCodeCoverage]
     internal record HealthDataMetadata;
 }
 #pragma warning restore SA1600

--- a/Apps/PatientDataAccess/src/HealthData.cs
+++ b/Apps/PatientDataAccess/src/HealthData.cs
@@ -17,10 +17,12 @@ namespace HealthGateway.PatientDataAccess
 {
 #pragma warning disable SA1201 // Elements should appear in the correct order
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// abstract record for health data.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public abstract record HealthData
     {
         /// <summary>
@@ -37,6 +39,7 @@ namespace HealthGateway.PatientDataAccess
     /// <summary>
     /// The details of a diagnostic imaging exam.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record DiagnosticImagingExam : HealthData
     {
         /// <summary>
@@ -83,6 +86,7 @@ namespace HealthGateway.PatientDataAccess
     /// <summary>
     /// The details of a BC Cancer screening exam.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record BcCancerScreening : HealthData
     {
         /// <summary>

--- a/Apps/PatientDataAccess/src/HealthServiceData.cs
+++ b/Apps/PatientDataAccess/src/HealthServiceData.cs
@@ -15,15 +15,19 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.PatientDataAccess
 {
+    using System.Diagnostics.CodeAnalysis;
+
 #pragma warning disable SA1201 // Elements should appear in the correct order
     /// <summary>
     /// abstract class for health service data.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public abstract record HealthServiceData : HealthData;
 
     /// <summary>
     /// BC Transplant organ donor service data.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record OrganDonorRegistration : HealthServiceData
     {
         /// <summary>

--- a/Apps/PatientDataAccess/src/IPatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/IPatientDataRepository.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.PatientDataAccess
 #pragma warning disable SA1201 // Elements should appear in the correct order
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -38,11 +39,13 @@ namespace HealthGateway.PatientDataAccess
     /// <summary>
     /// Abstract query record.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public abstract record PatientDataQuery;
 
     /// <summary>
     /// Query parameters for health services.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record HealthQuery(Guid Pid, IEnumerable<HealthCategory> Categories) : PatientDataQuery;
 
     /// <summary>
@@ -69,16 +72,19 @@ namespace HealthGateway.PatientDataAccess
     /// <summary>
     /// Query patient files.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record PatientFileQuery(Guid Pid, string FileId) : PatientDataQuery;
 
     /// <summary>
     /// The health data query result payload.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record PatientDataQueryResult(IEnumerable<HealthData> Items);
 
     /// <summary>
     /// Represents a patient file.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     public record PatientFile : HealthData
     {
         /// <summary>


### PR DESCRIPTION
# Implements [AB#16719](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16719)

## Description

Confirmed that Records used for AccountDataAccess, PatientDataAccess and Patient  are referenced in unit tests.  As a result can be excluded from code coverage.

Also, fixed sonar code smells for Common project.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
