### PR TITLE
Fix Sonar Reliability issues  in BannerListener for AB#16849

### DIFF
--- a/Apps/JobScheduler/src/Listeners/BannerListener.cs
+++ b/Apps/JobScheduler/src/Listeners/BannerListener.cs
@@ -82,7 +82,7 @@ namespace HealthGateway.JobScheduler.Listeners
                 {
                     if (con is not { State: ConnectionState.Open })
                     {
-                        con?.Dispose(); // Dispose the old connection if it exists
+                        await DisposeConnectionAsync(con); // Dispose the old connection if it exists
                         con = new NpgsqlConnection(configuration.GetConnectionString("GatewayConnection"));
 
                         await con.OpenAsync(stoppingToken);
@@ -127,8 +127,16 @@ namespace HealthGateway.JobScheduler.Listeners
                 }
             }
 
-            con?.Dispose(); // Dispose of the connection when done
+            await DisposeConnectionAsync(con); // Dispose of the connection when done
             logger.LogWarning("Banner Listener on {Channel} exiting...", Channel);
+        }
+
+        private static async Task DisposeConnectionAsync(NpgsqlConnection? connection)
+        {
+            if (connection != null)
+            {
+                await connection.DisposeAsync();
+            }
         }
 
         private void ClearCache()


### PR DESCRIPTION
# Implements [AB#16849](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16849)

## Description

Sonar reliability issues reported for BannerListener.  Use disposeAsync() instead of dispose().

- Changed dispose to disposeAsync
- Moved disposeAsync to helper method to check if connection is not null before calling disposeAsync

<img width="1210" alt="Screenshot 2024-09-19 at 10 27 07 AM" src="https://github.com/user-attachments/assets/782626da-6996-4409-93b2-36b7e04808c1">


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
