### PR TITLE
Fix sonar code smells for AB#16776.

### DIFF
--- a/Apps/GatewayApi/src/Models/CreateUserRequest.cs
+++ b/Apps/GatewayApi/src/Models/CreateUserRequest.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.GatewayApi.Models
 {
     using System;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Object that defines the request for creating a User.
@@ -35,5 +36,5 @@ namespace HealthGateway.GatewayApi.Models
     /// <param name="TermsOfServiceId">The terms of service id associated with the user profile to create.</param>
     /// <param name="SmsNumber">The sms number associated with the user profile to create.</param>
     /// <param name="Email">The email associated with the user profile to create.</param>
-    public record CreateUserProfile(string HdId, Guid TermsOfServiceId, string? SmsNumber = null, string? Email = null);
+    public record CreateUserProfile(string HdId, [property: JsonRequired] Guid TermsOfServiceId, string? SmsNumber = null, string? Email = null);
 }

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -91,6 +91,7 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="applicationSettingsService">The injected application settings service.</param>
         /// <param name="patientRepository">The injected patient repository.</param>
         /// <param name="messageSender">The injected message sender.</param>
+#pragma warning disable S107 // The number of DI parameters should be ignored
         public UserProfileServiceV2(
             ILogger<UserProfileServiceV2> logger,
             IPatientDetailsService patientDetailsService,

--- a/Apps/Laboratory/src/Models/PHSA/LabTestKit.cs
+++ b/Apps/Laboratory/src/Models/PHSA/LabTestKit.cs
@@ -25,6 +25,7 @@ namespace HealthGateway.Laboratory.Models.PHSA
         /// <summary>
         /// Gets or sets when the test was used.
         /// </summary>
+        [JsonRequired]
         [JsonPropertyName("testTakenMinutesAgo")]
         public int TestTakenMinutesAgo { get; set; }
 

--- a/Apps/Laboratory/src/Models/PHSA/PublicLabTestKit.cs
+++ b/Apps/Laboratory/src/Models/PHSA/PublicLabTestKit.cs
@@ -32,6 +32,7 @@ namespace HealthGateway.Laboratory.Models.PHSA
         /// <summary>
         /// Gets or sets the date of birth for the identified PHN.
         /// </summary>
+        [JsonRequired]
         [JsonPropertyName("dob")]
         public DateTime Dob { get; set; }
 
@@ -50,6 +51,7 @@ namespace HealthGateway.Laboratory.Models.PHSA
         /// <summary>
         /// Gets or sets when the test was used.
         /// </summary>
+        [JsonRequired]
         [JsonPropertyName("testTakenMinutesAgo")]
         public int TestTakenMinutesAgo { get; set; }
 


### PR DESCRIPTION
# Fixes [AB#16776](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16776)

## Description

Addressed sonar code smells:

- The number of DI parameters in UserProfileServiceV2 constructor
- Required should be defined for Guid TermsOfServiceId in CreateUserRequest
- Required should be defined for DateTime Dob in PublicLabTestKit
- Required should be defined for int TestTakenMinutesAgo in PublicLabTestKit
- Required should be defined for int TestTakenMinutesAgo in LasTestKit

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
