### PR TITLE
Fix ShouldDeepEqual implementation for AB#16742.

### DIFF
--- a/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
@@ -56,7 +56,7 @@ namespace AccountDataAccessTest
             // Verify
             IEnumerable<AgentAudit> collection = actual.ToList();
             Assert.Single(collection);
-            agentAudits.Single().ShouldDeepEqual(collection.Single());
+            collection.Single().ShouldDeepEqual(agentAudits.Single());
         }
 
         private static AuditRepository GetAuditRepository(IEnumerable<AgentAudit> agentAudits)

--- a/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
+++ b/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
@@ -175,8 +175,8 @@ namespace AccountDataAccessTest
             Assert.Equal(expectedLastName, actual.PreferredName.Surname);
             Assert.Equal(expectedBirthDate, actual.Birthdate);
             Assert.Equal(expectedGender, actual.Gender);
-            expectedPhysicalAddr.ShouldDeepEqual(actual.PhysicalAddress);
-            expectedPostalAddr.ShouldDeepEqual(actual.PostalAddress);
+            actual.PhysicalAddress.ShouldDeepEqual(expectedPhysicalAddr);
+            actual.PostalAddress.ShouldDeepEqual(expectedPostalAddr);
         }
 
         /// <summary>

--- a/Apps/AccountDataAccess/test/unit/PatientMappingsTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientMappingsTests.cs
@@ -150,7 +150,7 @@ namespace AccountDataAccessTest
             PatientModel actual = Mapper.Map<PatientModel>(patientIdentity);
 
             // Verify
-            expectedPatient.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expectedPatient);
         }
 
         /// <summary>
@@ -195,7 +195,7 @@ namespace AccountDataAccessTest
             PatientModel actual = Mapper.Map<PatientModel>(patientIdentity);
 
             // Verify
-            expectedPatient.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expectedPatient);
         }
     }
 }

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -72,7 +72,7 @@ namespace AccountDataAccessTest
             PatientQueryResult actual = await mock.PatientRepository.QueryAsync(mock.PatientDetailsQuery, CancellationToken.None);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual.Item);
+            actual.Item.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace AccountDataAccessTest
             BlockedAccess? actual = await mock.PatientRepository.GetBlockedAccessRecordsAsync(mock.Hdid);
 
             // Verify
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -204,7 +204,7 @@ namespace AccountDataAccessTest
             IEnumerable<DataSource> actual = await mock.PatientRepository.GetDataSourcesAsync(mock.Hdid);
 
             // Verify
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static bool AssertAgentAudit(AgentAudit expected, AgentAudit actual)

