### PR TITLE
Update CreateUserProfile to better bundle DB commits AB#16784

### DIFF
--- a/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
@@ -121,11 +121,11 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task ExpireAsync(MessagingVerification messageVerification, bool markDeleted, CancellationToken ct = default)
+        public async Task ExpireAsync(MessagingVerification messageVerification, bool markDeleted, bool commit = true, CancellationToken ct = default)
         {
             messageVerification.ExpireDate = DateTime.UtcNow;
             messageVerification.Deleted = markDeleted;
-            await this.UpdateAsync(messageVerification, ct: ct);
+            await this.UpdateAsync(messageVerification, commit, ct);
 
             this.logger.LogDebug("Finished Expiring messaging verification from DB");
         }

--- a/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/IMessagingVerificationDelegate.cs
@@ -67,9 +67,10 @@ namespace HealthGateway.Database.Delegates
         /// </summary>
         /// <param name="messageVerification">The message verification to expire.</param>
         /// <param name="markDeleted">Mark the verification as deleted.</param>
+        /// <param name="commit">If commit is set to true the change will be persisted immediately.</param>
         /// <param name="ct">A cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task ExpireAsync(MessagingVerification messageVerification, bool markDeleted, CancellationToken ct = default);
+        Task ExpireAsync(MessagingVerification messageVerification, bool markDeleted, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Retrieves a list of messaging verifications matching the query.

--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -259,16 +259,16 @@ namespace HealthGateway.GatewayApi.Controllers
         }
 
         /// <summary>
-        /// Validates an email address.
+        /// Verifies an email address.
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="verificationKey">The email verification key.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A boolean value indicating whether the validation was successful.</returns>
-        /// <response code="200">Returns a boolean value indicating whether the validation was successful.</response>
+        /// <returns>A boolean value indicating whether the verification was successful.</returns>
+        /// <response code="200">Returns a boolean value indicating whether the verification was successful.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="404">The verification key was not found.</response>
-        /// <response code="409">The validation has already been performed.</response>
+        /// <response code="409">The verification has already been performed.</response>
         /// <response code="500">Internal server error.</response>
         [HttpGet]
         [Route("{hdid}/email/validate/{verificationKey}")]
@@ -280,25 +280,25 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<bool> ValidateEmail(string hdid, Guid verificationKey, CancellationToken ct)
+        public async Task<bool> VerifyEmailAddress(string hdid, Guid verificationKey, CancellationToken ct)
         {
-            return await this.userEmailService.ValidateEmailAsync(hdid, verificationKey, ct);
+            return await this.userEmailService.VerifyEmailAddressAsync(hdid, verificationKey, ct);
         }
 
         /// <summary>
-        /// Validates an SMS number.
+        /// Verifies an SMS number.
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
-        /// <param name="validationCode">The SMS validation code.</param>
+        /// <param name="verificationCode">The SMS verification code.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A boolean value indicating whether the validation was successful.</returns>
-        /// <response code="200">Returns a boolean value indicating whether the validation was successful.</response>
+        /// <returns>A boolean value indicating whether the verification was successful.</returns>
+        /// <response code="200">Returns a boolean value indicating whether the verification was successful.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="404">User profile was not found.</response>
         /// <response code="500">Internal server error.</response>
         /// <response code="502">Upstream error.</response>
         [HttpGet]
-        [Route("{hdid}/sms/validate/{validationCode}")]
+        [Route("{hdid}/sms/validate/{verificationCode}")]
         [Authorize(Policy = UserProfilePolicy.Write)]
         [Produces("application/json")]
         [ProducesResponseType<bool>(StatusCodes.Status200OK)]
@@ -307,16 +307,16 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ProducesResponseType(StatusCodes.Status502BadGateway)]
-        public async Task<bool> ValidateSms(string hdid, string validationCode, CancellationToken ct)
+        public async Task<bool> VerifySmsNumber(string hdid, string verificationCode, CancellationToken ct)
         {
-            return await this.userSmsService.ValidateSmsAsync(hdid, validationCode, ct);
+            return await this.userSmsService.VerifySmsNumberAsync(hdid, verificationCode, ct);
         }
 
         /// <summary>
         /// Updates a user's email address.
         /// </summary>
         /// <param name="hdid">The user HDID.</param>
-        /// <param name="emailAddress">The new email.</param>
+        /// <param name="emailAddress">The new email address.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>An empty result.</returns>
         /// <response code="200">The user's email address has been successfully updated.</response>
