### PR TITLE
Refactor and simplify configureSettings AB#14988

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/models/configData.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/configData.ts
@@ -118,7 +118,7 @@ export interface ServicesSettings {
 
 export interface ServiceSettings {
     name: string;
-    enabled: string;
+    enabled: boolean;
 }
 
 // Various timeout values used by the VUE WebClient application.


### PR DESCRIPTION
# Implements [AB#14988](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/14988) ([AB#16817](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16817))

## Description

Refactors configureSettings command used in Cypress tests to only set default values for boolean properties (opening the possibility to use string and number properties in the future) and reorganizes the logic to minimize the customized behaviour needed for array properties.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