--- a/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
@@ -51,7 +51,7 @@ namespace AccountDataAccessTest.Strategy
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
 
             // Verify
             mock.CacheProvider.Verify(

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -62,7 +62,7 @@ namespace AccountDataAccessTest.Strategy
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
 
             // Verify
             mock.CacheProvider.Verify(
@@ -86,7 +86,7 @@ namespace AccountDataAccessTest.Strategy
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
@@ -51,7 +51,7 @@ namespace AccountDataAccessTest.Strategy
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
 
             // Verify
             mock.CacheProvider.Verify(

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -59,7 +59,7 @@ namespace AccountDataAccessTest.Strategy
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
 
             // Verify
             mock.CacheProvider.Verify(

--- a/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
@@ -53,7 +53,7 @@ namespace AccountDataAccessTest.Strategy
             PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
 
             // Verify
             mock.CacheProvider.Verify(

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -100,7 +100,7 @@ namespace HealthGateway.Admin.Tests.Services
             // Assert
             Assert.Single(actual);
             Assert.Equal(Hdid1, actual.First().Hdid);
-            mock.Expected.ShouldDeepEqual(actual.First().BlockedSources);
+            actual.First().BlockedSources.ShouldDeepEqual(mock.Expected);
         }
 
         private static IAdminReportService GetAdminReportService(

--- a/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
@@ -66,7 +66,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             // Assert
             Assert.Single(actual);
-            mock.Expected.ShouldDeepEqual(actual.First());
+            actual.First().ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace HealthGateway.Admin.Tests.Services
             AdminAgent actual = await mock.Service.ProvisionAgentAccessAsync(mock.AdminAgent);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
             mock.KeycloakAdminApiMock.Verify(
                 v => v.AddUserAsync(
                     It.Is<UserRepresentation>(x => x.Username == mock.Username),
@@ -167,7 +167,7 @@ namespace HealthGateway.Admin.Tests.Services
             AdminAgent actual = await mock.Service.UpdateAgentAccessAsync(mock.AdminAgent);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static AdminAgent GenerateAdminAgent(Guid id, string username, ISet<IdentityAccessRole> roles)

--- a/Apps/Admin/Tests/Services/CommunicationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CommunicationServiceTests.cs
@@ -108,7 +108,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<Communication> actual = await service.AddAsync(communication);
 
             // Assert
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<Communication> actual = await service.DeleteAsync(communication);
 
             // Assert
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -215,7 +215,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<IEnumerable<Communication>> actual = await service.GetAllAsync();
 
             // Assert
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -285,7 +285,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<Communication> actual = await service.UpdateAsync(communication);
 
             // Assert
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static ICommunicationService GetCommunicationService(Mock<ICommunicationDelegate> communicationDelegateMock)

--- a/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
@@ -325,7 +325,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             AdminUserProfileView actual = MappingService.MapToAdminUserProfileView(userRepresentation);
 
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Admin/Tests/Services/DashboardServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DashboardServiceTests.cs
@@ -50,7 +50,7 @@ namespace HealthGateway.Admin.Tests.Services
             AllTimeCounts actual = await mock.Service.GetAllTimeCountsAsync();
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace HealthGateway.Admin.Tests.Services
             DailyUsageCounts actual = await mock.Service.GetDailyUsageCountsAsync(mock.StartDate, mock.EndDate);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace HealthGateway.Admin.Tests.Services
             AppLoginCounts actual = await mock.Service.GetAppLoginCountsAsync(mock.StartDate, mock.EndDate);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace HealthGateway.Admin.Tests.Services
             IDictionary<string, int> actual = await mock.Service.GetRatingsSummaryAsync(mock.StartDate, mock.EndDate);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -135,7 +135,7 @@ namespace HealthGateway.Admin.Tests.Services
             IDictionary<int, int> actual = await mock.Service.GetAgeCountsAsync(mock.StartDate, mock.EndDate);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -94,7 +94,7 @@ namespace HealthGateway.Admin.Tests.Services
             DelegationInfo actualResult = await delegationService.GetDelegationInformationAsync(DependentPhn);
 
             Assert.NotNull(actualResult);
-            expectedDelegationInfo.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedDelegationInfo);
         }
 
         /// <summary>
@@ -123,7 +123,7 @@ namespace HealthGateway.Admin.Tests.Services
             DelegationInfo actualResult = await delegationService.GetDelegationInformationAsync(DependentPhn);
 
             Assert.NotNull(actualResult);
-            expectedDelegationInfo.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedDelegationInfo);
         }
 
         /// <summary>
@@ -469,7 +469,7 @@ namespace HealthGateway.Admin.Tests.Services
                 Protected = false,
             };
             DependentInfo actual = MappingService.MapToDependentInfo(patientModel);
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -502,7 +502,7 @@ namespace HealthGateway.Admin.Tests.Services
                 PhysicalAddress = patientModel.PhysicalAddress,
             };
             DelegateInfo actual = MappingService.MapToDelegateInfo(patientModel);
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static bool AssertProtectedDependant(Dependent expected, Dependent actual)

--- a/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
+++ b/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
@@ -81,7 +81,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<List<AdminUserProfileView>> actual = await mock.Service.GetInactiveUsersAsync(mock.InactiveDays);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static JwtModel GenerateJwt()

--- a/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
+++ b/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
@@ -85,7 +85,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<UserFeedbackView> actual = await mock.Service.AssociateFeedbackTagsAsync(userFeedbackId, adminTags.Select(x => x.AdminTagId).ToList());
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<AdminTagView> actual = await mock.Service.CreateTagAsync(mock.TagName);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<AdminTagView> actual = await mock.Service.CreateTagAsync(mock.TagName);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -136,7 +136,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<AdminTagView> actual = await mock.Service.DeleteTagAsync(new() { Id = mock.AdminTagId, Name = mock.TagName });
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<AdminTagView> actual = await mock.Service.DeleteTagAsync(new() { Id = mock.AdminTagId, Name = mock.TagName });
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -170,7 +170,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<IList<AdminTagView>> actual = await mock.Service.GetAllTagsAsync();
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<IList<UserFeedbackView>> actual = await mock.Service.GetUserFeedbackAsync();
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace HealthGateway.Admin.Tests.Services
             RequestResult<UserFeedbackView> actual = await mock.Service.UpdateFeedbackReviewAsync(mock.Update);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
 
             feedbackDelegateMock.Verify(
                 v => v.UpdateUserFeedbackAsync(

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -89,7 +89,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authentication
 
             JwtModel actualModel = await authDelegate.AuthenticateUserAsync(UserClientCredentialsRequest);
 
-            expected.ShouldDeepEqual(actualModel);
+            actualModel.ShouldDeepEqual(expected);
             mockCacheProvider.Verify(v => v.GetItemAsync<JwtModel>(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never());
             mockCacheProvider.Verify(v => v.AddItemAsync(It.IsAny<string>(), It.IsAny<JwtModel>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never());
         }
@@ -108,7 +108,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authentication
 
             JwtModel actualModel = await authDelegate.AuthenticateUserAsync(UserClientCredentialsRequest, true);
 
-            expected.ShouldDeepEqual(actualModel);
+            actualModel.ShouldDeepEqual(expected);
             mockCacheProvider.Verify(v => v.GetItemAsync<JwtModel>(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
             mockCacheProvider.Verify(v => v.AddItemAsync(It.IsAny<string>(), It.IsAny<JwtModel>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
         }
@@ -127,7 +127,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authentication
 
             JwtModel actualModel = await authDelegate.AuthenticateUserAsync(UserClientCredentialsRequest, true);
 
-            expected.ShouldDeepEqual(actualModel);
+            actualModel.ShouldDeepEqual(expected);
             mockCacheProvider.Verify(v => v.GetItemAsync<JwtModel>(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
             mockCacheProvider.Verify(v => v.AddItemAsync(It.IsAny<string>(), It.IsAny<JwtModel>(), It.IsAny<TimeSpan?>(), It.IsAny<CancellationToken>()), Times.Never());
         }
@@ -177,7 +177,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authentication
 
             JwtModel actualModel = await authDelegate.AuthenticateAsSystemAsync(SystemClientCredentialsRequest, cacheEnabled);
 
-            expected.ShouldDeepEqual(actualModel);
+            actualModel.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authentication
 
             ClientCredentialsRequest actualModel = authDelegate.GetClientCredentialsRequestFromConfig("Authentication");
 
-            UserClientCredentialsRequest.ShouldDeepEqual(actualModel);
+            actualModel.ShouldDeepEqual(UserClientCredentialsRequest);
         }
 
         /// <summary>

--- a/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
+++ b/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.CommonTests.Auditing
 {
     using System;
     using System.IO;
+    using System.Net;
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
@@ -46,7 +47,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new System.Net.IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
                 User = new(new ClaimsIdentity([new Claim("hdid", Hdid), new Claim("preferred_username", Idir)])),
             };
             AuditEvent expected = new()
@@ -68,7 +69,7 @@ namespace HealthGateway.CommonTests.Auditing
             AuditEvent actual = new();
             dbAuditLogger.PopulateWithHttpContext(ctx, actual);
 
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -79,7 +80,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new System.Net.IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
                 Response = { StatusCode = 401 },
             };
             AuditEvent expected = new()
@@ -110,7 +111,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new System.Net.IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
                 Response = { StatusCode = 405 },
             };
             AuditEvent expected = new()
@@ -141,7 +142,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new System.Net.IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
                 Response = { StatusCode = 500 },
             };
             AuditEvent expected = new()
@@ -173,7 +174,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new System.Net.IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
             };
             AuditEvent expected = new()
             {
@@ -211,7 +212,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new System.Net.IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
             };
             AuditEvent expected = new()
             {

--- a/Apps/Common/test/unit/Delegates/AesCryptoDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/AesCryptoDelegateTests.cs
@@ -56,7 +56,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             AesCryptoDelegate aesDelegate = new(configuration);
 
-            expectedConfig.ShouldDeepEqual(aesDelegate.AesConfig);
+            aesDelegate.AesConfig.ShouldDeepEqual(expectedConfig);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             AesCryptoDelegate aesDelegate = new(configuration);
 
-            expectedConfig.ShouldDeepEqual(aesDelegate.AesConfig);
+            aesDelegate.AesConfig.ShouldDeepEqual(expectedConfig);
         }
 
         /// <summary>

--- a/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.CommonTests.Delegates
             CDogsRequestModel request = GetRequestModel();
             RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request);
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -108,7 +108,7 @@ namespace HealthGateway.CommonTests.Delegates
             CDogsRequestModel request = GetRequestModel();
             RequestResult<ReportModel> actualResult = await cdogsDelegate.GenerateReportAsync(request);
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>

--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -355,8 +355,8 @@ namespace HealthGateway.CommonTests.Delegates
             Assert.Equal(expectedLastName, actual.ResourcePayload?.LastName);
             Assert.Equal(expectedBirthDate, actual.ResourcePayload?.Birthdate);
             Assert.Equal(expectedGender, actual.ResourcePayload?.Gender);
-            expectedPhysicalAddr.ShouldDeepEqual(actual.ResourcePayload?.PhysicalAddress);
-            expectedPostalAddr.ShouldDeepEqual(actual.ResourcePayload?.PostalAddress);
+            actual.ResourcePayload?.PhysicalAddress.ShouldDeepEqual(expectedPhysicalAddr);
+            actual.ResourcePayload?.PostalAddress.ShouldDeepEqual(expectedPostalAddr);
         }
 
         /// <summary>

--- a/Apps/Common/test/unit/Delegates/HmacHashDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/HmacHashDelegateTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             HmacHashDelegate hashDelegate = new(configuration);
 
-            expectedConfig.ShouldDeepEqual(hashDelegate.HashConfig);
+            hashDelegate.HashConfig.ShouldDeepEqual(expectedConfig);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             HmacHashDelegate hashDelegate = new(configuration);
 
-            expectedConfig.ShouldDeepEqual(hashDelegate.HashConfig);
+            hashDelegate.HashConfig.ShouldDeepEqual(expectedConfig);
         }
 
         /// <summary>

