### PR TITLE
Add wait to standard intercepts on login for AB#16731.

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
@@ -1,7 +1,18 @@
 const { AuthMethod } = require("../../../support/constants");
 
 function testPageBreadcrumb(url, dataTestId) {
+    if (url === "/covid19") {
+        cy.intercept("GET", "**/AuthenticatedVaccineStatus?hdid=*").as(
+            "getVaccinationStatus"
+        );
+    }
+
     cy.visit(url);
+
+    if (url === "/covid19") {
+        cy.wait("@getVaccinationStatus");
+    }
+
     cy.get("[data-testid=breadcrumbs]").should("be.visible");
     cy.get(`[data-testid='${dataTestId}'].v-breadcrumbs-item--active`).should(
         "be.visible"

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -647,6 +647,17 @@ describe("CRUD Operations", () => {
 
         cy.log("Adding same dependent as another user");
 
+        cy.configureSettings({
+            dependents: {
+                enabled: true,
+            },
+            datasets: [
+                {
+                    name: "covid19TestResult",
+                    enabled: true,
+                },
+            ],
+        });
         cy.login(
             Cypress.env("keycloak.protected.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/e2e/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/notificationCentre.js
@@ -1,9 +1,8 @@
-const { AuthMethod } = require("../../../support/constants");
+import { AuthMethod } from "../../../support/constants";
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 
 describe("Notification Centre", () => {
     beforeEach(() => {
-        cy.intercept("GET", "**/Notification/*").as("getNotification");
         cy.intercept("DELETE", "**/Notification/*").as("deleteNotification");
 
         cy.configureSettings({
@@ -23,9 +22,6 @@ describe("Notification Centre", () => {
     });
 
     it("Get notifications", () => {
-        // Wait for request to complete
-        cy.wait("@getNotification");
-
         cy.get("[data-testid=notification-centre-button]")
             .should("be.visible", "be.enabled")
             .click();

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
@@ -3,7 +3,7 @@ import {
     clickRegisterKitButton,
     getPcrTestTakenTime,
 } from "../../../support/functions/pcrTestKit";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const pcrTestUrl = "/pcrtest";
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
@@ -23,7 +23,7 @@ const processedBanner = "[data-testid=alreadyProcessedBanner]";
 
 describe("Authenticated Pcr Test Registration", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.configureSettings({
             covid19: {
@@ -104,7 +104,7 @@ describe("Authenticated Pcr Test Registration with Error", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -149,7 +149,7 @@ describe("Authenticated Pcr Test Registration Previously Processed", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
@@ -3,7 +3,7 @@ import {
     clickRegisterKitButton,
     getPcrTestTakenTime,
 } from "../../../support/functions/pcrTestKit";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const pcrTestUrl = "/pcrtest/222BAAB1-8C6E-4FA1-86ED-C4E3517A16A2";
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
@@ -26,7 +26,7 @@ describe("Authenticated Pcr Test Registration", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -81,7 +81,7 @@ describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -123,7 +123,7 @@ describe("Previously Registered Test Kit", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedVaccineCard.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedVaccineCard.js
@@ -1,11 +1,11 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const covid19Url = "/covid19";
 
 describe("Authenticated Vaccine Card Downloads", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/AuthenticatedVaccineStatus?hdid=*", {
             fixture:

--- a/Testing/functional/tests/cypress/integration/ui/covid19/federalProofOfVaccination.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/federalProofOfVaccination.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const homeUrl = "/home";
 
@@ -24,7 +24,7 @@ describe("Federal Proof of Vaccination", () => {
             }
         );
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.configureSettings({
             homepage: {
@@ -58,7 +58,7 @@ describe("Federal Proof of Vaccination", () => {
             datasets: [{ name: "immunization", enabled: true }],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const addQuickLinkButtonSelector = "[data-testid=add-quick-link-button]";
 const addQuickLinkChipSelector = "[data-testid=quick-link-modal-text] .v-chip";
@@ -24,7 +24,7 @@ function testGetConfigurationError(statusCode = serverErrorStatusCode) {
 function testGetProfileErrorOnLoad(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
 
-    setupStandardIntercepts({
+    setupStandardFixtures({
         userProfileStatusCode: statusCode,
     });
 
@@ -47,7 +47,7 @@ function testRegisterError(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
     const hdid = "S22BPV6WHS5TRLBL4XKGQDBVDUKLPIRSBGYSEJAHYMYRP22SP2TA";
 
-    setupStandardIntercepts({
+    setupStandardFixtures({
         patientHdid: hdid,
         userProfileHdid: hdid,
         patientFixture: "PatientService/patientUnregistered.json",
@@ -116,7 +116,7 @@ function testValidateEmailError(statusCode = serverErrorStatusCode) {
         statusCode,
     }).as("validateEmail");
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.login(
         Cypress.env("keycloak.username"),
@@ -170,7 +170,7 @@ function testAddQuickLinkError(statusCode = serverErrorStatusCode) {
         ],
     });
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.intercept("PUT", "**/UserProfile/*/preference", {
         statusCode,
@@ -218,7 +218,7 @@ function testAddCommentError(statusCode = serverErrorStatusCode) {
         ],
     });
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.intercept("POST", "**/UserProfile/*/Comment", {
         statusCode,
@@ -296,7 +296,7 @@ function testRemoveQuickLinkError(statusCode = serverErrorStatusCode) {
         ],
     });
 
-    setupStandardIntercepts({
+    setupStandardFixtures({
         userProfileFixture: "UserProfileService/userProfileQuickLinks.json",
     });
 
@@ -333,7 +333,7 @@ function testRemoveQuickLinkError(statusCode = serverErrorStatusCode) {
 function testHideVaccineCardQuickLinkError(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.intercept("PUT", "**/UserProfile/*/preference", {
         statusCode,
@@ -368,7 +368,7 @@ function testHideVaccineCardQuickLinkError(statusCode = serverErrorStatusCode) {
 function testEditSmsError(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.intercept("GET", "**/UserProfile/IsValidPhoneNumber/*", {
         body: true,
@@ -400,7 +400,7 @@ function testEditSmsError(statusCode = serverErrorStatusCode) {
 function testVerifySmsError(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.intercept("GET", "**/UserProfile/IsValidPhoneNumber/*", {
         body: true,
@@ -437,7 +437,7 @@ function testVerifySmsError(statusCode = serverErrorStatusCode) {
 function testEditEmailError(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.intercept("GET", "**/UserProfile/IsValidPhoneNumber/*", {
         body: true,

--- a/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/tooManyRequestsAlerts.js
@@ -1,5 +1,5 @@
 import { AuthMethod, monthNames } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const vaccineCardUrl = "/vaccinecard";
 const dependentHdid = "645645767756756767";
@@ -34,7 +34,7 @@ function populateDatePicker(selector, dateValue) {
 
 describe("Authenticated Vaccine Card Downloads", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/AuthenticatedVaccineStatus?hdid=*", {
             statusCode: 429,
@@ -58,7 +58,7 @@ describe("Authenticated Vaccine Card Downloads", () => {
     });
 
     it("Save As PDF Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/AuthenticatedVaccineStatus?hdid=*", {
             fixture:
@@ -192,7 +192,7 @@ describe("Landing Page - Too Many Requests", () => {
 
 describe("Immunization", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Immunization?hdid*", {
             statusCode: 429,
@@ -217,7 +217,7 @@ describe("Immunization", () => {
 
 describe("Encounter", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Encounter/*", {
             statusCode: 429,
@@ -242,7 +242,7 @@ describe("Encounter", () => {
 
 describe("Hospital Visits", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/HospitalVisit/*", {
             statusCode: 429,
@@ -267,7 +267,7 @@ describe("Hospital Visits", () => {
 
 describe("Medication Request", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/MedicationRequest/*", {
             statusCode: 429,
@@ -292,7 +292,7 @@ describe("Medication Request", () => {
 
 describe("Mobile - COVID-19 Orders", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Laboratory/Covid19Orders*", {
             statusCode: 429,
@@ -318,7 +318,7 @@ describe("Mobile - COVID-19 Orders", () => {
 
 describe("Mobile - Immunization: Unsuccessful Response", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Immunization?hdid*", {
             statusCode: 429,
@@ -344,7 +344,7 @@ describe("Mobile - Immunization: Unsuccessful Response", () => {
 
 describe("Mobile - Encounter", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Encounter/*", {
             statusCode: 429,
@@ -370,7 +370,7 @@ describe("Mobile - Encounter", () => {
 
 describe("Mobile - Hospital Visits", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/HospitalVisit/*", {
             statusCode: 429,
@@ -396,7 +396,7 @@ describe("Mobile - Hospital Visits", () => {
 
 describe("Mobile - Laboratory Orders", () => {
     it("Unsuccessful Response: Too Many Requests", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
             statusCode: 429,
@@ -422,7 +422,7 @@ describe("Mobile - Laboratory Orders", () => {
 
 describe("Mobile - Laboratory Orders Report Download", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Laboratory/LaboratoryOrders*", {
             fixture: "LaboratoryService/laboratoryOrders.json",
@@ -506,7 +506,7 @@ describe("Mobile - Laboratory Orders Report Download", () => {
 
 describe("Mobile - Covid19 Orders Report Download", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Laboratory/Covid19Orders*", {
             fixture: "LaboratoryService/covid19Orders.json",
@@ -591,7 +591,7 @@ describe("User Profile", () => {
     beforeEach(() => {
         cy.configureSettings({});
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("PUT", `**/UserProfile/${HDID}/sms`, {
             statusCode: 200,
@@ -662,7 +662,7 @@ describe("Dependents", () => {
     };
 
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Laboratory/Covid19Orders*", {
             fixture: "LaboratoryService/covid19Orders.json",
@@ -741,7 +741,7 @@ describe("Dependents", () => {
 
 describe("Dependent - Immunizaation History Tab - report download error handling", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/UserProfile/*/Dependent", {
             fixture: "UserProfileService/dependent.json",
@@ -843,7 +843,7 @@ describe("Dependent - Immunizaation History Tab - report download error handling
 
 describe("Comments", () => {
     it("Add Comment: Too Many Requests Error", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Laboratory/Covid19Orders*", {
             fixture: "LaboratoryService/covid19Orders.json",
@@ -887,7 +887,7 @@ describe("Comments", () => {
 
 describe("Notes", () => {
     it("Add Note: Too Many Requests Error", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Note/*", {
             fixture: "NoteService/notes-no-records.json",
@@ -924,7 +924,7 @@ describe("Notes", () => {
     });
 
     it("Edit Note: Too Many Requests Error", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Note/*", {
             fixture: "NoteService/notes-test-note.json",
@@ -957,7 +957,7 @@ describe("Notes", () => {
     });
 
     it("Delete Note: Too Many Requests Error", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/Note/*", {
             fixture: "NoteService/notes-test-note.json",
@@ -989,7 +989,7 @@ describe("Notes", () => {
 
 describe("Export Records - Immunizaation - report download error handling", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
         cy.intercept("GET", "**/Immunization?hdid=*", {
             fixture: "ImmunizationService/immunization.json",
         });

--- a/Testing/functional/tests/cypress/integration/ui/pages/Routes.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/Routes.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const profilePath = "/profile";
 const homePath = "/home";
@@ -18,7 +18,7 @@ describe("Bookmark", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
     });
 
     it("Redirect to UserProfile", () => {

--- a/Testing/functional/tests/cypress/integration/ui/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/home.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const homeUrl = "/home";
 const covid19Url = "/covid19";
@@ -9,7 +9,7 @@ describe("Authenticated User - Home Page", () => {
     it("Home Page exists", () => {
         cy.configureSettings({});
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -29,7 +29,7 @@ describe("Authenticated User - Home Page", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -44,7 +44,7 @@ describe("Authenticated User - Home Page", () => {
     it("Home - Link to COVID-19 page", () => {
         cy.configureSettings({});
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -63,7 +63,7 @@ describe("Authenticated User - Home Page", () => {
     it("Home - Link to timeline page", () => {
         cy.configureSettings({});
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -82,7 +82,7 @@ describe("Authenticated User - Home Page", () => {
     it("Home - Federal Card button disabled", () => {
         cy.configureSettings({});
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -103,7 +103,7 @@ describe("Authenticated User - Home Page", () => {
                 },
             ],
         });
-        setupStandardIntercepts({
+        setupStandardFixtures({
             userProfileFixture: "UserProfileService/userProfileQuickLinks.json",
         });
 

--- a/Testing/functional/tests/cypress/integration/ui/report/immunizationReport.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/immunizationReport.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 
@@ -31,7 +31,7 @@ describe("Immunization History Report", () => {
             isLoading = !isLoading;
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -117,7 +117,7 @@ describe("Export Reports - Immunizations - Invalid Doses", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/report/reportFiltering.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportFiltering.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const startDateId = "[data-testid=start-date-input] input";
 const endDateId = "[data-testid=end-date-input] input";
@@ -51,7 +51,7 @@ describe("Report Filtering", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/MedicationStatement/*", {
             fixture: "MedicationService/medicationStatement.json",

--- a/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 
@@ -22,7 +22,7 @@ describe("Reports - Medication", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -77,7 +77,7 @@ describe("Reports - Covid19", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -133,7 +133,7 @@ describe("Reports - Immunization", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -220,7 +220,7 @@ describe("Reports - MSP Visit", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -276,7 +276,7 @@ describe("Reports - Hospital Visits", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -332,7 +332,7 @@ describe("Reports - Notes (User-Entered)", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -388,7 +388,7 @@ describe("Reports - Laboratory Tests", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/services/menu.js
+++ b/Testing/functional/tests/cypress/integration/ui/services/menu.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 function toggleServices(enabled = true) {
     cy.configureSettings({
@@ -25,7 +25,7 @@ describe("Menu System when services are enabled", () => {
     beforeEach(() => {
         toggleServices(true);
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
     });
 
     it("Side bar contains services nav link and toggle validated", () => {
@@ -59,7 +59,7 @@ describe("Menu system when services are disabled", () => {
     beforeEach(() => {
         toggleServices(false);
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
     });
     it("Side bar does not contain services nav link when services is disabled", () => {
         cy.configureSettings({

--- a/Testing/functional/tests/cypress/integration/ui/services/organDonorRegistration.js
+++ b/Testing/functional/tests/cypress/integration/ui/services/organDonorRegistration.js
@@ -1,19 +1,9 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("Services - Organ Donor Registration Card", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
-
-        cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/services"
-        );
-    });
-
-    it("Should by default handle an unregistered patient", () => {
+        setupStandardFixtures();
         cy.configureSettings({
             services: {
                 enabled: true,
@@ -25,13 +15,22 @@ describe("Services - Organ Donor Registration Card", () => {
                 ],
             },
         });
+    });
 
+    it("Should by default handle an unregistered patient", () => {
         cy.intercept(
             "GET",
             `**/PatientData/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A*OrganDonorRegistrationStatus*`,
             {
                 fixture: "PatientData/donorRegistrationNotRegistered.json",
             }
+        );
+
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/services"
         );
 
         cy.get("[data-testid=organ-donor-registration-status]")
@@ -44,24 +43,19 @@ describe("Services - Organ Donor Registration Card", () => {
     });
 
     it("Should handle a Registered patient", () => {
-        cy.configureSettings({
-            services: {
-                enabled: true,
-                services: [
-                    {
-                        name: "organDonorRegistration",
-                        enabled: true,
-                    },
-                ],
-            },
-        });
-
         cy.intercept(
             "GET",
             `**/PatientData/P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A*OrganDonorRegistrationStatus*`,
             {
                 fixture: "PatientData/donorRegistrationRegistered.json",
             }
+        );
+
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/services"
         );
 
         cy.get("[data-testid=organ-donor-registration-status]")
@@ -89,20 +83,11 @@ describe("Services - Organ Donor Registration Card", () => {
 });
 
 describe("Services - Organ Donor Registration Card - ODR Dataset Blocked", () => {
-    beforeEach(() => {
-        cy.intercept("GET", `**/UserProfile/*`, {
-            fixture:
+    it("Should not show Organ Donor Registration Card", () => {
+        setupStandardFixtures({
+            userProfileFixture:
                 "UserProfileService/userProfileOrganDonorRegistrationDatasetBlocked.json",
         });
-        cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/services"
-        );
-    });
-
-    it("Should not show Organ Donor Registration Card", () => {
         cy.configureSettings({
             services: {
                 enabled: true,
@@ -114,6 +99,13 @@ describe("Services - Organ Donor Registration Card - ODR Dataset Blocked", () =>
                 ],
             },
         });
+
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/services"
+        );
 
         cy.get("[data-testid=organ-donor-registration-card]").should(
             "not.exist"

--- a/Testing/functional/tests/cypress/integration/ui/services/view.js
+++ b/Testing/functional/tests/cypress/integration/ui/services/view.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const servicesTestsConstants = {
     servicesUrl: "/services",
@@ -8,14 +8,7 @@ const servicesTestsConstants = {
 
 describe("Authenticated Services View", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
-
-        cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            "/services"
-        );
+        setupStandardFixtures();
     });
 
     it("The url should be the services url if services enabled", () => {
@@ -24,11 +17,27 @@ describe("Authenticated Services View", () => {
                 enabled: true,
             },
         });
+
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/services"
+        );
+
         cy.url().should("include", servicesTestsConstants.servicesUrl);
     });
 
     it("The url should be the unauthorized url if services is disabled", () => {
         cy.configureSettings({});
+
+        cy.login(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            "/services"
+        );
+
         cy.url().should("include", servicesTestsConstants.unauthorized);
     });
 });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/bcCancerScreening.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("BC Cancer Screening cards", () => {
     function testCard(cardTitle, cardButtonText) {
@@ -29,7 +29,7 @@ describe("BC Cancer Screening cards", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/encounter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/encounter.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("MSP Visits Rolloff", () => {
     beforeEach(() => {
@@ -17,7 +17,7 @@ describe("MSP Visits Rolloff", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/errors.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/errors.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("Banner Error", () => {
     beforeEach(() => {
@@ -15,7 +15,7 @@ describe("Banner Error", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/filter.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const HDID = "K6HL4VX67CZ2PGSZ2ZOIR4C3PGMFFBW5CIOXM74D6EQ7RYYL7P4A";
 
@@ -63,7 +63,7 @@ describe("Filters", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -200,7 +200,7 @@ describe("Describe Filters when all datasets blocked", () => {
             ],
         });
 
-        setupStandardIntercepts({
+        setupStandardFixtures({
             userProfileFixture:
                 "UserProfileService/userProfileMultipleDatasetsBlocked.json",
         });
@@ -238,7 +238,7 @@ describe("Describe Filters when clinical doc dataset is blocked but immunization
             ],
         });
 
-        setupStandardIntercepts({
+        setupStandardFixtures({
             userProfileFixture:
                 "UserProfileService/userProfileClinicalDocDatasetBlocked.json",
         });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/immunization.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/immunization.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("Immunization - With Refresh", () => {
     beforeEach(() => {
@@ -25,7 +25,7 @@ describe("Immunization - With Refresh", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -77,7 +77,7 @@ describe("Immunization", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -109,7 +109,7 @@ describe("Timeline - Immunization - Invalid Doses", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/medicationrequest.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/medicationrequest.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("Medication Request", () => {
     beforeEach(() => {
@@ -15,7 +15,7 @@ describe("Medication Request", () => {
             fixture: "MedicationService/medicationRequest.json",
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/menu.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/menu.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 function login(isMobile) {
     cy.configureSettings({
@@ -14,7 +14,7 @@ function login(isMobile) {
         cy.viewport("iphone-6"); // Set viewport to 375px x 667px
     }
 
-    setupStandardIntercepts();
+    setupStandardFixtures();
 
     cy.login(
         Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/clinicalDocument.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/clinicalDocument.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../../support/constants";
-import { setupStandardIntercepts } from "../../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../../support/functions/intercept";
 
 describe("Clinical Document", () => {
     beforeEach(() => {
@@ -22,7 +22,7 @@ describe("Clinical Document", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/covid19Order.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../../support/constants";
-import { setupStandardIntercepts } from "../../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../../support/functions/intercept";
 
 describe("COVID-19 Orders", () => {
     beforeEach(() => {
@@ -15,7 +15,7 @@ describe("COVID-19 Orders", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/immunization.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/immunization.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../../support/constants";
-import { setupStandardIntercepts } from "../../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../../support/functions/intercept";
 
 describe("Immunization", () => {
     beforeEach(() => {
@@ -15,7 +15,7 @@ describe("Immunization", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../../support/constants";
-import { setupStandardIntercepts } from "../../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../../support/functions/intercept";
 
 function checkPopoverIsVisible() {
     cy.get("[data-testid=laboratory-test-status-info-button]")
@@ -31,7 +31,7 @@ describe("Laboratory Orders", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(
@@ -253,7 +253,7 @@ describe("Laboratory Orders Refresh", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(
@@ -309,7 +309,7 @@ describe("Laboratory Orders Queued", () => {
                 },
             ],
         });
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrderReport.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrderReport.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../../support/constants";
-import { setupStandardIntercepts } from "../../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../../support/functions/intercept";
 
 describe("Laboratory Orders - Report", () => {
     beforeEach(() => {
@@ -22,7 +22,7 @@ describe("Laboratory Orders - Report", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.viewport("iphone-6");
         cy.login(

--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/medication.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/medication.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../../support/constants";
-import { setupStandardIntercepts } from "../../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../../support/functions/intercept";
 
 function selectCardByDate(date) {
     cy.contains("[data-testid=entryCardDate]", date)
@@ -21,7 +21,7 @@ describe("Medication", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/MedicationStatement/*", {
             fixture: "MedicationService/medicationStatement.json",

--- a/Testing/functional/tests/cypress/integration/ui/user/acceptTermsOfService.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/acceptTermsOfService.js
@@ -1,11 +1,12 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const HDID = "K6HL4VX67CZ2PGSZ2ZOIR4C3PGMFFBW5CIOXM74D6EQ7RYYL7P4A";
 
 describe("Need to accept terms of service", () => {
     beforeEach(() => {
-        setupStandardIntercepts({
+        cy.configureSettings({});
+        setupStandardFixtures({
             userProfileHdid: HDID,
             userProfileFixture: "UserProfileService/userProfileAcceptTos.json",
         });
@@ -17,7 +18,8 @@ describe("Need to accept terms of service", () => {
         cy.login(
             Cypress.env("keycloak.accept.tos.username"),
             Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak
+            AuthMethod.KeyCloak,
+            "/home"
         );
     });
 
@@ -38,7 +40,7 @@ describe("Need to accept terms of service", () => {
 
 describe("Does not need to accept terms of service", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/ui/user/appTour.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/appTour.js
@@ -1,9 +1,10 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("App Tour Authenticated", () => {
     beforeEach(() => {
-        setupStandardIntercepts();
+        cy.configureSettings({});
+        setupStandardFixtures();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),

--- a/Testing/functional/tests/cypress/integration/ui/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/dependents.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const sensitiveDocMessage =
     "The file that you are downloading contains personal information. If you are on a public computer, please ensure that the file is deleted before you log off.";
@@ -33,7 +33,7 @@ describe("COVID-19", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -185,7 +185,7 @@ describe("Dependents - Immunization Tab - Enabled", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -321,7 +321,7 @@ describe("Dependents - Lab Results Tab - Enabled", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -395,7 +395,7 @@ describe("Dependents - Clinical Document Tab - Enabled", () => {
             ],
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -463,7 +463,7 @@ describe("Dependents Tabs Disabled", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/user/emailValidation.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/emailValidation.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 describe("User Email Verification", () => {
     beforeEach(() => {
@@ -18,7 +18,7 @@ describe("User Email Verification", () => {
     });
 
     it("Check verified email invite", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -33,7 +33,7 @@ describe("User Email Verification", () => {
     });
 
     it("Check already verified email invite", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -48,7 +48,7 @@ describe("User Email Verification", () => {
     });
 
     it("Check expired email invite", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/notificationCentre.js
@@ -1,5 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import { setupStandardIntercepts } from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const notificationIdOne = "f57bcb39-64ca-0a17-5477-92ea7f084fbf";
 const notificationIdTwo = "72c2d6c0-b370-24e6-0b5c-04e42b6511c8";
@@ -20,10 +20,6 @@ describe("Notification Centre", () => {
             },
         });
 
-        cy.intercept("GET", `**/Notification/${HDID}`, {
-            fixture: "NotificationService/notifications.json",
-        });
-
         cy.intercept("DELETE", `**/Notification/${HDID}/*`, {
             statusCode: 200,
         });
@@ -32,7 +28,10 @@ describe("Notification Centre", () => {
             statusCode: 200,
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures({
+            notificationHdid: HDID,
+            notificationFixture: "NotificationService/notifications.json",
+        });
 
         cy.login(
             Cypress.env("keycloak.username"),
@@ -129,7 +128,7 @@ describe("Notification Badge", () => {
             },
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         // The scheduledDateTimeUtc must be after user profile's last login in lastLoginDateTimes, which is the second entry
         // not the first entry. The first entry is the current login.
@@ -201,7 +200,7 @@ describe("Categorized web alerts", () => {
             fixture: "ImmunizationService/immunization.json",
         });
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.login(
             Cypress.env("keycloak.username"),

--- a/Testing/functional/tests/cypress/integration/ui/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/profile.js
@@ -1,12 +1,5 @@
 import { AuthMethod } from "../../../support/constants";
-import {
-    CommunicationFixture,
-    CommunicationType,
-    setupCommunicationIntercept,
-    setupPatientIntercept,
-    setupUserProfileIntercept,
-    setupStandardIntercepts,
-} from "../../../support/functions/intercept";
+import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const fakeSMSNumber = "2506714848";
 const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
@@ -15,7 +8,7 @@ describe("User Profile", () => {
     beforeEach(() => {
         cy.configureSettings({});
 
-        setupStandardIntercepts();
+        setupStandardFixtures();
 
         cy.intercept("GET", "**/UserProfile/IsValidPhoneNumber/*", {
             body: true,
@@ -198,7 +191,7 @@ describe("User Profile - Validate Address", () => {
     });
 
     it("Verify user has combined address", () => {
-        setupStandardIntercepts();
+        setupStandardFixtures();
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
@@ -220,7 +213,7 @@ describe("User Profile - Validate Address", () => {
     });
 
     it("Verify user has different addresses", () => {
-        setupStandardIntercepts({
+        setupStandardFixtures({
             patientFixture: "PatientService/patientDifferentAddress.json",
         });
         cy.login(
@@ -252,7 +245,7 @@ describe("User Profile - Validate Address", () => {
     });
 
     it("Verify user has no address", () => {
-        setupStandardIntercepts({
+        setupStandardFixtures({
             patientFixture: "PatientService/patientNoAddress.json",
         });
         cy.login(
@@ -273,7 +266,7 @@ describe("User Profile - Validate Address", () => {
     });
 
     it("Verify user has only physical address", () => {
-        setupStandardIntercepts({
+        setupStandardFixtures({
             patientFixture: "PatientService/patientOnlyPhysicalAddress.json",
         });
         cy.login(
@@ -300,7 +293,7 @@ describe("User Profile - Validate Address", () => {
     });
 
     it("Verify user has only postal address", () => {
-        setupStandardIntercepts({
+        setupStandardFixtures({
             patientFixture: "PatientService/patientOnlyPostalAddress.json",
         });
         cy.login(

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -224,16 +224,25 @@ Cypress.Commands.add(
                 setupStandardAliases();
 
                 cy.log(`Visit path: ${path}`);
-                cy.visit(path, { timeout: 60000 });
 
                 if (configSettings === null) {
                     cy.readConfig().then((config) => {
-                        cy.log(`Read config: ${JSON.stringify(config)}`);
+                        cy.visit(path, { timeout: 60000 });
+
+                        cy.log(
+                            `Config in session was null so usiing config from Read config: ${JSON.stringify(
+                                config
+                            )}`
+                        );
+
                         // Make sure to wait on busy endpoint calls
                         waitForInitialDataLoad(username, config, path);
                     });
                 } else {
-                    cy.log(`Session config: ${JSON.stringify(configSettings)}`);
+                    cy.visit(path, { timeout: 60000 });
+
+                    cy.log(`Use config from session: ${configSettings}`);
+
                     // Make sure to wait on busy endpoint calls
                     waitForInitialDataLoad(
                         username,

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -7,7 +7,11 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
-const { AuthMethod, localDevUri } = require("./constants");
+import { AuthMethod, localDevUri } from "./constants";
+import {
+    setupWaitStandardIntercepts,
+    waitStandardIntercepts,
+} from "./functions/intercept";
 const { globalStorage } = require("./globalStorage");
 require("cy-verify-downloads").addCustomCommand();
 
@@ -206,7 +210,9 @@ Cypress.Commands.add(
                 });
             });
             cy.log(`Visit path: ${path}`);
+            setupWaitStandardIntercepts();
             cy.visit(path, { timeout: 60000 });
+            waitStandardIntercepts();
         } else if (authMethod == AuthMethod.BCSC) {
             cy.log(
                 `Authenticating as BC Services Card user ${username} using the UI`

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -230,7 +230,7 @@ Cypress.Commands.add(
                         cy.visit(path, { timeout: 60000 });
 
                         cy.log(
-                            `Config in session was null so usiing config from Read config: ${JSON.stringify(
+                            `Config in session was null so fetched actual config: ${JSON.stringify(
                                 config
                             )}`
                         );

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -9,8 +9,8 @@
 // ***********************************************
 import { AuthMethod, localDevUri } from "./constants";
 import {
-    setupWaitStandardIntercepts,
-    waitStandardIntercepts,
+    setupStandardAliases,
+    waitForInitialDataLoad,
 } from "./functions/intercept";
 const { globalStorage } = require("./globalStorage");
 require("cy-verify-downloads").addCustomCommand();
@@ -132,87 +132,102 @@ Cypress.Commands.add(
     "login",
     (username, password, authMethod = AuthMethod.BCSC, path = "/timeline") => {
         if (authMethod == AuthMethod.KeyCloak) {
-            cy.session([username, authMethod], () => {
-                cy.readConfig().then((config) => {
-                    cy.logout();
-                    let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
-                    let codeVerifier = generateRandomString(96);
-                    cy.log(
-                        `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
-                    );
-                    const loginCallback =
-                        config.openIdConnect.callbacks?.Logon ||
-                        `${Cypress.config().baseUrl}/loginCallback`;
-                    const stateStore = {
-                        id: stateId,
-                        created: new Date().getTime(),
-                        request_type: "si:r",
-                        code_verifier: codeVerifier,
-                        redirect_uri: loginCallback,
-                        authority: config.openIdConnect.authority,
-                        client_id: config.openIdConnect.clientId,
-                        response_mode: "query",
-                        scope: config.openIdConnect.scope,
-                        extraTokenParams: {},
-                    };
-                    cy.log("Creating OIDC StateStore in Local storage");
-                    window.sessionStorage.setItem(
-                        `oidc.${stateStore.id}`,
-                        JSON.stringify(stateStore)
-                    );
-
-                    const escapedRedirectPath = encodeURI(path);
-                    const redirectUri = `${loginCallback}?redirect=${escapedRedirectPath}`;
-
-                    cy.log("Requesting Keycloak Authentication form");
-                    cy.request({
-                        url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
-                        followRedirect: false,
-                        qs: {
-                            scope: config.openIdConnect.scope,
-                            response_type: config.openIdConnect.responseType,
-                            approval_prompt: "auto",
-                            redirect_uri: redirectUri,
+            cy.log("Calling session storage");
+            cy.window().then((window) => {
+                const configSettings =
+                    window.sessionStorage.getItem("configSettingsKey");
+                cy.session([username, authMethod], () => {
+                    cy.readConfig().then((config) => {
+                        cy.logout();
+                        let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
+                        let codeVerifier = generateRandomString(96);
+                        cy.log(
+                            `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
+                        );
+                        const loginCallback =
+                            config.openIdConnect.callbacks?.Logon ||
+                            `${Cypress.config().baseUrl}/loginCallback`;
+                        const stateStore = {
+                            id: stateId,
+                            created: new Date().getTime(),
+                            request_type: "si:r",
+                            code_verifier: codeVerifier,
+                            redirect_uri: loginCallback,
+                            authority: config.openIdConnect.authority,
                             client_id: config.openIdConnect.clientId,
                             response_mode: "query",
-                            state: stateStore.id,
-                        },
-                    })
-                        .then((response) => {
-                            cy.log("Posting credentials");
-                            const html = document.createElement("html");
-                            html.innerHTML = response.body;
-                            const form = html.getElementsByTagName("form")[0];
-                            const url = form.action;
-                            return cy.request({
-                                method: "POST",
-                                url,
-                                followRedirect: false,
-                                form: true,
-                                body: {
-                                    username: username,
-                                    password: password,
-                                },
-                            });
+                            scope: config.openIdConnect.scope,
+                            extraTokenParams: {},
+                        };
+                        cy.log("Creating OIDC StateStore in Local storage");
+                        window.sessionStorage.setItem(
+                            `oidc.${stateStore.id}`,
+                            JSON.stringify(stateStore)
+                        );
+
+                        const escapedRedirectPath = encodeURI(path);
+                        const redirectUri = `${loginCallback}?redirect=${escapedRedirectPath}`;
+
+                        cy.log("Requesting Keycloak Authentication form");
+                        cy.request({
+                            url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
+                            followRedirect: false,
+                            qs: {
+                                scope: config.openIdConnect.scope,
+                                response_type:
+                                    config.openIdConnect.responseType,
+                                approval_prompt: "auto",
+                                redirect_uri: redirectUri,
+                                client_id: config.openIdConnect.clientId,
+                                response_mode: "query",
+                                state: stateStore.id,
+                            },
                         })
-                        .then((response) => {
-                            let callBackQS = response.headers["location"];
-                            const callbackURL = `${callBackQS}`;
-                            cy.log(`Visiting Callback ${callBackQS}`, response);
-                            cy.visit(callbackURL, { timeout: 60000 });
-                            // store auth cookies
-                            cy.getCookies({ timeout: 60000 }).then(
-                                (cookies) => {
-                                    globalStorage.authCookies = cookies;
-                                }
-                            );
-                        });
+                            .then((response) => {
+                                cy.log("Posting credentials");
+                                const html = document.createElement("html");
+                                html.innerHTML = response.body;
+                                const form =
+                                    html.getElementsByTagName("form")[0];
+                                const url = form.action;
+                                return cy.request({
+                                    method: "POST",
+                                    url,
+                                    followRedirect: false,
+                                    form: true,
+                                    body: {
+                                        username: username,
+                                        password: password,
+                                    },
+                                });
+                            })
+                            .then((response) => {
+                                let callBackQS = response.headers["location"];
+                                const callbackURL = `${callBackQS}`;
+                                cy.log(
+                                    `Visiting Callback ${callBackQS}`,
+                                    response
+                                );
+                                cy.visit(callbackURL, { timeout: 60000 });
+                                // store auth cookies
+                                cy.getCookies({ timeout: 60000 }).then(
+                                    (cookies) => {
+                                        globalStorage.authCookies = cookies;
+                                    }
+                                );
+                            });
+                    });
                 });
+
+                // Setup standard aliases for busy endpoint calls
+                setupStandardAliases();
+
+                cy.log(`Visit path: ${path}`);
+                cy.visit(path, { timeout: 60000 });
+
+                // Make sure to wait on busy endpoint calls
+                waitForInitialDataLoad(username, configSettings, path);
             });
-            cy.log(`Visit path: ${path}`);
-            setupWaitStandardIntercepts();
-            cy.visit(path, { timeout: 60000 });
-            waitStandardIntercepts();
         } else if (authMethod == AuthMethod.BCSC) {
             cy.log(
                 `Authenticating as BC Services Card user ${username} using the UI`
@@ -397,6 +412,14 @@ Cypress.Commands.add("configureSettings", (settings) => {
             cy.intercept("GET", "**/configuration", {
                 statusCode: 200,
                 body: config,
+            });
+
+            // Set copy of confg in session to be accessed by login for handling wait on busy endpoint calls
+            cy.window().then((window) => {
+                window.sessionStorage.setItem(
+                    "configSettingsKey",
+                    JSON.stringify(config)
+                );
             });
         });
 });

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -428,7 +428,7 @@ Cypress.Commands.add("configureSettings", (settings) => {
                 body: config,
             });
 
-            // Set copy of confg in session to be accessed by login for handling wait on busy endpoint calls
+            // Set copy of config in session to be accessed by login for handling wait on busy endpoint calls
             cy.window().then((window) => {
                 window.sessionStorage.setItem(
                     "configSettingsKey",

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -346,7 +346,7 @@ function waitForOrganDonorRegistratonStatusService(
         !organDonorRegistrationBlocked &&
         path === "/services"
     ) {
-        cy.log("Wait on patient data for ogran donor registration.");
+        cy.log("Wait on patient data for organ donor registration.");
         cy.wait("@getOrganDonorRegistrationStatus", {
             timeout: defaultTimeout,
         });

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -217,10 +217,7 @@ function waitForNotification(featureToggle) {
         `waitForNotification called - enabled: ${featureToggle.notificationCentre.enabled}`
     );
 
-    if (
-        featureToggle.notificationCentre &&
-        featureToggle.notificationCentre.enabled
-    ) {
+    if (featureToggle.notificationCentre.enabled) {
         cy.log("Wait on notification.");
         cy.wait("@getNotification", { timeout: defaultTimeout });
     }
@@ -245,9 +242,10 @@ function waitForClinicalDocument(featureToggle, path, blockedDataSources) {
     );
 
     if (
-        (clinicalDocumentEnabled || dependentClinicalDocumentEnabled) &&
-        !clinicalDocumentBlocked &&
-        isTimelineOrDependentsTimeline(path)
+        (!clinicalDocumentBlocked &&
+            clinicalDocumentEnabled &&
+            isTimeline(path)) ||
+        (isDependentsTimeline(path) && dependentClinicalDocumentEnabled)
     ) {
         cy.log("Wait on clinical document.");
         cy.wait("@getClinicalDocument", { timeout: defaultTimeout });
@@ -277,9 +275,10 @@ function waitForPatientDataForBcCancerScreening(
     );
 
     if (
-        (bcCancerScreeningEnabled || dependentBcCancerScreeningEnabled) &&
-        !bcCancerScreeningBlocked &&
-        isTimelineOrDependentsTimeline(path)
+        (!bcCancerScreeningBlocked &&
+            bcCancerScreeningEnabled &&
+            isTimeline(path)) ||
+        (isDependentsTimeline(path) && dependentBcCancerScreeningEnabled)
     ) {
         cy.log("Wait on patient data for bc cancer screening.");
         cy.wait("@getPatientDataForBcCancerScreening", {
@@ -311,9 +310,10 @@ function waitForPatientDataForDiagnosticImaging(
     );
 
     if (
-        (diagnosticImagingEnabled || dependentDiagnosticImagingEnabled) &&
-        !diagnosticImagingBlocked &&
-        isTimelineOrDependentsTimeline(path)
+        (!diagnosticImagingBlocked &&
+            diagnosticImagingEnabled &&
+            isTimeline(path)) ||
+        (isDependentsTimeline(path) && dependentDiagnosticImagingEnabled)
     ) {
         cy.log("Wait on patient data for diagnostic imaging.");
         cy.wait("@getPatientDataForDiagnosticImaging", {
@@ -355,7 +355,6 @@ function waitForOrganDonorRegistratonStatusService(
 
 function checkBcCancerScreeningBlocked(blockedDataSources) {
     return (
-        blockedDataSources &&
         Array.isArray(blockedDataSources) &&
         blockedDataSources.includes("BcCancerScreening")
     );
@@ -363,7 +362,6 @@ function checkBcCancerScreeningBlocked(blockedDataSources) {
 
 function checkClinicalDocumentBlocked(blockedDataSources) {
     return (
-        blockedDataSources &&
         Array.isArray(blockedDataSources) &&
         blockedDataSources.includes("ClinicalDocument")
     );
@@ -371,7 +369,6 @@ function checkClinicalDocumentBlocked(blockedDataSources) {
 
 function checkDiagnosticImagingBlocked(blockedDataSources) {
     return (
-        blockedDataSources &&
         Array.isArray(blockedDataSources) &&
         blockedDataSources.includes("DiagnosticImaging")
     );
@@ -379,23 +376,15 @@ function checkDiagnosticImagingBlocked(blockedDataSources) {
 
 function checkOrganDonorRegistrationBlocked(blockedDataSources) {
     return (
-        blockedDataSources &&
         Array.isArray(blockedDataSources) &&
         blockedDataSources.includes("OrganDonorRegistration")
     );
 }
 
-function checkHealthConnectRegistryBlocked(blockedDataSources) {
-    return (
-        blockedDataSources &&
-        Array.isArray(blockedDataSources) &&
-        blockedDataSources.includes("HelathConnectRegistry")
-    );
+function isDependentsTimeline(path) {
+    return path.startsWith("/dependents/") && path.endsWith("/timeline");
 }
 
-function isTimelineOrDependentsTimeline(path) {
-    return (
-        path === "/timeline" ||
-        (path.startsWith("/dependents/") && path.endsWith("/timeline"))
-    );
+function isTimeline(path) {
+    return path === "/timeline";
 }

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -26,6 +26,7 @@ Usage: setupStandardIntercepts({ <IDENTIFIER>: <Identifier>, <SERVICE>Fixture: <
 ----------------------------------------------------------------------------------------------------
 */
 export function setupStandardIntercepts(options = {}) {
+    cy.log("Setting up standard intercepts.");
     const {
         patientHdid = defaultHdid,
         userProfileHdid = defaultHdid,
@@ -51,6 +52,36 @@ export function setupStandardIntercepts(options = {}) {
         communicationType: CommunicationType.InApp,
         communicationFixture: CommunicationFixture.InApp,
     });
+}
+
+export function setupWaitStandardIntercepts() {
+    cy.log("Setting up wait standard intercepts.");
+    cy.intercept("GET", "**/Patient/*").as("getPatient");
+    cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
+    cy.intercept("GET", "**/Communication/*").as("getCommunication");
+    cy.intercept("GET", "**/ClinicalDocument/*").as("getClinicalDocument");
+    cy.intercept("GET", "**/PatientData/*").as("getPatientData");
+}
+
+export function waitStandardIntercepts() {
+    cy.log("Waiting on standard intercepts.");
+
+    const waitForIntercept = (alias, timeout) => {
+        return cy.intercept(`@${alias}`, { timeout }).then((interception) => {
+            if (interception) {
+                cy.wait(`@${alias}`);
+            } else {
+                cy.log(`Intercept "${alias}" not found.`);
+            }
+        });
+    };
+
+    // Wait for each intercept with a reasonable timeout
+    waitForIntercept("getPatient", 5000);
+    waitForIntercept("getUserProfile", 5000);
+    waitForIntercept("getCommunication", 5000);
+    waitForIntercept("getClinicalDocument", 5000);
+    waitForIntercept("getPatientData", 5000);
 }
 
 /*

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -3,7 +3,7 @@ const defaultNotificationFixture = "NotificationService/notifications.json";
 const defaultPatientFixture = "PatientService/patientCombinedAddress.json";
 const defaultUserProfileFixture = "UserProfileService/userProfile.json";
 const defaultUserProfileStatusCode = 200;
-const defaultTimeout = 45000;
+const defaultTimeout = 60000;
 
 export const CommunicationType = {
     Banner: 0,
@@ -61,6 +61,65 @@ export function setupStandardFixtures(options = {}) {
     setupNotificationFixture({
         hdid: notificationHdid,
         notificationFixture: notificationFixture,
+    });
+}
+
+/*
+----------------------------------------------------------------------------------------------------
+Usage for setup<SERVICE>Fixture(options = {})
+
+Usage: setup<SERVICE>Fixture();
+Usage: setup<SERVICE>Fixture({ <Identifier> });
+Usage: setup<SERVICE>Fixture({ <SERVICE>Fixture: <ServiceFixture> });
+Usage: setup<SERVICE>Fixture({ <IDENTIFIER>: <Identifier>, <SERVICE>Fixture: <ServiceFixture> });
+----------------------------------------------------------------------------------------------------
+*/
+export function setupCommunicationFixture(options = {}) {
+    const {
+        communicationType = CommunicationType.Banner,
+        communicationFixture = CommunicationFixture.Banner,
+    } = options;
+
+    cy.intercept("GET", `**/Communication/${communicationType}`, {
+        fixture: communicationFixture,
+    });
+}
+
+export function setupPatientFixture(options = {}) {
+    const { hdid = defaultHdid, patientFixture = defaultPatientFixture } =
+        options;
+
+    cy.intercept("GET", `**/Patient/${hdid}*`, {
+        fixture: patientFixture,
+    });
+}
+
+export function setupUserProfileFixture(options = {}) {
+    const {
+        hdid = defaultHdid,
+        userProfileFixture = defaultUserProfileFixture,
+        statusCode = defaultUserProfileStatusCode,
+    } = options;
+
+    if (statusCode === 200) {
+        cy.intercept("GET", `**/UserProfile/${hdid}`, {
+            fixture: userProfileFixture,
+        });
+    } else {
+        cy.intercept("GET", `**/UserProfile/${hdid}`, {
+            statusCode,
+        });
+    }
+}
+
+export function setupNotificationFixture(options = {}) {
+    const {
+        hdid = defaultHdid,
+        notificationFixture = defaultNotificationFixture,
+    } = options;
+
+    cy.intercept("GET", `**/Notification/${hdid}`, {
+        fixture: notificationFixture,
     });
 }
 
@@ -339,63 +398,4 @@ function isTimelineOrDependentsTimeline(path) {
         path === "/timeline" ||
         (path.startsWith("/dependents/") && path.endsWith("/timeline"))
     );
-}
-
-/*
-----------------------------------------------------------------------------------------------------
-Usage for setup<SERVICE>Intercept(options = {})
-
-Usage: setup<SERVICE>Intercept();
-Usage: setup<SERVICE>Intercept({ <Identifier> });
-Usage: setup<SERVICE>Intercept({ <SERVICE>Fixture: <ServiceFixture> });
-Usage: setup<SERVICE>Intercept({ <IDENTIFIER>: <Identifier>, <SERVICE>Fixture: <ServiceFixture> });
-----------------------------------------------------------------------------------------------------
-*/
-export function setupCommunicationFixture(options = {}) {
-    const {
-        communicationType = CommunicationType.Banner,
-        communicationFixture = CommunicationFixture.Banner,
-    } = options;
-
-    cy.intercept("GET", `**/Communication/${communicationType}`, {
-        fixture: communicationFixture,
-    });
-}
-
-export function setupPatientFixture(options = {}) {
-    const { hdid = defaultHdid, patientFixture = defaultPatientFixture } =
-        options;
-
-    cy.intercept("GET", `**/Patient/${hdid}*`, {
-        fixture: patientFixture,
-    });
-}
-
-export function setupUserProfileFixture(options = {}) {
-    const {
-        hdid = defaultHdid,
-        userProfileFixture = defaultUserProfileFixture,
-        statusCode = defaultUserProfileStatusCode,
-    } = options;
-
-    if (statusCode === 200) {
-        cy.intercept("GET", `**/UserProfile/${hdid}`, {
-            fixture: userProfileFixture,
-        });
-    } else {
-        cy.intercept("GET", `**/UserProfile/${hdid}`, {
-            statusCode,
-        });
-    }
-}
-
-export function setupNotificationFixture(options = {}) {
-    const {
-        hdid = defaultHdid,
-        notificationFixture = defaultNotificationFixture,
-    } = options;
-
-    cy.intercept("GET", `**/Notification/${hdid}`, {
-        fixture: notificationFixture,
-    });
 }

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -1,7 +1,9 @@
 const defaultHdid = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
+const defaultNotificationFixture = "NotificationService/notifications.json";
 const defaultPatientFixture = "PatientService/patientCombinedAddress.json";
 const defaultUserProfileFixture = "UserProfileService/userProfile.json";
 const defaultUserProfileStatusCode = 200;
+const defaultTimeout = 45000;
 
 export const CommunicationType = {
     Banner: 0,
@@ -15,73 +17,317 @@ export const CommunicationFixture = {
 
 /*
 ----------------------------------------------------------------------------------------------------
-Usage for setupStandardIntercepts(options = {})
+Usage for setupStandardFixtures(options = {})
 
-Usage: setupStandardIntercepts();
-Usage: setupStandardIntercepts({ <PatientHdid> });
-Usage: setupStandardIntercepts({ userProfileHdid: <UserProfileHdid> });
-Usage: setupStandardIntercepts({ userProfileStatusCode: <UserProfileStatusCode> });
-Usage: setupStandardIntercepts({ <SERVICE>Fixture: <ServiceFixture> });
-Usage: setupStandardIntercepts({ <IDENTIFIER>: <Identifier>, <SERVICE>Fixture: <ServiceFixture> });
+Usage: setupStandardFixtures();
+Usage: setupStandardFixtures({ <PatientHdid> });
+Usage: setupStandardFixtures({ userProfileHdid: <UserProfileHdid> });
+Usage: setupStandardFixtures({ userProfileStatusCode: <UserProfileStatusCode> });
+Usage: setupStandardFixtures({ <SERVICE>Fixture: <ServiceFixture> });
+Usage: setupStandardFixtures({ <IDENTIFIER>: <Identifier>, <SERVICE>Fixture: <ServiceFixture> });
 ----------------------------------------------------------------------------------------------------
 */
-export function setupStandardIntercepts(options = {}) {
+export function setupStandardFixtures(options = {}) {
     cy.log("Setting up standard intercepts.");
+
     const {
         patientHdid = defaultHdid,
         userProfileHdid = defaultHdid,
+        notificationHdid = defaultHdid,
+        notificationFixture = defaultNotificationFixture,
         patientFixture = defaultPatientFixture,
         userProfileFixture = defaultUserProfileFixture,
         userProfileStatusCode = defaultUserProfileStatusCode,
     } = options;
 
-    setupPatientIntercept({
+    setupPatientFixture({
         hdid: patientHdid,
         patientFixture: patientFixture,
     });
 
-    setupUserProfileIntercept({
+    setupUserProfileFixture({
         hdid: userProfileHdid,
         userProfileFixture: userProfileFixture,
         statusCode: userProfileStatusCode,
     });
 
-    setupCommunicationIntercept();
+    setupCommunicationFixture();
 
-    setupCommunicationIntercept({
+    setupCommunicationFixture({
         communicationType: CommunicationType.InApp,
         communicationFixture: CommunicationFixture.InApp,
     });
+
+    setupNotificationFixture({
+        hdid: notificationHdid,
+        notificationFixture: notificationFixture,
+    });
 }
 
-export function setupWaitStandardIntercepts() {
-    cy.log("Setting up wait standard intercepts.");
-    cy.intercept("GET", "**/Patient/*").as("getPatient");
-    cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
-    cy.intercept("GET", "**/Communication/*").as("getCommunication");
+export function setupStandardAliases() {
+    cy.log("Setting up standard aliases.");
+
     cy.intercept("GET", "**/ClinicalDocument/*").as("getClinicalDocument");
+    cy.intercept("GET", `**/Communication/*`).as("getCommunication");
+    cy.intercept("GET", "**/Notification/*").as("getNotification");
+    cy.intercept("GET", "**/Patient/*").as("getPatient");
     cy.intercept("GET", "**/PatientData/*").as("getPatientData");
+    cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
 }
 
-export function waitStandardIntercepts() {
-    cy.log("Waiting on standard intercepts.");
+export function waitForInitialDataLoad(username, config, path) {
+    const configSettings = JSON.parse(config);
+    const featureToggle = configSettings?.webClient?.featureToggleConfiguration;
 
-    const waitForIntercept = (alias, timeout) => {
-        return cy.intercept(`@${alias}`, { timeout }).then((interception) => {
-            if (interception) {
-                cy.wait(`@${alias}`);
-            } else {
-                cy.log(`Intercept "${alias}" not found.`);
-            }
-        });
-    };
+    cy.log(`Username: ${username}`);
+    cy.log(`Feature Toggle: ${JSON.stringify(featureToggle)}`);
+    cy.log(`Path: ${path}`);
 
-    // Wait for each intercept with a reasonable timeout
-    waitForIntercept("getPatient", 5000);
-    waitForIntercept("getUserProfile", 5000);
-    waitForIntercept("getCommunication", 5000);
-    waitForIntercept("getClinicalDocument", 5000);
-    waitForIntercept("getPatientData", 5000);
+    cy.log("Wait on patient.");
+    cy.wait("@getPatient", { timeout: defaultTimeout });
+
+    waitForUserProfile(username).then((blockedDataSources) => {
+        waitForServices(featureToggle, path, blockedDataSources);
+        waitForClinicalDocument(featureToggle, path, blockedDataSources);
+        waitForPatientData(featureToggle, path, blockedDataSources);
+    });
+
+    cy.log("Wait on communication.");
+    cy.wait("@getCommunication", { timeout: defaultTimeout });
+
+    waitForNotification(featureToggle);
+}
+
+function waitForUserProfile(username) {
+    return new Cypress.Promise((resolve) => {
+        let blockedDataSources;
+
+        if (
+            username !== Cypress.env("keycloak.deceased.username") &&
+            username !== Cypress.env("keycloak.accountclosure.username")
+        ) {
+            cy.log("Wait on user profile.");
+            cy.wait("@getUserProfile", { timeout: defaultTimeout }).then(
+                (interception) => {
+                    const responseBody = interception.response.body;
+                    blockedDataSources =
+                        responseBody.resourcePayload?.blockedDataSources;
+
+                    cy.log(
+                        `Get User Profile Blocked Data Sources: ${
+                            blockedDataSources
+                                ? JSON.stringify(blockedDataSources)
+                                : "Blocked data sources are not available"
+                        }`
+                    );
+
+                    resolve(blockedDataSources);
+                }
+            );
+        } else {
+            resolve(blockedDataSources);
+        }
+    });
+}
+
+function waitForNotification(featureToggle) {
+    if (
+        featureToggle === undefined ||
+        (featureToggle?.notificationCentre &&
+            featureToggle?.notificationCentre.enabled)
+    ) {
+        cy.log("Wait on notification.");
+        cy.wait("@getNotification", { timeout: defaultTimeout });
+    }
+}
+
+function waitForClinicalDocument(featureToggle, path, blockedDataSources) {
+    cy.log("waitForClinicalDocument called");
+
+    const clinicalDocumentBlocked =
+        checkClinicalDocumentBlocked(blockedDataSources);
+
+    if (featureToggle === undefined) {
+        if (!clinicalDocumentBlocked && isTimelineOrDependentsTimeline(path)) {
+            cy.log("Wait on clinical document.");
+            cy.wait("@getClinicalDocument", { timeout: defaultTimeout });
+        }
+    } else {
+        const clinicalDocumentEnabled = featureToggle?.datasets.some(
+            (x) => x.enabled && x.name === "clinicalDocument"
+        );
+
+        const dependentClinicalDocumentEnabled =
+            featureToggle?.dependents.enabled &&
+            featureToggle?.dependents.datasets.some(
+                (x) => x.enabled && x.name === "clinicalDocument"
+            );
+
+        if (
+            (clinicalDocumentEnabled || dependentClinicalDocumentEnabled) &&
+            !clinicalDocumentBlocked &&
+            isTimelineOrDependentsTimeline(path)
+        ) {
+            cy.log("Wait on clinical document.");
+            cy.wait("@getClinicalDocument", { timeout: defaultTimeout });
+        }
+    }
+}
+
+function waitForPatientData(featureToggle, path, blockedDataSources) {
+    cy.log("waitForPatientData called");
+
+    const bcCancerScreeningBlocked =
+        checkBcCancerScreeningBlocked(blockedDataSources);
+    const diagnosticImagingBlocked =
+        checkDiagnosticImagingBlocked(blockedDataSources);
+
+    if (featureToggle === undefined) {
+        if (
+            !bcCancerScreeningBlocked &&
+            !diagnosticImagingBlocked &&
+            isTimelineOrDependentsTimeline(path)
+        ) {
+            cy.log("Wait on patient data.");
+            cy.wait("@getPatientData", { timeout: defaultTimeout });
+        }
+    } else {
+        const bcCancerScreeningEnabled = featureToggle?.datasets.some(
+            (x) => x.enabled && x.name === "bcCancerScreening"
+        );
+
+        const diagnosticImagingEnabled = featureToggle?.datasets.some(
+            (x) => x.enabled && x.name === "diagnosticImaging"
+        );
+
+        const dependentBcCancerScreeningEnabled =
+            featureToggle?.dependents.enabled &&
+            featureToggle?.dependents.datasets.some(
+                (x) => x.enabled && x.name === "bcCancerScreening"
+            );
+
+        const dependentDiagnosticImagingEnabled =
+            featureToggle?.dependents.enabled &&
+            featureToggle?.dependents.datasets.some(
+                (x) => x.enabled && x.name === "diagnosticImaging"
+            );
+
+        const dependentBcCancerScreeningNotDefined =
+            featureToggle?.dependents.enabled &&
+            !featureToggle?.dependents.datasets.some(
+                (x) => x.name === "bcCancerScreening" && x.enabled
+            );
+
+        const dependentDiagnosticImagingNotDefined =
+            featureToggle?.dependents.enabled &&
+            !featureToggle?.dependents.datasets.some(
+                (x) => x.name === "diagnosticImaging" && x.enabled
+            );
+
+        if (
+            (((bcCancerScreeningEnabled || dependentBcCancerScreeningEnabled) &&
+                !bcCancerScreeningBlocked) ||
+                ((diagnosticImagingEnabled ||
+                    dependentDiagnosticImagingEnabled) &&
+                    !diagnosticImagingBlocked)) &&
+            isTimelineOrDependentsTimeline(path)
+        ) {
+            cy.log("Wait on patient data.");
+            cy.wait("@getPatientData", { timeout: defaultTimeout });
+        }
+    }
+}
+
+function waitForServices(featureToggle, path, blockedDataSources) {
+    cy.log("waitForServices called");
+
+    const organDonorRegistrationBlocked =
+        checkOrganDonorRegistrationBlocked(blockedDataSources);
+    const healthConnectRegisgtryBlocked =
+        checkHealthConnectRegistryBlocked(blockedDataSources);
+
+    const organDonorRegistrationEnabled =
+        featureToggle?.services &&
+        featureToggle?.services.enabled &&
+        featureToggle?.datasets.some(
+            (x) => x.enabled && x.name === "organDonorRegistration"
+        );
+
+    const healthConnectRegisgtryEnabled =
+        featureToggle?.services &&
+        featureToggle?.services.enabled &&
+        featureToggle?.datasets.some(
+            (x) => x.enabled && x.name === "healthConnectRegistry"
+        );
+
+    if (featureToggle === undefined) {
+        if (
+            !organDonorRegistrationBlocked &&
+            !healthConnectRegisgtryBlocked &&
+            path === "/services"
+        ) {
+            cy.log("Wait on patient data.");
+            cy.wait("@getPatientData", { timeout: defaultTimeout });
+        }
+    } else {
+        if (
+            (organDonorRegistrationBlocked && !organDonorRegistrationBlocked) ||
+            (healthConnectRegisgtryEnabled &&
+                !healthConnectRegisgtryBlocked &&
+                path === "/services")
+        ) {
+            cy.log("Wait on patient data.");
+            cy.wait("@getPatientData", { timeout: defaultTimeout });
+        }
+    }
+}
+
+function checkBcCancerScreeningBlocked(blockedDataSources) {
+    return (
+        blockedDataSources &&
+        Array.isArray(blockedDataSources) &&
+        blockedDataSources.includes("BcCancerScreening")
+    );
+}
+
+function checkClinicalDocumentBlocked(blockedDataSources) {
+    cy.log("Check clinical doc: " + JSON.stringify(blockedDataSources));
+    return (
+        blockedDataSources &&
+        Array.isArray(blockedDataSources) &&
+        blockedDataSources.includes("ClinicalDocument")
+    );
+}
+
+function checkDiagnosticImagingBlocked(blockedDataSources) {
+    return (
+        blockedDataSources &&
+        Array.isArray(blockedDataSources) &&
+        blockedDataSources.includes("DiagnosticImaging")
+    );
+}
+
+function checkOrganDonorRegistrationBlocked(blockedDataSources) {
+    return (
+        blockedDataSources &&
+        Array.isArray(blockedDataSources) &&
+        blockedDataSources.includes("OrganDonorRegistration")
+    );
+}
+
+function checkHealthConnectRegistryBlocked(blockedDataSources) {
+    return (
+        blockedDataSources &&
+        Array.isArray(blockedDataSources) &&
+        blockedDataSources.includes("HelathConnectRegistry")
+    );
+}
+
+function isTimelineOrDependentsTimeline(path) {
+    return (
+        path === "/timeline" ||
+        (path.startsWith("/dependents/") && path.endsWith("/timeline"))
+    );
 }
 
 /*
@@ -94,7 +340,7 @@ Usage: setup<SERVICE>Intercept({ <SERVICE>Fixture: <ServiceFixture> });
 Usage: setup<SERVICE>Intercept({ <IDENTIFIER>: <Identifier>, <SERVICE>Fixture: <ServiceFixture> });
 ----------------------------------------------------------------------------------------------------
 */
-export function setupCommunicationIntercept(options = {}) {
+export function setupCommunicationFixture(options = {}) {
     const {
         communicationType = CommunicationType.Banner,
         communicationFixture = CommunicationFixture.Banner,
@@ -105,15 +351,16 @@ export function setupCommunicationIntercept(options = {}) {
     });
 }
 
-export function setupPatientIntercept(options = {}) {
+export function setupPatientFixture(options = {}) {
     const { hdid = defaultHdid, patientFixture = defaultPatientFixture } =
         options;
+
     cy.intercept("GET", `**/Patient/${hdid}*`, {
         fixture: patientFixture,
     });
 }
 
-export function setupUserProfileIntercept(options = {}) {
+export function setupUserProfileFixture(options = {}) {
     const {
         hdid = defaultHdid,
         userProfileFixture = defaultUserProfileFixture,
@@ -129,4 +376,15 @@ export function setupUserProfileIntercept(options = {}) {
             statusCode,
         });
     }
+}
+
+export function setupNotificationFixture(options = {}) {
+    const {
+        hdid = defaultHdid,
+        notificationFixture = defaultNotificationFixture,
+    } = options;
+
+    cy.intercept("GET", `**/Notification/${hdid}`, {
+        fixture: notificationFixture,
+    });
 }

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -231,21 +231,20 @@ function waitForClinicalDocument(featureToggle, path, blockedDataSources) {
         (x) => x.enabled && x.name === "clinicalDocument"
     );
 
-    const dependentClinicalDocumentEnabled =
-        featureToggle.dependents.enabled &&
+    const dependentClinicalDocumentDisabled =
         featureToggle.dependents.datasets.some(
-            (x) => x.enabled && x.name === "clinicalDocument"
+            (x) => !x.enabled && x.name === "clinicalDocument"
         );
 
     cy.log(
-        `waitForClinicalDocument called - enabled: ${clinicalDocumentEnabled} - dependent enabled: ${dependentClinicalDocumentEnabled} - blocked: ${clinicalDocumentBlocked}`
+        `waitForClinicalDocument called - enabled: ${clinicalDocumentEnabled} - dependent disabled: ${dependentClinicalDocumentDisabled} - blocked: ${clinicalDocumentBlocked}`
     );
 
     if (
-        (!clinicalDocumentBlocked &&
-            clinicalDocumentEnabled &&
-            isTimeline(path)) ||
-        (isDependentsTimeline(path) && dependentClinicalDocumentEnabled)
+        !clinicalDocumentBlocked &&
+        clinicalDocumentEnabled &&
+        (isTimeline(path) ||
+            (isDependentsTimeline(path) && !dependentClinicalDocumentDisabled))
     ) {
         cy.log("Wait on clinical document.");
         cy.wait("@getClinicalDocument", { timeout: defaultTimeout });
@@ -264,21 +263,20 @@ function waitForPatientDataForBcCancerScreening(
         (x) => x.enabled && x.name === "bcCancerScreening"
     );
 
-    const dependentBcCancerScreeningEnabled =
-        featureToggle.dependents.enabled &&
+    const dependentBcCancerScreeningDisabled =
         featureToggle.dependents.datasets.some(
-            (x) => x.enabled && x.name === "bcCancerScreening"
+            (x) => !x.enabled && x.name === "bcCancerScreening"
         );
 
     cy.log(
-        `waitForPatientDataForBcCancerScreening called - enabled: ${bcCancerScreeningEnabled} - dependent enabled: ${dependentBcCancerScreeningEnabled} - blocked: ${bcCancerScreeningBlocked}`
+        `waitForPatientDataForBcCancerScreening called - enabled: ${bcCancerScreeningEnabled} - dependent disabled: ${dependentBcCancerScreeningDisabled} - blocked: ${bcCancerScreeningBlocked}`
     );
 
     if (
-        (!bcCancerScreeningBlocked &&
-            bcCancerScreeningEnabled &&
-            isTimeline(path)) ||
-        (isDependentsTimeline(path) && dependentBcCancerScreeningEnabled)
+        !bcCancerScreeningBlocked &&
+        bcCancerScreeningEnabled &&
+        (isTimeline(path) ||
+            (isDependentsTimeline(path) && !dependentBcCancerScreeningDisabled))
     ) {
         cy.log("Wait on patient data for bc cancer screening.");
         cy.wait("@getPatientDataForBcCancerScreening", {
@@ -299,21 +297,20 @@ function waitForPatientDataForDiagnosticImaging(
         (x) => x.enabled && x.name === "diagnosticImaging"
     );
 
-    const dependentDiagnosticImagingEnabled =
-        featureToggle.dependents.enabled &&
+    const dependentDiagnosticImagingDisabled =
         featureToggle.dependents.datasets.some(
-            (x) => x.enabled && x.name === "diagnosticImaging"
+            (x) => !x.enabled && x.name === "diagnosticImaging"
         );
 
     cy.log(
-        `waitForPatientDataForDiagnosticImaging called - enabled: ${diagnosticImagingEnabled} - dependent enabled: ${dependentDiagnosticImagingEnabled} - blocked: ${diagnosticImagingBlocked}`
+        `waitForPatientDataForDiagnosticImaging called - enabled: ${diagnosticImagingEnabled} - dependent disabled: ${dependentDiagnosticImagingDisabled} - blocked: ${diagnosticImagingBlocked}`
     );
 
     if (
-        (!diagnosticImagingBlocked &&
-            diagnosticImagingEnabled &&
-            isTimeline(path)) ||
-        (isDependentsTimeline(path) && dependentDiagnosticImagingEnabled)
+        !diagnosticImagingBlocked &&
+        diagnosticImagingEnabled &&
+        (isTimeline(path) ||
+            (isDependentsTimeline(path) && !dependentDiagnosticImagingDisabled))
     ) {
         cy.log("Wait on patient data for diagnostic imaging.");
         cy.wait("@getPatientDataForDiagnosticImaging", {


### PR DESCRIPTION
# Fixes [AB#16731](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16731)

## Description

For e2e functional tests ensure there is a wait on standard intercepts.

- In intercepts.js renames *.Intercept functions to *.Fixture
- Edited 'configureSettnigs' in command.js to set copy of config into windows session
- Edited 'login' in commands.js to get config from windows session and to use that when calling waitForInitialDataLoad in intercept.js
- waitForIInitalDataLoad will apply a cy.wait on aliases defined for intercepts UserProfile, Patient, PatientData, ClinicalDocument, Notification.and Communication.  Note: the wait is only applied if the feature has been enabled and if the datasource has not been blocked (this is for datasets)

**Recent [AB#16731](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16731) runs:**

[Green](https://cloud.cypress.io/projects/ofnepc/runs/4186/overview?roarHideRunsWithDiffGroupsAndTags=1)
[Green](https://cloud.cypress.io/projects/ofnepc/runs/4180/overview?roarHideRunsWithDiffGroupsAndTags=1)
[Green](https://cloud.cypress.io/projects/ofnepc/runs/4178/overview/ab061f77-40c6-4669-93f8-aa9e08d3660b?roarHideRunsWithDiffGroupsAndTags=1)
[Green](https://cloud.cypress.io/projects/ofnepc/runs/4174/overview?roarHideRunsWithDiffGroupsAndTags=1)
[Green](https://cloud.cypress.io/projects/ofnepc/runs/4172/overview/71d30fa2-d312-4459-afa1-94bab38e080c?roarHideRunsWithDiffGroupsAndTags=1)
[Green](https://cloud.cypress.io/projects/ofnepc/runs/4168/overview?roarHideRunsWithDiffGroupsAndTags=1)
[Timeout on PHSA Organ Donor otherwise green](https://cloud.cypress.io/projects/ofnepc/runs/4166/overview?roarHideRunsWithDiffGroupsAndTags=1 )
[All Green](https://cloud.cypress.io/projects/ofnepc/runs/4164/overview?roarHideRunsWithDiffGroupsAndTags=1)
[All Green](https://cloud.cypress.io/projects/ofnepc/runs/4160/overview?roarHideRunsWithDiffGroupsAndTags=1)
[Timeout on PHSA Patient Data otherwise green](https://cloud.cypress.io/projects/ofnepc/runs/4158/overview?roarHideRunsWithDiffGroupsAndTags=1)

**Dev Run for comparison:**

[Green](https://cloud.cypress.io/projects/ofnepc/runs/4182/overview/83d6a8e5-8952-4767-9bfe-6cfc0a6d835f?roarHideRunsWithDiffGroupsAndTags=1)
[1 Failure](https://cloud.cypress.io/projects/ofnepc/runs/4170/overview?roarHideRunsWithDiffGroupsAndTags=1)
[Several Failures](https://cloud.cypress.io/projects/ofnepc/runs/4156/overview?roarHideRunsWithDiffGroupsAndTags=1)

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
