### PR TITLE
Simplify Health Gateway exceptions AB#16848

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -247,7 +247,7 @@ namespace HealthGateway.AccountDataAccess.Patient
             if (!responseCode.Contains("BCHCIM.GD.0.0013", StringComparison.InvariantCulture))
             {
                 this.logger.LogWarning("Client Registry did not return a person. Returned message code: {ResponseCode}", responseCode);
-                throw new NotFoundException(ErrorMessages.ClientRegistryDoesNotReturnPerson, ProblemType.InvalidData);
+                throw new NotFoundException(ErrorMessages.ClientRegistryDoesNotReturnPerson);
             }
         }
 
@@ -269,7 +269,7 @@ namespace HealthGateway.AccountDataAccess.Patient
                 if (!DateTime.TryParseExact(dobStr, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dob))
                 {
                     this.logger.LogWarning("Client Registry is unable to determine date of birth due to bad data format. Action Type: {ActionType}", ActionType.DataMismatch.Value);
-                    throw new NotFoundException(ErrorMessages.InvalidServicesCard, ProblemType.InvalidData);
+                    throw new NotFoundException(ErrorMessages.InvalidServicesCard);
                 }
 
                 // Initialize model

--- a/Apps/Admin/Server/Delegates/RestImmunizationAdminDelegate.cs
+++ b/Apps/Admin/Server/Delegates/RestImmunizationAdminDelegate.cs
@@ -77,7 +77,7 @@ namespace HealthGateway.Admin.Server.Delegates
 
             if (refreshInProgress)
             {
-                throw new UpstreamServiceException(ErrorMessages.MaximumRetryAttemptsReached, ProblemType.MaxRetriesReached);
+                throw new UpstreamServiceException(ErrorMessages.MaximumRetryAttemptsReached) { ProblemType = ProblemType.MaxRetriesReached };
             }
 
             return new()

--- a/Apps/Admin/Server/Delegates/RestVaccineStatusDelegate.cs
+++ b/Apps/Admin/Server/Delegates/RestVaccineStatusDelegate.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.Admin.Server.Delegates
 
             if (refreshInProgress)
             {
-                throw new UpstreamServiceException(ErrorMessages.MaximumRetryAttemptsReached, ProblemType.MaxRetriesReached);
+                throw new UpstreamServiceException(ErrorMessages.MaximumRetryAttemptsReached) { ProblemType = ProblemType.MaxRetriesReached };
             }
 
             return response;

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -207,8 +207,8 @@ namespace HealthGateway.Admin.Tests.Services
             PatientQuery query2 = new PatientDetailsQuery(Hdid: Hdid2, Source: PatientDetailSource.All);
 
             Mock<IPatientRepository> patientRepositoryMock = new();
-            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query1), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
-            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query2), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query1), It.IsAny<CancellationToken>())).Throws(() => new NotFoundException());
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.Is<PatientQuery>(x => x == query2), It.IsAny<CancellationToken>())).Throws(() => new NotFoundException());
 
             IAdminReportService service = GetAdminReportService(delegationDelegateMock, patientRepositoryMock: patientRepositoryMock);
             return service;