--- a/Apps/Common/test/unit/Delegates/NotificationSettingsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/NotificationSettingsDelegateTests.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.CommonTests.Delegates
             RequestResult<NotificationSettingsResponse> actualResult =
                 await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty);
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -95,7 +95,7 @@ namespace HealthGateway.CommonTests.Delegates
             RequestResult<NotificationSettingsResponse> actualResult =
                 await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty);
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -131,7 +131,7 @@ namespace HealthGateway.CommonTests.Delegates
             RequestResult<NotificationSettingsResponse> actualResult =
                 await notificationSettingsDelegate.SetNotificationSettingsAsync(request, string.Empty);
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         private static NotificationSettingsRequest GetNotificationSettingsRequest()

--- a/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
@@ -270,7 +270,7 @@ namespace HealthGateway.EncounterTests.Services
             RequestResult<IEnumerable<EncounterModel>> actualResult = await service.GetEncountersAsync(hdid);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            errorPatientResult.ResultError.ShouldDeepEqual(actualResult.ResultError);
+            actualResult.ResultError.ShouldDeepEqual(errorPatientResult.ResultError);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Controllers.Test/CommentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/CommentControllerTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             CommentController controller = new(commentServiceMock.Object);
 
             ActionResult<RequestResult<UserComment>> actualResult = await controller.Create(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
-            expectedResult.ShouldDeepEqual(actualResult.Value);
+            actualResult.Value.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -191,7 +191,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             RequestResult<UserComment>? actualRequestResult = actualResult.Value;
             Assert.NotNull(actualRequestResult);
             Assert.Equal(ResultType.Success, actualRequestResult.ResultStatus);
-            expectedResult.ShouldDeepEqual(actualRequestResult);
+            actualRequestResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/CommunicationControllerTests.cs
@@ -55,7 +55,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             CommunicationController controller = new(communicationServiceMock.Object);
             RequestResult<CommunicationModel> actualResult = await controller.Get();
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
@@ -69,7 +69,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 httpContextAccessorMock.Object);
             RequestResult<IEnumerable<DependentModel>> actualResult = await dependentController.GetAll(this.hdid, It.IsAny<CancellationToken>());
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 httpContextAccessorMock.Object);
             RequestResult<DependentModel> actualResult = await dependentController.AddDependent(new AddDependentRequest(), CancellationToken.None);
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 dependentServiceMock.Object,
                 httpContextAccessorMock.Object);
             ActionResult<RequestResult<DependentModel>> actualResult = await dependentController.Delete(delegateId, dependentId, dependentModel, CancellationToken.None);
