### PR TITLE
Override Kong plugin that rewrites HTTP error responses AB#16842

### DIFF
--- a/Tools/Kong/config.tmpl
+++ b/Tools/Kong/config.tmpl
@@ -17,6 +17,12 @@
         config:
           rewrite:
           - "--"
+      # override existing post-function_200 plugin that rewrites HTTP error responses
+      - name: post-function_200
+        tags: [ns.$KONG_NAMESPACE.$ENVIRONMENT]
+        enabled: true
+        config:
+          access: [ return ]
     routes:
       - name: $SERVICE-$KONG_NAMESPACE-get-post-put-delete
         methods:


### PR DESCRIPTION
# Implements [AB#16842](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16842)

## Description

The rewriting of our HTTP error responses by Kong was happening because of a post-function_200 plugin that is applied globally. By overriding that with our own post-function_200 plugin that does nothing, our error responses will not be rewritten.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
