### PR TITLE
Enforce smaller max width on landing site AB#16766

### DIFF
--- a/Apps/Landing/src/ClientApp/src/App.vue
+++ b/Apps/Landing/src/ClientApp/src/App.vue
@@ -11,10 +11,16 @@ import HeaderComponent from "@/components/site/HeaderComponent.vue";
         <HeaderComponent />
         <v-main class="position-relative">
             <CommunicationComponent />
-            <v-container fluid class="pt-6">
+            <v-container class="pt-6">
                 <router-view />
             </v-container>
         </v-main>
         <FooterComponent :order="-1" />
     </v-app>
 </template>
+
+<style lang="scss" scoped>
+.v-container {
+    max-width: 1200px;
+}
+</style>

--- a/Apps/Landing/src/ClientApp/src/App.vue
+++ b/Apps/Landing/src/ClientApp/src/App.vue
@@ -21,6 +21,6 @@ import HeaderComponent from "@/components/site/HeaderComponent.vue";
 
 <style lang="scss" scoped>
 .v-container {
-    max-width: 1200px;
+    max-width: var(--site-max-width);
 }
 </style>

--- a/Apps/Landing/src/ClientApp/src/assets/styles/main.scss
+++ b/Apps/Landing/src/ClientApp/src/assets/styles/main.scss
@@ -22,3 +22,7 @@
     hyphens: none;
     -webkit-hyphens: none;
 }
+
+:root {
+    --site-max-width: 1200px;
+}

--- a/Apps/Landing/src/ClientApp/src/components/site/CommunicationComponent.vue
+++ b/Apps/Landing/src/ClientApp/src/components/site/CommunicationComponent.vue
@@ -43,12 +43,11 @@ fetchCommunication(CommunicationType.Banner);
 </script>
 
 <template>
-    <!-- eslint-disable vue/no-v-html -->
-    <div
-        v-if="hasCommunication"
-        data-testid="communicationBanner"
-        class="bg-accent text-black text-center pa-2"
-        v-html="text"
-    />
-    <!-- eslint-enable vue/no-v-html -->
+    <v-banner v-if="hasCommunication" class="bg-accent justify-center">
+        <v-banner-text>
+            <!-- eslint-disable vue/no-v-html -->
+            <div data-testid="communicationBanner" v-html="text" />
+            <!-- eslint-enable vue/no-v-html -->
+        </v-banner-text>
+    </v-banner>
 </template>

--- a/Apps/Landing/src/ClientApp/src/components/site/CommunicationComponent.vue
+++ b/Apps/Landing/src/ClientApp/src/components/site/CommunicationComponent.vue
@@ -51,3 +51,9 @@ fetchCommunication(CommunicationType.Banner);
         </v-banner-text>
     </v-banner>
 </template>
+
+<style lang="scss">
+.v-banner__content {
+    max-width: var(--site-max-width);
+}
+</style>

--- a/Apps/Landing/src/ClientApp/src/components/site/FooterComponent.vue
+++ b/Apps/Landing/src/ClientApp/src/components/site/FooterComponent.vue
@@ -17,6 +17,7 @@ const isFooterFixed = computed(() => !layoutStore.isMobile);
         v-if="isFooterShown"
         data-testid="footer"
         color="white"
+        class="justify-center"
         elevation="4"
         :app="isFooterFixed"
     >
@@ -76,3 +77,9 @@ const isFooterFixed = computed(() => !layoutStore.isMobile);
         </v-row>
     </v-footer>
 </template>
+
+<style lang="scss" scoped>
+.v-footer > .v-row {
+    max-width: var(--site-max-width);
+}
+</style>

--- a/Apps/Landing/src/ClientApp/src/components/site/HeaderComponent.vue
+++ b/Apps/Landing/src/ClientApp/src/components/site/HeaderComponent.vue
@@ -64,7 +64,7 @@ nextTick(() => {
     <v-app-bar
         v-model="isHeaderVisible"
         :scroll-behavior="!isHeaderShown ? 'hide' : undefined"
-        class="d-print-none px-3 px-sm-5"
+        class="d-print-none px-3 px-sm-5 align-center"
         color="white"
         :scroll-threshold="headerScrollThreshold"
         height="82"
@@ -90,3 +90,9 @@ nextTick(() => {
         />
     </v-app-bar>
 </template>
+
+<style lang="scss">
+.v-toolbar__content {
+    max-width: var(--site-max-width);
+}
+</style>

--- a/Apps/WebClient/src/ClientApp/src/components/site/CommunicationComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/CommunicationComponent.vue
@@ -81,12 +81,11 @@ fetchCommunication(CommunicationType.InApp);
 </script>
 
 <template>
-    <!-- eslint-disable vue/no-v-html -->
-    <div
-        v-if="hasCommunication"
-        data-testid="communicationBanner"
-        class="bg-accent text-black text-center pa-2"
-        v-html="text"
-    />
-    <!-- eslint-enable vue/no-v-html -->
+    <v-banner v-if="hasCommunication" class="bg-accent justify-center">
+        <v-banner-text>
+            <!-- eslint-disable vue/no-v-html -->
+            <div data-testid="communicationBanner" v-html="text" />
+            <!-- eslint-enable vue/no-v-html -->
+        </v-banner-text>
+    </v-banner>
 </template>


### PR DESCRIPTION
# Implements [AB#16766](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16766)

## Description

- reduces max width of page, header, footer, and communication banner content to 1200px on landing site
- updates communication banner to use v-banner component on landing site and classic site

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

### Landing Site (width changes and communication banner changes)

![scrnli_6_18_2024_4-47-46 PM](https://github.com/bcgov/healthgateway/assets/16570293/7d79fa05-b4c1-4b86-942c-e741fd7b7b08)

### Classic Site (communication banner changes)

![scrnli_6_19_2024_4-07-26 PM](https://github.com/bcgov/healthgateway/assets/16570293/b480cd13-b2b4-4371-bd5e-da56cdb61ed8)

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
