### PR TITLE
Fix retry logic in BannerListener and AuditQueueListener for AB#16837.

### DIFF
--- a/Apps/JobScheduler/src/Listeners/AuditQueueListener.cs
+++ b/Apps/JobScheduler/src/Listeners/AuditQueueListener.cs
@@ -122,8 +122,8 @@ namespace HealthGateway.JobScheduler.Listeners
             // Retry 3: 8 seconds
             // Retry 4: 16 seconds
             // Retry 5: 16 seconds (maxRetryDelay at 16 seconds if applied)
-            int backoffDelay = Math.Min(this.retryDelay * (int)Math.Pow(this.exponentialBase, retryCount), this.maxBackoffDelay);
-            logger.LogWarning("Retrying due to error in {BackoffDelay}ms )", backoffDelay);
+            int backoffDelay = (int)Math.Min(this.retryDelay * Math.Pow(this.exponentialBase, retryCount), this.maxBackoffDelay);
+            logger.LogWarning("Retrying AuditQueueListener due to error in {BackoffDelay}ms )", backoffDelay);
 
             if (!stoppingToken.IsCancellationRequested)
             {

--- a/Apps/JobScheduler/src/Listeners/AuditQueueListener.cs
+++ b/Apps/JobScheduler/src/Listeners/AuditQueueListener.cs
@@ -24,6 +24,7 @@ namespace HealthGateway.JobScheduler.Listeners
     using HealthGateway.Common.Auditing;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
@@ -33,93 +34,134 @@ namespace HealthGateway.JobScheduler.Listeners
     /// A background listener that monitors the Audit queue and writes them to the database.
     /// Actions that may come are DELETE, UPDATE, and INSERT.
     /// </summary>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="services">The set of application services available.</param>
+    /// <param name="connectionMultiplexer">The injected connection multiplexer.</param>
+    /// <param name="configuration">The configuration to use.</param>
     [ExcludeFromCodeCoverage]
-    public class AuditQueueListener : BackgroundService
+    public class AuditQueueListener(
+        ILogger<AuditQueueListener> logger,
+        IServiceProvider services,
+        IConnectionMultiplexer connectionMultiplexer,
+        IConfiguration configuration) : BackgroundService
     {
-        private const int SleepDuration = 1000;
-        private const int RedisRetryDelay = 10000;
-        private readonly ILogger<AuditQueueListener> logger;
-        private readonly IServiceProvider services;
-        private readonly IConnectionMultiplexer connectionMultiplexer;
+        private const string ExponentialBaseKey = "ExponentialBase";
+        private const string ListenerKey = "AuditQueueListener";
+        private const string MaxBackoffDelayKey = "MaxBackoffDelay";
+        private const string MaxRetryCountBeforeResetKey = "MaxRetryCountBeforeReset";
+        private const string RetryDelayKey = "RetryDelay";
+        private const string SleepDurationKey = "SleepDuration";
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuditQueueListener"/> class.
-        /// </summary>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="services">The set of application services available.</param>
-        /// <param name="connectionMultiplexer">The injected connection multiplexer.</param>
-        public AuditQueueListener(
-            ILogger<AuditQueueListener> logger,
-            IServiceProvider services,
-            IConnectionMultiplexer connectionMultiplexer)
-        {
-            this.logger = logger;
-            this.services = services;
-            this.connectionMultiplexer = connectionMultiplexer;
-        }
+        private readonly int exponentialBase = configuration.GetValue($"{ListenerKey}:{ExponentialBaseKey}", 2);
+        private readonly int maxRetryDelay = configuration.GetValue($"{ListenerKey}:{MaxBackoffDelayKey}", 32000); // Set the default max backoff delay to 32 seconds
+        private readonly int maxRetryCountBeforeReset = configuration.GetValue($"{ListenerKey}:{MaxRetryCountBeforeResetKey}", 5); // Set the default max retry count before reset to 5 attempts
+        private readonly int retryDelay = configuration.GetValue($"{ListenerKey}:{RetryDelayKey}", 1000); // Used with exponentialBase and maxBackoffDelay to determine backoffDelay
+        private readonly int sleepDuration = configuration.GetValue($"{ListenerKey}:{SleepDurationKey}", 1000);
 
         /// <summary>
         /// Listens for Audit Events and writes them to the DB.
         /// </summary>
         /// <param name="stoppingToken">The cancellation token to use.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Team decision")]
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            this.logger.LogInformation("Audit Queue Listener is starting");
-            stoppingToken.Register(() => this.logger.LogInformation("AuditQueue Listener Shutdown as cancellation requested..."));
+            logger.LogInformation("Audit Queue Listener is starting");
+            stoppingToken.Register(() => logger.LogInformation("Audit Queue Listener Shutdown as cancellation requested"));
+
+            int retryCount = 0;
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 try
                 {
-                    IDatabase redisDb = this.connectionMultiplexer.GetDatabase();
+                    IDatabase redisDb = connectionMultiplexer.GetDatabase();
                     RedisValue auditValue = await redisDb.ListMoveAsync(
                         $"{RedisAuditLogger.AuditQueuePrefix}:{RedisAuditLogger.ActiveQueueName}",
                         $"{RedisAuditLogger.AuditQueuePrefix}:{RedisAuditLogger.ProcessingQueueName}",
                         ListSide.Left,
                         ListSide.Right);
+
                     if (auditValue.HasValue)
                     {
                         await this.ProcessAuditEventAsync(redisDb, auditValue, stoppingToken);
+                        retryCount = 0; // Reset retry count on successful processing
                     }
                     else
                     {
-                        await Task.Delay(SleepDuration, stoppingToken);
+                        await Task.Delay(this.sleepDuration, stoppingToken);
                     }
                 }
                 catch (RedisConnectionException ex)
                 {
-                    this.logger.LogError(ex, "Redis connection error occurred. Retrying after delay...");
-
-                    if (!stoppingToken.IsCancellationRequested)
-                    {
-                        await Task.Delay(RedisRetryDelay, stoppingToken);
-                    }
+                    logger.LogError(ex, "Redis connection error occurred in Audit Queue Listener. Retrying after delay");
+                    retryCount = await this.HandleExceptionAsync(retryCount, stoppingToken);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    // Occurs when a stale object is unsuccessfully from the UI
+                    logger.LogError(ex, "Database error occurred in Audit Queue Listener. Retrying after delay");
+                    retryCount = await this.HandleExceptionAsync(retryCount, stoppingToken);
+                }
+                catch (Exception ex)
+                {
+                    logger.LogError(ex, "Unexpected error in Audit Queue Listener. Retrying after delay");
+                    retryCount = await this.HandleExceptionAsync(retryCount, stoppingToken);
                 }
             }
 
-            this.logger.LogInformation("Audit Queue Listener has stopped");
+            logger.LogInformation("Audit Queue Listener has stopped");
+        }
+
+        private async Task<int> HandleExceptionAsync(int retryCount, CancellationToken stoppingToken)
+        {
+            retryCount++;
+
+            // Exponential backoff with a cap where exponentialBase is 2, maxRetryDelay is 32000ms, retryDelay is 1000ms and maxRetryCountBeforeReset is 5.
+            // Retry 1: 2 seconds
+            // Retry 2: 4 seconds
+            // Retry 3: 8 seconds
+            // Retry 4: 16 seconds
+            // Retry 5: 32 seconds
+            // Retry 6: 32 seconds (maxRetryCountBeforeReset at 6 and maxRetryDelay at 32 seconds if applied)
+            int backoffDelay = Math.Min(this.retryDelay * (int)Math.Pow(this.exponentialBase, retryCount), this.maxRetryDelay);
+            logger.LogWarning("Retrying due to error in {BackoffDelay}ms (Retry {RetryCount})", backoffDelay, retryCount);
+
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(backoffDelay, stoppingToken);
+            }
+
+            // Reset retry count after a certain number of retries
+            if (retryCount >= this.maxRetryCountBeforeReset)
+            {
+                retryCount = 0;
+                logger.LogInformation("Retry count reset after {MaxRetryCountBeforeReset} attempts", this.maxRetryCountBeforeReset);
+            }
+
+            return retryCount;
         }
 
         private async Task ProcessAuditEventAsync(IDatabase redisDb, RedisValue auditValue, CancellationToken ct)
         {
-            this.logger.LogTrace("Start Processing Audit Event...");
+            logger.LogTrace("Start Processing Audit Event...");
             AuditEvent? auditEvent = JsonSerializer.Deserialize<AuditEvent>(auditValue.ToString());
             if (auditEvent != null)
             {
                 try
                 {
-                    using IServiceScope scope = this.services.CreateScope();
+                    using IServiceScope scope = services.CreateScope();
                     IWriteAuditEventDelegate writeAuditEventDelegate = scope.ServiceProvider.GetRequiredService<IWriteAuditEventDelegate>();
                     await writeAuditEventDelegate.WriteAuditEventAsync(auditEvent, ct);
                     await redisDb.ListRemoveAsync($"{RedisAuditLogger.AuditQueuePrefix}:{RedisAuditLogger.ProcessingQueueName}", auditValue);
                 }
                 catch (DataException e)
                 {
-                    this.logger.LogError(e, "Error writing to DB:\n{Message}", e.Message);
+                    logger.LogError(e, "Error writing to DB:\n{Message}", e.Message);
                 }
             }
 
-            this.logger.LogTrace("Completed Audit Event Processing...");
+            logger.LogTrace("Completed Audit Event Processing...");
         }
     }
 }

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -25,8 +25,7 @@ namespace HealthGateway.JobScheduler.Listeners
     using HealthGateway.Common.Converters;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Context;
