### PR TITLE
Fix user profile not being saved before verifying email AB#16781

### DIFF
--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -214,7 +214,7 @@ namespace HealthGateway.GatewayApi.Services
                 LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType(),
             };
 
-            DbResult<UserProfile> dbResult = await this.userProfileDelegate.InsertUserProfileAsync(profile, !this.accountsChangeFeedEnabled, ct);
+            DbResult<UserProfile> dbResult = await this.userProfileDelegate.InsertUserProfileAsync(profile, ct: ct);
             if (dbResult.Status != DbStatusCode.Created)
             {
                 this.logger.LogError("Error creating user profile... {Hdid}", hdid);


### PR DESCRIPTION
# Fixes [AB#16781](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16781)

## Description

When the Accounts ChangeFeed option is enabled, new user profiles were not being being committed immediately, but together with queuing messages via the DbOutboxStore.  The reorganization of the code caused the email verification updates for pre-verified emails to happen between those 2 events instead of afterwards, and it failed when trying to find the UserProfile that had been added but not committed.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
