### PR TITLE
Increase code coverage in Admin for AB16821

### DIFF
--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -191,10 +191,11 @@ namespace HealthGateway.Admin.Server.Services
             if (this.changeFeedEnabled)
             {
                 await delegationDelegate.UpdateDelegationAsync(dependent, resourceDelegatesToDelete, agentAudit, false, ct);
-                IEnumerable<MessageEnvelope> events = new MessageEnvelope[]
-                {
+                IEnumerable<MessageEnvelope> events =
+                [
                     new(new DependentProtectionAddedEvent(dependentHdid), dependentHdid),
-                }.Concat(resourceDelegatesToDelete.Select(rd => new MessageEnvelope(new DependentRemovedEvent(rd.ProfileHdid, dependentHdid), rd.ProfileHdid)));
+                    .. resourceDelegatesToDelete.Select(rd => new MessageEnvelope(new DependentRemovedEvent(rd.ProfileHdid, dependentHdid), rd.ProfileHdid)),
+                ];
 
                 await messageSender.SendAsync(events, ct);
             }
@@ -238,9 +239,9 @@ namespace HealthGateway.Admin.Server.Services
                 await delegationDelegate.UpdateDelegationAsync(dependent, [], agentAudit, false, ct);
 
                 MessageEnvelope[] events =
-                {
+                [
                     new(new DependentProtectionRemovedEvent(dependentHdid), dependentHdid),
-                };
+                ];
 
                 await messageSender.SendAsync(events, ct);
             }

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -438,9 +438,8 @@ namespace HealthGateway.Admin.Tests.Services
             await Assert.ThrowsAsync<NotFoundException>(() => delegationService.GetDelegationInformationAsync(DependentPhn));
         }
 
-
         /// <summary>
-        /// Tests get delegate information - happy path.
+        /// GetDelegationInformationAsync throws exception - see Theory for exception type and criteria.
         /// </summary>
         /// <param name="resultType">Value for the result type in the request result.</param>
         /// <param name="isActionTypeValidation">Value indicating if there is an action type validation error.</param>