-    using Microsoft.EntityFrameworkCore;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
@@ -36,11 +35,18 @@ namespace HealthGateway.JobScheduler.Listeners
     /// Implements the abstract DB Listener and listens on the BannerChange channel.
     /// Actions that may come are DELETE, UPDATE, and INSERT.
     /// </summary>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="services">The set of application services available.</param>
+    /// <param name="configuration">The configuration to use.</param>
     [ExcludeFromCodeCoverage]
-    public class BannerListener : BackgroundService
+    public class BannerListener(ILogger<BannerListener> logger, IServiceProvider services, IConfiguration configuration) : BackgroundService
     {
         private const string Channel = "BannerChange";
-        private const int SleepDuration = 10000;
+        private const string ExponentialBaseKey = "ExponentialBase";
+        private const string ListenerKey = "BannerListener";
+        private const string MaxBackoffDelayKey = "MaxBackoffDelay";
+        private const string MaxRetryCountBeforeResetKey = "MaxRetryCountBeforeReset";
+        private const string RetryDelayKey = "RetryDelay";
 
         private static readonly JsonSerializerOptions EventSerializerOptions = new()
         {
@@ -48,86 +54,130 @@ namespace HealthGateway.JobScheduler.Listeners
             Converters = { new DateTimeConverter(), new JsonStringEnumConverter() },
         };
 
-        private readonly ILogger<BannerListener> logger;
-        private readonly IServiceProvider services;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="BannerListener"/> class.
-        /// </summary>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="services">The set of application services available.</param>
-        public BannerListener(
-            ILogger<BannerListener> logger,
-            IServiceProvider services)
-        {
-            this.logger = logger;
-            this.services = services;
-        }
+        private readonly int exponentialBase = configuration.GetValue($"{ListenerKey}:{ExponentialBaseKey}", 2);
+        private readonly int maxBackoffDelay = configuration.GetValue($"{ListenerKey}:{MaxBackoffDelayKey}", 32000); // Set the default max backoff delay to 32 seconds
+        private readonly int maxRetryCountBeforeReset = configuration.GetValue($"{ListenerKey}:{MaxRetryCountBeforeResetKey}", 5); // Set the default max retry count before reset to 5 attempts
+        private readonly int retryDelay = configuration.GetValue($"{ListenerKey}:{RetryDelayKey}", 1000); // Used with exponentialBase and maxBackoffDelay to determine backoffDelay
 
         /// <summary>
         /// Creates a new DB Connection for push notifications from the DB for a specific channel.
         /// </summary>
         /// <param name="stoppingToken">The cancellation token to use.</param>
         /// <returns>The task.</returns>
+        [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Team decision")]
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            this.logger.LogInformation("Banner Listener is starting");
-            stoppingToken.Register(() => this.logger.LogInformation("Banner Listener Shutdown as cancellation requested"));
+            logger.LogInformation("Banner Listener is starting");
+            stoppingToken.Register(() => logger.LogInformation("Banner Listener Shutdown as cancellation requested"));
+
             this.ClearCache();
+            NpgsqlConnection? con = null;
             int attempts = 0;
+            int retryCount = 0; // to determine backoffDelay
+
             while (!stoppingToken.IsCancellationRequested)
             {
                 attempts++;
-                this.logger.LogInformation("Registering Channel Notification on channel {Channel}, attempts = {Attempts}", Channel, attempts);
+                logger.LogInformation("Registering Channel Notification on channel {Channel}, attempts = {Attempts}", Channel, attempts);
+
                 try
                 {
-                    using IServiceScope scope = this.services.CreateScope();
-                    using GatewayDbContext dbContext = scope.ServiceProvider.GetRequiredService<GatewayDbContext>();
-                    using NpgsqlConnection con = (NpgsqlConnection)dbContext.Database.GetDbConnection();
-                    await con.OpenAsync(stoppingToken);
-                    con.Notification += this.ReceiveEvent;
-                    using NpgsqlCommand cmd = new();
-                    cmd.CommandText = @$"LISTEN ""{Channel}"";";
-                    cmd.CommandType = CommandType.Text;
-                    cmd.Connection = con;
-                    await cmd.ExecuteNonQueryAsync(stoppingToken);
+                    if (con is not { State: ConnectionState.Open })
+                    {
+                        con?.Dispose(); // Dispose the old connection if it exists
+                        con = new NpgsqlConnection(configuration.GetConnectionString("GatewayConnection"));
+
+                        await con.OpenAsync(stoppingToken);
+
+                        // Subscribe to the event
+                        con.Notification += this.ReceiveEvent;
+
+                        await using NpgsqlCommand cmd = new();
+                        cmd.CommandText = $"""LISTEN "{Channel}";""";
+                        cmd.CommandType = CommandType.Text;
+                        cmd.Connection = con;
+
+                        await cmd.ExecuteNonQueryAsync(stoppingToken);
+                    }
+
+                    // Reset retry count on successful connection
+                    retryCount = 0;
 
                     while (!stoppingToken.IsCancellationRequested)
                     {
+                        // Ensure the connection is still open before waiting for events
+                        if (con.State != ConnectionState.Open)
+                        {
+                            throw new NpgsqlException("Database connection closed unexpectedly.");
+                        }
+
                         // Wait for the event
                         await con.WaitAsync(stoppingToken);
                     }
-
-                    await con.CloseAsync();
                 }
                 catch (NpgsqlException e)
                 {
-                    this.logger.LogError(e, "DB Error encountered in WaitChannelNotification: {Channel}\n{Message}", Channel, e.Message);
-                    if (!stoppingToken.IsCancellationRequested)
-                    {
-                        await Task.Delay(SleepDuration, stoppingToken);
-                    }
+                    logger.LogError(e, "Database Error encountered in Banner Listener: {Channel}\n{Message}", Channel, e.Message);
+                    retryCount = await this.HandleExceptionAsync(con, retryCount, stoppingToken);
                 }
-
-                this.logger.LogWarning("Banner Listener on {Channel} exiting...", Channel);
+                catch (Exception e)
+                {
+                    logger.LogError(e, "Unexpected error in Banner Listener");
+                    retryCount = await this.HandleExceptionAsync(con, retryCount, stoppingToken);
+                }
             }
+
+            con?.Dispose(); // Dispose of the connection when done
+            logger.LogWarning("Banner Listener on {Channel} exiting...", Channel);
         }
 
         private void ClearCache()
         {
-            using IServiceScope scope = this.services.CreateScope();
+            using IServiceScope scope = services.CreateScope();
             ICommunicationService cs = scope.ServiceProvider.GetRequiredService<ICommunicationService>();
-            this.logger.LogInformation("Clearing Banner and InApp Cache");
+            logger.LogInformation("Clearing Banner and InApp Cache");
             cs.ClearCache();
+        }
+
+        private async Task<int> HandleExceptionAsync(NpgsqlConnection con, int retryCount, CancellationToken stoppingToken)
+        {
+            // Unsubscribe the event
+            con.Notification -= this.ReceiveEvent;
+
+            retryCount++;
+
+            // Exponential backoff with a cap where exponentialBase is 2, maxBackoffDelay is 32000ms, retryDelay is 1000ms and maxRetryCountBeforeReset is 5.
+            // Retry 1: 2 seconds
+            // Retry 2: 4 seconds
+            // Retry 3: 8 seconds
+            // Retry 4: 16 seconds
+            // Retry 5: 32 seconds
+            // Retry 6: 32 seconds (maxRetryCountBeforeReset at 6 and maxRetryDelay at 32 seconds if applied)
+            int backoffDelay = Math.Min(this.retryDelay * (int)Math.Pow(this.exponentialBase, retryCount), this.maxBackoffDelay);
+            logger.LogWarning("Retrying due to error in {BackoffDelay}ms (Retry {RetryCount})", backoffDelay, retryCount);
+
+            if (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(backoffDelay, stoppingToken);
+            }
+
+            // Reset retry count after a certain number of retries
+            if (retryCount >= this.maxRetryCountBeforeReset)
+            {
+                retryCount = 0;
+                logger.LogInformation("Retry count reset after {MaxRetryCountBeforeReset} attempts", this.maxRetryCountBeforeReset);
+            }
+
+            return retryCount;
         }
 
         private void ReceiveEvent(object sender, NpgsqlNotificationEventArgs e)
         {
-            this.logger.LogDebug("Banner Event received on channel {Channel}", Channel);
+            logger.LogDebug("Banner Event received on channel {Channel}", Channel);
             BannerChangeEvent? changeEvent = JsonSerializer.Deserialize<BannerChangeEvent>(e.Payload, EventSerializerOptions);
-            using IServiceScope scope = this.services.CreateScope();
+            using IServiceScope scope = services.CreateScope();
             ICommunicationService cs = scope.ServiceProvider.GetRequiredService<ICommunicationService>();
-            this.logger.LogInformation("Banner Event received and being processed");
+            logger.LogInformation("Banner Event received and being processed");
             cs.ProcessChange(changeEvent);
         }
     }

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -45,7 +45,6 @@ namespace HealthGateway.JobScheduler.Listeners
         private const string ExponentialBaseKey = "ExponentialBase";
         private const string ListenerKey = "BannerListener";
         private const string MaxBackoffDelayKey = "MaxBackoffDelay";
