### PR TITLE
Fix web client and admin flaky functional tests for AB#16747

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
@@ -83,20 +83,6 @@ describe("Beta feature access", () => {
         cy.get("[data-testid=salesforce-access-switch]").click();
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
-        // Search and verify results again
-        cy.log(
-            "After assigning salesforce access, search and verify assigning of salesforce feature again."
-        );
-        cy.get("[data-testid=query-input]")
-            .should("be.visible")
-            .should("be.enabled")
-            .click()
-            .clear()
-            .should("be.empty")
-            .type(validEmail);
-        cy.get("[data-testid=search-button]").click();
-        cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
-
         // Tab to View and verify assigned feature(s)
         cy.log("Verify assigned feature(s) on View tab.");
         selectTab("[data-testid=beta-access-tabs]", "View");

--- a/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
@@ -10,6 +10,9 @@ function testPageBreadcrumb(url, dataTestId) {
     cy.intercept("GET", "**/Patient/*").as("getPatient");
     cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
     cy.intercept("GET", "**/UserProfile/*/Dependent*").as("getDependent");
+    cy.intercept("GET", "**/UserProfile/termsofservice").as(
+        "getTermsOfService"
+    );
 
     cy.visit(url);
 
@@ -21,9 +24,8 @@ function testPageBreadcrumb(url, dataTestId) {
         cy.wait("@getDependent", { timeout: defaultTimeout });
     }
 
-    if (url !== "/dependents" && url !== "/profile") {
-        cy.wait("@getPatient", { timeout: defaultTimeout });
-        cy.wait("@getUserProfile", { timeout: defaultTimeout });
+    if (url == "/termsOfService") {
+        cy.wait("@getTermsOfService", { timeout: defaultTimeout });
     }
 
     cy.wait("@getCommunication", { timeout: defaultTimeout });

--- a/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
@@ -6,9 +6,6 @@ function testPageBreadcrumb(url, dataTestId) {
     cy.intercept("GET", "**/AuthenticatedVaccineStatus?hdid=*").as(
         "getVaccinationStatus"
     );
-    cy.intercept("GET", `**/Communication/*`).as("getCommunication");
-    cy.intercept("GET", "**/Patient/*").as("getPatient");
-    cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
     cy.intercept("GET", "**/UserProfile/*/Dependent*").as("getDependent");
     cy.intercept("GET", "**/UserProfile/termsofservice").as(
         "getTermsOfService"
@@ -27,8 +24,6 @@ function testPageBreadcrumb(url, dataTestId) {
     if (url == "/termsOfService") {
         cy.wait("@getTermsOfService", { timeout: defaultTimeout });
     }
-
-    cy.wait("@getCommunication", { timeout: defaultTimeout });
 
     cy.get("[data-testid=breadcrumbs]").should("be.visible");
     cy.get(`[data-testid='${dataTestId}'].v-breadcrumbs-item--active`).should(

--- a/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/breadcrumbs.js
@@ -9,7 +9,7 @@ function testPageBreadcrumb(url, dataTestId) {
     cy.intercept("GET", `**/Communication/*`).as("getCommunication");
     cy.intercept("GET", "**/Patient/*").as("getPatient");
     cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
-    cy.intercept("GET", "**/UserProfile/*/Dependent").as("getDependent");
+    cy.intercept("GET", "**/UserProfile/*/Dependent*").as("getDependent");
 
     cy.visit(url);
 

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/modals/protectiveWordModal.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/modals/protectiveWordModal.js
@@ -76,7 +76,9 @@ describe("Validate Modals Popup", () => {
             AuthMethod.KeyCloak
         );
         cy.checkTimelineHasLoaded();
-        cy.get("[data-testid=protectiveWordCloseButton]").click();
+        cy.get("[data-testid=protectiveWordCloseButton]")
+            .should("be.visible", "be.enabled")
+            .click();
         cy.get("[data-testid=protectiveWordModal]").should("not.exist");
     });
 });

--- a/Testing/functional/tests/cypress/integration/e2e/user/acceptTermsOfService.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/acceptTermsOfService.js
@@ -1,21 +1,27 @@
-const { AuthMethod } = require("../../../support/constants");
+import { AuthMethod } from "../../../support/constants";
 const HDID = "K6HL4VX67CZ2PGSZ2ZOIR4C3PGMFFBW5CIOXM74D6EQ7RYYL7P4A";
+const defaultTimeout = 60000;
 
 describe("Need to accept terms of service", () => {
-    beforeEach(() => {
+    it("Validate accept terms of service", () => {
         cy.configureSettings({});
+        cy.intercept("GET", "**/UserProfile/termsofservice").as(
+            "getTermsOfService"
+        );
         cy.login(
             Cypress.env("keycloak.accept.tos.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
             "/home"
         );
-    });
+        cy.wait("@getTermsOfService", { timeout: defaultTimeout });
 
-    it("Validate accept terms of service", () => {
+        cy.get("[data-testid=tos-page-title]")
+            .should("exist")
+            .contains("Update to our Terms of Service");
+
         cy.url().should("include", "/acceptTermsOfService");
 
-        cy.get("[data-testid=tos-page-title]").should("be.visible");
         cy.get("[data-testid=tos-text-area-component]").should("be.visible");
 
         cy.get("[data-testid=accept-tos-checkbox] input").should("be.enabled");

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -324,9 +324,11 @@ describe("dependents", () => {
             "Validating Immunization History Tab - Verify result and download"
         );
 
+        cy.intercept("GET", "**/Immunization?hdid*").as("getImmunization");
         cy.get(
             `[data-testid=immunization-tab-title-${validDependentHdid}]`
         ).click();
+        cy.wait("@getImmunization", { timeout: defaultTimeout });
 
         // History tab
         cy.log("Validating history tab");
@@ -403,9 +405,11 @@ describe("dependents", () => {
             "Validating Immunization Forecast Tab - Verify result and download"
         );
 
+        cy.intercept("GET", "**/Immunization?hdid*").as("getImmunization");
         cy.get(
             `[data-testid=immunization-tab-title-${validDependentHdid}]`
         ).click();
+        cy.wait("@getImmunization", { timeout: defaultTimeout });
 
         // Forecast tab
         cy.log("Validating forecast tab");
@@ -514,16 +518,12 @@ describe("dependents", () => {
     it("Validate Clinical Document - Verify result and download", () => {
         cy.log("Validating Clinical Document Tab - Verify result and download");
 
-        cy.intercept("GET", "**/UserProfile/*/Dependent").as("getDependent");
-        cy.intercept("GET", `**/Communication/*`).as("getCommunication");
         cy.intercept("GET", "**/ClinicalDocument/*").as("getClinicalDocument");
 
         cy.get(
             `[data-testid=clinical-document-tab-title-${validDependentHdid}]`
         ).click();
 
-        cy.wait("@getDependent", { timeout: defaultTimeout });
-        cy.wait("@getCommunication", { timeout: defaultTimeout });
         cy.wait("@getClinicalDocument", { timeout: defaultTimeout });
 
         // Expecting more than 1 row to return because also need to consider the table headers.

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -140,9 +140,11 @@ describe("dependents", () => {
             force: true,
         });
 
+        cy.intercept("POST", "**/UserProfile/*/Dependent").as("postDependent");
         cy.get("[data-testid=register-dependent-btn]")
             .should("be.disabled")
             .click({ force: true });
+        cy.wait("@postDependent", { timeout: defaultTimeout });
 
         // Validate the modal has not closed
         cy.get("[data-testid=add-dependent-dialog]").should("exist");
@@ -256,7 +258,9 @@ describe("dependents", () => {
             force: true,
         });
 
+        cy.intercept("POST", "**/UserProfile/*/Dependent").as("postDependent");
         cy.get("[data-testid=register-dependent-btn]").click();
+        cy.wait("@postDependent", { timeout: defaultTimeout });
 
         // Validate the modal is done
         cy.get("[data-testid=add-dependent-dialog]").should("not.exist");
@@ -307,7 +311,9 @@ describe("dependents", () => {
             force: true,
         });
 
+        cy.intercept("POST", "**/UserProfile/*/Dependent").as("postDependent");
         cy.get("[data-testid=register-dependent-btn]").click();
+        cy.wait("@postDependent", { timeout: defaultTimeout });
 
         // Validate the modal is not done
         cy.get("[data-testid=add-dependent-dialog]").should("exist");
@@ -603,7 +609,9 @@ describe("CRUD Operations", () => {
             force: true,
         });
 
+        cy.intercept("POST", "**/UserProfile/*/Dependent").as("postDependent");
         cy.get("[data-testid=register-dependent-btn]").click();
+        cy.wait("@postDependent", { timeout: defaultTimeout });
 
         // Validate the modal is done
         cy.get("[data-testid=add-dependent-dialog]").should("not.exist");
@@ -633,7 +641,11 @@ describe("CRUD Operations", () => {
 
         cy.get("@newDependentCard").within(() => {
             // Validate the tab and elements are present
+            cy.intercept("GET", "**/Laboratory/Covid19Orders*").as(
+                "getCovid19Orders"
+            );
             cy.get("[data-testid=covid19TabTitle]").click();
+            cy.wait("@getCovid19Orders", { timeout: defaultTimeout });
             cy.get("[data-testid=dependentCovidTestDate]").each(($date) => {
                 cy.wrap($date).contains(/\d{4}-[A-Z]{1}[a-z]{2}-\d{2}/);
             });
@@ -697,7 +709,9 @@ describe("CRUD Operations", () => {
             force: true,
         });
 
+        cy.intercept("POST", "**/UserProfile/*/Dependent").as("postDependent");
         cy.get("[data-testid=register-dependent-btn]").click();
+        cy.wait("@postDependent", { timeout: defaultTimeout });
 
         // Validate the modal is done
         cy.get("[data-testid=add-dependent-dialog]").should("not.exist");

--- a/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
@@ -5,8 +5,6 @@ const homePath = "/home";
 const encounterModule = "Encounter";
 const immunizationModule = "Immunization";
 const laboratoryModule = "Laboratory";
-const allLaboratoryModule = "AllLaboratory";
-const medicationRequestModule = "MedicationRequest";
 
 const encounterTitle = "Health Visits";
 const immunizationTitle = "Immunizations";

--- a/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
@@ -34,6 +34,26 @@ function getQuickLinkCard(title) {
         .parents(quickLinkCardSelector);
 }
 
+function clickRemoveQuickLinkSelector(isPost = false) {
+    if (isPost) {
+        cy.intercept("POST", "**/UserProfile/*/preference*").as(
+            "postUserProfilePreference"
+        );
+    } else {
+        cy.intercept("PUT", "**/UserProfile/*/preference*").as(
+            "putUserProfilePreference"
+        );
+    }
+
+    cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+
+    if (isPost) {
+        cy.wait("@postUserProfilePreference", { timeout: defaultTimeout });
+    } else {
+        cy.wait("@putUserProfilePreference", { timeout: defaultTimeout });
+    }
+}
+
 describe("Quick Links", () => {
     it("Add, Verify Timeline Link and Remove Quick Link", () => {
         cy.configureSettings({
@@ -106,7 +126,8 @@ describe("Quick Links", () => {
                 .should("be.visible", "be.enabled")
                 .click();
         });
-        cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+
+        clickRemoveQuickLinkSelector();
 
         cy.log("Verifying quick link card no longer exists");
         cy.contains(cardButtonTitleSelector, laboratoryTitle).should(
@@ -247,7 +268,7 @@ describe("Quick Links", () => {
         getQuickLinkCard(encounterTitle).within(() => {
             cy.get(quickLinkMenuButtonSelector).click();
         });
-        cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        clickRemoveQuickLinkSelector();
         cy.contains(cardButtonTitleSelector, encounterTitle).should(
             "not.exist"
         );
@@ -256,7 +277,7 @@ describe("Quick Links", () => {
                 .should("be.visible", "be.enabled")
                 .click();
         });
-        cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        clickRemoveQuickLinkSelector();
         cy.contains(cardButtonTitleSelector, immunizationTitle).should(
             "not.exist"
         );
@@ -317,7 +338,7 @@ describe("Organ Donor Quick Link", () => {
                 .should("be.visible", "be.enabled")
                 .click();
         });
-        cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        clickRemoveQuickLinkSelector(true);
 
         cy.log("Verifying organ donor quick link no longer exists");
         cy.get(organDonorQuickLinkCardSelector).should("not.exist");
@@ -427,7 +448,7 @@ describe("Vaccine Card Quick Link", () => {
                 .should("be.visible", "be.enabled")
                 .click();
         });
-        cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        clickRemoveQuickLinkSelector(true);
 
         cy.log("Verifying vaccine card quick link no longer exists");
         cy.get(vaccineCardQuickLinkCardSelector).should("not.exist");
@@ -496,7 +517,7 @@ describe("Health Connect Registry Card", () => {
                 .should("be.visible", "be.enabled")
                 .click();
         });
-        cy.get(quickLinkRemoveButtonSelector).should("be.visible").click();
+        clickRemoveQuickLinkSelector(true);
 
         cy.log("Verifying health connect quick link no longer exists");
         cy.get(healthConnectQuickLinkCardSelector).should("not.exist");

--- a/Testing/functional/tests/cypress/integration/ui/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/dependents.js
@@ -454,9 +454,14 @@ describe("Dependents - Clinical Document Tab - Enabled", () => {
     });
 });
 
-describe("Dependents Tabs Disabled", () => {
+describe("Dependents - Tabs Disabled", () => {
     const dependentHdid = "645645767756756767";
+
     beforeEach(() => {
+        cy.intercept("GET", "**/UserProfile/*/Dependent", {
+            fixture: "UserProfileService/dependent.json",
+        });
+
         cy.configureSettings({
             dependents: {
                 enabled: true,
@@ -476,11 +481,11 @@ describe("Dependents Tabs Disabled", () => {
     it("Immunization and Clinical Documents Tabs - Configuration Disabled", () => {
         cy.log("Validating Immunization Tab - configuration disabled");
         cy.get(`[data-testid=immunization-tab-${dependentHdid}]`).should(
-            "not.exist"
+            "not.be.visible"
         );
         cy.log("Validating Clinical Documents Tab - configuration disabled");
         cy.get(`[data-testid=clinical-document-tab-${dependentHdid}]`).should(
-            "not.exist"
+            "not.be.visible"
         );
     });
 });

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -143,6 +143,7 @@ export function setupStandardAliases() {
         "**/PatientData/*?patientDataTypes=OrganDonorRegistrationStatus*"
     ).as("getOrganDonorRegistrationStatus");
     cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
+    cy.intercept("GET", "**/UserProfile/*/Dependent").as("getDependent");
 }
 
 export function waitForInitialDataLoad(username, config, path) {
@@ -178,6 +179,7 @@ export function waitForInitialDataLoad(username, config, path) {
     cy.wait("@getCommunication", { timeout: defaultTimeout });
 
     waitForNotification(featureToggle);
+    waitForDependent(featureToggle, path);
 }
 
 function waitForUserProfile(username) {
@@ -248,6 +250,17 @@ function waitForClinicalDocument(featureToggle, path, blockedDataSources) {
     ) {
         cy.log("Wait on clinical document.");
         cy.wait("@getClinicalDocument", { timeout: defaultTimeout });
+    }
+}
+
+function waitForDependent(featureToggle, path) {
+    cy.log(
+        `waitForDependent called - enabled: ${featureToggle.dependents.enabled} - path: ${path}`
+    );
+
+    if (featureToggle.dependents.enabled && isDependents(path)) {
+        cy.log("Wait on dependent.");
+        cy.wait("@getDependent", { timeout: defaultTimeout });
     }
 }
 
@@ -376,6 +389,10 @@ function checkOrganDonorRegistrationBlocked(blockedDataSources) {
         Array.isArray(blockedDataSources) &&
         blockedDataSources.includes("OrganDonorRegistration")
     );
+}
+
+function isDependents(path) {
+    return path === "/dependents";
 }
 
 function isDependentsTimeline(path) {

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -143,7 +143,7 @@ export function setupStandardAliases() {
         "**/PatientData/*?patientDataTypes=OrganDonorRegistrationStatus*"
     ).as("getOrganDonorRegistrationStatus");
     cy.intercept("GET", "**/UserProfile/*").as("getUserProfile");
-    cy.intercept("GET", "**/UserProfile/*/Dependent").as("getDependent");
+    cy.intercept("GET", "**/UserProfile/*/Dependent*").as("getDependent");
 }
 
 export function waitForInitialDataLoad(username, config, path) {


### PR DESCRIPTION
# Fixes [AB#16747](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16747)

## Description

- Simplify admin beta access test by removing unnecessary search
- Ensure wait and text check on accept terms of service
- Ensure wait on post and put preferences for quick links
- Ensure wait when dependent is called
- Ensure wait on user and patient are called for reports
- Ensure wait on blocked access is called for reports
- Ensure waits are called for breadcrumbs
- Ensure fixtures are used for ui dependents
- Removed unused constants

Note: there are still the odd 502s in UserProfileService and timeouts for downloads from PHSA, which result in flaky tests.

**Admin Cypress:**

https://cloud.cypress.io/projects/rccf87/runs/1779/overview?roarHideRunsWithDiffGroupsAndTags=1

**Web Client Cypress:**

- https://dev.azure.com/qslvic/Health%20Gateway/_build/results?buildId=42011&view=results
- https://cloud.cypress.io/projects/ofnepc/runs/4308/overview/54b57c6d-ec39-446a-8f90-9604b5faad9e?roarHideRunsWithDiffGroupsAndTags=1
- https://cloud.cypress.io/projects/ofnepc/runs/4306/overview?roarHideRunsWithDiffGroupsAndTags=1
- https://cloud.cypress.io/projects/ofnepc/runs/4304/overview/521661ad-0b02-4a23-b76b-4f44e29bee23?roarHideRunsWithDiffGroupsAndTags=1
- https://cloud.cypress.io/projects/ofnepc/runs/4302/overview/ce9cbab0-534f-4f8b-96a9-bb41c26ae7c2?roarHideRunsWithDiffGroupsAndTags=1
- https://cloud.cypress.io/projects/ofnepc/runs/4298/overview?roarHideRunsWithDiffGroupsAndTags=1

**Get User Profile and Get Dependent Wait are called:**

<img width="484" alt="Screenshot 2024-05-30 at 2 50 48 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/2730b66c-cae7-472f-98d0-f9f03f960577">

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