@@ -455,16 +454,12 @@ namespace HealthGateway.Admin.Tests.Services
         public async Task GetDelegateInformationShouldThrowException(ResultType resultType, bool isActionTypeValidation, string? resultMessage, Type expectedException)
         {
             // Arrange
-            PatientModel patientModel = GetPatientModel(DelegateHdid, DelegatePhn);
-
-            // Ensure actionCode is set to ActionType.Validation when isActionTypeValidation is true
             ActionType? actionCode = isActionTypeValidation ? ActionType.Validation : null;
 
             RequestResult<PatientModel> patientResult = GetPatientResult(
                 resultType: resultType,
                 actionCode: actionCode,
-                resultMessage: resultMessage
-            );
+                resultMessage: resultMessage);
 
             IDelegationService delegationService = GetDelegationService(patientResult);
 

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -152,7 +152,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDelegateInformationThrowBadRequestException()
+        public async Task GetDelegateInformationShouldThrowBadRequestException()
         {
             // Arrange
             DateTime invalidBirthDate = DateTime.UtcNow;
@@ -369,7 +369,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldUnprotectDependentThrowNotFoundException()
+        public async Task UnprotectDependentShouldThrowNotFoundException()
         {
             // Arrange
             string invalidDependentHdid = DelegateHdid;
@@ -393,7 +393,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task GetDelegationInformationThrowsValidationException()
+        public async Task GetDelegationInformationShouldThrowValidationException()
         {
             RequestResult<PatientModel> dependentResult = GetDependentResult(DateTime.Now.AddYears(-14)); // Invalid age
             RequestResult<PatientModel> delegateResult = GetDelegateResult();
@@ -413,7 +413,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task GetDelegationInformationThrowsNotFoundException()
+        public async Task GetDelegationInformationShouldThrowsNotFoundException()
         {
             RequestResultError error = new() { ActionCode = ActionType.Invalid, ResultMessage = "Bad request" };
             RequestResult<PatientModel> patientResult = new()
@@ -436,6 +436,42 @@ namespace HealthGateway.Admin.Tests.Services
                 MappingService);
 
             await Assert.ThrowsAsync<NotFoundException>(() => delegationService.GetDelegationInformationAsync(DependentPhn));
+        }
+
+
+        /// <summary>
+        /// Tests get delegate information - happy path.
+        /// </summary>
+        /// <param name="resultType">Value for the result type in the request result.</param>
+        /// <param name="isActionTypeValidation">Value indicating if there is an action type validation error.</param>
+        /// <param name="resultMessage">Value for the message value in the request result.</param>
+        /// <param name="expectedException">The expected exception to be thrown.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(ResultType.ActionRequired, true, null, typeof(System.ComponentModel.DataAnnotations.ValidationException))]
+        [InlineData(ResultType.Error, false, "Communication Exception", typeof(UpstreamServiceException))]
+        [InlineData(ResultType.Error, false, null, typeof(NotFoundException))]
+        [InlineData(ResultType.ActionRequired, false, null, typeof(NotFoundException))]
+        public async Task GetDelegateInformationShouldThrowException(ResultType resultType, bool isActionTypeValidation, string? resultMessage, Type expectedException)
+        {
+            // Arrange
+            PatientModel patientModel = GetPatientModel(DelegateHdid, DelegatePhn);
+
+            // Ensure actionCode is set to ActionType.Validation when isActionTypeValidation is true
+            ActionType? actionCode = isActionTypeValidation ? ActionType.Validation : null;
+
+            RequestResult<PatientModel> patientResult = GetPatientResult(
+                resultType: resultType,
+                actionCode: actionCode,
+                resultMessage: resultMessage
+            );
+
+            IDelegationService delegationService = GetDelegationService(patientResult);
+
+            // Act and Assert
+            await Assert.ThrowsAsync(
+                expectedException,
+                async () => { await delegationService.GetDelegationInformationAsync(DependentPhn); });
         }
 
         /// <summary>
@@ -678,12 +714,13 @@ namespace HealthGateway.Admin.Tests.Services
             };
         }
 
-        private static RequestResult<PatientModel> GetPatientResult(PatientModel patientModel)
+        private static RequestResult<PatientModel> GetPatientResult(PatientModel? patientModel = null, ResultType? resultType = null, ActionType? actionCode = null, string? resultMessage = null)
         {
             return new()
             {
-                ResultStatus = ResultType.Success,
+                ResultStatus = resultType ?? ResultType.Success,
                 ResourcePayload = patientModel,
+                ResultError = actionCode != null || !string.IsNullOrEmpty(resultMessage) ? new() { ActionCode = actionCode, ResultMessage = resultMessage ?? string.Empty } : null,
             };
         }
 

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -72,6 +72,30 @@ namespace HealthGateway.Admin.Tests.Services
         private static readonly DateTime Birthdate2 = DateTime.Parse("1999-12-31", CultureInfo.InvariantCulture);
 
         /// <summary>
+        /// BlockAccessAsync - Happy Path.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldBlockAccess()
+        {
+            // Arrange
+            IEnumerable<DataSource> dataSources = [DataSource.Immunization];
+            const string reason = "test";
+            Mock<IPatientRepository> patientRepositoryMock = new();
+            ISupportService service = CreateSupportService(patientRepositoryMock: patientRepositoryMock);
+
+            // Act
+            await service.BlockAccessAsync(Hdid, dataSources, reason);
+
+            // Verify
+            patientRepositoryMock.Verify(
+                v => v.BlockAccessAsync(
+                    It.IsAny<BlockAccessCommand>(),
+                    It.IsAny<CancellationToken>()),
+                Times.Once());
+        }
+
+        /// <summary>
         /// GetPatientSupportDetailsAsync - Happy Path.
         /// </summary>
         /// <param name="includeMessagingVerifications">Value indicating whether messaging verifications are included.</param>