--- a/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
@@ -640,8 +640,7 @@ namespace HealthGateway.Admin.Tests.Services
             if (response == null)
             {
                 mock.Setup(d => d.GetVaccineStatusWithRetriesAsync(It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                    .Throws(
-                        new UpstreamServiceException(ErrorMessages.MaximumRetryAttemptsReached, ProblemType.MaxRetriesReached));
+                    .Throws(new UpstreamServiceException(ErrorMessages.MaximumRetryAttemptsReached) { ProblemType = ProblemType.MaxRetriesReached });
             }
             else
             {

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -390,7 +390,7 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IPatientRepository> patientRepositoryMock = new();
 
             // Patient not found exception
-            patientRepositoryMock.Setup(s => s.QueryAsync(It.IsAny<PatientQuery>(), It.IsAny<CancellationToken>())).Throws<NotFoundException>();
+            patientRepositoryMock.Setup(s => s.QueryAsync(It.IsAny<PatientQuery>(), It.IsAny<CancellationToken>())).Throws(() => new NotFoundException());
 
             UserProfile profile = new() { HdId = Hdid, CreatedDateTime = DateTime.Now.Subtract(TimeSpan.FromDays(3)), LastLoginDateTime = DateTime.Now };
             Mock<IUserProfileDelegate> userProfileDelegateMock = GetUserProfileDelegateMock(profile);

--- a/Apps/Common/src/ErrorHandling/Exceptions/AlreadyExistsException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/AlreadyExistsException.cs
@@ -21,44 +21,21 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
 
     /// <summary>
     /// <see cref="AlreadyExistsException"/> is used when a desired action conflicts with a record that already exists.
-    /// The default problem type is <see cref="ProblemType.RecordAlreadyExists"/>.
-    /// The default status code is <see cref="HttpStatusCode.Conflict"/> (409).
+    /// The default problem type is <see cref="ProblemType.RecordAlreadyExists"/>. The associated status code is <see cref="HttpStatusCode.Conflict"/> (409).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     [ExcludeFromCodeCoverage]
     public class AlreadyExistsException : HealthGatewayException
     {
-        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.Conflict;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class.
-        /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public AlreadyExistsException(string message, ProblemType problemType = ProblemType.RecordAlreadyExists)
-            : base(message)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class.
         /// </summary>
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public AlreadyExistsException(string message, Exception innerException, ProblemType problemType = ProblemType.RecordAlreadyExists)
+        public AlreadyExistsException(string? message = null, Exception? innerException = null)
             : base(message, innerException)
         {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AlreadyExistsException"/> class.
-        /// </summary>
-        public AlreadyExistsException()
-        {
-            this.SetErrorProperties(DefaultStatusCode, ProblemType.RecordAlreadyExists);
+            this.ProblemType = ProblemType.RecordAlreadyExists;
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/DatabaseException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/DatabaseException.cs
@@ -21,44 +21,21 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
 
     /// <summary>
     /// <see cref="DatabaseException"/> is used when an unexpected database error occurs.
-    /// The default problem type is <see cref="ProblemType.DatabaseError"/>.
-    /// The default status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
+    /// The default problem type is <see cref="ProblemType.DatabaseError"/>. The associated status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     [ExcludeFromCodeCoverage]
     public class DatabaseException : HealthGatewayException
     {
-        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatabaseException"/> class.
-        /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public DatabaseException(string message, ProblemType problemType = ProblemType.DatabaseError)
-            : base(message)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="DatabaseException"/> class.
         /// </summary>
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public DatabaseException(string message, Exception innerException, ProblemType problemType = ProblemType.DatabaseError)
+        public DatabaseException(string? message = null, Exception? innerException = null)
             : base(message, innerException)
         {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DatabaseException"/> class.
-        /// </summary>
-        public DatabaseException()
-        {
-            this.SetErrorProperties(DefaultStatusCode, ProblemType.DatabaseError);
+            this.ProblemType = ProblemType.DatabaseError;
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/HealthGatewayException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/HealthGatewayException.cs
@@ -17,67 +17,19 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using System.Net;
 
     /// <summary>
     /// Abstract exception class for Health Gateway.
     /// </summary>
+    /// <param name="message">Error message detailing the failure in question.</param>
+    /// <param name="innerException">An internal exception that results in a higher order failure.</param>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     [ExcludeFromCodeCoverage]
-    public abstract class HealthGatewayException : Exception
+    public abstract class HealthGatewayException(string? message = null, Exception? innerException = null) : Exception(message, innerException)
     {
-        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;
-
         /// <summary>
-        /// Initializes a new instance of the <see cref="HealthGatewayException"/> class.
+        /// Gets the problem type.
         /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        protected HealthGatewayException(string message, ProblemType problemType = ProblemType.ServerError)
-            : base(message)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HealthGatewayException"/> class.
-        /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="innerException">An internal exception that results in a higher order failure.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        protected HealthGatewayException(string message, Exception innerException, ProblemType problemType = ProblemType.ServerError)
-            : base(message, innerException)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HealthGatewayException"/> class.
-        /// </summary>
-        protected HealthGatewayException()
-        {
-            this.SetErrorProperties(DefaultStatusCode, ProblemType.ServerError);
-        }
-
-        /// <summary>
-        /// Gets or sets the problem type.
-        /// </summary>
-        public ProblemType ProblemType { get; protected set; }
-
-        /// <summary>
-        /// Gets or sets the HTTP status code.
-        /// </summary>
-        public HttpStatusCode StatusCode { get; set; }
-
-        /// <summary>
-        /// Sets the error properties of the exception.
-        /// </summary>
-        /// <param name="statusCode">The HTTP status code to be reported in the API response.</param>
-        /// <param name="problemType">Concise coded reason for the failure.</param>
-        protected void SetErrorProperties(HttpStatusCode statusCode, ProblemType problemType)
-        {
-            this.StatusCode = statusCode;
-            this.ProblemType = problemType;
-        }
+        public ProblemType ProblemType { get; init; } = ProblemType.ServerError;
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/InvalidDataException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/InvalidDataException.cs
@@ -20,46 +20,22 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
     using System.Net;
 
     /// <summary>
-    /// <see cref="InvalidDataException"/> is used when an expected input or data record does not match the desired
-    /// requirements.
-    /// The default problem type is <see cref="ProblemType.InvalidData"/>.
-    /// The default status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
+    /// <see cref="InvalidDataException"/> is used when a returned data record does not meet expectations.
+    /// The default problem type is <see cref="ProblemType.InvalidData"/>. The associated status code is <see cref="HttpStatusCode.InternalServerError"/> (500).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     [ExcludeFromCodeCoverage]
     public class InvalidDataException : HealthGatewayException
     {
-        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.InternalServerError;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidDataException"/> class.
-        /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public InvalidDataException(string message, ProblemType problemType = ProblemType.InvalidData)
-            : base(message)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="InvalidDataException"/> class.
         /// </summary>
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public InvalidDataException(string message, Exception innerException, ProblemType problemType = ProblemType.InvalidData)
+        public InvalidDataException(string? message = null, Exception? innerException = null)
             : base(message, innerException)
         {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="InvalidDataException"/> class.
-        /// </summary>
-        public InvalidDataException()
-        {
-            this.SetErrorProperties(DefaultStatusCode, ProblemType.InvalidData);
+            this.ProblemType = ProblemType.InvalidData;
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/NotFoundException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/NotFoundException.cs
@@ -21,44 +21,21 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
 
     /// <summary>
     /// <see cref="NotFoundException"/> is used when a desired record is not found.
-    /// The default problem type is <see cref="ProblemType.RecordNotFound"/>.
-    /// The default status code is <see cref="HttpStatusCode.NotFound"/> (404).
+    /// The default problem type is <see cref="ProblemType.RecordNotFound"/>. The associated status code is <see cref="HttpStatusCode.NotFound"/> (404).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     [ExcludeFromCodeCoverage]
     public class NotFoundException : HealthGatewayException
     {
-        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.NotFound;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NotFoundException"/> class.
-        /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public NotFoundException(string message, ProblemType problemType = ProblemType.RecordNotFound)
-            : base(message)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="NotFoundException"/> class.
         /// </summary>
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public NotFoundException(string message, Exception innerException, ProblemType problemType = ProblemType.RecordNotFound)
+        public NotFoundException(string? message = null, Exception? innerException = null)
             : base(message, innerException)
         {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="NotFoundException"/> class.
-        /// </summary>
-        public NotFoundException()
-        {
-            this.SetErrorProperties(DefaultStatusCode, ProblemType.RecordNotFound);
+            this.ProblemType = ProblemType.RecordNotFound;
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
+++ b/Apps/Common/src/ErrorHandling/Exceptions/UpstreamServiceException.cs
@@ -21,44 +21,21 @@ namespace HealthGateway.Common.ErrorHandling.Exceptions
 
     /// <summary>
     /// <see cref="UpstreamServiceException"/> is used when a remote service fails to respond appropriately.
-    /// The default problem type is <see cref="ProblemType.UpstreamError"/>.
-    /// The default status code is <see cref="HttpStatusCode.BadGateway"/> (502).
+    /// The default problem type is <see cref="ProblemType.UpstreamError"/>. The associated status code is <see cref="HttpStatusCode.BadGateway"/> (502).
     /// </summary>
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "The constructors should be explicit")]
     [ExcludeFromCodeCoverage]
     public class UpstreamServiceException : HealthGatewayException
     {
-        private const HttpStatusCode DefaultStatusCode = HttpStatusCode.BadGateway;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpstreamServiceException"/> class.
-        /// </summary>
-        /// <param name="message">Error message detailing the failure in question.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public UpstreamServiceException(string message, ProblemType problemType = ProblemType.UpstreamError)
-            : base(message)
-        {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UpstreamServiceException"/> class.
         /// </summary>
         /// <param name="message">Error message detailing the failure in question.</param>
         /// <param name="innerException">An internal exception that results in a higher order failure.</param>
-        /// <param name="problemType">A concise coded reason for the failure.</param>
-        public UpstreamServiceException(string message, Exception innerException, ProblemType problemType = ProblemType.UpstreamError)
+        public UpstreamServiceException(string? message = null, Exception? innerException = null)
             : base(message, innerException)
         {
-            this.SetErrorProperties(DefaultStatusCode, problemType);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="UpstreamServiceException"/> class.
-        /// </summary>
-        public UpstreamServiceException()
-        {
-            this.SetErrorProperties(DefaultStatusCode, ProblemType.UpstreamError);
+            this.ProblemType = ProblemType.UpstreamError;
         }
     }
 }

--- a/Apps/Common/src/ErrorHandling/ProblemType.cs
+++ b/Apps/Common/src/ErrorHandling/ProblemType.cs
@@ -23,22 +23,22 @@ using System.Runtime.Serialization;
 public enum ProblemType
 {
     /// <summary>
-    /// Generic server error.
+    /// Invalid input provided.
     /// </summary>
-    [EnumMember(Value = "server-error")]
-    ServerError,
+    [EnumMember(Value = "invalid-input")]
+    InvalidInput,
 
     /// <summary>
-    /// Dataset is in the process of being refreshed.
+    /// User is not authorized to access data.
     /// </summary>
-    [EnumMember(Value = "refresh-in-progress")]
-    RefreshInProgress,
+    [EnumMember(Value = "forbidden")]
+    Forbidden,
 
     /// <summary>
-    /// Maximum number of retries has been reached.
+    /// Record was not found.
     /// </summary>
-    [EnumMember(Value = "max-retries-reached")]
-    MaxRetriesReached,
+    [EnumMember(Value = "record-not-found")]
+    RecordNotFound,
 
     /// <summary>
     /// Record already exists.
@@ -47,10 +47,16 @@ public enum ProblemType
     RecordAlreadyExists,
 
     /// <summary>
-    /// Record was not found.
+    /// Generic server error.
     /// </summary>
-    [EnumMember(Value = "record-not-found")]
-    RecordNotFound,
+    [EnumMember(Value = "server-error")]
+    ServerError,
+
+    /// <summary>
+    /// Error when performing a database operation.
+    /// </summary>
+    [EnumMember(Value = "database-error")]
+    DatabaseError,
 
     /// <summary>
     /// Service or database did not return valid data.
@@ -65,14 +71,14 @@ public enum ProblemType
     UpstreamError,
 
     /// <summary>
-    /// Invalid input provided.
+    /// Maximum number of retries has been reached.
     /// </summary>
-    [EnumMember(Value = "invalid-input")]
-    InvalidInput,
+    [EnumMember(Value = "max-retries-reached")]
+    MaxRetriesReached,
 
     /// <summary>
-    /// Error when performing a database operation.
+    /// Dataset is in the process of being refreshed.
     /// </summary>
-    [EnumMember(Value = "database-error")]
-    DatabaseError,
+    [EnumMember(Value = "refresh-in-progress")]
+    RefreshInProgress,
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -212,7 +212,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 (await Should.ThrowAsync<DatabaseException>(async () => await service.AddDependentAsync(this.mockParentHdid, addDependentRequest)))
                 .ShouldNotBeNull();
 
-            exception.StatusCode.ShouldBe(HttpStatusCode.InternalServerError);
+            exception.ProblemType.ShouldBe(ProblemType.DatabaseError);
         }
 
         /// <summary>


### PR DESCRIPTION
# Implements AB#16848

## Description

- removes extra constructors from custom exceptions
  - a different ProblemType from the default can be specified using the ProblemType property, though we only do this with UpstreamExceptions currently
  - .NET doesn't consider a constructor with all optional parameters to be the same as a default parameterless constructor
    - this means unit tests should use one of the Throws() overloads that creates an instance - in other words, not `Throws<X>()`, but `Throws(new X())` or `Throws(() => new X())`
- removes status codes from custom exceptions
  - they are now determined solely by the ProblemType
  - this means that each ProblemType can only be associated with one status, which matches how problem details is supposed to work (since each of our ProblemTypes correlates to a unique problem details type)
  - the only place this had an impact was in the NotFoundExceptions in ClientRegistriesDelegate that were using ProblemType.InvalidData
    - ProblemType.InvalidData is the default problem type for InvalidDataException and maps to HTTP 500 responses
    - to preserve the HTTP 404 response behaviour for these exceptions (without introducing additional catches and throws at a higher level), these were left as NotFoundExceptions but now use the default ProblemType.RecordNotFound
- updates ExceptionUtilities to determine the status code, title, and type for a ProblemDetails response based on one of our defined ProblemTypes
  - for general exceptions, the exception type is now used to determine a ProblemType, enabling some logic to be shared when generating problem details
    - the 3 previous methods (for ValidationExceptions, HealthGatewayExceptions, and general Exceptions) have been refactored into 2: GenerateValidationProblemDetails and GenerateProblemDetails
- reorders ProblemType enum values based on the HTTP status codes they are associated with
- adds ProblemType.Forbidden, mapping to HTTP 403, which is what we use for the built-in UnauthorizedAccessException

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