-        private const string MaxRetryCountBeforeResetKey = "MaxRetryCountBeforeReset";
         private const string RetryDelayKey = "RetryDelay";
 
         private static readonly JsonSerializerOptions EventSerializerOptions = new()
@@ -55,8 +54,7 @@ namespace HealthGateway.JobScheduler.Listeners
         };
 
         private readonly int exponentialBase = configuration.GetValue($"{ListenerKey}:{ExponentialBaseKey}", 2);
-        private readonly int maxBackoffDelay = configuration.GetValue($"{ListenerKey}:{MaxBackoffDelayKey}", 32000); // Set the default max backoff delay to 32 seconds
-        private readonly int maxRetryCountBeforeReset = configuration.GetValue($"{ListenerKey}:{MaxRetryCountBeforeResetKey}", 5); // Set the default max retry count before reset to 5 attempts
+        private readonly int maxBackoffDelay = configuration.GetValue($"{ListenerKey}:{MaxBackoffDelayKey}", 16000); // Set the default max backoff delay to 16 seconds
         private readonly int retryDelay = configuration.GetValue($"{ListenerKey}:{RetryDelayKey}", 1000); // Used with exponentialBase and maxBackoffDelay to determine backoffDelay
 
         /// <summary>
@@ -118,12 +116,14 @@ namespace HealthGateway.JobScheduler.Listeners
                 catch (NpgsqlException e)
                 {
                     logger.LogError(e, "Database Error encountered in Banner Listener: {Channel}\n{Message}", Channel, e.Message);
-                    retryCount = await this.HandleExceptionAsync(con, retryCount, stoppingToken);
+                    retryCount++;
+                    await this.HandleExceptionAsync(con, retryCount, stoppingToken);
                 }
                 catch (Exception e)
                 {
                     logger.LogError(e, "Unexpected error in Banner Listener");
-                    retryCount = await this.HandleExceptionAsync(con, retryCount, stoppingToken);
+                    retryCount++;
+                    await this.HandleExceptionAsync(con, retryCount, stoppingToken);
                 }
             }
 
