### PR TITLE
Remove non-prod banner for classic and legacy routes AB#16761

### DIFF
--- a/Apps/Landing/src/ClientApp/src/components/site/DevBannerComponent.vue
+++ b/Apps/Landing/src/ClientApp/src/components/site/DevBannerComponent.vue
@@ -12,7 +12,9 @@ const isProduction = computed(
     () =>
         Process.NODE_ENV == EnvironmentType.production &&
         (host.value.startsWith("HEALTHGATEWAY") ||
-            host.value.startsWith("WWW.HEALTHGATEWAY"))
+            host.value.startsWith("WWW.HEALTHGATEWAY") ||
+            host.value.startsWith("CLASSIC.HEALTHGATEWAY") ||
+            host.value.startsWith("LEGACY.HEALTHGATEWAY"))
 );
 </script>
 

--- a/Apps/WebClient/src/ClientApp/src/components/site/DevBannerComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/DevBannerComponent.vue
@@ -12,7 +12,9 @@ const isProduction = computed(
     () =>
         Process.NODE_ENV == EnvironmentType.production &&
         (host.value.startsWith("HEALTHGATEWAY") ||
-            host.value.startsWith("WWW.HEALTHGATEWAY"))
+            host.value.startsWith("WWW.HEALTHGATEWAY") ||
+            host.value.startsWith("CLASSIC.HEALTHGATEWAY") ||
+            host.value.startsWith("LEGACY.HEALTHGATEWAY"))
 );
 </script>
 


### PR DESCRIPTION
# Fixes [AB#16761](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16761)

## Description

Updates the Vue front-ends so the non-production banner won't be displayed on "classic.healthgateway.gov.bc.ca" or on "legacy.healthgateway.gov.bc.ca".

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