@@ -93,7 +117,7 @@ namespace HealthGateway.Admin.Tests.Services
         [InlineData(false, null, false, null, false, null, false, false, null, false, true, ClientRegistryType.Hdid)]
         [InlineData(false, null, false, null, false, null, false, false, null, true, false, ClientRegistryType.Phn)]
         [InlineData(false, null, false, null, false, null, false, false, null, false, true, ClientRegistryType.Phn)]
-        public async Task ShouldGetPatientSupportDetailsAsync(
+        public async Task ShouldGetPatientSupportDetails(
             bool includeMessagingVerifications,
             int? expectedMessagingVerificationCount,
             bool includeAgentActions,
@@ -173,11 +197,11 @@ namespace HealthGateway.Admin.Tests.Services
         }
 
         /// <summary>
-        /// Get patient support details async throws exception given null phn and invalid date of birth.
+        /// GetPatientSupportDetailsAsync throws InvalidDataException when null phn and invalid date of birth.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task GetPatientSupportDetailsAsyncThrowsInvalidPhnDob()
+        public async Task GetPatientSupportDetailsShouldThrowInvalidDataException()
         {
             // Arrange
             PatientDetailsQuery query = new() { Phn = Phn, Source = PatientDetailSource.Empi, UseCache = false };
@@ -197,35 +221,32 @@ namespace HealthGateway.Admin.Tests.Services
                 null,
                 GetAuthenticationDelegateMock(AccessToken));
 
-            // Verify
-            InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(Actual);
+            // Act and Verify
+            InvalidDataException exception = await Assert.ThrowsAsync<InvalidDataException>(
+                async () =>
+                {
+                    await supportService.GetPatientSupportDetailsAsync(
+                        new()
+                        {
+                            QueryType = ClientRegistryType.Phn,
+                            QueryParameter = Phn,
+                            IncludeMessagingVerifications = false,
+                            IncludeBlockedDataSources = false,
+                            IncludeAgentActions = false,
+                            IncludeDependents = false,
+                            IncludeCovidDetails = true,
+                            RefreshVaccineDetails = false,
+                        });
+                });
             Assert.Equal(ErrorMessages.PhnOrDateOfBirthInvalid, exception.Message);
-            return;
-
-            // Act
-            async Task Actual()
-            {
-                await supportService.GetPatientSupportDetailsAsync(
-                    new()
-                    {
-                        QueryType = ClientRegistryType.Phn,
-                        QueryParameter = Phn,
-                        IncludeMessagingVerifications = false,
-                        IncludeBlockedDataSources = false,
-                        IncludeAgentActions = false,
-                        IncludeDependents = false,
-                        IncludeCovidDetails = true,
-                        RefreshVaccineDetails = false,
-                    });
-            }
         }
 
         /// <summary>
-        /// Get patient support details async throws exception given invalid phn.
+        /// GetPatientSupportDetailsAsync throws UnauthorizedAccessException when access token cannot be found.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task GetPatientSupportDetailsAsyncThrowsCannotFindAccessToken()
+        public async Task GetPatientSupportDetailsShouldThrowUnauthorizedAccessException()
         {
             // Arrange
             PatientDetailsQuery query = new() { Hdid = Hdid, Source = PatientDetailSource.All, UseCache = false };
@@ -243,25 +264,23 @@ namespace HealthGateway.Admin.Tests.Services
                 null,
                 GetAuthenticationDelegateMock(accessToken));
 
