### PR TITLE
Fix notification settings including unverified email AB#16801

### DIFF
--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -259,15 +259,15 @@ namespace HealthGateway.GatewayApi.Services
             UserProfile dbModel = insertResult.Payload;
             string? requestedSmsNumber = createProfileRequest.Profile.SmsNumber;
             string? requestedEmail = createProfileRequest.Profile.Email;
+            bool isEmailVerified = !string.IsNullOrWhiteSpace(requestedEmail) && requestedEmail.Equals(jwtEmailAddress, StringComparison.OrdinalIgnoreCase);
 
             UserProfileModel userProfileModel = await this.BuildUserProfileModelAsync(dbModel, ct: ct);
 
-            NotificationSettingsRequest notificationRequest = new(dbModel, requestedEmail, requestedSmsNumber);
+            NotificationSettingsRequest notificationRequest = new(dbModel, isEmailVerified ? requestedEmail : string.Empty, requestedSmsNumber);
 
             // Add email verification
             if (!string.IsNullOrWhiteSpace(requestedEmail))
             {
-                bool isEmailVerified = requestedEmail.Equals(jwtEmailAddress, StringComparison.OrdinalIgnoreCase);
                 await this.userEmailService.CreateUserEmailAsync(hdid, requestedEmail, isEmailVerified, !this.notificationsChangeFeedEnabled, ct);
                 userProfileModel.Email = requestedEmail;
                 userProfileModel.IsEmailVerified = isEmailVerified;

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -381,7 +381,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             // queue notification settings job
-            NotificationSettingsRequest notificationSettingsRequest = new(profile, requestedEmail, requestedSmsNumber) { SmsVerificationCode = smsVerificationCode };
+            NotificationSettingsRequest notificationSettingsRequest = new(profile, profile.Email, requestedSmsNumber) { SmsVerificationCode = smsVerificationCode };
             await this.notificationSettingsService.QueueNotificationSettingsAsync(notificationSettingsRequest, ct);
         }
 


### PR DESCRIPTION
# Fixes [AB#16801](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16801)

## Description

Resolves issue where any requested email address submitted during registration was included in the notification settings request that is sent off, instead of only including requested email addresses that have been verified.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

I believe the SMS number does not have the same issue, because within NotificationSettingsRequest, an additional property is populated, indicating whether the provided SMS is verified.

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
