### PR TITLE
Return Salesforce beta access for all users AB#16823

### DIFF
--- a/Apps/GatewayApi/src/MapProfiles/UserProfileProfile.cs
+++ b/Apps/GatewayApi/src/MapProfiles/UserProfileProfile.cs
@@ -37,7 +37,7 @@ namespace HealthGateway.GatewayApi.MapProfiles
                 .ForMember(dest => dest.IsEmailVerified, opt => opt.MapFrom(src => !string.IsNullOrEmpty(src.Email)))
                 .ForMember(dest => dest.IsSmsNumberVerified, opt => opt.MapFrom(src => !string.IsNullOrEmpty(src.SmsNumber)))
                 .ForMember(dest => dest.AcceptedTermsOfService, opt => opt.MapFrom(src => src.TermsOfServiceId != Guid.Empty))
-                .ForMember(dest => dest.BetaFeatures, opt => opt.MapFrom(src => GetBetaFeaturesFromCodes(src.BetaFeatureCodes)))
+                .ForMember(dest => dest.BetaFeatures, opt => opt.MapFrom(src => GetBetaFeaturesFromCodes(src.BetaFeatureCodes).Append(Database.Constants.BetaFeature.Salesforce).Distinct()))
                 .ReverseMap();
 
             this.CreateMap<Database.Constants.BetaFeature, BetaFeature>()

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -905,6 +905,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         HasTermsOfServiceUpdated = true,
                         LastLoginDateTime = lastLoginDateTime,
                         HasTourUpdated = false,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
                     }
                     : null,
                 ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
@@ -1024,6 +1025,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         IsEmailVerified = true,
                         Email = updatedUserProfile.Email,
                         ClosedDateTime = updatedUserProfile.ClosedDateTime,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
                     }
                     : null,
                 ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
@@ -1146,6 +1148,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         IsEmailVerified = true,
                         Email = updatedUserProfile.Email,
                         ClosedDateTime = updatedUserProfile.ClosedDateTime,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
                     }
                     : null,
                 ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists

--- a/Testing/functional/tests/cypress/integration/e2e/user/betaFeatures.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/betaFeatures.js
@@ -16,14 +16,13 @@ describe("Beta Features", () => {
         cy.get("[data-testid=beta-alert]").should("be.visible");
     });
 
-    it("No Link to Beta Site on Home Page for Unapproved User", () => {
+    it("Link to Beta Site on Home Page for Unapproved User", () => {
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
             homeUrl
         );
-        cy.get("[data-testid=add-quick-link-button]").should("be.visible");
-        cy.get("[data-testid=beta-alert]").should("not.exist");
+        cy.get("[data-testid=beta-alert]").should("be.visible");
     });
 });


### PR DESCRIPTION
# Implements [AB#16823](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16823)

## Description

Updates mapping profile so all user profiles will specify they have access to the Salesforce beta, regardless of whether access has been specifically assigned for that user in the database.

## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
