### PR TITLE
Expand beta access by 100,000 users per day AB#16810

### DIFF
--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -199,7 +199,7 @@
         "Delay": 60,
         "Enabled": true,
         "MaxBatchSize": 500,
-        "UserCount": 10000,
+        "UserCount": 100000,
         "BetaFeature": "Salesforce"
     },
     "PharmacyAssessmentFile": {


### PR DESCRIPTION
# Implements [AB#16810](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16810)

## Description

Increases the rate at which users are given access to the beta from 10,000/day to 100,000/day.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
