### PR TITLE
Add intercept and wait on admin endpoint calls for AB#16782

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/beta-access.cy.js
@@ -4,6 +4,23 @@ const existingEmail = "somebody@healthgateway.gov.bc.ca";
 const validEmail = "nobody@healthgateway.gov.bc.ca";
 const notFoundEmail = "nobody@salesforce.gov.bc.ca";
 const invalidEmail = "nobody@";
+const defaultTimeout = 60000;
+
+function setupGetUserAccessAlias() {
+    cy.intercept("GET", "**/BetaFeature/UserAccess*").as("getUserAccess");
+}
+
+function setupPutUserAccessAlias() {
+    cy.intercept("PUT", "**/UserAccess").as("putUserAccess");
+}
+
+function waitForGetUserAccess() {
+    cy.wait("@getUserAccess", { timeout: defaultTimeout });
+}
+
+function waitForPutUserAccess() {
+    cy.wait("@putUserAccess", { timeout: defaultTimeout });
+}
 
 describe("Beta feature access", () => {
     beforeEach(() => {
@@ -48,8 +65,11 @@ describe("Beta feature access", () => {
             .should("be.enabled")
             .clear()
             .type(notFoundEmail);
+
         cy.get(".d-flex").contains("Invalid email format").should("not.exist");
+        setupGetUserAccessAlias();
         cy.get("[data-testid=search-button]").click();
+        waitForGetUserAccess();
 
         cy.get("[data-testid=get-user-access-error-message]").should(
             "be.visible"
@@ -62,13 +82,17 @@ describe("Beta feature access", () => {
         // Tab to Search and search with a valid email
         cy.log("Verify search with valid email.");
         selectTab("[data-testid=beta-access-tabs]", "Search");
+        setupGetUserAccessAlias();
+
         cy.get("[data-testid=query-input]")
             .should("be.visible")
             .should("be.enabled")
             .clear()
             .type(validEmail);
+
         cy.get(".d-flex").contains("Invalid email format").should("not.exist");
         cy.get("[data-testid=search-button]").click();
+        waitForGetUserAccess();
 
         cy.get("[data-testid=get-user-access-error-message]").should(
             "not.exist"
@@ -80,7 +104,9 @@ describe("Beta feature access", () => {
 
         // Assign salesforce feature
         cy.log("Verify assign salesforce feature on Search.");
+        setupPutUserAccessAlias();
         cy.get("[data-testid=salesforce-access-switch]").click();
+        waitForPutUserAccess();
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
         // Tab to View and verify assigned feature(s)
@@ -132,7 +158,9 @@ describe("Beta feature access", () => {
 
         // Assign salesforce feature again on Search
         cy.log("Verify re-assign salesforce feature access on Search tab.");
+        setupPutUserAccessAlias();
         cy.get("[data-testid=salesforce-access-switch]").click();
+        waitForPutUserAccess();
         cy.get("[data-testid=salesforce-access-switch]").should("be.checked");
 
         // Tab back to View and verify salesforce is assigned
@@ -155,7 +183,9 @@ describe("Beta feature access", () => {
 
         // Un-assign salesforce on Search
         cy.log("Verify un-assign salesforce feature on Search tab.");
+        setupPutUserAccessAlias();
         cy.get("[data-testid=salesforce-access-switch]").click();
+        waitForPutUserAccess();
         cy.get("[data-testid=salesforce-access-switch]").should(
             "not.be.checked"
         );

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/communications.cy.js
@@ -1,5 +1,7 @@
 import { getTodayPlusDaysDate } from "../../utilities/sharedUtilities";
 
+const defaultTimeout = 60000;
+
 describe("Communications", () => {
     beforeEach(() => {
         cy.login(
@@ -26,7 +28,10 @@ describe("Communications", () => {
             .clear()
             .focus()
             .type("Test Notification Content");
+
+        cy.intercept("POST", "**/Broadcast/").as("postBroadcast");
         cy.get("[data-testid=save-btn]").click();
+        cy.wait("@postBroadcast", { timeout: defaultTimeout });
         cy.get("[data-testid=broadcast-dialog-modal-text]").should("not.exist");
 
         cy.log("Validate notification was created.");
@@ -86,7 +91,9 @@ describe("Communications", () => {
             .focus()
             .type("https://www.healthgateway.gov.bc.ca");
 
+        cy.intercept("PUT", "**/Broadcast/").as("putBroadcast");
         cy.get("[data-testid=save-btn]").click();
+        cy.wait("@putBroadcast", { timeout: defaultTimeout });
         cy.get("[data-testid=broadcast-dialog-modal-text]").should("not.exist");
 
         cy.log("Validate notification was edited.");
@@ -111,12 +118,13 @@ describe("Communications", () => {
             });
 
         cy.get("[data-testid=confirm-delete-message]").should("be.visible");
+        cy.intercept("DELETE", "**/Broadcast/").as("deleteBroadcast");
         cy.get("[data-testid=confirm-delete-btn]").click();
+        cy.wait("@deleteBroadcast", { timeout: defaultTimeout });
         cy.get("[data-testid=confirm-delete-message]").should("not.exist");
 
         cy.log("Validate notification was deleted.");
 
-        cy.validateTableLoad("[data-testid=broadcast-table]");
         cy.get(rowSelector)
             .first()
             .within(() => {
@@ -191,7 +199,10 @@ describe("Communications", () => {
                 .focus()
                 .type("Edited Mobile Comm");
         });
+
+        cy.intercept("PUT", "**/Communication/").as("putCommunication");
         cy.get("[data-testid=save-btn]").click();
+        cy.wait("@putCommunication", { timeout: defaultTimeout });
         cy.get("[data-testid=comm-table-subject]").contains(
             "Edited Mobile Comm"
         );
@@ -205,7 +216,11 @@ describe("Communications", () => {
         cy.get("[data-testid=confirm-cancel-btn]").click();
         cy.get("[data-testid=confirm-delete-message]").should("not.exist");
         cy.get("[data-testid=comm-table-delete-btn]").click();
+
+        cy.intercept("DELETE", "**/Communication/").as("deleteCommunication");
         cy.get("[data-testid=confirm-delete-btn]").click();
+        cy.wait("@deleteCommunication", { timeout: defaultTimeout });
+
         cy.get("[data-testid=confirm-delete-message]").should("not.exist");
         cy.get("[data-testid=comm-table-subject]").should("not.exist");
 
@@ -227,7 +242,10 @@ describe("Communications", () => {
         cy.get("[data-testid=status-type]")
             .contains("Publish")
             .click({ force: true });
+
+        cy.intercept("POST", "**/Communication/").as("postCommunication");
         cy.get("[data-testid=save-btn]").click({ force: true });
+        cy.wait("@postCommunication", { timeout: defaultTimeout });
         cy.get("[data-testid=comm-table-subject]").contains("New Mobile Comm");
 
         cy.log("Validate add communication finished.");

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/reports.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/reports.cy.js
@@ -18,17 +18,11 @@ function waitForPatientDetailsDataLoad() {
 
 describe("Reports", () => {
     beforeEach(() => {
-        cy.intercept("GET", `**/AdminReport/BlockedAccess`).as(
-            "getBlockedAccess"
-        );
-
         cy.login(
             Cypress.env("keycloak_username"),
             Cypress.env("keycloak_password"),
             "/reports"
         );
-
-        cy.wait("@getBlockedAccess", { timeout: defaultTimeout });
     });
 
     it("Verify blocked access reports", () => {

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/support.cy.js
@@ -47,17 +47,23 @@ describe("Support", () => {
     });
 
     it("Verify no results hdid query.", () => {
-        performSearch("HDID", hdidNotFound);
+        performSearch("HDID", hdidNotFound, {
+            waitForPatientSupportDetails: false,
+        });
         getTableRows("[data-testid=user-table]").should("have.length", 0);
     });
 
     it("Verify no results sms query.", () => {
-        performSearch("SMS", smsNotFound);
+        performSearch("SMS", smsNotFound, {
+            waitForPatientSupportDetails: false,
+        });
         getTableRows("[data-testid=user-table]").should("have.length", 0);
     });
 
     it("Verify no results email query.", () => {
-        performSearch("Email", emailNotFound);
+        performSearch("Email", emailNotFound, {
+            waitForPatientSupportDetails: false,
+        });
         getTableRows("[data-testid=user-table]").should("have.length", 0);
     });
 

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
@@ -221,14 +221,15 @@ describe("Patient details as admin", () => {
         cy.intercept("GET", `**/Document?phn=${phn}`, {
             statusCode: 500,
         });
-    
+
         performSearch("PHN", phn);
         selectPatientTab("Profile");
         cy.scrollTo("bottom", { ensureScrollable: false });
         cy.get("[data-testid=print-button]").should("be.visible").click();
         cy.scrollTo("top", { ensureScrollable: false });
-        cy.get("[data-testid=user-banner-print-vaccine-card-error-message]")
-            .should("be.visible");
+        cy.get(
+            "[data-testid=user-banner-print-vaccine-card-error-message]"
+        ).should("be.visible");
     });
 });
 

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/support.cy.js
@@ -17,7 +17,10 @@ const hdid = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
 const sms = "2506715000";
 
 function verifyParameterIsRequired(queryType) {
-    performSearch(queryType, null);
+    performSearch(queryType, null, {
+        waitForUser: false,
+        waitForPatientSupportDetails: false,
+    });
     cy.get("div").contains("Search parameter is required").should("be.visible");
     cy.get("[data-testid=user-table]").should("not.exist");
 }
@@ -84,6 +87,11 @@ describe("Support", () => {
             }
         );
 
+        // Patient support details
+        cy.intercept("GET", "**/PatientSupportDetails*", {
+            fixture: "SupportService/patient-details.json",
+        });
+
         cy.login(
             Cypress.env("keycloak_username"),
             Cypress.env("keycloak_password"),
@@ -124,7 +132,10 @@ describe("Support", () => {
     });
 
     it("Verify error handling", () => {
-        performSearch("PHN", phnError);
+        performSearch("PHN", phnError, {
+            waitForUser: false,
+            waitForPatientSupportDetails: false,
+        });
         cy.get("[data-testid=user-banner-feedback-error-message]").should(
             "be.visible"
         );
@@ -137,7 +148,10 @@ describe("Support", () => {
     });
 
     it("Verify query fails on invalid PHN", () => {
-        performSearch("PHN", phnInvalid);
+        performSearch("PHN", phnInvalid, {
+            waitForUser: false,
+            waitForPatientSupportDetails: false,
+        });
         cy.get(".d-flex").contains("Invalid PHN").should("be.visible");
         cy.get("[data-testid=user-table]").should("not.exist");
     });
@@ -151,7 +165,9 @@ describe("Support", () => {
     });
 
     it("Verify clear button", () => {
-        performSearch("SMS", sms);
+        performSearch("SMS", sms, {
+            waitForPatientSupportDetails: false,
+        });
         verifySupportTableResults(hdid, phn, 2);
         cy.get("[data-testid=clear-btn]").click();
         cy.get("[data-testid=query-type-select]").should("have.value", "Sms");

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -7,6 +7,10 @@
 // commands please read more here:
 // https://on.cypress.io/custom-commands
 // ***********************************************
+import {
+    setupStandardAliases,
+    waitForInitialDataLoad,
+} from "./functions/intercept";
 require("cy-verify-downloads").addCustomCommand();
 
 const openIdConnectClientId = "hg-admin";
@@ -102,7 +106,11 @@ Cypress.Commands.add("login", (username, password, path) => {
         });
     });
     cy.log(`Visiting ${path}`);
+    setupStandardAliases(path);
+
     cy.visit(path, { timeout: 60000 });
+    waitForInitialDataLoad(path);
+
     // wait for log in to complete
     cy.get("[data-testid=user-account-icon]").should("exist");
 });

--- a/Apps/Admin/Tests/Functional/cypress/support/functions/intercept.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/functions/intercept.js
@@ -25,19 +25,19 @@ export function setupStandardAliases(page) {
 
 export function waitForInitialDataLoad(page) {
     switch (page) {
-        case "dashboard":
+        case "/dashboard":
             waitForDashboard();
             break;
-        case "communications":
+        case "/communications":
             waitForCommunication();
             break;
-        case "feedback":
+        case "/feedback":
             waitForFeedback();
             break;
-        case "beta-access":
+        case "/beta-access":
             waitForBetaAccess();
             break;
-        case "reports":
+        case "/reports":
             waitForReport();
             break;
         default:
@@ -69,7 +69,7 @@ function setupCommunicationAliases() {
     cy.log("Setting up communication aliases.");
 
     cy.intercept("GET", "**/Broadcast/").as("getBroadcast");
-    cy.intercept("GET", `**/Communication/*`).as("getCommunication");
+    cy.intercept("GET", `**/Communication/`).as("getCommunication");
 }
 
 function setupFeedbackAliases() {
@@ -96,24 +96,29 @@ function setupReportAliases() {
 
 function waitForDashboard() {
     cy.log("Wait on dashboard");
-    cy.wait("@getAllTimeCounts", { timeout: defaultTimeout });
-    cy.wait("@getAppLoginCounts", { timeout: defaultTimeout });
-    cy.wait("@getRatingsSummary", { timeout: defaultTimeout });
-    cy.wait("@getAgeCounts", { timeout: defaultTimeout });
-    cy.wait("@getDailyUsageCounts", { timeout: defaultTimeout });
-    cy.wait("@getRecurringUserCount", { timeout: defaultTimeout });
+    cy.wait(
+        [
+            "@getAllTimeCounts",
+            "@getAppLoginCounts",
+            "@getRatingsSummary",
+            "@getAgeCounts",
+            "@getDailyUsageCounts",
+            "@getRecurringUserCount",
+        ],
+        { timeout: defaultTimeout }
+    );
 }
 
 function waitForCommunication() {
     cy.log("Wait on communication");
-    cy.wait("@getBroadcast", { timeout: defaultTimeout });
-    cy.wait("@getCommunication", { timeout: defaultTimeout });
+    cy.wait(["@getBroadcast", "@getCommunication"], {
+        timeout: defaultTimeout,
+    });
 }
 
 function waitForFeedback() {
     cy.log("Wait on feedback");
-    cy.wait("@getTag", { timeout: defaultTimeout });
-    cy.wait("@getUserFeedback", { timeout: defaultTimeout });
+    cy.wait(["@getTag", "@getUserFeedback"], { timeout: defaultTimeout });
 }
 
 function waitForBetaAccess() {
@@ -123,6 +128,7 @@ function waitForBetaAccess() {
 
 function waitForReport() {
     cy.log("Wait on report");
-    cy.wait("@getBlockedAccess", { timeout: defaultTimeout });
-    cy.wait("@getProtectedDependents", { timeout: defaultTimeout });
+    cy.wait(["@getBlockedAccess", "@getProtectedDependents"], {
+        timeout: defaultTimeout,
+    });
 }

--- a/Apps/Admin/Tests/Functional/cypress/support/functions/intercept.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/functions/intercept.js
@@ -1,0 +1,128 @@
+const defaultTimeout = 60000;
+
+export function setupStandardAliases(page) {
+    switch (page) {
+        case "/dashboard":
+            setupDashboardAliases();
+            break;
+        case "/communications":
+            setupCommunicationAliases();
+            break;
+        case "/feedback":
+            setupFeedbackAliases();
+            break;
+        case "/beta-access":
+            setupBetaAccessAliases();
+            break;
+        case "/reports":
+            setupReportAliases();
+            break;
+        default:
+            cy.log(`Alias setup on login not required for page: ${page}`);
+            break;
+    }
+}
+
+export function waitForInitialDataLoad(page) {
+    switch (page) {
+        case "dashboard":
+            waitForDashboard();
+            break;
+        case "communications":
+            waitForCommunication();
+            break;
+        case "feedback":
+            waitForFeedback();
+            break;
+        case "beta-access":
+            waitForBetaAccess();
+            break;
+        case "reports":
+            waitForReport();
+            break;
+        default:
+            cy.log(
+                `Wait for initial data load on login not required for page: ${page}`
+            );
+            break;
+    }
+}
+
+function setupDashboardAliases() {
+    cy.log("Setting up dashboard aliases.");
+
+    cy.intercept("GET", "**/Dashboard/AllTimeCounts").as("getAllTimeCounts");
+    cy.intercept("GET", `**/Dashboard/AppLoginCounts*`).as("getAppLoginCounts");
+    cy.intercept("GET", "**/Dashboard/Ratings/Summary*").as(
+        "getRatingsSummary"
+    );
+    cy.intercept("GET", "**/Dashboard/AgeCounts*").as("getAgeCounts");
+    cy.intercept("GET", "**/Dashboard/DailyUsageCounts*").as(
+        "getDailyUsageCounts"
+    );
+    cy.intercept("GET", "**/Dashboard/RecurringUserCount*").as(
+        "getRecurringUserCount"
+    );
+}
+
+function setupCommunicationAliases() {
+    cy.log("Setting up communication aliases.");
+
+    cy.intercept("GET", "**/Broadcast/").as("getBroadcast");
+    cy.intercept("GET", `**/Communication/*`).as("getCommunication");
+}
+
+function setupFeedbackAliases() {
+    cy.log("Setting up feedback aliases.");
+
+    cy.intercept("GET", "**/Tag/").as("getTag");
+    cy.intercept("GET", `**/UserFeedback/`).as("getUserFeedback");
+}
+
+function setupBetaAccessAliases() {
+    cy.log("Setting up beta access aliases.");
+
+    cy.intercept("GET", "**/BetaFeature/AllUserAccess").as("getAllUserAccess");
+}
+
+function setupReportAliases() {
+    cy.log("Setting up report aliases.");
+
+    cy.intercept("GET", "**/AdminReport/BlockedAccess").as("getBlockedAccess");
+    cy.intercept("GET", "**/AdminReport/ProtectedDependents*").as(
+        "getProtectedDependents"
+    );
+}
+
+function waitForDashboard() {
+    cy.log("Wait on dashboard");
+    cy.wait("@getAllTimeCounts", { timeout: defaultTimeout });
+    cy.wait("@getAppLoginCounts", { timeout: defaultTimeout });
+    cy.wait("@getRatingsSummary", { timeout: defaultTimeout });
+    cy.wait("@getAgeCounts", { timeout: defaultTimeout });
+    cy.wait("@getDailyUsageCounts", { timeout: defaultTimeout });
+    cy.wait("@getRecurringUserCount", { timeout: defaultTimeout });
+}
+
+function waitForCommunication() {
+    cy.log("Wait on communication");
+    cy.wait("@getBroadcast", { timeout: defaultTimeout });
+    cy.wait("@getCommunication", { timeout: defaultTimeout });
+}
+
+function waitForFeedback() {
+    cy.log("Wait on feedback");
+    cy.wait("@getTag", { timeout: defaultTimeout });
+    cy.wait("@getUserFeedback", { timeout: defaultTimeout });
+}
+
+function waitForBetaAccess() {
+    cy.log("Wait on beta access");
+    cy.wait("@getAllUserAccess", { timeout: defaultTimeout });
+}
+
+function waitForReport() {
+    cy.log("Wait on report");
+    cy.wait("@getBlockedAccess", { timeout: defaultTimeout });
+    cy.wait("@getProtectedDependents", { timeout: defaultTimeout });
+}


### PR DESCRIPTION
# Fixes [AB#16782](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16782)

## Description

To reduce the flakiness of some tests, implemented intercept and waits on endpoint calls.  This will ensure that the endpoints are finished before assertions are done on the UI.

Add intercept and wait to:

- agent access
- beta access
- communications
- delegation
- feedback review
- reports

Updated helpers to reduce the amount of code duplication:

- commands
- intercept
- support utilities

**Cypress Admin:** https://cloud.cypress.io/projects/rccf87/runs/2114/overview?roarHideRunsWithDiffGroupsAndTags=1

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
