### PR TITLE
Create UserValidationService and RegistrationService from UserProfileServiceV2 for AB#16811

### DIFF
--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -49,6 +49,7 @@ namespace HealthGateway.GatewayApi.Controllers
         private readonly IUserPreferenceServiceV2 userPreferenceService;
         private readonly ILegalAgreementServiceV2 legalAgreementService;
         private readonly IUserValidationService userValidationService;
+        private readonly IRegistrationService registrationService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileControllerV2"/> class.
@@ -60,6 +61,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <param name="userPreferenceService">The injected user preference service.</param>
         /// <param name="legalAgreementService">The injected legal agreement service.</param>
         /// <param name="userValidationService">The injected user validation service.</param>
+        /// <param name="registrationService">The injected registration service.</param>
         public UserProfileControllerV2(
             IUserProfileServiceV2 userProfileService,
             IHttpContextAccessor httpContextAccessor,
@@ -67,7 +69,8 @@ namespace HealthGateway.GatewayApi.Controllers
             IUserSmsServiceV2 userSmsService,
             IUserPreferenceServiceV2 userPreferenceService,
             ILegalAgreementServiceV2 legalAgreementService,
-            IUserValidationService userValidationService)
+            IUserValidationService userValidationService,
+            IRegistrationService registrationService)
         {
             this.userProfileService = userProfileService;
             this.httpContextAccessor = httpContextAccessor;
@@ -76,6 +79,7 @@ namespace HealthGateway.GatewayApi.Controllers
             this.userPreferenceService = userPreferenceService;
             this.legalAgreementService = legalAgreementService;
             this.userValidationService = userValidationService;
+            this.registrationService = registrationService;
         }
 
         /// <summary>
@@ -116,7 +120,7 @@ namespace HealthGateway.GatewayApi.Controllers
             ClaimsPrincipal user = this.httpContextAccessor.HttpContext!.User;
             DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(user);
             string? jwtEmailAddress = user.FindFirstValue(ClaimTypes.Email);
-            return await this.userProfileService.CreateUserProfileAsync(createUserRequest, jwtAuthTime, jwtEmailAddress, ct);
+            return await this.registrationService.CreateUserProfileAsync(createUserRequest, jwtAuthTime, jwtEmailAddress, ct);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -48,6 +48,7 @@ namespace HealthGateway.GatewayApi.Controllers
         private readonly IUserSmsServiceV2 userSmsService;
         private readonly IUserPreferenceServiceV2 userPreferenceService;
         private readonly ILegalAgreementServiceV2 legalAgreementService;
+        private readonly IUserValidationService userValidationService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileControllerV2"/> class.
@@ -58,13 +59,15 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <param name="userSmsService">The injected user sms service.</param>
         /// <param name="userPreferenceService">The injected user preference service.</param>
         /// <param name="legalAgreementService">The injected legal agreement service.</param>
+        /// <param name="userValidationService">The injected user validation service.</param>
         public UserProfileControllerV2(
             IUserProfileServiceV2 userProfileService,
             IHttpContextAccessor httpContextAccessor,
             IUserEmailServiceV2 userEmailService,
             IUserSmsServiceV2 userSmsService,
             IUserPreferenceServiceV2 userPreferenceService,
-            ILegalAgreementServiceV2 legalAgreementService)
+            ILegalAgreementServiceV2 legalAgreementService,
+            IUserValidationService userValidationService)
         {
             this.userProfileService = userProfileService;
             this.httpContextAccessor = httpContextAccessor;
@@ -72,6 +75,7 @@ namespace HealthGateway.GatewayApi.Controllers
             this.userSmsService = userSmsService;
             this.userPreferenceService = userPreferenceService;
             this.legalAgreementService = legalAgreementService;
+            this.userValidationService = userValidationService;
         }
 
         /// <summary>
@@ -178,7 +182,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status502BadGateway)]
         public async Task<bool> Validate(string hdid, CancellationToken ct)
         {
-            return await this.userProfileService.ValidateEligibilityAsync(hdid, ct);
+            return await this.userValidationService.ValidateEligibilityAsync(hdid, ct);
         }
 
         /// <summary>
@@ -486,7 +490,7 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<bool> IsValidPhoneNumber(string phoneNumber, CancellationToken ct)
         {
-            return await this.userProfileService.IsPhoneNumberValidAsync(phoneNumber, ct);
+            return await this.userValidationService.IsPhoneNumberValidAsync(phoneNumber, ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/IRegistrationService.cs
+++ b/Apps/GatewayApi/src/Services/IRegistrationService.cs
@@ -1,0 +1,38 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Services
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.GatewayApi.Models;
+
+    /// <summary>
+    /// The registration service.
+    /// </summary>
+    public interface IRegistrationService
+    {
+        /// <summary>
+        /// Creates a user profile.
+        /// </summary>
+        /// <param name="createProfileRequest">The request to create a user profile model.</param>
+        /// <param name="jwtAuthTime">The authenticated login time from the JWT.</param>
+        /// <param name="jwtEmailAddress">The email address contained in the JWT.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The user profile.</returns>
+        Task<UserProfileModel> CreateUserProfileAsync(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default);
+    }
+}

--- a/Apps/GatewayApi/src/Services/IUserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileServiceV2.cs
@@ -61,14 +61,6 @@ namespace HealthGateway.GatewayApi.Services
         Task RecoverUserProfileAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
-        /// Determines whether a user is eligible to create a Health Gateway account.
-        /// </summary>
-        /// <param name="hdid">The requested user HDID.</param>
-        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A boolean result.</returns>
-        Task<bool> ValidateEligibilityAsync(string hdid, CancellationToken ct = default);
-
-        /// <summary>
         /// Updates a user's profile to capture approval of the terms of service.
         /// </summary>
         /// <param name="hdid">The user HDID.</param>
@@ -76,13 +68,5 @@ namespace HealthGateway.GatewayApi.Services
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         Task UpdateAcceptedTermsAsync(string hdid, Guid termsOfServiceId, CancellationToken ct = default);
-
-        /// <summary>
-        /// Determines whether a phone number is valid.
-        /// </summary>
-        /// <param name="phoneNumber">Phone number stripped of any mask characters.</param>
-        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>A boolean value indicating whether the phone number is valid.</returns>
-        Task<bool> IsPhoneNumberValidAsync(string phoneNumber, CancellationToken ct = default);
     }
 }

--- a/Apps/GatewayApi/src/Services/IUserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileServiceV2.cs
@@ -35,16 +35,6 @@ namespace HealthGateway.GatewayApi.Services
         Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default);
 
         /// <summary>
-        /// Creates a user profile.
-        /// </summary>
-        /// <param name="createProfileRequest">The request to create a user profile model.</param>
-        /// <param name="jwtAuthTime">The authenticated login time from the JWT.</param>
-        /// <param name="jwtEmailAddress">The email address contained in the JWT.</param>
-        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>The user profile.</returns>
-        Task<UserProfileModel> CreateUserProfileAsync(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default);
-
-        /// <summary>
         /// Closes a user profile.
         /// </summary>
         /// <param name="hdid">The requested user HDID.</param>

--- a/Apps/GatewayApi/src/Services/IUserValidationService.cs
+++ b/Apps/GatewayApi/src/Services/IUserValidationService.cs
@@ -1,0 +1,42 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Services
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// The user validation service.
+    /// </summary>
+    public interface IUserValidationService
+    {
+        /// <summary>
+        /// Determines whether a phone number is valid.
+        /// </summary>
+        /// <param name="phoneNumber">Phone number stripped of any mask characters.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A boolean value indicating whether the phone number is valid.</returns>
+        Task<bool> IsPhoneNumberValidAsync(string phoneNumber, CancellationToken ct = default);
+
+        /// <summary>
+        /// Determines whether a user is eligible to create a Health Gateway account.
+        /// </summary>
+        /// <param name="hdid">The requested user HDID.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>A boolean result.</returns>
+        Task<bool> ValidateEligibilityAsync(string hdid, CancellationToken ct = default);
+    }
+}

--- a/Apps/GatewayApi/src/Services/RegistrationService.cs
+++ b/Apps/GatewayApi/src/Services/RegistrationService.cs
@@ -38,9 +38,6 @@ namespace HealthGateway.GatewayApi.Services
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RegistrationService"/> class.
-    /// </summary>
     /// <param name="configuration">The injected configuration.</param>
     /// <param name="logger">The injected logger.</param>
     /// <param name="authenticationDelegate">The injected authentication delegate.</param>

