### PR TITLE
Change priority subject determination for AB#16772.

### DIFF
--- a/Apps/Common/src/AccessManagement/Authorization/Handlers/BaseFhirAuthorizationHandler.cs
+++ b/Apps/Common/src/AccessManagement/Authorization/Handlers/BaseFhirAuthorizationHandler.cs
@@ -31,9 +31,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
     public abstract class BaseFhirAuthorizationHandler : IAuthorizationHandler
     {
         private const string System = "system";
-        private const string RouteResourceIdentifier = "hdid";
 
-        private readonly IHttpContextAccessor httpContextAccessor;
         private readonly ILogger logger;
 
         /// <summary>
@@ -44,28 +42,16 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
         protected BaseFhirAuthorizationHandler(ILogger logger, IHttpContextAccessor httpContextAccessor)
         {
             this.logger = logger;
-            this.httpContextAccessor = httpContextAccessor;
+            this.HttpContextAccessor = httpContextAccessor;
         }
+
+        /// <summary>
+        /// Gets the HTTP context accessor.
+        /// </summary>
+        protected IHttpContextAccessor HttpContextAccessor { get; }
 
         /// <inheritdoc/>
         public abstract Task HandleAsync(AuthorizationHandlerContext context);
-
-        /// <summary>
-        /// Gets the subject identifier for requested health data resource(s) from the request context.
-        /// </summary>
-        /// <param name="lookupMethod">The mechanism with which to retrieve the subject identifier.</param>
-        /// <returns>The subject identifier for requested health data resource(s).</returns>
-        protected string? GetResourceHdid(FhirSubjectLookupMethod lookupMethod)
-        {
-            string? retVal = lookupMethod switch
-            {
-                FhirSubjectLookupMethod.Route => this.httpContextAccessor.HttpContext?.Request.RouteValues[RouteResourceIdentifier] as string,
-                FhirSubjectLookupMethod.Parameter => this.httpContextAccessor.HttpContext?.Request.Query[RouteResourceIdentifier],
-                _ => null,
-            };
-
-            return retVal;
-        }
 
         /// <summary>
         /// Check if the authenticated user has system-delegated access to the resource(s).

--- a/Apps/Common/src/AccessManagement/Authorization/Handlers/PersonalAccessHandler.cs
+++ b/Apps/Common/src/AccessManagement/Authorization/Handlers/PersonalAccessHandler.cs
@@ -19,6 +19,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authorization.Claims;
     using HealthGateway.Common.AccessManagement.Authorization.Requirements;
+    using HealthGateway.Common.Utils;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
     using Microsoft.Extensions.Logging;
@@ -50,7 +51,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
         {
             foreach (PersonalFhirRequirement requirement in context.PendingRequirements.OfType<PersonalFhirRequirement>())
             {
-                string? resourceHdid = this.GetResourceHdid(requirement.SubjectLookupMethod);
+                string? resourceHdid = HttpContextHelper.GetResourceHdid(this.HttpContextAccessor.HttpContext, requirement.SubjectLookupMethod);
                 if (resourceHdid == null)
                 {
                     this.logger.LogWarning("PersonalAccessHandler has been invoked without patient HDID specified in the request, ignoring");

--- a/Apps/Common/src/AccessManagement/Authorization/Handlers/UserDelegatedAccessHandler.cs
+++ b/Apps/Common/src/AccessManagement/Authorization/Handlers/UserDelegatedAccessHandler.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
+    using HealthGateway.Common.Utils;
     using HealthGateway.Database.Delegates;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Http;
@@ -72,7 +73,7 @@ namespace HealthGateway.Common.AccessManagement.Authorization.Handlers
             IEnumerable<PersonalFhirRequirement> pendingRequirements = context.PendingRequirements.OfType<PersonalFhirRequirement>();
             foreach (PersonalFhirRequirement requirement in pendingRequirements)
             {
-                string? resourceHdid = this.GetResourceHdid(requirement.SubjectLookupMethod);
+                string? resourceHdid = HttpContextHelper.GetResourceHdid(this.HttpContextAccessor.HttpContext, requirement.SubjectLookupMethod);
                 if (resourceHdid == null)
                 {
                     this.logger.LogWarning("UserDelegatedAccessHandler has been invoked without patient HDID specified in the request, ignoring");

--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -57,10 +57,17 @@ namespace HealthGateway.Common.Auditing
             auditEvent.ApplicationType = GetApplicationType();
             auditEvent.TransactionResultCode = GetTransactionResultType(context.Response.StatusCode);
 
-            auditEvent.ApplicationSubject = subjectQuery ?? hdid ?? subjectPhn;
+            // Check if Hdid is in route values
+            RouteValueDictionary routeValues = context.Request.RouteValues;
+            string? routeHdid = routeValues["Hdid"] as string;
+
+            // Check if Hdid is in query parameters
+            context.Request.Query.TryGetValue("Hdid", out StringValues queryHdidParameter);
+            string? queryHdid = queryHdidParameter.FirstOrDefault();
+
+            auditEvent.ApplicationSubject = routeHdid ?? queryHdid ?? hdid ?? subjectPhn ?? subjectQuery;
             auditEvent.CreatedBy = hdid ?? idir ?? UserId.DefaultUser;
 
-            RouteValueDictionary routeValues = context.Request.RouteValues;
             auditEvent.TransactionName = @$"{routeValues["controller"]}\{routeValues["action"]}";
 
             auditEvent.Trace = context.TraceIdentifier;

--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.Common.Auditing
             auditEvent.ApplicationType = GetApplicationType();
             auditEvent.TransactionResultCode = GetTransactionResultType(context.Response.StatusCode);
 
-            auditEvent.ApplicationSubject = hdid ?? subjectPhn ?? subjectQuery;
+            auditEvent.ApplicationSubject = subjectQuery ?? hdid ?? subjectPhn;
             auditEvent.CreatedBy = hdid ?? idir ?? UserId.DefaultUser;
 
             RouteValueDictionary routeValues = context.Request.RouteValues;

--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -59,11 +59,15 @@ namespace HealthGateway.Common.Auditing
 
             // Check if Hdid is in route values
             RouteValueDictionary routeValues = context.Request.RouteValues;
-            string? routeHdid = routeValues["Hdid"] as string;
+            string? routeHdid = routeValues
+                .FirstOrDefault(r => string.Equals(r.Key, "Hdid", StringComparison.OrdinalIgnoreCase))
+                .Value as string;
 
             // Check if Hdid is in query parameters
-            context.Request.Query.TryGetValue("Hdid", out StringValues queryHdidParameter);
-            string? queryHdid = queryHdidParameter.FirstOrDefault();
+            string? queryHdid = context.Request.Query
+                .FirstOrDefault(q => q.Key.Equals("Hdid", StringComparison.OrdinalIgnoreCase))
+                .Value
+                .FirstOrDefault();
 
             auditEvent.ApplicationSubject = routeHdid ?? queryHdid ?? hdid ?? subjectPhn ?? subjectQuery;
             auditEvent.CreatedBy = hdid ?? idir ?? UserId.DefaultUser;

--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -59,15 +59,11 @@ namespace HealthGateway.Common.Auditing
 
             // Check if Hdid is in route values
             RouteValueDictionary routeValues = context.Request.RouteValues;
-            string? routeHdid = routeValues
-                .FirstOrDefault(r => string.Equals(r.Key, "Hdid", StringComparison.OrdinalIgnoreCase))
-                .Value as string;
+            string? routeHdid = routeValues["Hdid"] as string;
 
             // Check if Hdid is in query parameters
-            string? queryHdid = context.Request.Query
-                .FirstOrDefault(q => q.Key.Equals("Hdid", StringComparison.OrdinalIgnoreCase))
-                .Value
-                .FirstOrDefault();
+            context.Request.Query.TryGetValue("Hdid", out StringValues queryHdidParameter);
+            string? queryHdid = queryHdidParameter.FirstOrDefault();
 
             auditEvent.ApplicationSubject = routeHdid ?? queryHdid ?? hdid ?? subjectPhn ?? subjectQuery;
             auditEvent.CreatedBy = hdid ?? idir ?? UserId.DefaultUser;

--- a/Apps/Common/src/Auditing/AuditLogger.cs
+++ b/Apps/Common/src/Auditing/AuditLogger.cs
@@ -22,7 +22,9 @@ namespace HealthGateway.Common.Auditing
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Utils;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Models;
     using Microsoft.AspNetCore.Http;
@@ -58,16 +60,15 @@ namespace HealthGateway.Common.Auditing
             auditEvent.TransactionResultCode = GetTransactionResultType(context.Response.StatusCode);
 
             // Check if Hdid is in route values
-            RouteValueDictionary routeValues = context.Request.RouteValues;
-            string? routeHdid = routeValues["Hdid"] as string;
+            string? routeHdid = HttpContextHelper.GetResourceHdid(context, FhirSubjectLookupMethod.Route);
 
             // Check if Hdid is in query parameters
-            context.Request.Query.TryGetValue("Hdid", out StringValues queryHdidParameter);
-            string? queryHdid = queryHdidParameter.FirstOrDefault();
+            string? queryHdid = HttpContextHelper.GetResourceHdid(context, FhirSubjectLookupMethod.Parameter);
 
             auditEvent.ApplicationSubject = routeHdid ?? queryHdid ?? hdid ?? subjectPhn ?? subjectQuery;
             auditEvent.CreatedBy = hdid ?? idir ?? UserId.DefaultUser;
 
+            RouteValueDictionary routeValues = context.Request.RouteValues;
             auditEvent.TransactionName = @$"{routeValues["controller"]}\{routeValues["action"]}";
 
             auditEvent.Trace = context.TraceIdentifier;

--- a/Apps/Common/src/Utils/HttpContextHelper.cs
+++ b/Apps/Common/src/Utils/HttpContextHelper.cs
@@ -1,0 +1,46 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Common.Utils
+{
+    using HealthGateway.Common.Constants;
+    using Microsoft.AspNetCore.Http;
+
+    /// <summary>
+    /// HttpContextHelper class.
+    /// </summary>
+    public static class HttpContextHelper
+    {
+        private const string RouteResourceIdentifier = "hdid";
+
+        /// <summary>
+        /// Gets the subject identifier for requested health data resource(s) from the request context.
+        /// </summary>
+        /// <param name="context">The HTTP context containing information about the current request.</param>
+        /// <param name="lookupMethod">The mechanism with which to retrieve the subject identifier.</param>
+        /// <returns>The subject identifier for requested health data resource(s).</returns>
+        public static string? GetResourceHdid(HttpContext? context, FhirSubjectLookupMethod lookupMethod)
+        {
+            string? retVal = lookupMethod switch
+            {
+                FhirSubjectLookupMethod.Route => context?.Request.RouteValues[RouteResourceIdentifier] as string,
+                FhirSubjectLookupMethod.Parameter => context?.Request.Query[RouteResourceIdentifier],
+                _ => null,
+            };
+
+            return retVal;
+        }
+    }
+}

--- a/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
+++ b/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             // Arrange
             AuditEvent actual = new();
-            GetPopulateWithHttpContextMock mock = SetupGetPopulateWithHttpContextMock(useRouteValues, useQueryParamValues);
+            PopulateWithHttpContextMock mock = SetupPopulateWithHttpContextMock(useRouteValues, useQueryParamValues);
 
             // Act
             mock.DbAuditLogger.PopulateWithHttpContext(mock.DefaultHttpContext, actual);
@@ -235,7 +235,7 @@ namespace HealthGateway.CommonTests.Auditing
                 Times.Once);
         }
 
-        private static GetPopulateWithHttpContextMock SetupGetPopulateWithHttpContextMock(bool useRouteValues, bool useQueryParamValues)
+        private static PopulateWithHttpContextMock SetupPopulateWithHttpContextMock(bool useRouteValues, bool useQueryParamValues)
         {
             DefaultHttpContext ctx = new()
             {
@@ -248,7 +248,7 @@ namespace HealthGateway.CommonTests.Auditing
                 ctx.Request.Query = new QueryCollection(
                     new Dictionary<string, StringValues>
                     {
-                        { "Hdid", RouteHdid },
+                        { "HDID", RouteHdid }, // Use HDID for Hdid to check for case insensitivity
                     });
             }
 
@@ -256,7 +256,7 @@ namespace HealthGateway.CommonTests.Auditing
             {
                 ctx.Request.RouteValues = new RouteValueDictionary
                 {
-                    { "Hdid", QueryParamHdid },
+                    { "hdid", QueryParamHdid }, // Use hdid for Hdid to check for case insensitivity
                 };
             }
 
@@ -279,6 +279,6 @@ namespace HealthGateway.CommonTests.Auditing
             return new(dbAuditLogger, ctx, expected);
         }
 
-        private sealed record GetPopulateWithHttpContextMock(DbAuditLogger DbAuditLogger, DefaultHttpContext DefaultHttpContext, AuditEvent Expected);
+        private sealed record PopulateWithHttpContextMock(DbAuditLogger DbAuditLogger, DefaultHttpContext DefaultHttpContext, AuditEvent Expected);
     }
 }

--- a/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
+++ b/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
@@ -41,7 +41,7 @@ namespace HealthGateway.CommonTests.Auditing
     {
         private const string Hdid = "EXAMPLE-HDID";
         private const string RouteHdid = "EXAMPLE-ROUTE-HDID";
-        private const string QueryParamHdid = "EXAMPLE-QUERY_PARAM-HDID";
+        private const string QueryParamHdid = "EXAMPLE-QUERY-PARAM-HDID";
         private const string Idir = "EXAMPLE-IDIR";
 
         /// <summary>
@@ -245,19 +245,19 @@ namespace HealthGateway.CommonTests.Auditing
 
             if (useRouteValues)
             {
-                ctx.Request.Query = new QueryCollection(
-                    new Dictionary<string, StringValues>
-                    {
-                        { "HDID", RouteHdid }, // Use HDID for Hdid to check for case insensitivity
-                    });
+                ctx.Request.RouteValues = new RouteValueDictionary
+                {
+                    { "HDID", RouteHdid }, // Use HDID for Hdid to check for case insensitivity
+                };
             }
 
             if (useQueryParamValues)
             {
-                ctx.Request.RouteValues = new RouteValueDictionary
-                {
-                    { "hdid", QueryParamHdid }, // Use hdid for Hdid to check for case insensitivity
-                };
+                ctx.Request.Query = new QueryCollection(
+                    new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "hdid", QueryParamHdid }, // Use hdid for Hdid to check for case insensitivity
+                    });
             }
 
             AuditEvent expected = new()

--- a/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
+++ b/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
@@ -247,7 +247,7 @@ namespace HealthGateway.CommonTests.Auditing
             {
                 ctx.Request.RouteValues = new RouteValueDictionary
                 {
-                    { "HDID", RouteHdid }, // Use HDID for Hdid to check for case insensitivity
+                    { "Hdid", RouteHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
                 };
             }
 
@@ -256,7 +256,7 @@ namespace HealthGateway.CommonTests.Auditing
                 ctx.Request.Query = new QueryCollection(
                     new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
                     {
-                        { "hdid", QueryParamHdid }, // Use hdid for Hdid to check for case insensitivity
+                        { "Hdid", QueryParamHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
                     });
             }
 

--- a/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
+++ b/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
@@ -1,0 +1,103 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Utils;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Primitives;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// HttpContextHelper's Unit Tests.
+    /// </summary>
+    public class HttpContextHelperTests
+    {
+        private const string RouteHdid = "ROUTE-HDID";
+        private const string QueryParamHdid = "QUERY-PARAM-HDID";
+
+        /// <summary>
+        /// Should GetResourceHdid.
+        /// </summary>
+        /// <param name="lookupMethod">The mechanism with which to retrieve the subject identifier.</param>
+        [InlineData(FhirSubjectLookupMethod.Route)]
+        [InlineData(FhirSubjectLookupMethod.Parameter)]
+        [InlineData((FhirSubjectLookupMethod)999)]
+        [Theory]
+        public void ShouldGetResourceHdid(FhirSubjectLookupMethod lookupMethod)
+        {
+            // Arrange
+            GetResourceHdidMock mock = SetupGetResourceHdidMock(lookupMethod);
+
+            // Act
+            string? actual = HttpContextHelper.GetResourceHdid(mock.HttpContext, lookupMethod);
+
+            // Assert
+            Assert.Equal(mock.Expected, actual);
+        }
+
+        [SuppressMessage("ReSharper", "SwitchStatementHandlesSomeKnownEnumValuesWithDefault", Justification = "Unknown enum value expected and is handled in mock setup.")]
+        private static GetResourceHdidMock SetupGetResourceHdidMock(FhirSubjectLookupMethod lookupMethod)
+        {
+            Mock<HttpRequest> httpRequestMock = new();
+
+            switch (lookupMethod)
+            {
+                case FhirSubjectLookupMethod.Parameter:
+                {
+                    QueryCollection queryCollection = new(
+                        new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+                        {
+                            { "Hdid", QueryParamHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
+                        });
+
+                    httpRequestMock.Setup(s => s.Query).Returns(queryCollection);
+                    break;
+                }
+
+                case FhirSubjectLookupMethod.Route:
+                {
+                    RouteValueDictionary routeValues = new()
+                    {
+                        { "Hdid", RouteHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
+                    };
+
+                    httpRequestMock.Setup(s => s.RouteValues).Returns(routeValues);
+                    break;
+                }
+            }
+
+            Mock<HttpContext> httpContextMock = new();
+            httpContextMock.Setup(s => s.Request).Returns(httpRequestMock.Object);
+
+            string? expected = lookupMethod switch
+            {
+                FhirSubjectLookupMethod.Parameter => QueryParamHdid,
+                FhirSubjectLookupMethod.Route => RouteHdid,
+                _ => null,
+            };
+
+            return new(httpContextMock.Object, expected);
+        }
+
+        private sealed record GetResourceHdidMock(HttpContext HttpContext, string Expected);
+    }
+}


### PR DESCRIPTION
# Fixes [AB#16772](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16772)

## Description

Change priority for application subject determination:

- Check if Hdid exists in route values
- Check if Hdid exists in query parameters

Created common HttpContextHelper class with common code to access Hdid Route and Parameter Values:

- Moved GetResourceHdid from BaseFhirAuthorizationHandler to HttpContextHelper
- Created unit test for HttpContextHelper

Priority:

1. Hdid in route
2. Hdid in query parameter
3. Hdid in claim identity
4. Subject PHN
5. Subject query

Also updated unit tests.

<img width="769" alt="Screenshot 2024-06-24 at 12 56 37 PM" src="https://github.com/bcgov/healthgateway/assets/58790456/5afdf9e9-d3f2-40a7-a46e-f72bbc9b0f16">


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