@@ -338,9 +338,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
-        public async Task<IActionResult> UpdateUserEmail(string hdid, [FromBody] string emailAddress = "", CancellationToken ct = default)
+        public async Task<IActionResult> UpdateUserEmailAddress(string hdid, [FromBody] string emailAddress = "", CancellationToken ct = default)
         {
-            await this.userEmailService.UpdateUserEmailAsync(hdid, emailAddress, ct);
+            await this.userEmailService.UpdateEmailAddressAsync(hdid, emailAddress, ct);
             return this.Ok();
         }
 
@@ -372,7 +372,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> UpdateUserSmsNumberAsync(string hdid, [FromBody] string smsNumber, CancellationToken ct)
         {
-            await this.userSmsService.UpdateUserSmsAsync(hdid, smsNumber, ct);
+            await this.userSmsService.UpdateSmsNumberAsync(hdid, smsNumber, ct);
             return this.Ok();
         }
 

--- a/Apps/GatewayApi/src/Services/IUserEmailServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/IUserEmailServiceV2.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApi.Services
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using HealthGateway.Database.Models;
 
     /// <summary>
     /// The user email service.
@@ -25,32 +26,35 @@ namespace HealthGateway.GatewayApi.Services
     public interface IUserEmailServiceV2
     {
         /// <summary>
-        /// Validates an email address using the given invite key.
+        /// Verifies an email address using the given invite key.
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
         /// <param name="inviteKey">The email invite key.</param>
         /// <param name="ct">A cancellation token.</param>
-        /// <returns>Returns a boolean value indicating whether the validation was successful.</returns>
-        Task<bool> ValidateEmailAsync(string hdid, Guid inviteKey, CancellationToken ct = default);
+        /// <returns>A boolean value indicating whether the verification was successful.</returns>
+        Task<bool> VerifyEmailAddressAsync(string hdid, Guid inviteKey, CancellationToken ct = default);
 
         /// <summary>
-        /// Initializes user's email address.
-        /// </summary>
-        /// <param name="hdid">The user hdid.</param>
-        /// <param name="emailAddress">Email address to be set for the user.</param>
-        /// <param name="isVerified">Indicates whether the email address is verified.</param>
-        /// <param name="commit">If set to true the changes to database are persisted immediately.</param>
-        /// <param name="ct">A cancellation token.</param>
-        /// <returns>returns true if the email was successfully created.</returns>
-        Task<bool> CreateUserEmailAsync(string hdid, string emailAddress, bool isVerified, bool commit = true, CancellationToken ct = default);
-
-        /// <summary>
-        /// Updates the user email.
+        /// Updates user's email address.
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="emailAddress">Email address to be set for the user.</param>
         /// <param name="ct">A cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task UpdateUserEmailAsync(string hdid, string emailAddress, CancellationToken ct = default);
+        Task UpdateEmailAddressAsync(string hdid, string emailAddress, CancellationToken ct = default);
+
+        /// <summary>
+        /// Generates a messaging verification and email template using the provided HDID, email address, and invite key.
+        /// </summary>
+        /// <param name="hdid">The user hdid.</param>
+        /// <param name="emailAddress">Email address to verify.</param>
+        /// <param name="inviteKey">The email invite key.</param>
+        /// <param name="isVerified">
+        /// If the address is already verified, the verification will be marked as already validated
+        /// and the generated email will be marked as already sent.
+        /// </param>
+        /// <param name="ct">A cancellation token.</param>
+        /// <returns>The generated messaging verification.</returns>
+        Task<MessagingVerification> GenerateMessagingVerificationAsync(string hdid, string emailAddress, Guid inviteKey, bool isVerified, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IUserSmsServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/IUserSmsServiceV2.cs
@@ -25,22 +25,13 @@ namespace HealthGateway.GatewayApi.Services
     public interface IUserSmsServiceV2
     {
         /// <summary>
-        /// Validates the SMS number that matches the given validation code.
-        /// </summary>
-        /// <param name="hdid">The requested user hdid.</param>
-        /// <param name="validationCode">The SMS validation code.</param>
-        /// <param name="ct">A cancellation token.</param>
-        /// <returns>Returns a request result containing true if the SMS verification was found and validated.</returns>
-        Task<bool> ValidateSmsAsync(string hdid, string validationCode, CancellationToken ct = default);
-
-        /// <summary>
-        /// Create the user SMS number.
+        /// Verifies an SMS number for a user with the given verification code.
         /// </summary>
         /// <param name="hdid">The user hdid.</param>
-        /// <param name="sms">SMS number to be set for the user.</param>
+        /// <param name="verificationCode">The SMS verification code.</param>
         /// <param name="ct">A cancellation token.</param>
-        /// <returns>returns true if the sms number was successfully created.</returns>
-        Task<MessagingVerification> CreateUserSmsAsync(string hdid, string sms, CancellationToken ct = default);
+        /// <returns>A value indicating whether the verification was successful.</returns>
+        Task<bool> VerifySmsNumberAsync(string hdid, string verificationCode, CancellationToken ct = default);
 
         /// <summary>
         /// Updates the user SMS number.
@@ -49,6 +40,15 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="sms">SMS number to be set for the user.</param>
         /// <param name="ct">A cancellation token.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        Task UpdateUserSmsAsync(string hdid, string sms, CancellationToken ct = default);
+        Task UpdateSmsNumberAsync(string hdid, string sms, CancellationToken ct = default);
+
+        /// <summary>
+        /// Generates a messaging verification using the provided HDID and SMS number.
+        /// </summary>
+        /// <param name="hdid">The user hdid.</param>
+        /// <param name="sms">SMS number to verify.</param>
+        /// <param name="sanitize">If set to true, the provided SMS number will be sanitized before being used.</param>
+        /// <returns>The generated messaging verification.</returns>
+        MessagingVerification GenerateMessagingVerification(string hdid, string sms, bool sanitize = true);
     }
 }

--- a/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.GatewayApi.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
@@ -42,17 +41,18 @@ namespace HealthGateway.GatewayApi.Services
     public class UserEmailServiceV2 : IUserEmailServiceV2
     {
         private const int MaxVerificationAttempts = 5;
+        private const string EmailConfigExpirySecondsKey = "EmailVerificationExpirySeconds";
+        private const string WebClientConfigSection = "WebClient";
 
-        private readonly string emailConfigExpirySecondsKey = "EmailVerificationExpirySeconds";
         private readonly IEmailQueueService emailQueueService;
-        private readonly int emailVerificationExpirySeconds;
         private readonly ILogger logger;
         private readonly IMessagingVerificationDelegate messageVerificationDelegate;
         private readonly INotificationSettingsService notificationSettingsService;
         private readonly IUserProfileDelegate profileDelegate;
-        private readonly string webClientConfigSection = "WebClient";
-        private readonly bool notificationsChangeFeedEnabled;
         private readonly IMessageSender messageSender;
+
+        private readonly int emailVerificationExpirySeconds;
+        private readonly bool notificationsChangeFeedEnabled;
         private readonly EmailTemplateConfig emailTemplateConfig;
 
         /// <summary>
@@ -79,41 +79,29 @@ namespace HealthGateway.GatewayApi.Services
             this.profileDelegate = profileDelegate;
             this.emailQueueService = emailQueueService;
             this.notificationSettingsService = notificationSettingsService;
-            this.emailVerificationExpirySeconds = configuration.GetSection(this.webClientConfigSection).GetValue(this.emailConfigExpirySecondsKey, 5);
-
             this.messageSender = messageSender;
-            ChangeFeedOptions? changeFeedConfiguration = configuration.GetSection(ChangeFeedOptions.ChangeFeed)
-                .Get<ChangeFeedOptions>();
-            this.notificationsChangeFeedEnabled = changeFeedConfiguration?.Notifications.Enabled ?? false;
+
+            this.emailVerificationExpirySeconds = configuration.GetSection(WebClientConfigSection).GetValue(EmailConfigExpirySecondsKey, 5);
+            this.notificationsChangeFeedEnabled = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>()?.Notifications.Enabled ?? false;
             this.emailTemplateConfig = configuration.GetSection(EmailTemplateConfig.ConfigurationSectionKey).Get<EmailTemplateConfig>() ?? new();
         }
 
         /// <inheritdoc/>
-        public async Task<bool> ValidateEmailAsync(string hdid, Guid inviteKey, CancellationToken ct = default)
+        public async Task<bool> VerifyEmailAddressAsync(string hdid, Guid inviteKey, CancellationToken ct = default)
         {
-            this.logger.LogTrace("Validating email... {InviteKey}", inviteKey);
+            this.logger.LogTrace("Verifying email address... {InviteKey}", inviteKey);
 
             MessagingVerification? matchingVerification = await this.messageVerificationDelegate.GetLastByInviteKeyAsync(inviteKey, ct);
             UserProfile userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
 
-            if (matchingVerification == null ||
-                matchingVerification.UserProfileId != hdid ||
-                matchingVerification.Deleted)
+            if (matchingVerification == null || matchingVerification.UserProfileId != hdid || matchingVerification.Deleted)
             {
                 this.logger.LogDebug("Invalid email verification");
-
-                MessagingVerification? lastEmailVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
-                if (lastEmailVerification is { Validated: false })
-                {
-                    lastEmailVerification.VerificationAttempts++;
-                    await this.messageVerificationDelegate.UpdateAsync(lastEmailVerification, ct: ct);
-                }
-
+                await this.IncrementEmailVerificationAttempts(hdid, ct);
                 return false;
             }
 
-            if (matchingVerification.VerificationAttempts >= MaxVerificationAttempts ||
-                matchingVerification.ExpireDate < DateTime.UtcNow)
+            if (matchingVerification.VerificationAttempts >= MaxVerificationAttempts || matchingVerification.ExpireDate < DateTime.UtcNow)
             {
                 this.logger.LogDebug("Email verification expired");
                 return false;
@@ -121,89 +109,73 @@ namespace HealthGateway.GatewayApi.Services
 
             if (matchingVerification.Validated)
             {
-                this.logger.LogDebug("Email already validated");
-                throw new AlreadyExistsException("Email already validated");
+                this.logger.LogDebug("Email already verified");
+                throw new AlreadyExistsException("Email already verified");
             }
 
-            matchingVerification.Validated = true;
-            await this.messageVerificationDelegate.UpdateAsync(matchingVerification, false, ct);
+            await this.SetAddressValidated(userProfile, matchingVerification, true, ct);
+            await this.NotifyVerificationSuccessful(hdid, matchingVerification.Email!.To, ct);
+            await this.QueueNotificationSettingsRequest(userProfile, ct);
 
-            userProfile.Email = matchingVerification.Email!.To; // Gets the user email from the email sent.
+            this.logger.LogDebug("Email verified");
+            return true;
+        }
+
+        /// <inheritdoc/>
+        public async Task UpdateEmailAddressAsync(string hdid, string emailAddress, CancellationToken ct = default)
+        {
+            this.logger.LogTrace("Updating user email...");
+            bool isEmpty = string.IsNullOrEmpty(emailAddress);
+            Guid inviteKey = Guid.NewGuid();
+
+            await new OptionalEmailAddressValidator().ValidateAndThrowAsync(emailAddress, ct);
+            UserProfile userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, true, ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
+
+            // expire previous email verification in DB without committing changes
+            MessagingVerification? lastEmailVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
+            if (lastEmailVerification != null)
+            {
+                this.logger.LogInformation("Expiring old email validation for user {Hdid}", hdid);
+                await this.messageVerificationDelegate.ExpireAsync(lastEmailVerification, isEmpty, false, ct);
+                if (emailAddress.Equals(lastEmailVerification.Email?.To, StringComparison.OrdinalIgnoreCase))
+                {
+                    // reuse same invite key if the last verification was for the same email address
+                    inviteKey = lastEmailVerification.InviteKey!.Value;
+                }
+            }
+
+            // add new messaging verification to DB without committing changes
+            MessagingVerification? messagingVerification = null;
+            if (!isEmpty)
+            {
+                messagingVerification = await this.GenerateMessagingVerificationAsync(hdid, emailAddress, inviteKey, false, ct);
+                await this.messageVerificationDelegate.InsertAsync(messagingVerification, false, ct);
+            }
+
+            this.logger.LogInformation("Removing email from user {Hdid}", hdid);
+            userProfile.Email = null;
+            userProfile.BetaFeatureCodes = [];
+
+            // update user profile in DB and commit changes
             DbResult<UserProfile> dbResult = await this.profileDelegate.UpdateAsync(userProfile, true, ct);
             if (dbResult.Status != DbStatusCode.Updated)
             {
                 throw new DatabaseException(dbResult.Message);
             }
 
-            if (this.notificationsChangeFeedEnabled)
-            {
-                MessageEnvelope[] events = [new(new NotificationChannelVerifiedEvent(hdid, NotificationChannel.Email, matchingVerification.Email!.To), hdid)];
-                await this.messageSender.SendAsync(events, ct);
-            }
-
-            // Update the notification settings
-            await this.notificationSettingsService.QueueNotificationSettingsAsync(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber), ct);
-
-            this.logger.LogDebug("Email validated");
-            return true;
-        }
-
-        /// <inheritdoc/>
-        [ExcludeFromCodeCoverage]
-        public async Task<bool> CreateUserEmailAsync(string hdid, string emailAddress, bool isVerified, bool commit = true, CancellationToken ct = default)
-        {
-            this.logger.LogTrace("Creating user email...");
-            await this.AddVerificationEmailAsync(hdid, emailAddress, Guid.NewGuid(), isVerified, commit, ct);
-            this.logger.LogDebug("Finished creating user email");
-            return true;
-        }
-
-        /// <inheritdoc/>
-        [ExcludeFromCodeCoverage]
-        public async Task UpdateUserEmailAsync(string hdid, string emailAddress, CancellationToken ct = default)
-        {
-            this.logger.LogTrace("Updating user email...");
-
-            await new OptionalEmailAddressValidator().ValidateAndThrowAsync(emailAddress, ct);
-            UserProfile userProfile = await this.profileDelegate.GetUserProfileAsync(hdid, true, ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
-
-            this.logger.LogInformation("Removing email from user {Hdid}", hdid);
-            userProfile.Email = null;
-            userProfile.BetaFeatureCodes = [];
-            DbResult<UserProfile> dbResult = await this.profileDelegate.UpdateAsync(userProfile, ct: ct);
-            if (dbResult.Status != DbStatusCode.Updated)
-            {
-                throw new DatabaseException(dbResult.Message);
-            }
-
-            // Update the notification settings
-            await this.notificationSettingsService.QueueNotificationSettingsAsync(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber), ct);
-
-            bool isEmpty = string.IsNullOrEmpty(emailAddress);
-            Guid inviteKey = Guid.NewGuid();
-
-            MessagingVerification? lastEmailVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
-            if (lastEmailVerification != null)
-            {
-                this.logger.LogInformation("Expiring old email validation for user {Hdid}", hdid);
-                await this.messageVerificationDelegate.ExpireAsync(lastEmailVerification, isEmpty, ct);
-                if (emailAddress.Equals(lastEmailVerification.Email?.To, StringComparison.OrdinalIgnoreCase))
-                {
-                    inviteKey = lastEmailVerification.InviteKey!.Value;
-                }
-            }
-
-            if (!isEmpty)
+            if (messagingVerification != null)
             {
                 this.logger.LogInformation("Sending new email verification for user {Hdid}", hdid);
-                await this.AddVerificationEmailAsync(hdid, emailAddress, inviteKey, ct: ct);
+                await this.emailQueueService.QueueNewEmailAsync(messagingVerification.Email, true, ct);
             }
+
+            await this.QueueNotificationSettingsRequest(userProfile, ct);
 
             this.logger.LogDebug("Finished updating user email");
         }
 
-        [ExcludeFromCodeCoverage]
-        private async Task AddVerificationEmailAsync(string hdid, string toEmail, Guid inviteKey, bool isVerified = false, bool commit = true, CancellationToken ct = default)
+        /// <inheritdoc/>
+        public async Task<MessagingVerification> GenerateMessagingVerificationAsync(string hdid, string emailAddress, Guid inviteKey, bool isVerified, CancellationToken ct = default)
         {
             float verificationExpiryHours = (float)this.emailVerificationExpirySeconds / 3600;
 
@@ -217,27 +189,62 @@ namespace HealthGateway.GatewayApi.Services
             EmailTemplate emailTemplate = await this.emailQueueService.GetEmailTemplateAsync(EmailTemplateName.RegistrationTemplate, ct) ??
                                           throw new DatabaseException(ErrorMessages.EmailTemplateNotFound);
 
-            MessagingVerification messageVerification = new()
+            MessagingVerification messagingVerification = new()
             {
                 InviteKey = inviteKey,
                 UserProfileId = hdid,
                 ExpireDate = DateTime.UtcNow.AddSeconds(this.emailVerificationExpirySeconds),
-                Email = this.emailQueueService.ProcessTemplate(toEmail, emailTemplate, keyValues),
-                EmailAddress = toEmail,
+                Email = this.emailQueueService.ProcessTemplate(emailAddress, emailTemplate, keyValues),
+                EmailAddress = emailAddress,
                 Validated = isVerified,
             };
 
             if (isVerified)
             {
-                messageVerification.Email.EmailStatusCode = EmailStatus.Processed;
-                await this.messageVerificationDelegate.InsertAsync(messageVerification, commit, ct);
-                await this.ValidateEmailAsync(hdid, inviteKey, ct);
+                // for verified email addresses, mark verification email as already sent
+                messagingVerification.Email.EmailStatusCode = EmailStatus.Processed;
             }
-            else
+
+            return messagingVerification;
+        }
+
+        private async Task IncrementEmailVerificationAttempts(string hdid, CancellationToken ct)
+        {
+            MessagingVerification? latestEmailVerification = await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct);
+            if (latestEmailVerification is { Validated: false })
             {
-                await this.messageVerificationDelegate.InsertAsync(messageVerification, ct: ct);
-                await this.emailQueueService.QueueNewEmailAsync(messageVerification.Email, ct: ct);
+                latestEmailVerification.VerificationAttempts++;
+                await this.messageVerificationDelegate.UpdateAsync(latestEmailVerification, true, ct);
             }
+        }
+
+        private async Task SetAddressValidated(UserProfile userProfile, MessagingVerification matchingVerification, bool commit = true, CancellationToken ct = default)
+        {
+            // update Validated value in MessagingVerification
+            matchingVerification.Validated = true;
+            await this.messageVerificationDelegate.UpdateAsync(matchingVerification, false, ct);
+
+            // add email address to UserProfile
+            userProfile.Email = matchingVerification.Email!.To;
+            DbResult<UserProfile> dbResult = await this.profileDelegate.UpdateAsync(userProfile, commit, ct);
+            if (commit && dbResult.Status != DbStatusCode.Updated)
+            {
+                throw new DatabaseException(dbResult.Message);
+            }
+        }
+
+        private async Task NotifyVerificationSuccessful(string hdid, string emailAddress, CancellationToken ct)
+        {
+            if (this.notificationsChangeFeedEnabled)
+            {
+                MessageEnvelope[] events = [new(new NotificationChannelVerifiedEvent(hdid, NotificationChannel.Email, emailAddress), hdid)];
+                await this.messageSender.SendAsync(events, ct);
+            }
+        }
+
+        private async Task QueueNotificationSettingsRequest(UserProfile userProfile, CancellationToken ct)
+        {
+            await this.notificationSettingsService.QueueNotificationSettingsAsync(new NotificationSettingsRequest(userProfile, userProfile.Email, userProfile.SmsNumber), ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -159,7 +159,7 @@ namespace HealthGateway.GatewayApi.Services
             if (lastSmsVerification != null)
             {
                 this.logger.LogInformation("Expiring old sms validation for user {Hdid}", hdid);
-                await this.messageVerificationDelegate.ExpireAsync(lastSmsVerification, isDeleted, ct);
+                await this.messageVerificationDelegate.ExpireAsync(lastSmsVerification, isDeleted, ct: ct);
             }
 
             NotificationSettingsRequest notificationRequest = new(userProfile, userProfile.Email, sanitizedSms);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -149,7 +149,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
                 messagingVerificationDelegateMock
                     .Verify(
-                        s => s.ExpireAsync(It.IsAny<MessagingVerification>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                        s => s.ExpireAsync(It.IsAny<MessagingVerification>(), It.IsAny<bool>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
                         Times.Once);
 
                 messagingVerificationDelegateMock
@@ -220,7 +220,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             userProfileDelegateMock ??= new();
             userProfileDelegateMock.Setup(s => s.GetUserProfileAsync(It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);
-            userProfileDelegateMock.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(new DbResult<UserProfile> { Status = DbStatusCode.Updated });
+            userProfileDelegateMock.Setup(s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new DbResult<UserProfile> { Status = DbStatusCode.Updated });
 
             messageSenderMock ??= new();
             notificationSettingsServiceMock ??= new();


### PR DESCRIPTION
# Implements [AB#16784](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16784)

## Description

- refactors CreateUserProfileAsync in UserProfileServiceV2 (and related methods in UserEmailServiceV2 / UserSmsServiceV2)
  - reduces the number of database commits by bundling several DB changes into a single commit
    - there remain separate commits for sending change feed messages due to the way that code is organized
  - ensures user profile and messaging verifications will be committed within the method and before any other changes
  - removes reliance on re-using UserEmailServiceV2.ValidateEmailAsync when creating profile
    - introduces GenerateMessagingVerification that can be used when creating and when validating
  - fixes V2 bug where verified email address was not being saved to the profile due to a change not being committed at the right time
  - fixes sending NotificationChannelVerifiedEvent and NotificationSettingsRequest twice during registration
  - moves some of the logic into private methods for improved organization
  - adds comments within the method to help track the different steps

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