--- a/Apps/GatewayApi/src/Services/RegistrationService.cs
+++ b/Apps/GatewayApi/src/Services/RegistrationService.cs
@@ -1,0 +1,182 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Services
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using FluentValidation;
+    using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Data.Validations;
+    using HealthGateway.Common.Delegates;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
+    using HealthGateway.Common.Messaging;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.Events;
+    using HealthGateway.Common.Services;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Validations;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+
+    /// <inheritdoc/>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RegistrationService"/> class.
+    /// </summary>
+    /// <param name="configuration">The injected configuration.</param>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="authenticationDelegate">The injected authentication delegate.</param>
+    /// <param name="cryptoDelegate">The injected crypto delegate.</param>
+    /// <param name="emailQueueService">The injected service to queue emails.</param>
+    /// <param name="messageSender">The injected message sender.</param>
+    /// <param name="messageVerificationDelegate">The injected message verification delegate.</param>
+    /// <param name="notificationSettingsService">The injected notifications settings service.</param>
+    /// <param name="patientDetailsService">The injected patient details service.</param>
+    /// <param name="userEmailService">The injected user email service.</param>
+    /// <param name="userSmsService">The injected user SMS service.</param>
+    /// <param name="userProfileDelegate">The injected user profile database delegate.</param>
+    /// <param name="userProfileService">The injected user profile service.</param>
+    public class RegistrationService(
+        IConfiguration configuration,
+        ILogger<RegistrationService> logger,
+        IAuthenticationDelegate authenticationDelegate,
+        ICryptoDelegate cryptoDelegate,
+        IEmailQueueService emailQueueService,
+        IMessageSender messageSender,
+        IMessagingVerificationDelegate messageVerificationDelegate,
+        INotificationSettingsService notificationSettingsService,
+        IPatientDetailsService patientDetailsService,
+        IUserEmailServiceV2 userEmailService,
+        IUserSmsServiceV2 userSmsService,
+        IUserProfileDelegate userProfileDelegate,
+        IUserProfileServiceV2 userProfileService) : IRegistrationService
+    {
+        private const string MinPatientAgeKey = "MinPatientAge";
+        private const string WebClientConfigSection = "WebClient";
+        private const int DefaultPatientAge = 12;
+        private readonly int minPatientAge = configuration.GetSection(WebClientConfigSection).GetValue(MinPatientAgeKey, DefaultPatientAge);
+        private readonly bool accountsChangeFeedEnabled = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>()?.Accounts.Enabled ?? false;
+        private readonly bool notificationsChangeFeedEnabled = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>()?.Notifications.Enabled ?? false;
+
+        /// <inheritdoc/>
+        public async Task<UserProfileModel> CreateUserProfileAsync(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default)
+        {
+            logger.LogTrace("Creating user profile... {Hdid}", createProfileRequest.Profile.HdId);
+            string hdid = createProfileRequest.Profile.HdId;
+            string? requestedEmail = createProfileRequest.Profile.Email;
+            string? requestedSmsNumber = createProfileRequest.Profile.SmsNumber;
+            bool isEmailVerified = !string.IsNullOrWhiteSpace(requestedEmail) && string.Equals(requestedEmail, jwtEmailAddress, StringComparison.OrdinalIgnoreCase);
+
+            // validate provided SMS number and patient age
+            await new SmsNumberValidator().ValidateAndThrowAsync(requestedSmsNumber, ct);
+            PatientDetails patient = await patientDetailsService.GetPatientAsync(hdid, ct: ct);
+            if (this.minPatientAge > 0)
+            {
+                await new AgeRangeValidator(this.minPatientAge).ValidateAndThrowAsync(patient.Birthdate.ToDateTime(TimeOnly.MinValue), ct);
+            }
+
+            // add SMS and email messaging verifications to DB without committing changes
+            MessagingVerification? smsVerification = await this.AddSmsVerification(hdid, requestedSmsNumber, ct);
+            MessagingVerification? emailVerification = await this.AddEmailVerification(hdid, requestedEmail, isEmailVerified, ct);
+
+            // initialize user profile
+            UserProfile profile = new()
+            {
+                HdId = hdid,
+                IdentityManagementId = null,
+                TermsOfServiceId = createProfileRequest.Profile.TermsOfServiceId,
+                Email = isEmailVerified ? requestedEmail : string.Empty,
+                SmsNumber = null,
+                CreatedBy = hdid,
+                UpdatedBy = hdid,
+                LastLoginDateTime = jwtAuthTime,
+                EncryptionKey = cryptoDelegate.GenerateKey(),
+                YearOfBirth = patient.Birthdate.Year,
+                LastLoginClientCode = authenticationDelegate.FetchAuthenticatedUserClientType(),
+            };
+
+            // add user profile to DB and commit changes
+            DbResult<UserProfile> dbResult = await userProfileDelegate.InsertUserProfileAsync(profile, true, ct);
+            if (dbResult.Status != DbStatusCode.Created)
+            {
+                logger.LogError("Error creating user profile... {Hdid}", hdid);
+                throw new DatabaseException(dbResult.Message);
+            }
+
+            // queue verification email
+            if (emailVerification != null && !isEmailVerified)
+            {
+                await emailQueueService.QueueNewEmailAsync(emailVerification.Email, true, ct);
+            }
+
+            // notify partners about new account
+            await this.NotifyAccountCreated(profile, requestedEmail, requestedSmsNumber, isEmailVerified, smsVerification?.SmsValidationCode, ct);
+
+            // build and return model
+            UserProfileModel userProfileModel = await userProfileService.GetUserProfileAsync(hdid, jwtAuthTime, ct);
+            logger.LogTrace("Finished creating user profile... {Hdid}", dbResult.Payload.HdId);
+            return userProfileModel;
+        }
+
+        private async Task<MessagingVerification?> AddSmsVerification(string hdid, string? requestedSmsNumber, CancellationToken ct)
+        {
+            MessagingVerification? smsVerification = null;
+            if (!string.IsNullOrWhiteSpace(requestedSmsNumber))
+            {
+                smsVerification = userSmsService.GenerateMessagingVerification(hdid, requestedSmsNumber);
+                await messageVerificationDelegate.InsertAsync(smsVerification, false, ct);
+            }
+
+            return smsVerification;
+        }
+
+        private async Task<MessagingVerification?> AddEmailVerification(string hdid, string? requestedEmail, bool isEmailVerified, CancellationToken ct)
+        {
+            MessagingVerification? emailVerification = null;
+            if (!string.IsNullOrWhiteSpace(requestedEmail))
+            {
+                emailVerification = await userEmailService.GenerateMessagingVerificationAsync(hdid, requestedEmail, Guid.NewGuid(), isEmailVerified, ct);
+                await messageVerificationDelegate.InsertAsync(emailVerification, false, ct);
+            }
+
+            return emailVerification;
+        }
+
+        private async Task NotifyAccountCreated(UserProfile profile, string requestedEmail, string requestedSmsNumber, bool isEmailVerified, string smsVerificationCode, CancellationToken ct)
+        {
+            // notify account was created
+            if (this.accountsChangeFeedEnabled)
+            {
+                await messageSender.SendAsync([new MessageEnvelope(new AccountCreatedEvent(profile.HdId, DateTime.UtcNow), profile.HdId)], ct);
+            }
+
+            // notify email verification was successful
+            if (isEmailVerified && this.notificationsChangeFeedEnabled)
+            {
+                await messageSender.SendAsync([new(new NotificationChannelVerifiedEvent(profile.HdId, NotificationChannel.Email, requestedEmail), profile.HdId)], ct);
+            }
+
+            // queue notification settings job
+            NotificationSettingsRequest notificationSettingsRequest = new(profile, profile.Email, requestedSmsNumber) { SmsVerificationCode = smsVerificationCode };
+            await notificationSettingsService.QueueNotificationSettingsAsync(notificationSettingsRequest, ct);
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -288,18 +288,6 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public async Task<bool> ValidateEligibilityAsync(string hdid, CancellationToken ct = default)
-        {
-            if (this.minPatientAge == 0)
-            {
-                return true;
-            }
-
-            PatientDetails patient = await this.patientDetailsService.GetPatientAsync(hdid, ct: ct);
-            return (await new AgeRangeValidator(this.minPatientAge).ValidateAsync(patient.Birthdate.ToDateTime(TimeOnly.MinValue), ct)).IsValid;
-        }
-
-        /// <inheritdoc/>
         public async Task UpdateAcceptedTermsAsync(string hdid, Guid termsOfServiceId, CancellationToken ct = default)
         {
             UserProfile userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
@@ -310,12 +298,6 @@ namespace HealthGateway.GatewayApi.Services
             {
                 throw new DatabaseException(result.Message);
             }
-        }
-
-        /// <inheritdoc/>
-        public async Task<bool> IsPhoneNumberValidAsync(string phoneNumber, CancellationToken ct = default)
-        {
-            return (await new SmsNumberValidator().ValidateAsync(phoneNumber, ct)).IsValid;
         }
 
         private async Task<UserProfileModel> BuildUserProfileModelAsync(

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -35,75 +35,46 @@ namespace HealthGateway.GatewayApi.Services
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
-    public class UserProfileServiceV2 : IUserProfileServiceV2
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserProfileServiceV2"/> class.
+    /// </summary>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="patientDetailsService">The injected patient details service.</param>
+    /// <param name="emailQueueService">The injected service to queue emails.</param>
+    /// <param name="userProfileDelegate">The injected user profile database delegate.</param>
+    /// <param name="userPreferenceService">The injected user preference service.</param>
+    /// <param name="legalAgreementService">The injected legal agreement service.</param>
+    /// <param name="messageVerificationDelegate">The injected message verification delegate.</param>
+    /// <param name="configuration">The injected configuration.</param>
+    /// <param name="mappingService">The injected mapping service.</param>
+    /// <param name="authenticationDelegate">The injected authentication delegate.</param>
+    /// <param name="applicationSettingsService">The injected application settings service.</param>
+    /// <param name="patientRepository">The injected patient repository.</param>
+    public class UserProfileServiceV2(
+        ILogger<UserProfileServiceV2> logger,
+        IPatientDetailsService patientDetailsService,
+        IEmailQueueService emailQueueService,
+        IUserProfileDelegate userProfileDelegate,
+        IUserPreferenceServiceV2 userPreferenceService,
+        ILegalAgreementServiceV2 legalAgreementService,
+        IMessagingVerificationDelegate messageVerificationDelegate,
+        IConfiguration configuration,
+        IGatewayApiMappingService mappingService,
+        IAuthenticationDelegate authenticationDelegate,
+        IApplicationSettingsService applicationSettingsService,
+        IPatientRepository patientRepository) : IUserProfileServiceV2
     {
         private const string UserProfileHistoryRecordLimitKey = "UserProfileHistoryRecordLimit";
         private const string WebClientConfigSection = "WebClient";
-        private readonly EmailTemplateConfig emailTemplateConfig;
-        private readonly int userProfileHistoryRecordLimit;
-
-        private readonly ILogger<UserProfileServiceV2> logger;
-        private readonly IPatientDetailsService patientDetailsService;
-        private readonly IEmailQueueService emailQueueService;
-        private readonly IUserProfileDelegate userProfileDelegate;
-        private readonly IUserPreferenceServiceV2 userPreferenceService;
-        private readonly ILegalAgreementServiceV2 legalAgreementService;
-        private readonly IMessagingVerificationDelegate messageVerificationDelegate;
-        private readonly IGatewayApiMappingService mappingService;
-        private readonly IAuthenticationDelegate authenticationDelegate;
-        private readonly IApplicationSettingsService applicationSettingsService;
-        private readonly IPatientRepository patientRepository;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UserProfileServiceV2"/> class.
-        /// </summary>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="patientDetailsService">The injected patient details service.</param>
-        /// <param name="emailQueueService">The injected service to queue emails.</param>
-        /// <param name="userProfileDelegate">The injected user profile database delegate.</param>
-        /// <param name="userPreferenceService">The injected user preference service.</param>
-        /// <param name="legalAgreementService">The injected legal agreement service.</param>
-        /// <param name="messageVerificationDelegate">The injected message verification delegate.</param>
-        /// <param name="configuration">The injected configuration.</param>
-        /// <param name="mappingService">The injected mapping service.</param>
-        /// <param name="authenticationDelegate">The injected authentication delegate.</param>
-        /// <param name="applicationSettingsService">The injected application settings service.</param>
-        /// <param name="patientRepository">The injected patient repository.</param>
-        public UserProfileServiceV2(
-            ILogger<UserProfileServiceV2> logger,
-            IPatientDetailsService patientDetailsService,
-            IEmailQueueService emailQueueService,
-            IUserProfileDelegate userProfileDelegate,
-            IUserPreferenceServiceV2 userPreferenceService,
-            ILegalAgreementServiceV2 legalAgreementService,
-            IMessagingVerificationDelegate messageVerificationDelegate,
-            IConfiguration configuration,
-            IGatewayApiMappingService mappingService,
-            IAuthenticationDelegate authenticationDelegate,
-            IApplicationSettingsService applicationSettingsService,
-            IPatientRepository patientRepository)
-        {
-            this.logger = logger;
-            this.patientDetailsService = patientDetailsService;
-            this.emailQueueService = emailQueueService;
-            this.userProfileDelegate = userProfileDelegate;
-            this.userPreferenceService = userPreferenceService;
-            this.legalAgreementService = legalAgreementService;
-            this.messageVerificationDelegate = messageVerificationDelegate;
-            this.mappingService = mappingService;
-            this.authenticationDelegate = authenticationDelegate;
-            this.applicationSettingsService = applicationSettingsService;
-            this.patientRepository = patientRepository;
-            this.emailTemplateConfig = configuration.GetSection(EmailTemplateConfig.ConfigurationSectionKey).Get<EmailTemplateConfig>() ?? new();
-            this.userProfileHistoryRecordLimit = configuration.GetSection(WebClientConfigSection).GetValue(UserProfileHistoryRecordLimitKey, 4);
-        }
+        private readonly EmailTemplateConfig emailTemplateConfig = configuration.GetSection(EmailTemplateConfig.ConfigurationSectionKey).Get<EmailTemplateConfig>() ?? new();
+        private readonly int userProfileHistoryRecordLimit = configuration.GetSection(WebClientConfigSection).GetValue(UserProfileHistoryRecordLimitKey, 4);
 
         /// <inheritdoc/>
         public async Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default)
         {
-            this.logger.LogTrace("Getting user profile... {Hdid}", hdid);
-            UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
-            this.logger.LogDebug("Finished getting user profile...{Hdid}", hdid);
+            logger.LogTrace("Getting user profile... {Hdid}", hdid);
+            UserProfile? userProfile = await userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
+            logger.LogDebug("Finished getting user profile...{Hdid}", hdid);
 
             if (userProfile == null)
             {
@@ -113,29 +84,29 @@ namespace HealthGateway.GatewayApi.Services
             DateTime previousLastLogin = userProfile.LastLoginDateTime;
             if (DateTime.Compare(previousLastLogin, jwtAuthTime) != 0)
             {
-                this.logger.LogTrace("Updating user last login and year of birth... {Hdid}", hdid);
+                logger.LogTrace("Updating user last login and year of birth... {Hdid}", hdid);
                 userProfile.LastLoginDateTime = jwtAuthTime;
-                userProfile.LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType();
+                userProfile.LastLoginClientCode = authenticationDelegate.FetchAuthenticatedUserClientType();
 
                 // Update user year of birth.
-                PatientDetails patient = await this.patientDetailsService.GetPatientAsync(hdid, ct: ct);
+                PatientDetails patient = await patientDetailsService.GetPatientAsync(hdid, ct: ct);
                 userProfile.YearOfBirth = patient.Birthdate.Year;
 
                 // Try to update user profile with last login time; ignore any failures
-                await this.userProfileDelegate.UpdateAsync(userProfile, ct: ct);
+                await userProfileDelegate.UpdateAsync(userProfile, ct: ct);
 
-                this.logger.LogDebug("Finished updating user last login and year of birth... {Hdid}", hdid);
+                logger.LogDebug("Finished updating user last login and year of birth... {Hdid}", hdid);
             }
 
-            IList<UserProfileHistory> userProfileHistoryList = await this.userProfileDelegate.GetUserProfileHistoryListAsync(hdid, this.userProfileHistoryRecordLimit, ct);
+            IList<UserProfileHistory> userProfileHistoryList = await userProfileDelegate.GetUserProfileHistoryListAsync(hdid, this.userProfileHistoryRecordLimit, ct);
 
             string? emailAddress = !string.IsNullOrEmpty(userProfile.Email)
                 ? userProfile.Email
-                : (await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct))?.Email?.To;
+                : (await messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Email, ct))?.Email?.To;
 
             string? smsNumber = !string.IsNullOrEmpty(userProfile.SmsNumber)
                 ? userProfile.SmsNumber
-                : (await this.messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Sms, ct))?.SmsNumber;
+                : (await messageVerificationDelegate.GetLastForUserAsync(hdid, MessagingVerificationType.Sms, ct))?.SmsNumber;
 
             UserProfileModel userProfileModel = await this.BuildUserProfileModelAsync(userProfile, userProfileHistoryList, emailAddress, smsNumber, ct);
 
@@ -145,20 +116,20 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task CloseUserProfileAsync(string hdid, CancellationToken ct = default)
         {
-            this.logger.LogTrace("Closing user profile... {Hdid}", hdid);
+            logger.LogTrace("Closing user profile... {Hdid}", hdid);
 
-            UserProfile userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
+            UserProfile userProfile = await userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
 
             if (userProfile.ClosedDateTime != null)
             {
-                this.logger.LogTrace("Profile already closed");
+                logger.LogTrace("Profile already closed");
                 return;
             }
 
             // Mark profile for deletion
             userProfile.ClosedDateTime = DateTime.UtcNow;
-            userProfile.IdentityManagementId = new(this.authenticationDelegate.FetchAuthenticatedUserId());
-            DbResult<UserProfile> dbResult = await this.userProfileDelegate.UpdateAsync(userProfile, ct: ct);
+            userProfile.IdentityManagementId = new(authenticationDelegate.FetchAuthenticatedUserId());
+            DbResult<UserProfile> dbResult = await userProfileDelegate.UpdateAsync(userProfile, ct: ct);
             if (dbResult.Status != DbStatusCode.Updated)
             {
                 throw new DatabaseException(dbResult.Message);
@@ -170,19 +141,19 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task RecoverUserProfileAsync(string hdid, CancellationToken ct = default)
         {
-            this.logger.LogTrace("Recovering user profile... {Hdid}", hdid);
-            UserProfile userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
+            logger.LogTrace("Recovering user profile... {Hdid}", hdid);
+            UserProfile userProfile = await userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
 
             if (userProfile.ClosedDateTime == null)
             {
-                this.logger.LogTrace("Profile already is active, recover not needed");
+                logger.LogTrace("Profile already is active, recover not needed");
                 return;
             }
 
             // Unmark profile for deletion
             userProfile.ClosedDateTime = null;
             userProfile.IdentityManagementId = null;
-            DbResult<UserProfile> dbResult = await this.userProfileDelegate.UpdateAsync(userProfile, true, ct);
+            DbResult<UserProfile> dbResult = await userProfileDelegate.UpdateAsync(userProfile, true, ct);
             if (dbResult.Status != DbStatusCode.Updated)
             {
                 throw new DatabaseException(dbResult.Message);
@@ -194,10 +165,10 @@ namespace HealthGateway.GatewayApi.Services
         /// <inheritdoc/>
         public async Task UpdateAcceptedTermsAsync(string hdid, Guid termsOfServiceId, CancellationToken ct = default)
         {
-            UserProfile userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
+            UserProfile userProfile = await userProfileDelegate.GetUserProfileAsync(hdid, ct: ct) ?? throw new NotFoundException(ErrorMessages.UserProfileNotFound);
             userProfile.TermsOfServiceId = termsOfServiceId;
 
-            DbResult<UserProfile> result = await this.userProfileDelegate.UpdateAsync(userProfile, ct: ct);
+            DbResult<UserProfile> result = await userProfileDelegate.UpdateAsync(userProfile, ct: ct);
             if (result.Status != DbStatusCode.Updated)
             {
                 throw new DatabaseException(result.Message);
@@ -211,18 +182,18 @@ namespace HealthGateway.GatewayApi.Services
             string smsNumber,
             CancellationToken ct = default)
         {
-            Guid? termsOfServiceId = await this.legalAgreementService.GetActiveLegalAgreementId(LegalAgreementType.TermsOfService, ct);
-            UserProfileModel userProfileModel = this.mappingService.MapToUserProfileModel(userProfile, termsOfServiceId);
+            Guid? termsOfServiceId = await legalAgreementService.GetActiveLegalAgreementId(LegalAgreementType.TermsOfService, ct);
+            UserProfileModel userProfileModel = mappingService.MapToUserProfileModel(userProfile, termsOfServiceId);
             userProfileModel.Email = emailAddress;
             userProfileModel.SmsNumber = smsNumber;
 
-            DateTime? latestTourChangeDateTime = await this.applicationSettingsService.GetLatestTourChangeDateTimeAsync(ct);
+            DateTime? latestTourChangeDateTime = await applicationSettingsService.GetLatestTourChangeDateTimeAsync(ct);
             userProfileModel.HasTourUpdated = historyCollection.Count != 0 &&
                                               latestTourChangeDateTime != null &&
                                               historyCollection.Max(x => x.LastLoginDateTime) < latestTourChangeDateTime;
 
-            userProfileModel.BlockedDataSources = await this.patientRepository.GetDataSourcesAsync(userProfile.HdId, ct);
-            userProfileModel.Preferences = await this.userPreferenceService.GetUserPreferencesAsync(userProfileModel.HdId, ct);
+            userProfileModel.BlockedDataSources = await patientRepository.GetDataSourcesAsync(userProfile.HdId, ct);
+            userProfileModel.Preferences = await userPreferenceService.GetUserPreferencesAsync(userProfileModel.HdId, ct);
             userProfileModel.LastLoginDateTimes = [userProfile.LastLoginDateTime, ..historyCollection.Select(h => h.LastLoginDateTime)];
 
             return userProfileModel;
@@ -233,7 +204,7 @@ namespace HealthGateway.GatewayApi.Services
             if (!string.IsNullOrWhiteSpace(emailAddress))
             {
                 Dictionary<string, string> keyValues = new() { [EmailTemplateVariable.Host] = this.emailTemplateConfig.Host };
-                await this.emailQueueService.QueueNewEmailAsync(emailAddress, emailTemplateName, keyValues, ct: ct);
+                await emailQueueService.QueueNewEmailAsync(emailAddress, emailTemplateName, keyValues, ct: ct);
             }
         }
     }

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -20,117 +20,81 @@ namespace HealthGateway.GatewayApi.Services
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using FluentValidation;
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
-    using HealthGateway.Common.Data.Validations;
-    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.ErrorHandling.Exceptions;
-    using HealthGateway.Common.Messaging;
-    using HealthGateway.Common.Models;
-    using HealthGateway.Common.Models.Events;
     using HealthGateway.Common.Services;
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Wrapper;
     using HealthGateway.GatewayApi.Models;
-    using HealthGateway.GatewayApi.Validations;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
     public class UserProfileServiceV2 : IUserProfileServiceV2
     {
-        private const string MinPatientAgeKey = "MinPatientAge";
         private const string UserProfileHistoryRecordLimitKey = "UserProfileHistoryRecordLimit";
         private const string WebClientConfigSection = "WebClient";
         private readonly EmailTemplateConfig emailTemplateConfig;
-
-        private readonly bool accountsChangeFeedEnabled;
-        private readonly bool notificationsChangeFeedEnabled;
-        private readonly int minPatientAge;
         private readonly int userProfileHistoryRecordLimit;
 
         private readonly ILogger<UserProfileServiceV2> logger;
         private readonly IPatientDetailsService patientDetailsService;
-        private readonly IUserEmailServiceV2 userEmailService;
-        private readonly IUserSmsServiceV2 userSmsService;
         private readonly IEmailQueueService emailQueueService;
-        private readonly INotificationSettingsService notificationSettingsService;
         private readonly IUserProfileDelegate userProfileDelegate;
         private readonly IUserPreferenceServiceV2 userPreferenceService;
         private readonly ILegalAgreementServiceV2 legalAgreementService;
         private readonly IMessagingVerificationDelegate messageVerificationDelegate;
-        private readonly ICryptoDelegate cryptoDelegate;
         private readonly IGatewayApiMappingService mappingService;
         private readonly IAuthenticationDelegate authenticationDelegate;
         private readonly IApplicationSettingsService applicationSettingsService;
         private readonly IPatientRepository patientRepository;
-        private readonly IMessageSender messageSender;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UserProfileServiceV2"/> class.
         /// </summary>
         /// <param name="logger">The injected logger.</param>
         /// <param name="patientDetailsService">The injected patient details service.</param>
-        /// <param name="userEmailService">The injected user email service.</param>
-        /// <param name="userSmsService">The injected user SMS service.</param>
         /// <param name="emailQueueService">The injected service to queue emails.</param>
-        /// <param name="notificationSettingsService">The injected notifications settings service.</param>
         /// <param name="userProfileDelegate">The injected user profile database delegate.</param>
         /// <param name="userPreferenceService">The injected user preference service.</param>
         /// <param name="legalAgreementService">The injected legal agreement service.</param>
         /// <param name="messageVerificationDelegate">The injected message verification delegate.</param>
-        /// <param name="cryptoDelegate">The injected crypto delegate.</param>
         /// <param name="configuration">The injected configuration.</param>
         /// <param name="mappingService">The injected mapping service.</param>
         /// <param name="authenticationDelegate">The injected authentication delegate.</param>
         /// <param name="applicationSettingsService">The injected application settings service.</param>
         /// <param name="patientRepository">The injected patient repository.</param>
-        /// <param name="messageSender">The injected message sender.</param>
-#pragma warning disable S107 // The number of DI parameters should be ignored
         public UserProfileServiceV2(
             ILogger<UserProfileServiceV2> logger,
             IPatientDetailsService patientDetailsService,
-            IUserEmailServiceV2 userEmailService,
-            IUserSmsServiceV2 userSmsService,
             IEmailQueueService emailQueueService,
-            INotificationSettingsService notificationSettingsService,
             IUserProfileDelegate userProfileDelegate,
             IUserPreferenceServiceV2 userPreferenceService,
             ILegalAgreementServiceV2 legalAgreementService,
             IMessagingVerificationDelegate messageVerificationDelegate,
-            ICryptoDelegate cryptoDelegate,
             IConfiguration configuration,
             IGatewayApiMappingService mappingService,
             IAuthenticationDelegate authenticationDelegate,
             IApplicationSettingsService applicationSettingsService,
-            IPatientRepository patientRepository,
-            IMessageSender messageSender)
+            IPatientRepository patientRepository)
         {
             this.logger = logger;
             this.patientDetailsService = patientDetailsService;
-            this.userEmailService = userEmailService;
-            this.userSmsService = userSmsService;
             this.emailQueueService = emailQueueService;
-            this.notificationSettingsService = notificationSettingsService;
             this.userProfileDelegate = userProfileDelegate;
             this.userPreferenceService = userPreferenceService;
             this.legalAgreementService = legalAgreementService;
             this.messageVerificationDelegate = messageVerificationDelegate;
-            this.cryptoDelegate = cryptoDelegate;
             this.mappingService = mappingService;
             this.authenticationDelegate = authenticationDelegate;
             this.applicationSettingsService = applicationSettingsService;
             this.patientRepository = patientRepository;
-            this.messageSender = messageSender;
             this.emailTemplateConfig = configuration.GetSection(EmailTemplateConfig.ConfigurationSectionKey).Get<EmailTemplateConfig>() ?? new();
-            this.accountsChangeFeedEnabled = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>()?.Accounts.Enabled ?? false;
-            this.notificationsChangeFeedEnabled = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>()?.Notifications.Enabled ?? false;
-            this.minPatientAge = configuration.GetSection(WebClientConfigSection).GetValue(MinPatientAgeKey, 12);
             this.userProfileHistoryRecordLimit = configuration.GetSection(WebClientConfigSection).GetValue(UserProfileHistoryRecordLimitKey, 4);
         }
 
@@ -175,66 +139,6 @@ namespace HealthGateway.GatewayApi.Services
 
             UserProfileModel userProfileModel = await this.BuildUserProfileModelAsync(userProfile, userProfileHistoryList, emailAddress, smsNumber, ct);
 
-            return userProfileModel;
-        }
-
-        /// <inheritdoc/>
-        public async Task<UserProfileModel> CreateUserProfileAsync(CreateUserRequest createProfileRequest, DateTime jwtAuthTime, string? jwtEmailAddress, CancellationToken ct = default)
-        {
-            this.logger.LogTrace("Creating user profile... {Hdid}", createProfileRequest.Profile.HdId);
-            string hdid = createProfileRequest.Profile.HdId;
-            string? requestedEmail = createProfileRequest.Profile.Email;
-            string? requestedSmsNumber = createProfileRequest.Profile.SmsNumber;
-            bool isEmailVerified = !string.IsNullOrWhiteSpace(requestedEmail) && string.Equals(requestedEmail, jwtEmailAddress, StringComparison.OrdinalIgnoreCase);
-
-            // validate provided SMS number and patient age
-            await new SmsNumberValidator().ValidateAndThrowAsync(requestedSmsNumber, ct);
-            PatientDetails patient = await this.patientDetailsService.GetPatientAsync(hdid, ct: ct);
-            if (this.minPatientAge > 0)
-            {
-                await new AgeRangeValidator(this.minPatientAge).ValidateAndThrowAsync(patient.Birthdate.ToDateTime(TimeOnly.MinValue), ct);
-            }
-
-            // add SMS and email messaging verifications to DB without committing changes
-            MessagingVerification? smsVerification = await this.AddSmsVerification(hdid, requestedSmsNumber, ct);
-            MessagingVerification? emailVerification = await this.AddEmailVerification(hdid, requestedEmail, isEmailVerified, ct);
-
-            // initialize user profile
-            UserProfile profile = new()
-            {
-                HdId = hdid,
-                IdentityManagementId = null,
-                TermsOfServiceId = createProfileRequest.Profile.TermsOfServiceId,
-                Email = isEmailVerified ? requestedEmail : string.Empty,
-                SmsNumber = null,
-                CreatedBy = hdid,
-                UpdatedBy = hdid,
-                LastLoginDateTime = jwtAuthTime,
-                EncryptionKey = this.cryptoDelegate.GenerateKey(),
-                YearOfBirth = patient.Birthdate.Year,
-                LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType(),
-            };
-
-            // add user profile to DB and commit changes
-            DbResult<UserProfile> dbResult = await this.userProfileDelegate.InsertUserProfileAsync(profile, true, ct);
-            if (dbResult.Status != DbStatusCode.Created)
-            {
-                this.logger.LogError("Error creating user profile... {Hdid}", hdid);
-                throw new DatabaseException(dbResult.Message);
-            }
-
-            // queue verification email
-            if (emailVerification != null && !isEmailVerified)
-            {
-                await this.emailQueueService.QueueNewEmailAsync(emailVerification.Email, true, ct);
-            }
-
-            // notify partners about new account
-            await this.NotifyAccountCreated(profile, requestedEmail, requestedSmsNumber, isEmailVerified, smsVerification?.SmsValidationCode, ct);
-
-            // build and return model
-            UserProfileModel userProfileModel = await this.BuildUserProfileModelAsync(dbResult.Payload, [], requestedEmail, requestedSmsNumber, ct);
-            this.logger.LogTrace("Finished creating user profile... {Hdid}", dbResult.Payload.HdId);
             return userProfileModel;
         }
 
@@ -322,49 +226,6 @@ namespace HealthGateway.GatewayApi.Services
             userProfileModel.LastLoginDateTimes = [userProfile.LastLoginDateTime, ..historyCollection.Select(h => h.LastLoginDateTime)];
 
             return userProfileModel;
-        }
-
-        private async Task<MessagingVerification?> AddSmsVerification(string hdid, string? requestedSmsNumber, CancellationToken ct)
-        {
-            MessagingVerification? smsVerification = null;
-            if (!string.IsNullOrWhiteSpace(requestedSmsNumber))
-            {
-                smsVerification = this.userSmsService.GenerateMessagingVerification(hdid, requestedSmsNumber);
-                await this.messageVerificationDelegate.InsertAsync(smsVerification, false, ct);
-            }
-
-            return smsVerification;
-        }
-
-        private async Task<MessagingVerification?> AddEmailVerification(string hdid, string? requestedEmail, bool isEmailVerified, CancellationToken ct)
-        {
-            MessagingVerification? emailVerification = null;
-            if (!string.IsNullOrWhiteSpace(requestedEmail))
-            {
-                emailVerification = await this.userEmailService.GenerateMessagingVerificationAsync(hdid, requestedEmail, Guid.NewGuid(), isEmailVerified, ct);
-                await this.messageVerificationDelegate.InsertAsync(emailVerification, false, ct);
-            }
-
-            return emailVerification;
-        }
-
-        private async Task NotifyAccountCreated(UserProfile profile, string requestedEmail, string requestedSmsNumber, bool isEmailVerified, string smsVerificationCode, CancellationToken ct)
-        {
-            // notify account was created
-            if (this.accountsChangeFeedEnabled)
-            {
-                await this.messageSender.SendAsync([new MessageEnvelope(new AccountCreatedEvent(profile.HdId, DateTime.UtcNow), profile.HdId)], ct);
-            }
-
-            // notify email verification was successful
-            if (isEmailVerified && this.notificationsChangeFeedEnabled)
-            {
-                await this.messageSender.SendAsync([new(new NotificationChannelVerifiedEvent(profile.HdId, NotificationChannel.Email, requestedEmail), profile.HdId)], ct);
-            }
-
-            // queue notification settings job
-            NotificationSettingsRequest notificationSettingsRequest = new(profile, profile.Email, requestedSmsNumber) { SmsVerificationCode = smsVerificationCode };
-            await this.notificationSettingsService.QueueNotificationSettingsAsync(notificationSettingsRequest, ct);
         }
 
         private async Task SendEmailAsync(string? emailAddress, string emailTemplateName, CancellationToken ct)

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -35,9 +35,6 @@ namespace HealthGateway.GatewayApi.Services
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UserProfileServiceV2"/> class.
-    /// </summary>
     /// <param name="logger">The injected logger.</param>
     /// <param name="patientDetailsService">The injected patient details service.</param>
     /// <param name="emailQueueService">The injected service to queue emails.</param>

--- a/Apps/GatewayApi/src/Services/UserValidationService.cs
+++ b/Apps/GatewayApi/src/Services/UserValidationService.cs
@@ -24,9 +24,6 @@ namespace HealthGateway.GatewayApi.Services
     using Microsoft.Extensions.Configuration;
 
     /// <inheritdoc/>
-    /// <summary>
-    /// Initializes a new instance of the <see cref="UserValidationService"/> class.
-    /// </summary>
     /// <param name="configuration">The injected configuration.</param>
     /// <param name="patientDetailsService">The injected patient details service.</param>
     public class UserValidationService(IConfiguration configuration, IPatientDetailsService patientDetailsService) : IUserValidationService

--- a/Apps/GatewayApi/src/Services/UserValidationService.cs
+++ b/Apps/GatewayApi/src/Services/UserValidationService.cs
@@ -1,0 +1,57 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApi.Services
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Data.Validations;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Validations;
+    using Microsoft.Extensions.Configuration;
+
+    /// <inheritdoc/>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserValidationService"/> class.
+    /// </summary>
+    /// <param name="configuration">The injected configuration.</param>
+    /// <param name="patientDetailsService">The injected patient details service.</param>
+    public class UserValidationService(IConfiguration configuration, IPatientDetailsService patientDetailsService) : IUserValidationService
+    {
+        private const string MinPatientAgeKey = "MinPatientAge";
+        private const string WebClientConfigSection = "WebClient";
+        private const int DefaultPatientAge = 12;
+        private readonly int minPatientAge = configuration.GetSection(WebClientConfigSection).GetValue(MinPatientAgeKey, DefaultPatientAge);
+
+        /// <inheritdoc/>
+        public async Task<bool> IsPhoneNumberValidAsync(string phoneNumber, CancellationToken ct = default)
+        {
+            return (await new SmsNumberValidator().ValidateAsync(phoneNumber, ct)).IsValid;
+        }
+
+        /// <inheritdoc/>
+        public async Task<bool> ValidateEligibilityAsync(string hdid, CancellationToken ct = default)
+        {
+            if (this.minPatientAge == 0)
+            {
+                return true;
+            }
+
+            PatientDetails patient = await patientDetailsService.GetPatientAsync(hdid, ct: ct);
+            return (await new AgeRangeValidator(this.minPatientAge).ValidateAsync(patient.Birthdate.ToDateTime(TimeOnly.MinValue), ct)).IsValid;
+        }
+    }
+}

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -104,6 +104,7 @@ namespace HealthGateway.GatewayApi
             services.AddTransient<IUserSmsServiceV2, UserSmsServiceV2>();
             services.AddTransient<IWebAlertService, WebAlertService>();
             services.AddTransient<IUserValidationService, UserValidationService>();
+            services.AddTransient<IRegistrationService, RegistrationService>();
 
             // Add delegates
             services.AddTransient<IApplicationSettingsDelegate, DbApplicationSettingsDelegate>();

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -103,6 +103,7 @@ namespace HealthGateway.GatewayApi
             services.AddTransient<IUserSmsService, UserSmsService>();
             services.AddTransient<IUserSmsServiceV2, UserSmsServiceV2>();
             services.AddTransient<IWebAlertService, WebAlertService>();
+            services.AddTransient<IUserValidationService, UserValidationService>();
 
             // Add delegates
             services.AddTransient<IApplicationSettingsDelegate, DbApplicationSettingsDelegate>();

--- a/Apps/GatewayApi/test/unit/Services.Test/RegistrationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/RegistrationServiceTests.cs
@@ -1,0 +1,612 @@
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
+namespace HealthGateway.GatewayApiTests.Services.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using DeepEqual.Syntax;
+    using FluentValidation;
+    using HealthGateway.Common.AccessManagement.Authentication;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.Common.Delegates;
+    using HealthGateway.Common.ErrorHandling.Exceptions;
+    using HealthGateway.Common.Messaging;
+    using HealthGateway.Common.Models;
+    using HealthGateway.Common.Models.Events;
+    using HealthGateway.Common.Services;
+    using HealthGateway.Database.Constants;
+    using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Models;
+    using HealthGateway.Database.Wrapper;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Services;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// RegistrationService's Unit Tests.
+    /// </summary>
+    public class RegistrationServiceTests
+    {
+        private const string Hdid = "hdid-mock";
+        private const string EmailAddress = "user@HealthGateway.ca";
+        private const string SmsNumber = "2505556000";
+        private const string SmsVerificationCode = "12345";
+        private const string InvalidSmsNumber = "xxx000xxxx";
+
+        private static readonly Guid TermsOfServiceGuid = Guid.Parse("c99fd839-b4a2-40f9-b103-529efccd0dcd");
+
+        /// <summary>
+        /// CreateUserProfileAsync.
+        /// </summary>
+        /// <param name="requestedSmsNumber">The value representing the requested sms number.</param>
+        /// <param name="requestedEmailAddress">The value representing the requested email address.</param>
+        /// <param name="jwtEmailAddress">The value representing the jwt email address.</param>
+        /// <param name="minPatientAge">The value representing the valid minimum age to create a profile.</param>
+        /// <param name="patientAge">The value representing the patient's age.</param>
+        /// <param name="accountsChangeFeedEnabled">The value indicates whether accounts change feed has been enabled or not.</param>
+        /// <param name="notificationsChangeFeedEnabled">
+        /// The value indicates whether notification change feed has been enabled or
+        /// not.
+        /// </param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(SmsNumber, EmailAddress, EmailAddress, 18, 18, true, true)] // Happy path
+        [InlineData(SmsNumber, EmailAddress, EmailAddress, 18, 19, false, false)] // Happy path
+        [InlineData(null, null, EmailAddress, 18, 18, true, true)] // Both sms and email are null in request
+        [InlineData("", "", EmailAddress, 18, 18, true, true)] // Both sms and email are empty string in request
+        [InlineData(SmsNumber, EmailAddress, null, 18, 18, true, true)] // Jwt email address is null
+        [InlineData(SmsNumber, EmailAddress, "", 18, 18, true, true)] // Jwt email address is empty string
+        public async Task ShouldCreateUserProfileAsync(
+            string? requestedSmsNumber,
+            string? requestedEmailAddress,
+            string? jwtEmailAddress,
+            int minPatientAge,
+            int patientAge,
+            bool accountsChangeFeedEnabled,
+            bool notificationsChangeFeedEnabled)
+        {
+            // Arrange
+            DateTime currentUtcDate = DateTime.UtcNow.Date;
+
+            bool isEmailVerified =
+                !string.IsNullOrWhiteSpace(requestedEmailAddress)
+                && string.Equals(requestedEmailAddress, jwtEmailAddress, StringComparison.OrdinalIgnoreCase);
+
+            Times expectedVerificationSmsInsertTimes = ConvertToTimes(!string.IsNullOrWhiteSpace(requestedSmsNumber));
+            Times expectedVerificationEmailInsertTimes = ConvertToTimes(!string.IsNullOrWhiteSpace(requestedEmailAddress));
+            Times expectedQueueNewEmailByEntityTimes = ConvertToTimes(!isEmailVerified && !string.IsNullOrWhiteSpace(requestedEmailAddress));
+            Times expectedMessageAccountCreatedEventTimes = ConvertToTimes(accountsChangeFeedEnabled);
+            Times expectedNotificationChannelVerifiedEventTimes = ConvertToTimes(isEmailVerified && notificationsChangeFeedEnabled);
+
+            UserProfileModel expected = GenerateUserProfileModel(currentUtcDate, requestedEmailAddress, requestedSmsNumber);
+
+            CreateUserProfileMock mock = SetupCreateUserProfileMock(
+                currentUtcDate,
+                requestedSmsNumber,
+                requestedEmailAddress,
+                jwtEmailAddress,
+                minPatientAge,
+                patientAge,
+                accountsChangeFeedEnabled,
+                notificationsChangeFeedEnabled);
+
+            // Act
+            UserProfileModel actual = await mock.Service.CreateUserProfileAsync(
+                mock.CreateProfileRequest,
+                mock.JwtAuthTime,
+                mock.JwtEmailAddress);
+
+            // Assert and Verify
+            actual.ShouldDeepEqual(expected);
+
+            VerifyVerificationSmsInsert(mock.MessagingVerificationDelegateMock, expectedVerificationSmsInsertTimes);
+            VerifyVerificationEmailInsert(mock.MessagingVerificationDelegateMock, expectedVerificationEmailInsertTimes);
+            VerifyQueueNotificationSettingsRequest(mock.NotificationSettingsServiceMock);
+            VerifyQueueNewEmailByEntity(mock.EmailQueueServiceMock, expectedQueueNewEmailByEntityTimes);
+            VerifyMessageAccountCreatedEvent(mock.MessageSenderMock, expectedMessageAccountCreatedEventTimes);
+            VerifyNotificationChannelVerifiedEvent(mock.MessageSenderMock, expectedNotificationChannelVerifiedEventTimes);
+        }
+
+        /// <summary>
+        /// CreateUserProfileAsync throws Exception.
+        /// </summary>
+        /// <param name="requestedSmsNumber">The value representing the requested sms number.</param>
+        /// <param name="minPatientAge">The value representing the valid minimum age to create a profile.</param>
+        /// <param name="patientAge">The value representing the patient's age.</param>
+        /// <param name="profileInsertStatus">The db status returned when user profile is inserted in the database </param>
+        /// <param name="expectedException">The expected exception type to be thrown.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(InvalidSmsNumber, 18, 18, null, typeof(ValidationException))]
+        [InlineData(SmsNumber, 18, 17, null, typeof(ValidationException))]
+        [InlineData(SmsNumber, 18, 18, DbStatusCode.Error, typeof(DatabaseException))]
+        public async Task CreateUserProfileAsyncThrowsException(
+            string? requestedSmsNumber,
+            int minPatientAge,
+            int patientAge,
+            DbStatusCode? profileInsertStatus,
+            Type expectedException)
+        {
+            // Arrange
+            CreateUserProfileExceptionMock mock = SetupCreateUserProfileThrowsExceptionMock(
+                requestedSmsNumber,
+                minPatientAge,
+                patientAge,
+                profileInsertStatus);
+
+            // Act and assert
+            await Assert.ThrowsAsync(
+                expectedException,
+                async () =>
+                {
+                    await mock.Service.CreateUserProfileAsync(
+                        mock.CreateProfileRequest,
+                        mock.JwtAuthTime,
+                        mock.JwtEmailAddress);
+                });
+        }
+
+        private static void VerifyNotificationChannelVerifiedEvent(Mock<IMessageSender> messageSenderMock, Times? times = null)
+        {
+            messageSenderMock.Verify(
+                v => v.SendAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(
+                        envelopes => envelopes.First().Content is NotificationChannelVerifiedEvent),
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyQueueNewEmailByEntity(Mock<IEmailQueueService> emailQueueServiceMock, Times? times = null)
+        {
+            emailQueueServiceMock.Verify(
+                v => v.QueueNewEmailAsync(
+                    It.IsAny<Email>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyQueueNotificationSettingsRequest(Mock<INotificationSettingsService> notificationSettingsServiceMock, Times? times = null)
+        {
+            notificationSettingsServiceMock.Verify(
+                v => v.QueueNotificationSettingsAsync(
+                    It.IsAny<NotificationSettingsRequest>(),
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyMessageAccountCreatedEvent(Mock<IMessageSender> messageSenderMock, Times? times = null)
+        {
+            messageSenderMock.Verify(
+                v => v.SendAsync(
+                    It.Is<IEnumerable<MessageEnvelope>>(
+                        envelopes => envelopes.First().Content is AccountCreatedEvent),
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyVerificationEmailInsert(Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock, Times? times = null)
+        {
+            messagingVerificationDelegateMock.Verify(
+                v => v.InsertAsync(
+                    It.Is<MessagingVerification>(
+                        x => string.IsNullOrWhiteSpace(x.SmsNumber)
+                             && x.Email != null
+                             && !string.IsNullOrWhiteSpace(x.EmailAddress)),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyVerificationSmsInsert(Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock, Times? times = null)
+        {
+            messagingVerificationDelegateMock.Verify(
+                v => v.InsertAsync(
+                    It.Is<MessagingVerification>(
+                        x => !string.IsNullOrWhiteSpace(x.SmsNumber)
+                             && x.Email == null
+                             && string.IsNullOrWhiteSpace(x.EmailAddress)),
+                    It.IsAny<bool>(),
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static Times ConvertToTimes(bool expected)
+        {
+            return expected ? Times.Once() : Times.Never();
+        }
+
+        private static DateTime GenerateBirthDate(int patientAge = 18)
+        {
+            DateTime currentUtcDate = DateTime.UtcNow.Date;
+            return currentUtcDate.AddYears(-patientAge);
+        }
+
+        private static Email GenerateEmail(Guid? emailId = null, string toEmailAddress = EmailAddress)
+        {
+            return new()
+            {
+                Id = emailId ?? Guid.NewGuid(),
+                To = toEmailAddress,
+            };
+        }
+
+        private static MessagingVerification GenerateMessagingVerification(
+            string smsVerificationCode = SmsVerificationCode,
+            bool validated = true,
+            Guid? inviteKey = null,
+            string? emailAddress = null,
+            string? smsNumber = null)
+        {
+            return new()
+            {
+                Id = Guid.NewGuid(),
+                InviteKey = inviteKey ?? Guid.NewGuid(),
+                SmsNumber = smsNumber,
+                SmsValidationCode = smsVerificationCode,
+                EmailAddress = emailAddress,
+                Validated = validated,
+                Email = emailAddress != null ? GenerateEmail(toEmailAddress: emailAddress) : null,
+            };
+        }
+
+        private static PatientDetails GeneratePatientDetails(string hdid = Hdid, DateOnly? birthDate = null)
+        {
+            return new()
+            {
+                HdId = hdid,
+                Birthdate = birthDate ?? DateOnly.FromDateTime(GenerateBirthDate()),
+            };
+        }
+
+        private static UserProfile GenerateUserProfile(
+            string hdid = Hdid,
+            DateTime? loginDate = null,
+            DateTime? closedDateTime = null,
+            int daysFromLoginDate = 0,
+            string? email = null,
+            string? smsNumber = null,
+            BetaFeature? betaFeature = null)
+        {
+            DateTime lastLoginDateTime = loginDate?.Date ?? DateTime.UtcNow.Date;
+
+            return new()
+            {
+                HdId = hdid,
+                TermsOfServiceId = TermsOfServiceGuid,
+                Email = email,
+                SmsNumber = smsNumber,
+                ClosedDateTime = closedDateTime,
+                LastLoginDateTime = lastLoginDateTime.AddDays(-daysFromLoginDate),
+                BetaFeatureCodes =
+                [
+                    new BetaFeatureCode
+                        { Code = betaFeature ?? BetaFeature.Salesforce },
+                ],
+            };
+        }
+
+        private static DbResult<UserProfile> GenerateUserProfileDbResult(
+            DbStatusCode status,
+            UserProfile? userProfile = null)
+        {
+            return new()
+            {
+                Status = status,
+                Payload = userProfile!,
+            };
+        }
+
+        private static UserProfileModel GenerateUserProfileModel(DateTime currentUtcDate, string? email = EmailAddress, string? smsNumber = SmsNumber)
+        {
+            return new()
+            {
+                HdId = Hdid,
+                TermsOfServiceId = TermsOfServiceGuid,
+                Email = email,
+                IsEmailVerified = !string.IsNullOrWhiteSpace(email),
+                AcceptedTermsOfService = true,
+                SmsNumber = smsNumber,
+                IsSmsNumberVerified = !string.IsNullOrWhiteSpace(smsNumber),
+                HasTermsOfServiceUpdated = true,
+                HasTourUpdated = false,
+                LastLoginDateTime = currentUtcDate,
+                LastLoginDateTimes = [currentUtcDate],
+                BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
+            };
+        }
+
+        private static IConfigurationRoot GetIConfiguration(
+            int minPatientAge = 12,
+            bool accountsChangeFeedEnabled = false,
+            bool notificationsChangeFeedEnabled = false)
+        {
+            Dictionary<string, string?> myConfiguration = new()
+            {
+                { "WebClient:MinPatientAge", minPatientAge.ToString(CultureInfo.InvariantCulture) },
+                { "ChangeFeed:Accounts:Enabled", accountsChangeFeedEnabled.ToString() },
+                { "ChangeFeed:Notifications:Enabled", notificationsChangeFeedEnabled.ToString() },
+            };
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection([.. myConfiguration])
+                .Build();
+        }
+
+        private static IRegistrationService GetRegistrationService(
+            IConfigurationRoot? configurationRoot = null,
+            Mock<IAuthenticationDelegate>? authenticationDelegateMock = null,
+            Mock<IEmailQueueService>? emailQueueServiceMock = null,
+            Mock<IMessageSender>? messageSenderMock = null,
+            Mock<IMessagingVerificationDelegate>? messagingVerificationDelegateMock = null,
+            Mock<INotificationSettingsService>? notificationSettingsServiceMock = null,
+            Mock<IPatientDetailsService>? patientDetailsServiceMock = null,
+            Mock<IUserEmailServiceV2>? userEmailServiceMock = null,
+            Mock<IUserProfileDelegate>? userProfileDelegateMock = null,
+            Mock<IUserProfileServiceV2>? userProfileServiceMock = null,
+            Mock<IUserSmsServiceV2>? userSmsServiceMock = null)
+        {
+            configurationRoot ??= GetIConfiguration();
+            authenticationDelegateMock ??= new();
+            emailQueueServiceMock ??= new();
+            messageSenderMock ??= new();
+            messagingVerificationDelegateMock ??= new();
+            notificationSettingsServiceMock ??= new();
+            patientDetailsServiceMock ??= new();
+            userEmailServiceMock ??= new();
+            userProfileDelegateMock ??= new();
+            userProfileServiceMock ??= new();
+            userSmsServiceMock ??= new();
+
+            return new RegistrationService(
+                configurationRoot,
+                new Mock<ILogger<RegistrationService>>().Object,
+                authenticationDelegateMock.Object,
+                new Mock<ICryptoDelegate>().Object,
+                emailQueueServiceMock.Object,
+                messageSenderMock.Object,
+                messagingVerificationDelegateMock.Object,
+                notificationSettingsServiceMock.Object,
+                patientDetailsServiceMock.Object,
+                userEmailServiceMock.Object,
+                userSmsServiceMock.Object,
+                userProfileDelegateMock.Object,
+                userProfileServiceMock.Object);
+        }
+
+        private static Mock<IPatientDetailsService> SetupPatientDetailsServiceMock(PatientDetails patientDetails)
+        {
+            Mock<IPatientDetailsService> patientDetailsServiceMock = new();
+            patientDetailsServiceMock.Setup(
+                    s => s.GetPatientAsync(
+                        It.Is<string>(x => x == Hdid),
+                        It.IsAny<PatientIdentifierType>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(patientDetails);
+
+            return patientDetailsServiceMock;
+        }
+
+        private static Mock<IUserProfileDelegate> SetupUserProfileDelegateMock(
+            Mock<IUserProfileDelegate>? userProfileDelegateMock = null,
+            DbResult<UserProfile>? insertProfileResult = null,
+            DbResult<UserProfile>? updateProfileResult = null)
+        {
+            userProfileDelegateMock ??= new();
+
+            if (insertProfileResult != null)
+            {
+                userProfileDelegateMock.Setup(
+                        s => s.InsertUserProfileAsync(
+                            It.IsAny<UserProfile>(),
+                            It.IsAny<bool>(),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(insertProfileResult);
+            }
+
+            if (updateProfileResult != null)
+            {
+                userProfileDelegateMock.Setup(
+                        s => s.UpdateAsync(
+                            It.IsAny<UserProfile>(),
+                            It.IsAny<bool>(),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(updateProfileResult);
+            }
+
+            return userProfileDelegateMock;
+        }
+
+        private static Mock<IUserProfileServiceV2> SetupUserProfileServiceMock(UserProfileModel userProfileModel)
+        {
+            Mock<IUserProfileServiceV2> userProfileServiceMock = new();
+
+            userProfileServiceMock.Setup(
+                    s => s.GetUserProfileAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<DateTime>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(userProfileModel);
+
+            return userProfileServiceMock;
+        }
+
+        private static Mock<IUserEmailServiceV2> SetupUserEmailServiceMock(MessagingVerification messagingVerification)
+        {
+            Mock<IUserEmailServiceV2> userEmailServiceMock = new();
+
+            userEmailServiceMock.Setup(
+                    s => s.GenerateMessagingVerificationAsync(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<Guid>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(messagingVerification);
+
+            return userEmailServiceMock;
+        }
+
+        private static Mock<IUserSmsServiceV2> SetupUserSmsServiceMock(MessagingVerification messagingVerification)
+        {
+            Mock<IUserSmsServiceV2> userSmsServiceMock = new();
+
+            userSmsServiceMock.Setup(
+                    s => s.GenerateMessagingVerification(
+                        It.IsAny<string>(),
+                        It.IsAny<string>(),
+                        It.IsAny<bool>()))
+                .Returns(messagingVerification);
+
+            return userSmsServiceMock;
+        }
+
+        private static CreateUserProfileMock SetupCreateUserProfileMock(
+            DateTime currentDateTime,
+            string? requestedSmsNumber,
+            string? requestedEmailAddress,
+            string? jwtEmailAddress,
+            int minPatientAge,
+            int patientAge,
+            bool accountsChangeFeedEnabled,
+            bool notificationsChangeFeedEnabled)
+        {
+            CreateUserRequest createUserRequest = new()
+            {
+                Profile = new(Hdid, Guid.NewGuid(), requestedSmsNumber, requestedEmailAddress),
+            };
+
+            Mock<IEmailQueueService> emailQueueServiceMock = new();
+
+            Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock = new();
+            Mock<IMessageSender> messageSenderMock = new();
+
+            Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
+
+            PatientDetails patientDetails = GeneratePatientDetails(birthDate: DateOnly.FromDateTime(GenerateBirthDate(patientAge)));
+            Mock<IPatientDetailsService> patientDetailsServiceMock = SetupPatientDetailsServiceMock(patientDetails);
+
+            MessagingVerification emailVerification = GenerateMessagingVerification(emailAddress: requestedEmailAddress);
+            Mock<IUserEmailServiceV2> userEmailServiceMock = SetupUserEmailServiceMock(emailVerification);
+
+            UserProfile insertUserProfile = GenerateUserProfile(
+                loginDate: currentDateTime,
+                email: requestedEmailAddress,
+                smsNumber: requestedSmsNumber);
+            DbResult<UserProfile> insertProfileResult = GenerateUserProfileDbResult(DbStatusCode.Created, insertUserProfile);
+            Mock<IUserProfileDelegate> userProfileDelegateMock = SetupUserProfileDelegateMock(insertProfileResult: insertProfileResult);
+
+            MessagingVerification smsVerification = GenerateMessagingVerification(smsNumber: requestedSmsNumber);
+            Mock<IUserSmsServiceV2> userSmsServiceMock = SetupUserSmsServiceMock(smsVerification);
+
+            UserProfileModel userProfileModel = GenerateUserProfileModel(currentDateTime, requestedEmailAddress, requestedSmsNumber);
+            Mock<IUserProfileServiceV2> userProfileServiceMock = SetupUserProfileServiceMock(userProfileModel);
+
+            IConfigurationRoot configuration = GetIConfiguration(
+                minPatientAge,
+                accountsChangeFeedEnabled,
+                notificationsChangeFeedEnabled);
+
+            IRegistrationService service = GetRegistrationService(
+                configuration,
+                emailQueueServiceMock: emailQueueServiceMock,
+                messageSenderMock: messageSenderMock,
+                messagingVerificationDelegateMock: messagingVerificationDelegateMock,
+                notificationSettingsServiceMock: notificationSettingsServiceMock,
+                patientDetailsServiceMock: patientDetailsServiceMock,
+                userEmailServiceMock: userEmailServiceMock,
+                userProfileDelegateMock: userProfileDelegateMock,
+                userSmsServiceMock: userSmsServiceMock,
+                userProfileServiceMock: userProfileServiceMock);
+
+            return new(
+                service,
+                messagingVerificationDelegateMock,
+                notificationSettingsServiceMock,
+                emailQueueServiceMock,
+                messageSenderMock,
+                createUserRequest,
+                DateTime.UtcNow,
+                jwtEmailAddress);
+        }
+
+        private static CreateUserProfileExceptionMock SetupCreateUserProfileThrowsExceptionMock(
+            string? requestedSmsNumber,
+            int minPatientAge,
+            int patientAge,
+            DbStatusCode? profileInsertStatus)
+        {
+            CreateUserRequest createUserRequest = new()
+            {
+                Profile = new(Hdid, Guid.NewGuid(), requestedSmsNumber, EmailAddress),
+            };
+
+            PatientDetails patientDetails = GeneratePatientDetails(birthDate: DateOnly.FromDateTime(GenerateBirthDate(patientAge)));
+            Mock<IPatientDetailsService> patientDetailsServiceMock = SetupPatientDetailsServiceMock(patientDetails);
+
+            MessagingVerification emailVerification = GenerateMessagingVerification(emailAddress: EmailAddress);
+            Mock<IUserEmailServiceV2> userEmailServiceMock = SetupUserEmailServiceMock(emailVerification);
+
+            DbResult<UserProfile>? insertProfileResult =
+                profileInsertStatus != null ? GenerateUserProfileDbResult(profileInsertStatus.Value) : null;
+            Mock<IUserProfileDelegate> userProfileDelegateMock = SetupUserProfileDelegateMock(insertProfileResult: insertProfileResult);
+
+            MessagingVerification smsVerification = GenerateMessagingVerification(smsNumber: requestedSmsNumber);
+            Mock<IUserSmsServiceV2> userSmsServiceMock = SetupUserSmsServiceMock(smsVerification);
+
+            IConfigurationRoot configuration = GetIConfiguration(
+                minPatientAge: minPatientAge);
+
+            IRegistrationService service = GetRegistrationService(
+                configuration,
+                emailQueueServiceMock: new(),
+                messageSenderMock: new(),
+                messagingVerificationDelegateMock: new(),
+                notificationSettingsServiceMock: new(),
+                patientDetailsServiceMock: patientDetailsServiceMock,
+                userEmailServiceMock: userEmailServiceMock,
+                userSmsServiceMock: userSmsServiceMock,
+                userProfileDelegateMock: userProfileDelegateMock,
+                userProfileServiceMock: new());
+
+            return new(service, createUserRequest, DateTime.Today, EmailAddress);
+        }
+
+        private sealed record CreateUserProfileMock(
+            IRegistrationService Service,
+            Mock<IMessagingVerificationDelegate> MessagingVerificationDelegateMock,
+            Mock<INotificationSettingsService> NotificationSettingsServiceMock,
+            Mock<IEmailQueueService> EmailQueueServiceMock,
+            Mock<IMessageSender> MessageSenderMock,
+            CreateUserRequest CreateProfileRequest,
+            DateTime JwtAuthTime,
+            string? JwtEmailAddress);
+
+        private sealed record CreateUserProfileExceptionMock(
+            IRegistrationService Service,
+            CreateUserRequest CreateProfileRequest,
+            DateTime JwtAuthTime,
+            string? JwtEmailAddress);
+    }
+}

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
@@ -339,29 +339,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         }
 
         /// <summary>
-        /// IsPhoneNumberValidAsync returns false for invalid phone number.
-        /// </summary>
-        /// <param name="phoneNumber">The phone number to validate.</param>
-        /// <param name="expected">The expected value of the validation result.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [InlineData("3345678901", true)]
-        [InlineData("2507001000", true)]
-        [InlineData("xxx3277465", false)]
-        [InlineData("abc", false)]
-        [Theory]
-        public async Task PhoneNumberIsNotValid(string phoneNumber, bool expected)
-        {
-            // Arrange
-            PhoneNumberValidMock mock = SetupPhoneNumberValidMock(phoneNumber);
-
-            // Act
-            bool actual = await mock.Service.IsPhoneNumberValidAsync(mock.PhoneNumber);
-
-            // Assert
-            Assert.Equal(expected, actual);
-        }
-
-        /// <summary>
         /// RecoverUserProfile - Happy Path.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -488,30 +465,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 Assert.Fail("Expected UpdateAcceptedTermsThrowsExceptionMock but got a different type.");
             }
-        }
-
-        /// <summary>
-        /// ValidateEligibilityAsync.
-        /// </summary>
-        /// <param name="minPatientAge">The minimum patient age to validate against.</param>
-        /// <param name="patientAge">The patient age to validate.</param>
-        /// <param name="expected">The expected eligibility result.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [InlineData(0, 0, true)]
-        [InlineData(19, 19, true)]
-        [InlineData(19, 20, true)]
-        [InlineData(19, 18, false)]
-        [Theory]
-        public async Task ShouldValidateEligibilityAsync(int minPatientAge, int patientAge, bool expected)
-        {
-            // Arrange
-            ValidateEligibilityMock mock = SetupValidateEligibilityMock(minPatientAge, patientAge);
-
-            // Act
-            bool actual = await mock.Service.ValidateEligibilityAsync(mock.Hdid);
-
-            // Assert
-            Assert.Equal(expected, actual);
         }
 
         private static void VerifyNotificationChannelVerifiedEvent(Mock<IMessageSender> messageSenderMock, Times? times = null)
@@ -1142,12 +1095,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new(service, createUserRequest, DateTime.Today, EmailAddress);
         }
 
-        private static PhoneNumberValidMock SetupPhoneNumberValidMock(string phoneNumber)
-        {
-            IUserProfileServiceV2 service = GetUserProfileService(configurationRoot: GetIConfiguration());
-            return new(service, phoneNumber);
-        }
-
         private static BaseUserProfileServiceMock SetupRecoverUserProfileMock(
             bool userProfileExists = true,
             DateTime? profileClosedDateTime = null,
@@ -1265,24 +1212,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 jwtAuthTime);
         }
 
-        private static ValidateEligibilityMock SetupValidateEligibilityMock(
-            int minPatientAge = 0,
-            int patientAge = 0)
-        {
-            IConfigurationRoot configuration = GetIConfiguration(
-                minPatientAge: minPatientAge);
-
-            DateTime birthDate = GenerateBirthDate(patientAge);
-            PatientDetails patientDetails = GeneratePatientDetails(birthDate: DateOnly.FromDateTime(birthDate));
-            Mock<IPatientDetailsService> patientDetailsServiceMock = SetupPatientDetailsServiceMock(patientDetails);
-
-            IUserProfileServiceV2 service = GetUserProfileService(
-                patientDetailsServiceMock,
-                configurationRoot: configuration);
-
-            return new(service, Hdid);
-        }
-
         private abstract record BaseUserProfileServiceMock;
 
         private sealed record UserProfileMock(
@@ -1328,10 +1257,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IUserProfileServiceV2 Service,
             string Hdid) : BaseUserProfileServiceMock;
 
-        private sealed record PhoneNumberValidMock(
-            IUserProfileServiceV2 Service,
-            string PhoneNumber);
-
         private sealed record RecoverUserProfileMock(
             IUserProfileServiceV2 Service,
             Mock<IUserProfileDelegate> UserProfileDelegateMock,
@@ -1341,9 +1266,5 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         private sealed record RecoverUserProfileExceptionMock(
             IUserProfileServiceV2 Service,
             string Hdid) : BaseUserProfileServiceMock;
-
-        private sealed record ValidateEligibilityMock(
-            IUserProfileServiceV2 Service,
-            string Hdid);
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
@@ -69,7 +69,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(19, 20, true)]
         [InlineData(19, 18, false)]
         [Theory]
-        public async Task ShouldValidateEligibilityAsync(int minPatientAge, int patientAge, bool expected)
+        public async Task ShouldValidateEligibility(int minPatientAge, int patientAge, bool expected)
         {
             // Arrange
             ValidateEligibilityMock mock = SetupValidateEligibilityMock(minPatientAge, patientAge);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
@@ -35,7 +35,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         private const string Hdid = "hdid-mock";
 
         /// <summary>
-        /// IsPhoneNumberValidAsync returns false for invalid phone number.
+        /// IsPhoneNumberValidAsync.
         /// </summary>
         /// <param name="phoneNumber">The phone number to validate.</param>
         /// <param name="expected">The expected value of the validation result.</param>
@@ -45,7 +45,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData("xxx3277465", false)]
         [InlineData("abc", false)]
         [Theory]
-        public async Task PhoneNumberIsNotValid(string phoneNumber, bool expected)
+        public async Task ShouldValidatePhoneNumber(string phoneNumber, bool expected)
         {
             // Arrange
             PhoneNumberValidMock mock = SetupPhoneNumberValidMock(phoneNumber);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
@@ -1,0 +1,170 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.GatewayApiTests.Services.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Constants;
+    using HealthGateway.GatewayApi.Models;
+    using HealthGateway.GatewayApi.Services;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// UserValidationService's Unit Tests.
+    /// </summary>
+    public class UserValidationServiceTests
+    {
+        private const string Hdid = "hdid-mock";
+
+        /// <summary>
+        /// IsPhoneNumberValidAsync returns false for invalid phone number.
+        /// </summary>
+        /// <param name="phoneNumber">The phone number to validate.</param>
+        /// <param name="expected">The expected value of the validation result.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [InlineData("3345678901", true)]
+        [InlineData("2507001000", true)]
+        [InlineData("xxx3277465", false)]
+        [InlineData("abc", false)]
+        [Theory]
+        public async Task PhoneNumberIsNotValid(string phoneNumber, bool expected)
+        {
+            // Arrange
+            PhoneNumberValidMock mock = SetupPhoneNumberValidMock(phoneNumber);
+
+            // Act
+            bool actual = await mock.Service.IsPhoneNumberValidAsync(mock.PhoneNumber);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        /// <summary>
+        /// ValidateEligibilityAsync.
+        /// </summary>
+        /// <param name="minPatientAge">The minimum patient age to validate against.</param>
+        /// <param name="patientAge">The patient age to validate.</param>
+        /// <param name="expected">The expected eligibility result.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [InlineData(0, 0, true)]
+        [InlineData(19, 19, true)]
+        [InlineData(19, 20, true)]
+        [InlineData(19, 18, false)]
+        [Theory]
+        public async Task ShouldValidateEligibilityAsync(int minPatientAge, int patientAge, bool expected)
+        {
+            // Arrange
+            ValidateEligibilityMock mock = SetupValidateEligibilityMock(minPatientAge, patientAge);
+
+            // Act
+            bool actual = await mock.Service.ValidateEligibilityAsync(mock.Hdid);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        private static DateTime GenerateBirthDate(int patientAge = 18)
+        {
+            DateTime currentUtcDate = DateTime.UtcNow.Date;
+            return currentUtcDate.AddYears(-patientAge);
+        }
+
+        private static PatientDetails GeneratePatientDetails(string hdid = Hdid, DateOnly? birthDate = null)
+        {
+            return new()
+            {
+                HdId = hdid,
+                Birthdate = birthDate ?? DateOnly.FromDateTime(GenerateBirthDate()),
+            };
+        }
+
+        private static IConfigurationRoot GetIConfiguration(
+            int minPatientAge = 12)
+        {
+            Dictionary<string, string?> myConfiguration = new()
+            {
+                { "WebClient:MinPatientAge", minPatientAge.ToString(CultureInfo.InvariantCulture) },
+            };
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection([.. myConfiguration])
+                .Build();
+        }
+
+        private static IUserValidationService GetUserValidationService(
+            IConfigurationRoot? configurationRoot = null,
+            Mock<IPatientDetailsService>? patientDetailsServiceMock = null)
+        {
+            patientDetailsServiceMock ??= new();
+            configurationRoot ??= GetIConfiguration();
+
+            return new UserValidationService(
+                configurationRoot,
+                patientDetailsServiceMock.Object);
+        }
+
+        private static Mock<IPatientDetailsService> SetupPatientDetailsServiceMock(PatientDetails patientDetails)
+        {
+            Mock<IPatientDetailsService> patientDetailsServiceMock = new();
+            patientDetailsServiceMock.Setup(
+                    s => s.GetPatientAsync(
+                        It.Is<string>(x => x == Hdid),
+                        It.IsAny<PatientIdentifierType>(),
+                        It.IsAny<bool>(),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(patientDetails);
+
+            return patientDetailsServiceMock;
+        }
+
+        private static PhoneNumberValidMock SetupPhoneNumberValidMock(string phoneNumber)
+        {
+            IUserValidationService service = GetUserValidationService(configurationRoot: GetIConfiguration());
+            return new(service, phoneNumber);
+        }
+
+        private static ValidateEligibilityMock SetupValidateEligibilityMock(
+            int minPatientAge = 0,
+            int patientAge = 0)
+        {
+            IConfigurationRoot configuration = GetIConfiguration(
+                minPatientAge: minPatientAge);
+
+            DateTime birthDate = GenerateBirthDate(patientAge);
+            PatientDetails patientDetails = GeneratePatientDetails(birthDate: DateOnly.FromDateTime(birthDate));
+            Mock<IPatientDetailsService> patientDetailsServiceMock = SetupPatientDetailsServiceMock(patientDetails);
+
+            IUserValidationService service = GetUserValidationService(
+                configuration,
+                patientDetailsServiceMock);
+
+            return new(service, Hdid);
+        }
+
+        private sealed record PhoneNumberValidMock(
+            IUserValidationService Service,
+            string PhoneNumber);
+
+        private sealed record ValidateEligibilityMock(
+            IUserValidationService Service,
+            string Hdid);
+    }
+}


### PR DESCRIPTION
# Implements [AB#16811](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16811)

## Description

- Move CreateUserProfileAsync from UserProfileServiceV2 to RegistrationService
- Move IsPhoneNunberValidAsync from UserProfileServiceV2 to UserValidationService
- Move ValidateEligibilityAsync from UserProfileServiceV2 to UserValidationService
- Removed no longer applicable unit tests from UserProfileServiceV2Tests
- Created unit tests for RegistrationService
- Created unit tests for UserValidationService
- Updated UserProfileServiceV2 to use primary constructor
- Removed disabling of pragma warning for DI parameters in UserProfileServiceV2

**Unit Tests:**

<img width="408" alt="Screenshot 2024-08-01 at 11 44 08 AM" src="https://github.com/user-attachments/assets/20163442-455d-4262-81f6-56bef2c83429">

**Cypress:**

Note: Organ Donor failures expected due to PHSA data issues.

https://cloud.cypress.io/projects/ofnepc/runs/4561/overview?roarHideRunsWithDiffGroupsAndTags=1

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
