### PR TITLE
Introduce RestUserProfileServiceV2 in ClientApp AB#16743

### DIFF
--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -128,7 +128,6 @@ namespace HealthGateway.GatewayApi.Controllers
         /// The client does not have access rights to the content; that is, it is unauthorized, so the server
         /// is refusing to give the requested resource. Unlike 401, the client's identity is known to the server.
         /// </response>
-        /// <response code="404">User profile was not found.</response>
         /// <response code="500">Internal server error.</response>
         /// <response code="502">Upstream error.</response>
         [HttpGet]
@@ -139,7 +138,6 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
-        [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status502BadGateway)]
         public async Task<UserProfileModel> GetUserProfile(string hdid, CancellationToken ct)

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -137,8 +137,13 @@ namespace HealthGateway.GatewayApi.Services
         public async Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default)
         {
             this.logger.LogTrace("Getting user profile... {Hdid}", hdid);
-            UserProfile userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, true, ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
+            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
             this.logger.LogDebug("Finished getting user profile...{Hdid}", hdid);
+
+            if (userProfile == null)
+            {
+                return new UserProfileModel();
+            }
 
             DateTime previousLastLogin = userProfile.LastLoginDateTime;
             if (DateTime.Compare(previousLastLogin, jwtAuthTime) != 0)

--- a/Apps/WebClient/src/ClientApp/src/ioc/initialization.ts
+++ b/Apps/WebClient/src/ClientApp/src/ioc/initialization.ts
@@ -49,7 +49,7 @@ import { RestTrackingService } from "@/services/restTrackingService";
 import { RestUserCommentService } from "@/services/restUserCommentService";
 import { RestUserFeedbackService } from "@/services/restUserFeedback";
 import { RestUserNoteService } from "@/services/restUserNoteService";
-import { RestUserProfileService } from "@/services/restUserProfileService";
+import { RestUserProfileServiceV2 } from "@/services/restUserProfileServiceV2";
 import { RestUserRatingService } from "@/services/restUserRatingService";
 import { RestVaccinationStatusService } from "@/services/restVaccinationStatusService";
 import { useConfigStore } from "@/stores/config";
@@ -264,7 +264,7 @@ export async function initializeServices(): Promise<void> {
     container.set<IUserProfileService>(
         SERVICE_IDENTIFIER.UserProfileService,
         (c) =>
-            new RestUserProfileService(
+            new RestUserProfileServiceV2(
                 c.get<ILogger>(SERVICE_IDENTIFIER.Logger),
                 c.get<IHttpDelegate>(DELEGATE_IDENTIFIER.HttpDelegate),
                 configStore.config

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -127,12 +127,12 @@ export interface IUserProfileService {
     getProfile(hdid: string): Promise<UserProfile>;
     validateAge(hdid: string): Promise<boolean>;
     getTermsOfService(): Promise<TermsOfService>;
-    closeAccount(hdid: string): Promise<UserProfile>;
-    recoverAccount(hdid: string): Promise<UserProfile>;
+    closeAccount(hdid: string): Promise<void>;
+    recoverAccount(hdid: string): Promise<void>;
     validateEmail(hdid: string, inviteKey: string): Promise<boolean>;
     validateSms(hdid: string, digit: string): Promise<boolean>;
-    updateEmail(hdid: string, email: string): Promise<boolean>;
-    updateSmsNumber(hdid: string, smsNumber: string): Promise<boolean>;
+    updateEmail(hdid: string, email: string): Promise<void>;
+    updateSmsNumber(hdid: string, smsNumber: string): Promise<void>;
     updateUserPreference(
         hdid: string,
         userPreference: UserPreference
@@ -141,10 +141,7 @@ export interface IUserProfileService {
         hdid: string,
         userPreference: UserPreference
     ): Promise<UserPreference>;
-    updateAcceptedTerms(
-        hdid: string,
-        termsOfServiceId: string
-    ): Promise<UserProfile>;
+    updateAcceptedTerms(hdid: string, termsOfServiceId: string): Promise<void>;
     isPhoneNumberValid(phoneNumber: string): Promise<boolean>;
 }
 

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -129,10 +129,7 @@ export interface IUserProfileService {
     getTermsOfService(): Promise<TermsOfService>;
     closeAccount(hdid: string): Promise<UserProfile>;
     recoverAccount(hdid: string): Promise<UserProfile>;
-    validateEmail(
-        hdid: string,
-        inviteKey: string
-    ): Promise<RequestResult<boolean>>;
+    validateEmail(hdid: string, inviteKey: string): Promise<boolean>;
     validateSms(hdid: string, digit: string): Promise<boolean>;
     updateEmail(hdid: string, email: string): Promise<boolean>;
     updateSmsNumber(hdid: string, smsNumber: string): Promise<boolean>;

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
@@ -80,7 +80,7 @@ export class RestUserProfileService implements IUserProfileService {
             });
     }
 
-    public closeAccount(hdid: string): Promise<UserProfile> {
+    public closeAccount(hdid: string): Promise<void> {
         return this.http
             .delete<RequestResult<UserProfile>>(
                 `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}`
@@ -98,11 +98,10 @@ export class RestUserProfileService implements IUserProfileService {
                 this.logger.debug(
                     `closeAccount ${JSON.stringify(requestResult)}`
                 );
-                return RequestResultUtil.handleResult(requestResult);
             });
     }
 
-    public recoverAccount(hdid: string): Promise<UserProfile> {
+    public recoverAccount(hdid: string): Promise<void> {
         return this.http
             .get<RequestResult<UserProfile>>(
                 `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/recover`
@@ -120,7 +119,6 @@ export class RestUserProfileService implements IUserProfileService {
                 this.logger.debug(
                     `recoverAccount ${JSON.stringify(requestResult)}`
                 );
-                return RequestResultUtil.handleResult(requestResult);
             });
     }
 
@@ -215,7 +213,7 @@ export class RestUserProfileService implements IUserProfileService {
             );
     }
 
-    public updateEmail(hdid: string, email: string): Promise<boolean> {
+    public updateEmail(hdid: string, email: string): Promise<void> {
         const headers: Dictionary<string> = {};
         headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
 
@@ -233,11 +231,10 @@ export class RestUserProfileService implements IUserProfileService {
                     err,
                     ServiceCode.HealthGatewayUser
                 );
-            })
-            .then(() => true);
+            });
     }
 
-    public updateSmsNumber(hdid: string, smsNumber: string): Promise<boolean> {
+    public updateSmsNumber(hdid: string, smsNumber: string): Promise<void> {
         const headers: Dictionary<string> = {};
         headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
 
@@ -255,8 +252,7 @@ export class RestUserProfileService implements IUserProfileService {
                     err,
                     ServiceCode.HealthGatewayUser
                 );
-            })
-            .then(() => true);
+            });
     }
 
     public updateUserPreference(
@@ -290,7 +286,7 @@ export class RestUserProfileService implements IUserProfileService {
     public updateAcceptedTerms(
         hdid: string,
         termsOfServiceId: string
-    ): Promise<UserProfile> {
+    ): Promise<void> {
         const headers: Dictionary<string> = {};
         headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
 
@@ -315,7 +311,6 @@ export class RestUserProfileService implements IUserProfileService {
                         requestResult
                     )}`
                 );
-                return RequestResultUtil.handleResult(requestResult);
             });
     }
 

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileServiceV2.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileServiceV2.ts
@@ -1,0 +1,288 @@
+import { ServiceCode } from "@/constants/serviceCodes";
+import { Dictionary } from "@/models/baseTypes";
+import { ExternalConfiguration } from "@/models/configData";
+import { HttpError } from "@/models/errors";
+import { TermsOfService } from "@/models/termsOfService";
+import type { UserPreference } from "@/models/userPreference";
+import UserProfile, { CreateUserRequest } from "@/models/userProfile";
+import {
+    IHttpDelegate,
+    ILogger,
+    IUserProfileService,
+} from "@/services/interfaces";
+import ErrorTranslator from "@/utility/errorTranslator";
+
+export class RestUserProfileServiceV2 implements IUserProfileService {
+    private readonly APPLICATION_JSON: string =
+        "application/json; charset=utf-8";
+    private readonly CONTENT_TYPE: string = "Content-Type";
+    private readonly USER_PROFILE_BASE_URI: string = "UserProfile";
+    private readonly API_VERSION: string = "2.0";
+    private logger;
+    private http;
+    private baseUri;
+
+    constructor(
+        logger: ILogger,
+        http: IHttpDelegate,
+        config: ExternalConfiguration
+    ) {
+        this.logger = logger;
+        this.http = http;
+        this.baseUri = config.serviceEndpoints["GatewayApi"];
+    }
+
+    public getProfile(hdid: string): Promise<UserProfile> {
+        return this.http
+            .getWithCors<UserProfile>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.getProfile()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public createProfile(
+        createRequest: CreateUserRequest
+    ): Promise<UserProfile> {
+        return this.http
+            .post<UserProfile>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${createRequest.profile.hdid}?api-version=${this.API_VERSION}`,
+                createRequest
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.createProfile()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public closeAccount(hdid: string): Promise<void> {
+        return this.http
+            .delete<void>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.closeAccount()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public recoverAccount(hdid: string): Promise<void> {
+        return this.http
+            .get<void>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/recover?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.recoverAccount()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public validateAge(hdid: string): Promise<boolean> {
+        return this.http
+            .get<boolean>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/Validate?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.validateAge()`
+                );
+
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public getTermsOfService(): Promise<TermsOfService> {
+        return this.http
+            .get<TermsOfService>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/termsofservice?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.getTermsOfService()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public validateEmail(hdid: string, inviteKey: string): Promise<boolean> {
+        return this.http
+            .get<boolean>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/email/validate/${inviteKey}?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.validateEmail()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public validateSms(hdid: string, digit: string): Promise<boolean> {
+        return this.http
+            .get<boolean>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/sms/validate/${digit}?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.validateSms()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public updateEmail(hdid: string, email: string): Promise<void> {
+        const headers: Dictionary<string> = {};
+        headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
+
+        return this.http
+            .put<void>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/email?api-version=${this.API_VERSION}`,
+                JSON.stringify(email),
+                headers
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.updateEmail()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public updateSmsNumber(hdid: string, smsNumber: string): Promise<void> {
+        const headers: Dictionary<string> = {};
+        headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
+
+        return this.http
+            .put<void>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/sms?api-version=${this.API_VERSION}`,
+                JSON.stringify(smsNumber),
+                headers
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.updateSmsNumber()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public updateUserPreference(
+        hdid: string,
+        userPreference: UserPreference
+    ): Promise<UserPreference> {
+        return this.http
+            .put<UserPreference>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/preference?api-version=${this.API_VERSION}`,
+                userPreference
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.updateUserPreference()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public updateAcceptedTerms(
+        hdid: string,
+        termsOfServiceId: string
+    ): Promise<void> {
+        const headers: Dictionary<string> = {};
+        headers[this.CONTENT_TYPE] = this.APPLICATION_JSON;
+
+        return this.http
+            .put<void>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/acceptedterms?api-version=${this.API_VERSION}`,
+                JSON.stringify(termsOfServiceId),
+                headers
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.updateAcceptedTerms()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public createUserPreference(
+        hdid: string,
+        userPreference: UserPreference
+    ): Promise<UserPreference> {
+        return this.http
+            .post<UserPreference>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}/preference?api-version=${this.API_VERSION}`,
+                userPreference
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.createUserPreference()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+
+    public isPhoneNumberValid(phoneNumber: string): Promise<boolean> {
+        return this.http
+            .get<boolean>(
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/IsValidPhoneNumber/${phoneNumber}?api-version=${this.API_VERSION}`
+            )
+            .catch((err: HttpError) => {
+                this.logger.error(
+                    `Error in RestUserProfileService.isPhoneNumberValid()`
+                );
+                throw ErrorTranslator.internalNetworkError(
+                    err,
+                    ServiceCode.HealthGatewayUser
+                );
+            });
+    }
+}

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -355,18 +355,14 @@ export const useUserStore = defineStore("user", () => {
     function validateEmail(inviteKey: string) {
         return userProfileService
             .validateEmail(user.value.hdid, inviteKey)
-            .then((result) => {
-                if (result.resourcePayload === true) {
-                    user.value.verifiedEmail = true;
-                }
-                return result;
-            })
             .catch((resultError: ResultError) => {
-                handleError(
-                    resultError,
-                    ErrorType.Update,
-                    ErrorSourceType.User
-                );
+                if (resultError.statusCode !== 409) {
+                    handleError(
+                        resultError,
+                        ErrorType.Update,
+                        ErrorSourceType.User
+                    );
+                }
                 throw resultError;
             });
     }

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -269,17 +269,8 @@ export const useUserStore = defineStore("user", () => {
     }
 
     function updateUserEmail(emailAddress: string): Promise<void> {
-        const userProfileService = container.get<IUserProfileService>(
-            SERVICE_IDENTIFIER.UserProfileService
-        );
-
         return userProfileService
             .updateEmail(user.value.hdid, emailAddress)
-            .then((emailUpdated) => {
-                if (!emailUpdated) {
-                    logger.warn(`updateEmail response false`);
-                }
-            })
             .catch((resultError: ResultError) => {
                 setUserError(resultError.message);
                 throw resultError;

--- a/Testing/functional/tests/cypress/fixtures/WebClientService/EmailValidation/invalid.json
+++ b/Testing/functional/tests/cypress/fixtures/WebClientService/EmailValidation/invalid.json
@@ -4,5 +4,10 @@
     "pageIndex": null,
     "pageSize": null,
     "resultStatus": 0,
-    "resultError": null
+    "resultError": {
+        "resultMessage": "Email Verification Already verified",
+        "errorCode": "GatewayApiServer-I",
+        "traceId": "12b748b97a5963815da048f5920b406e",
+        "actionCode": null
+    }
 }


### PR DESCRIPTION
# Implements [AB#16743](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16743)

## Description

- updates IUserProfileService so it can be implemented by both RestUserProfileService and the new RestUserProfileServiceV2
  - replaces return value types to match what is used in practice
  - updates validateEmail return value type to avoid relying on RequestResult
- adds RestUserProfileServiceV2 and swaps to use it by default
- updates UserProfileControllerV2 in back-end to return empty UserProfile instead of 404 when retrieving a profile (since this is the expected behaviour for registration)

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