-            expectedResult.ShouldDeepEqual(actualResult.Value);
+            actualResult.Value.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Controllers.Test/NoteControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/NoteControllerTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 
             RequestResult<UserNote> actualResult = await controller.CreateNote(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 
             RequestResult<UserNote> actualResult = await controller.UpdateNote(Hdid, expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 
             RequestResult<UserNote> actualResult = await controller.DeleteNote(expectedResult.ResourcePayload, It.IsAny<CancellationToken>());
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/PhsaControllerTests.cs
@@ -60,7 +60,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             ActionResult<RequestResult<IEnumerable<DependentModel>>> actualResult = await phsaController.GetAll(this.hdid, default);
 
             RequestResult<IEnumerable<DependentModel>>? actualRequestResult = actualResult.Value;
-            expectedResult.ShouldDeepEqual(actualRequestResult);
+            actualRequestResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 It.IsAny<CancellationToken>());
 
             RequestResult<IEnumerable<GetDependentResponse>>? actualRequestResult = actualResult.Value;
-            expectedResult.ShouldDeepEqual(actualRequestResult);
+            actualRequestResult.ShouldDeepEqual(expectedResult);
         }
 
         private static IEnumerable<GetDependentResponse> GetMockDependentResponses()

--- a/Apps/GatewayApi/test/unit/Controllers.Test/ReportControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/ReportControllerTests.cs
@@ -60,7 +60,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             ReportController controller = new(reportServiceMock.Object);
             RequestResult<ReportModel> actualResult = await controller.GenerateReport(request, It.IsAny<CancellationToken>());
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserFeedbackControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserFeedbackControllerTests.cs
@@ -132,7 +132,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             RequestResult<RatingModel> actual = await mock.Controller.CreateRating(mock.Rating, default);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static CreateRatingMock SetupCreateRatingMock()

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             RequestResult<UserProfileModel> expected = this.GetUserProfileExpectedRequestResultMock(ResultType.Success);
             RequestResult<UserProfileModel> actualResult = await this.GetUserProfile(expected);
 
