### PR TITLE
Fixed incorrect ProducesResponse for GetLastTermsOfService for AB#16805

### DIFF
--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -250,7 +250,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [Route("termsofservice")]
         [AllowAnonymous]
         [Produces("application/json")]
-        [ProducesResponseType<bool>(StatusCodes.Status200OK)]
+        [ProducesResponseType<TermsOfServiceModel>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError)]
         [ResponseCache(Location = ResponseCacheLocation.Any, Duration = 3600)]
         public async Task<TermsOfServiceModel> GetLastTermsOfService(CancellationToken ct)


### PR DESCRIPTION
# Fixes [AB#16805](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16805)

## Description

While investigating missing terms of service issue in production, discovered minor defect regarding 'ProducesResponse'  for GetLastTermsOfService endpoint call.  Incorrect type was documented.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
