### PR TITLE
Update vaccine card redirect on landing site for AB#16804

### DIFF
--- a/Apps/Landing/src/ClientApp/src/constants/path.ts
+++ b/Apps/Landing/src/ClientApp/src/constants/path.ts
@@ -14,4 +14,5 @@ export enum Path {
     Services = "/services",
     Timeline = "/timeline",
     ValidateEmail = "/validateEmail",
+    VaccineCard = "/vaccinecard",
 }

--- a/Apps/Landing/src/ClientApp/src/models/configData.ts
+++ b/Apps/Landing/src/ClientApp/src/models/configData.ts
@@ -45,6 +45,8 @@ export interface WebClientConfiguration {
     timeouts: TimeOutsConfiguration;
     // Gets or sets the URL for the beta application.
     betaUrl?: string;
+    // Gets or sets the URL for the classic application.
+    classicUrl?: string;
     // Gets or sets the ExternalURLs used by the Webclient.
     externalURLs: Dictionary<string>;
     // Gets or sets the FeatureToggleConfiguration state.

--- a/Apps/Landing/src/ClientApp/src/router/beforeEachGuard.ts
+++ b/Apps/Landing/src/ClientApp/src/router/beforeEachGuard.ts
@@ -9,7 +9,8 @@ export const beforeEachGuard: NavigationGuard = async (
     const configStore = useConfigStore();
     const webClientConfig = configStore.config.webClient;
 
-    const meta: { redirectPath?: string } = to.meta;
+    const meta: { redirectPath?: string; classicRedirectPath?: string } =
+        to.meta;
 
     if (meta?.redirectPath && webClientConfig.betaUrl) {
         let url = webClientConfig.betaUrl + meta.redirectPath;
@@ -17,6 +18,12 @@ export const beforeEachGuard: NavigationGuard = async (
             url += "/" + to.params.inviteKey;
         }
 
+        window.location.assign(url);
+        return false;
+    }
+
+    if (meta?.classicRedirectPath && webClientConfig.classicUrl) {
+        const url = webClientConfig.classicUrl + meta.classicRedirectPath;
         window.location.assign(url);
         return false;
     }

--- a/Apps/Landing/src/ClientApp/src/router/index.ts
+++ b/Apps/Landing/src/ClientApp/src/router/index.ts
@@ -106,6 +106,13 @@ const routes = [
         },
     },
     {
+        path: Path.VaccineCard,
+        component: NotFoundView,
+        meta: {
+            classicRedirectPath: "vaccinecard",
+        },
+    },
+    {
         path: "/:pathMatch(.*)*", // will catch all other paths not covered previously
         redirect: Path.NotFound,
     },

--- a/Apps/WebClient/src/Server/Models/WebClientConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/WebClientConfiguration.cs
@@ -45,6 +45,11 @@ namespace HealthGateway.WebClient.Server.Models
         public Uri? BetaUrl { get; set; }
 
         /// <summary>
+        /// Gets or sets the URL for the classic application.
+        /// </summary>
+        public Uri? ClassicUrl { get; set; }
+
+        /// <summary>
         /// Gets or sets the ExternalURLs used by the Webclient.
         /// </summary>
         [JsonPropertyName("externalURLs")]

--- a/Apps/WebClient/src/appsettings.Development.json
+++ b/Apps/WebClient/src/appsettings.Development.json
@@ -25,6 +25,7 @@
             "ResendSMS": "1"
         },
         "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/",
+        "ClassicUrl": "http://localhost:5002/",
         "OfflineMode": {
             "StartDateTime": "2020/06/01 12:00:00PM",
             "EndDateTime": "2020/06/01 12:00:00PM",

--- a/Apps/WebClient/src/appsettings.hgdev.json
+++ b/Apps/WebClient/src/appsettings.hgdev.json
@@ -42,7 +42,8 @@
         "TimeOuts": {
             "ResendSMS": "1"
         },
-        "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/"
+        "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/",
+        "ClassicUrl": "https://dev-classic.healthgateway.gov.bc.ca/"
     },
     "ServiceEndpoints": {
         "ClinicalDocument": "https://hg.dev.api.gov.bc.ca/api/clinicaldocumentservice/",

--- a/Apps/WebClient/src/appsettings.hgmock.json
+++ b/Apps/WebClient/src/appsettings.hgmock.json
@@ -35,7 +35,8 @@
         "TimeOuts": {
             "ResendSMS": "1"
         },
-        "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/"
+        "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/",
+        "ClassicUrl": "https://dev-classic.healthgateway.gov.bc.ca/"
     },
     "ServiceEndpoints": {
         "ClinicalDocument": "https://hg-mock.api.gov.bc.ca/api/clinicaldocumentservice/",

--- a/Apps/WebClient/src/appsettings.hgpoc.json
+++ b/Apps/WebClient/src/appsettings.hgpoc.json
@@ -35,7 +35,8 @@
         "TimeOuts": {
             "ResendSMS": "1"
         },
-        "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/"
+        "BetaUrl": "https://dev-secure.healthgateway.gov.bc.ca/",
+        "ClassicUrl": "https://dev-classic.healthgateway.gov.bc.ca/",
     },
     "ServiceEndpoints": {
         "ClinicalDocument": "https://poc.healthgateway.gov.bc.ca/api/clinicaldocumentservice/",

--- a/Apps/WebClient/src/appsettings.hgtest.json
+++ b/Apps/WebClient/src/appsettings.hgtest.json
@@ -9,7 +9,8 @@
     },
     "WebClient": {
         "LogLevel": "Debug",
-        "BetaUrl": "https://qa-secure.healthgateway.gov.bc.ca/"
+        "BetaUrl": "https://qa-secure.healthgateway.gov.bc.ca/",
+        "ClassicUrl": "https://test-classic.healthgateway.gov.bc.ca/"
     },
     "ServiceEndpoints": {
         "ClinicalDocument": "https://hg.test.api.gov.bc.ca/api/clinicaldocumentservice/",

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -69,6 +69,7 @@
             "ResendSMS": "1"
         },
         "BetaUrl": "https://beta.healthgateway.gov.bc.ca/",
+        "ClassicUrl": "https://classic.healthgateway.gov.bc.ca/",
         "ExternalURLs": {
             "HealthLinkImmunizationSchedule": "https://www.healthlinkbc.ca/tools-videos/bc-immunization-schedules",
             "HealthLinkVaccineSearch": "https://www.healthlinkbc.ca/search/"


### PR DESCRIPTION
# Implements [AB#16804](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16804)

## Description

- Add redirect ivaccine card redirect in Landing to healthgateway classic
- Updated asspettings to classic healthgateway

Note: classic.healthgateway for prod needs to be created before deploying to prod

https://github.com/user-attachments/assets/42491186-510b-486f-9370-3b2bc19f4f96

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