@@ -139,36 +139,24 @@ namespace HealthGateway.JobScheduler.Listeners
             cs.ClearCache();
         }
 
-        private async Task<int> HandleExceptionAsync(NpgsqlConnection con, int retryCount, CancellationToken stoppingToken)
+        private async Task HandleExceptionAsync(NpgsqlConnection con, int retryCount, CancellationToken stoppingToken)
         {
             // Unsubscribe the event
             con.Notification -= this.ReceiveEvent;
 
-            retryCount++;
-
-            // Exponential backoff with a cap where exponentialBase is 2, maxBackoffDelay is 32000ms, retryDelay is 1000ms and maxRetryCountBeforeReset is 5.
+            // Exponential backoff with a cap where exponentialBase is 2, maxBackoffDelay is 16000ms and retryDelay is 1000ms.
             // Retry 1: 2 seconds
             // Retry 2: 4 seconds
             // Retry 3: 8 seconds
             // Retry 4: 16 seconds
-            // Retry 5: 32 seconds
-            // Retry 6: 32 seconds (maxRetryCountBeforeReset at 6 and maxRetryDelay at 32 seconds if applied)
+            // Retry 5: 16 seconds (maxRetryDelay at 16 seconds if applied)
             int backoffDelay = Math.Min(this.retryDelay * (int)Math.Pow(this.exponentialBase, retryCount), this.maxBackoffDelay);
-            logger.LogWarning("Retrying due to error in {BackoffDelay}ms (Retry {RetryCount})", backoffDelay, retryCount);
+            logger.LogWarning("Retrying due to error in {BackoffDelay}ms )", backoffDelay);
 
             if (!stoppingToken.IsCancellationRequested)
             {
                 await Task.Delay(backoffDelay, stoppingToken);
             }
-
-            // Reset retry count after a certain number of retries
-            if (retryCount >= this.maxRetryCountBeforeReset)
-            {
-                retryCount = 0;
-                logger.LogInformation("Retry count reset after {MaxRetryCountBeforeReset} attempts", this.maxRetryCountBeforeReset);
-            }
-
-            return retryCount;
         }
 
         private void ReceiveEvent(object sender, NpgsqlNotificationEventArgs e)