-            // Act
-            async Task Actual()
-            {
-                await supportService.GetPatientSupportDetailsAsync(
-                    new()
-                    {
-                        QueryType = ClientRegistryType.Hdid,
-                        QueryParameter = Hdid,
-                        IncludeMessagingVerifications = true,
-                        IncludeBlockedDataSources = true,
-                        IncludeAgentActions = true,
-                        IncludeDependents = false,
-                        IncludeCovidDetails = true,
-                        RefreshVaccineDetails = false,
-                    });
-            }
-
-            // Verify
-            UnauthorizedAccessException exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(Actual);
+            // Act and Verify
+            UnauthorizedAccessException exception = await Assert.ThrowsAsync<UnauthorizedAccessException>(
+                async () =>
+                {
+                    await supportService.GetPatientSupportDetailsAsync(
+                        new()
+                        {
+                            QueryType = ClientRegistryType.Hdid,
+                            QueryParameter = Hdid,
+                            IncludeMessagingVerifications = true,
+                            IncludeBlockedDataSources = true,
+                            IncludeAgentActions = true,
+                            IncludeDependents = false,
+                            IncludeCovidDetails = true,
+                            RefreshVaccineDetails = false,
+                        });
+                });
             Assert.Equal(ErrorMessages.CannotFindAccessToken, exception.Message);
         }
 
@@ -339,6 +358,40 @@ namespace HealthGateway.Admin.Tests.Services
             // Patient not found
             PatientModel? patient = null;
             Mock<IPatientRepository> patientRepositoryMock = GetPatientRepositoryMock((query, patient));
+
+            UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
+            Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);
+
+            ISupportService supportService = CreateSupportService(patientRepositoryMock: patientRepositoryMock, userProfileDelegateMock: userProfileDelegateMock);
+
+            IEnumerable<PatientSupportResult> expectedResult =
+            [
+                GetExpectedPatientSupportDetails(patient, profile),
+            ];
+
+            // Act
+            IEnumerable<PatientSupportResult> actualResult = await supportService.GetPatientsAsync(PatientQueryType.Hdid, Hdid);
+
+            // Assert
+            Assert.Single(actualResult);
+            Assert.Equal(PatientStatus.NotFound, actualResult.First().Status);
+            actualResult.ShouldDeepEqual(expectedResult);
+        }
+
+        /// <summary>
+        /// GetPatientsAsync - HDID - NotFoundException thrown by IPatientRepository.QueryAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetPatientByHdidNotFoundException()
+        {
+            // Arrange
+            PatientDetailsQuery query = new() { Hdid = Hdid, Source = PatientDetailSource.All, UseCache = false };
+
+            PatientModel? patient = null;
+            Mock<IPatientRepository> patientRepositoryMock = new();
+            // Patient not found exception
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.IsAny<PatientQuery>(), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
 
             UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
             Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -386,10 +386,9 @@ namespace HealthGateway.Admin.Tests.Services
         public async Task ShouldGetPatientByHdidNotFoundException()
         {
             // Arrange
-            PatientDetailsQuery query = new() { Hdid = Hdid, Source = PatientDetailSource.All, UseCache = false };
-
             PatientModel? patient = null;
             Mock<IPatientRepository> patientRepositoryMock = new();
+
             // Patient not found exception
             patientRepositoryMock.Setup(s => s.QueryAsync(It.IsAny<PatientQuery>(), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
 


### PR DESCRIPTION
# Implements [AB#16821](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16821)

## Description

Increased unit test code coverage in Admin services:

- added unit tests
- updated test names if necessary
- moved 'expect' logic to test from mock setup

Minor fixes to CovidSupportService:

- Simplify if logic
- Simplified if logic to map status indictor to enum
- Note: line 118 scenario will never occur with current code but has been left in to insure this scenario is handled if new code is added

Minor fixes to DelegationService:

- Collection initialization change
- Concatenation change so that code coverage can see it

**Unit Tests:**

<img width="1864" alt="Screenshot 2024-08-23 at 1 29 04 PM" src="https://github.com/user-attachments/assets/95dd05cf-d59c-4c0e-b0fc-a8e7934bd5a6">

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