-            expected.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<ILegalAgreementService>().Object);
 
             ActionResult<RequestResult<UserProfileModel>> actualResult = await service.CreateUserProfile(this.hdid, createUserRequest, CancellationToken.None);
-            expected.ShouldDeepEqual(actualResult.Value);
+            actualResult.Value.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -326,7 +326,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 legalAgreementServiceMock.Object);
 
             RequestResult<TermsOfServiceModel> actualResult = await service.GetLastTermsOfService(It.IsAny<CancellationToken>());
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -540,7 +540,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<ILegalAgreementService>().Object);
 
             RequestResult<UserProfileModel> actualResult = await controller.UpdateAcceptedTerms(this.hdid, Guid.Empty, It.IsAny<CancellationToken>());
-            expected.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expected);
         }
 
         private static Mock<IHttpContextAccessor> CreateValidHttpContext(string token, string userId, string hdid)

--- a/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
@@ -102,7 +102,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (success)
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {
@@ -157,7 +157,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (success)
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {
@@ -211,7 +211,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (success)
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {
@@ -265,7 +265,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (success)
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {
@@ -319,7 +319,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (success)
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/GatewayApiCommunicationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/GatewayApiCommunicationServiceTests.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<CommunicationModel> actual = await mock.Service.GetActiveCommunicationAsync(mock.CommunicationType);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<CommunicationModel> actual = await mock.Service.GetActiveCommunicationAsync(mock.CommunicationType);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static IGatewayApiCommunicationService GetGatewayCommunicationService(IMock<ICommunicationService> communicationServiceMock)

--- a/Apps/GatewayApi/test/unit/Services.Test/LegalAgreementServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/LegalAgreementServiceTests.cs
@@ -56,7 +56,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<TermsOfServiceModel> actual = await mock.LegalAgreementService.GetActiveTermsOfServiceAsync();
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Guid? actual = await mock.LegalAgreementService.GetActiveLegalAgreementId(LegalAgreementType.TermsOfService);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static ActiveTermsOfServiceMock SetupActiveTermsOfServiceMock(bool legalAgreementFound)

--- a/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
@@ -156,7 +156,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 {
                     case (true, DbStatusCode.Read):
                         Assert.Equal(ResultType.Success, actual.ResultStatus);
-                        expected.ShouldDeepEqual(actual.ResourcePayload);
+                        actual.ResourcePayload.ShouldDeepEqual(expected);
                         break;
 
                     case (true, _):
@@ -216,7 +216,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
                 Assert.Null(actual.ResultError);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {
@@ -269,7 +269,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
                 Assert.Null(actual.ResultError);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {
@@ -322,7 +322,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 Assert.Equal(ResultType.Success, actual.ResultStatus);
                 Assert.Null(actual.ResultError);
-                expected.ShouldDeepEqual(actual.ResourcePayload);
+                actual.ResourcePayload.ShouldDeepEqual(expected);
             }
             else
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/PatientDetailsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/PatientDetailsServiceTests.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             PatientDetails actual = await mock.Service.GetPatientAsync(mock.Identifier, mock.IdentifierType);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
@@ -85,7 +85,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<ReportModel> actualResult = await service.GetReportAsync(reportRequest);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<RatingModel> actual = await mock.Service.CreateRatingAsync(mock.Rating);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -76,7 +76,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<RatingModel> actual = await mock.Service.CreateRatingAsync(mock.Rating);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -93,7 +93,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             DbResult<UserFeedback> actual = await mock.Service.CreateUserFeedbackAsync(mock.Feedback, mock.Hdid);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static Mock<ICryptoDelegate> GetCryptoDelegateMock()

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<UserPreferenceModel> actual = await mock.Service.CreateUserPreferenceAsync(mock.UserPreferenceModel);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -79,7 +79,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<UserPreferenceModel> actual = await mock.Service.UpdateUserPreferenceAsync(mock.UserPreferenceModel);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Dictionary<string, UserPreferenceModel> actual = await mock.Service.GetUserPreferencesAsync(mock.Hdid);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static IUserPreferenceService GetUserPreferenceService(IMock<IUserPreferenceDelegate> userPreferenceDelegateMock)

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -93,7 +93,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<UserProfileModel> actual = await mock.Service.GetUserProfileAsync(mock.Hdid, mock.JwtAuthTime);
 
             // Assert
-            mock.Expected.Result.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected.Result);
 
             mock.UserProfileDelegateMock.Verify(
                 v => v.UpdateAsync(
@@ -140,7 +140,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<UserProfileModel> actual = await mock.Service.UpdateAcceptedTermsAsync(mock.Hdid, mock.TermsOfServiceId);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 mock.JwtEmailAddress);
 
             // Assert
-            mock.Expected.Result.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected.Result);
 
             mock.UserEmailServiceMock.Verify(
                 v => v.CreateUserEmailAsync(
@@ -242,7 +242,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<UserProfileModel> actual = await mock.Service.CloseUserProfileAsync(mock.Hdid, mock.UserId);
 
             // Assert
-            mock.Expected.Result.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected.Result);
 
             mock.EmailQueueServiceMock.Verify(
                 v => v.QueueNewEmailAsync(
@@ -276,7 +276,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<UserProfileModel> actual = await mock.Service.RecoverUserProfileAsync(mock.Hdid);
 
             // Assert
-            mock.Expected.Result.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected.Result);
 
             mock.EmailQueueServiceMock.Verify(
                 v => v.QueueNewEmailAsync(
@@ -305,7 +305,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             bool actual = await mock.Service.IsPhoneNumberValidAsync(mock.PhoneNumber);
 
             // Assert
-            Assert.Equal(mock.Expected, actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -348,7 +348,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<bool> actual = await mock.Service.ValidateMinimumAgeAsync(mock.Age);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<bool> actual = await mock.Service.ValidateMinimumAgeAsync(mock.Age);
 
             // Assert
-            mock.Expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(mock.Expected);
         }
 
         private static PatientModel GeneratePatientModel(DateTime birthDate)

--- a/Apps/GatewayApi/test/unit/Services.Test/WebAlertServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/WebAlertServiceTests.cs
@@ -66,7 +66,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IEnumerable<WebAlert> actual = await service.GetWebAlertsAsync(Hdid);
 
             // Assert
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>

--- a/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
+++ b/Apps/Immunization/test/unit/Controllers.Test/PublicVaccineStatusControllerTests.cs
@@ -69,7 +69,7 @@ namespace HealthGateway.ImmunizationTests.Controllers.Test
 
             // Verify
             Assert.Equal(ResultType.Success, actual.ResultStatus);
-            expectedRequestResult.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expectedRequestResult);
         }
     }
 }

--- a/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/VaccineStatusDelegateTests.cs
@@ -80,7 +80,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 await vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
+            actualResult.ResourcePayload.ShouldDeepEqual(expectedPayload);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 await vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            expectedError.ShouldDeepEqual(actualResult.ResultError);
+            actualResult.ResultError.ShouldDeepEqual(expectedError);
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 await vaccineStatusDelegate.GetVaccineStatusPublicAsync(query, this.accessToken, string.Empty);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            expectedError.ShouldDeepEqual(actualResult.ResultError);
+            actualResult.ResultError.ShouldDeepEqual(expectedError);
         }
 
         /// <summary>
@@ -180,7 +180,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 await vaccineStatusDelegate.GetVaccineStatusAsync(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
-            expectedPayload.ShouldDeepEqual(actualResult.ResourcePayload);
+            actualResult.ResourcePayload.ShouldDeepEqual(expectedPayload);
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 await vaccineStatusDelegate.GetVaccineStatusAsync(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            expectedError.ShouldDeepEqual(actualResult.ResultError);
+            actualResult.ResultError.ShouldDeepEqual(expectedError);
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 await vaccineStatusDelegate.GetVaccineStatusAsync(this.hdId, true, this.accessToken);
 
             Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            expectedError.ShouldDeepEqual(actualResult.ResultError);
+            actualResult.ResultError.ShouldDeepEqual(expectedError);
         }
 
         private static RequestResultError GetRequestResultError()

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -113,7 +113,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             if (canAccessDataSource)
             {
-                expectedResult.ShouldDeepEqual(actualResult);
+                actualResult.ShouldDeepEqual(expectedResult);
             }
             else
             {
@@ -174,7 +174,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             RequestResult<ImmunizationEvent> actualResult = await service.GetImmunizationAsync("immz_id");
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             RequestResult<ImmunizationResult> actualResult = await service.GetImmunizationsAsync(It.IsAny<string>());
 
             // Assert
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
             ImmunizationRecommendation? actualRecommendation = actualResult.ResourcePayload?.Recommendations.First();
             Assert.NotNull(actualRecommendation);
             Assert.Equal(RecommendationSetId, actualRecommendation.RecommendationSetId);
@@ -275,7 +275,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             RequestResult<ImmunizationResult> actualResult = await service.GetImmunizationsAsync(It.IsAny<string>());
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         private static RequestResult<PhsaResult<ImmunizationResponse>> GetPhsaResult(ImmunizationRecommendationResponse immzRecommendationResponse)

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -130,13 +130,13 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 string dovString = this.dov.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
                 RequestResult<VaccineStatus> actualResultPublic = await service.GetPublicVaccineStatusAsync(this.phn, dobString, dovString);
 
-                expectedResult.ShouldDeepEqual(actualResultPublic);
+                actualResultPublic.ShouldDeepEqual(expectedResult);
             }
             else
             {
                 RequestResult<VaccineStatus> actualResultAuthenticated = await service.GetAuthenticatedVaccineStatusAsync(this.hdid);
 
-                expectedResult.ShouldDeepEqual(actualResultAuthenticated);
+                actualResultAuthenticated.ShouldDeepEqual(expectedResult);
             }
         }
 

--- a/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
+++ b/Apps/Laboratory/test/unit/Delegates/LaboratoryDelegateTests.cs
@@ -564,7 +564,7 @@ namespace HealthGateway.LaboratoryTests.Delegates
                 ResultReady = result,
             };
             Covid19Test actual = MappingService.MapToCovid19Test(phsaData);
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static IConfigurationRoot GetIConfigurationRoot()

--- a/Apps/Medication/test/unit/Controllers/MedicationStatementControllerTests.cs
+++ b/Apps/Medication/test/unit/Controllers/MedicationStatementControllerTests.cs
@@ -106,7 +106,7 @@ namespace HealthGateway.MedicationTests.Controllers
 
             // Verify
             Assert.NotNull(actual);
-            expectedResult.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expectedResult);
 
             // Medication Summary
             Assert.Equal(expectedPharmacistAssessment, actual.ResourcePayload![0].MedicationSummary.IsPharmacistAssessment);

--- a/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
+++ b/Apps/Medication/test/unit/Delegates/MedicationDelegateTests.cs
@@ -151,7 +151,7 @@ namespace HealthGateway.MedicationTests.Delegates
                     string.Empty);
 
             Assert.Equal(ResultType.Success, response.ResultStatus);
-            medicationHistory.Response.ShouldDeepEqual(response.ResourcePayload);
+            response.ResourcePayload.ShouldDeepEqual(medicationHistory.Response);
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace HealthGateway.MedicationTests.Delegates
                     string.Empty);
 
             Assert.Equal(ResultType.Success, response.ResultStatus);
