### PR TITLE
Remove unnecessary payload when removing dependent AB#16794

### DIFF
--- a/Apps/GatewayApi/src/Controllers/DependentController.cs
+++ b/Apps/GatewayApi/src/Controllers/DependentController.cs
@@ -114,10 +114,9 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <summary>
         /// Deletes a dependent from the database.
         /// </summary>
-        /// <returns>The http status.</returns>
+        /// <returns>An empty dependent model wrapped in a RequestResult.</returns>
         /// <param name="hdid">The Delegate hdid.</param>
         /// <param name="dependentHdid">The Dependent hdid.</param>
-        /// <param name="dependent">The dependent model object to be deleted.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <response code="200">The Dependent record was deleted.</response>
         /// <response code="400">The request is invalid.</response>
@@ -130,15 +129,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpDelete]
         [Authorize(Policy = UserProfilePolicy.Write)]
         [Route("{hdid}/[controller]/{dependentHdid}")]
-        public async Task<ActionResult<RequestResult<DependentModel>>> Delete(string hdid, string dependentHdid, [FromBody] DependentModel dependent, CancellationToken ct)
+        public async Task<ActionResult<RequestResult<DependentModel>>> Delete(string hdid, string dependentHdid, CancellationToken ct)
         {
-            if (dependent.OwnerId != dependentHdid || dependent.DelegateId != hdid)
-            {
-                this.logger.LogError("Parameters do not match body of delete");
-                return new BadRequestResult();
-            }
-
-            return await this.dependentService.RemoveAsync(dependent, ct);
+            return await this.dependentService.RemoveAsync(hdid, dependentHdid, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/IDependentService.cs
+++ b/Apps/GatewayApi/src/Services/IDependentService.cs
@@ -58,11 +58,12 @@ namespace HealthGateway.GatewayApi.Services
         Task<RequestResult<DependentModel>> AddDependentAsync(string delegateHdid, AddDependentRequest addDependentRequest, CancellationToken ct = default);
 
         /// <summary>
-        /// Removes a dependent delegate relation.
+        /// Removes a dependent-delegate relation.
         /// </summary>
-        /// <param name="dependent">The dependent model to be deleted.</param>
+        /// <param name="delegateHdid">The HDID of the delegate.</param>
+        /// <param name="dependentHdid">The HDID of the dependent.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A dependent model wrapped in a RequestResult.</returns>
-        Task<RequestResult<DependentModel>> RemoveAsync(DependentModel dependent, CancellationToken ct = default);
+        /// <returns>An empty dependent model wrapped in a RequestResult.</returns>
+        Task<RequestResult<DependentModel>> RemoveAsync(string delegateHdid, string dependentHdid, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
@@ -122,16 +122,15 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         {
             string delegateId = this.hdid;
             string dependentId = "123";
-            DependentModel dependentModel = new() { DelegateId = delegateId, OwnerId = dependentId };
 
             RequestResult<DependentModel> expectedResult = new()
             {
-                ResourcePayload = dependentModel,
+                ResourcePayload = new(),
                 ResultStatus = ResultType.Success,
             };
 
             Mock<IDependentService> dependentServiceMock = new();
-            dependentServiceMock.Setup(s => s.RemoveAsync(dependentModel, CancellationToken.None)).ReturnsAsync(expectedResult);
+            dependentServiceMock.Setup(s => s.RemoveAsync(delegateId, dependentId, CancellationToken.None)).ReturnsAsync(expectedResult);
 
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
@@ -139,40 +138,8 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
                 new Mock<ILogger<DependentController>>().Object,
                 dependentServiceMock.Object,
                 httpContextAccessorMock.Object);
-            ActionResult<RequestResult<DependentModel>> actualResult = await dependentController.Delete(delegateId, dependentId, dependentModel, CancellationToken.None);
+            ActionResult<RequestResult<DependentModel>> actualResult = await dependentController.Delete(delegateId, dependentId, CancellationToken.None);
             actualResult.Value.ShouldDeepEqual(expectedResult);
-        }
-
-        /// <summary>
-        /// DeleteDependent - BadRequest path scenario.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldFailDeleteDependent()
-        {
-            string delegateId = this.hdid;
-            string dependentId = "123";
-            DependentModel dependentModel = new() { DelegateId = delegateId, OwnerId = dependentId };
-
-            RequestResult<DependentModel> expectedResult = new()
-            {
-                ResourcePayload = dependentModel,
-                ResultStatus = ResultType.Success,
-            };
-
-            Mock<IDependentService> dependentServiceMock = new();
-            dependentServiceMock.Setup(s => s.RemoveAsync(dependentModel, CancellationToken.None)).ReturnsAsync(expectedResult);
-
-            Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, delegateId);
-
-            DependentController dependentController = new(
-                new Mock<ILogger<DependentController>>().Object,
-                dependentServiceMock.Object,
-                httpContextAccessorMock.Object);
-
-            ActionResult<RequestResult<DependentModel>> actualResult = await dependentController.Delete("anotherId", "wrongId", dependentModel, CancellationToken.None);
-
-            Assert.IsType<BadRequestResult>(actualResult.Result);
         }
 
         private static IEnumerable<DependentModel> GetMockDependents()

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -410,7 +410,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [Fact]
         public async Task ValidateRemove()
         {
-            DependentModel delegateModel = new() { OwnerId = this.mockHdId, DelegateId = this.mockParentHdid };
             IList<ResourceDelegate> resourceDelegates = new[] { new ResourceDelegate { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId } };
             DbResult<ResourceDelegate> dbResult = new()
             {
@@ -418,7 +417,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
             IDependentService service = this.SetupMockForRemoveDependent(resourceDelegates, dbResult);
 
-            RequestResult<DependentModel> actualResult = await service.RemoveAsync(delegateModel);
+            RequestResult<DependentModel> actualResult = await service.RemoveAsync(this.mockParentHdid, this.mockHdId);
 
             Assert.Equal(ResultType.Success, actualResult.ResultStatus);
         }
@@ -426,12 +425,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [Fact]
         public async Task ValidateRemoveNotFound()
         {
-            DependentModel delegateModel = new() { OwnerId = this.mockHdId, DelegateId = this.mockParentHdid };
             IDependentService service = this.SetupMockForRemoveDependent([], new());
 
             async Task Actual()
             {
-                await service.RemoveAsync(delegateModel);
+                await service.RemoveAsync(this.mockParentHdid, this.mockHdId);
             }
 
             await Assert.ThrowsAsync<NotFoundException>(Actual);
@@ -440,8 +438,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [Fact]
         public async Task ValidateRemoveDatabaseException()
         {
-            DependentModel delegateModel = new() { OwnerId = this.mockHdId, DelegateId = this.mockParentHdid };
-            IList<ResourceDelegate> resourceDelegates = new[] { new ResourceDelegate { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId } };
+            IList<ResourceDelegate> resourceDelegates = [new ResourceDelegate { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId }];
             DbResult<ResourceDelegate> dbResult = new()
             {
                 Status = DbStatusCode.Error,
@@ -450,7 +447,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             async Task Actual()
             {
-                await service.RemoveAsync(delegateModel);
+                await service.RemoveAsync(this.mockParentHdid, this.mockHdId);
             }
 
             await Assert.ThrowsAsync<DatabaseException>(Actual);


### PR DESCRIPTION
# Fixes [AB#16794](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16794)

## Description

Removes the dependent model payload from the delete dependent endpoint, as the only properties being used were the HDIDs, which are passed in separately via the path, and the deserialization was causing a parsing issue when sending a DateTime instead of DateOnly for DateOfBirth.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