--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -150,8 +150,8 @@ namespace HealthGateway.JobScheduler.Listeners
             // Retry 3: 8 seconds
             // Retry 4: 16 seconds
             // Retry 5: 16 seconds (maxRetryDelay at 16 seconds if applied)
-            int backoffDelay = Math.Min(this.retryDelay * (int)Math.Pow(this.exponentialBase, retryCount), this.maxBackoffDelay);
-            logger.LogWarning("Retrying due to error in {BackoffDelay}ms )", backoffDelay);
+            int backoffDelay = (int)Math.Min(this.retryDelay * Math.Pow(this.exponentialBase, retryCount), this.maxBackoffDelay);
+            logger.LogWarning("Retrying Banner Listener due to error in {BackoffDelay}ms )", backoffDelay);
 
             if (!stoppingToken.IsCancellationRequested)
             {

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -217,6 +217,19 @@
     "AdminFeedback": {
         "AdminEmail": "healthgateway@gov.bc.ca"
     },
+    "BannerListener": {
+        "ExponentialBase": 2,
+        "MaxBackoffDelay": 32000,
+        "MaxRetryCountBeforeReset": 5,
+        "RetryDelay": 1000
+    },
+    "AuditQueueListener": {
+        "ExponentialBase": 2,
+        "MaxBackoffDelay": 32000,
+        "MaxRetryCountBeforeReset": 5,
+        "RetryDelay": 1000,
+        "SleepDuration": 1000
+    },
     "ChangeFeed": {
         "Accounts": {
             "Enabled": true

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -219,14 +219,12 @@
     },
     "BannerListener": {
         "ExponentialBase": 2,
-        "MaxBackoffDelay": 32000,
-        "MaxRetryCountBeforeReset": 5,
+        "MaxBackoffDelay": 16000,
         "RetryDelay": 1000
     },
     "AuditQueueListener": {
         "ExponentialBase": 2,
-        "MaxBackoffDelay": 32000,
-        "MaxRetryCountBeforeReset": 5,
+        "MaxBackoffDelay": 16000,
         "RetryDelay": 1000,
         "SleepDuration": 1000
     },


### PR DESCRIPTION
# Fixes Implements [AB#16837](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16837)

## Description

Both BannerListener and AuditQueueListener had issues when there was a database connection issue.  Both BannerListener and AuditQueueListener would exit out of loop whenever an exception was thrown and not handled.

BannerListener fixes:

- Used new NpgsqlConnection because connection from DbContext was returning a stale connection; it was not returning the most up to date connection with most recent connection after database connection drop
- Add additional exception handling in addition to NpgsqlException
- Add more robust retry logic.  Listener will retry after 2, 4, 8, 16 and 32 seconds.  After 32 seconds, it will restart again at 2.
- Fixed warnings
- Moved delay values to configuration
- Utilized class constructor injection instead of normal constructor


AuditQueueListener fixes:

- Add additional exception handling in addition to RedisConnectionException
- Add more robust retry logic.  Listener will retry after 2, 4, 8, 16 and 32 seconds.  After 32 seconds, it will restart again at 2.
- Fixed warnings
- Moved delay values to configuration
- Utilized class constructor injection instead of normal constructor


https://github.com/user-attachments/assets/8b62c70c-2d26-4cd3-8982-15c9195348c0

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