-            medicationHistory.Response.ShouldDeepEqual(response.ResourcePayload);
+            response.ResourcePayload.ShouldDeepEqual(medicationHistory.Response);
         }
 
         /// <summary>

--- a/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
+++ b/Apps/Patient/test/unit/Controllers/PatientControllerTests.cs
@@ -78,7 +78,7 @@ namespace HealthGateway.PatientTests.Controllers
             RequestResult<PatientModel> actualResult = await patientController.GetPatient("123", default);
 
             // Assert
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>

--- a/Apps/WebClient/test/unit/Controllers/RobotsControllerTests.cs
+++ b/Apps/WebClient/test/unit/Controllers/RobotsControllerTests.cs
@@ -83,7 +83,7 @@ namespace HealthGateway.WebClientTests.Controllers
 
             // Assert
             Assert.IsType<ContentResult>(actualResult);
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
     }
 }

--- a/Apps/WebClient/test/unit/Services/ConfigurationServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services/ConfigurationServiceTests.cs
@@ -59,7 +59,7 @@ namespace HealthGateway.WebClientTests.Services
             ExternalConfiguration expectedResult = GenerateExternalConfiguration();
             ExternalConfiguration actualResult = await this.service.GetConfigurationAsync();
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace HealthGateway.WebClientTests.Services
 
             MobileConfiguration actualResult = await this.service.GetMobileConfigurationAsync();
 
-            expectedResult.ShouldDeepEqual(actualResult);
+            actualResult.ShouldDeepEqual(expectedResult);
         }
 
         /// <summary>
@@ -153,7 +153,7 @@ namespace HealthGateway.WebClientTests.Services
             ExternalConfiguration actual = await configurationService.GetConfigurationAsync();
 
             // Assert
-            expected.ShouldDeepEqual(actual);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static ExternalConfiguration GenerateExternalConfiguration(


### PR DESCRIPTION
# Fixes [AB#16742](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16742)

## Description

Fix ShouldDeepEqual implementation in unit tests:

- should be <actual>ShouldDeepEqual<expected>

<img width="602" alt="Screenshot 2024-05-27 at 3 49 39 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/16c1f0cc-5aad-4a6e-8989-85c0bb18f528">

<img width="452" alt="Screenshot 2024-05-27 at 3 49 45 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/4beaa5ee-3941-47b9-bdb6-44a5f382d946">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
