### PR TITLE
Configure services to output to Azure Monitor AB#16831

### DIFF
--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -149,13 +149,21 @@
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [
-            "ClinicalDocumentService",
-            "PatientService",
+            "RestImmunizationAdminDelegate",
+            "RestVaccineStatusDelegate",
+            "BroadcastService",
+
+            "PatientQueryStrategy",
             "ClientRegistriesDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService"
         ],
-        "ServiceName": "BlazorAdmin",
+        "ServiceName": "Admin",
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",

--- a/Apps/ClinicalDocument/src/Startup.cs
+++ b/Apps/ClinicalDocument/src/Startup.cs
@@ -100,6 +100,7 @@ namespace HealthGateway.ClinicalDocument
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
             this.startupConfig.UseRest(app);
         }
     }

--- a/Apps/ClinicalDocument/src/appsettings.json
+++ b/Apps/ClinicalDocument/src/appsettings.json
@@ -26,9 +26,7 @@
         ]
     },
     "RequestLogging": {
-        "ExcludedPaths": [
-            "/health"
-        ]
+        "ExcludedPaths": ["/health"]
     },
     "OpenIdConnect": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
@@ -65,18 +63,20 @@
         "Enabled": false,
         "Sources": [
             "ClinicalDocumentService",
-            "PatientService",
-            "ClientRegistriesDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService",
+            "PersonalAccountsService"
         ],
         "ServiceName": "ClinicalDocumentService",
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",
-        "IgnorePathPrefixes": [
-            "/health"
-        ]
+        "IgnorePathPrefixes": ["/health"]
     },
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd.azure-api.net/identity",

--- a/Apps/Common/src/AspNetConfiguration/Modules/Observability.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Observability.cs
@@ -137,6 +137,11 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                             .AddNpgsql()
                             ;
 
+                        foreach (string source in otlpConfig.Sources)
+                        {
+                            builder.AddSource(source);
+                        }
+
                         if (otlpConfig.TraceConsoleExporterEnabled)
                         {
                             builder.AddConsoleExporter();

--- a/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/StartupConfiguration.cs
@@ -256,6 +256,15 @@ namespace HealthGateway.Common.AspNetConfiguration
         }
 
         /// <summary>
+        /// Configures the app to use middleware to enrich tracing telemetry with additional properties.
+        /// </summary>
+        /// <param name="app">The application builder provider.</param>
+        public void EnrichTracing(IApplicationBuilder app)
+        {
+            Observability.EnrichTracing(app, this.Configuration);
+        }
+
+        /// <summary>
         /// Configures the app to use messaging.
         /// </summary>
         /// <param name="services">The service collection provider.</param>

--- a/Apps/Common/src/Common.csproj
+++ b/Apps/Common/src/Common.csproj
@@ -7,7 +7,6 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.8" />

--- a/Apps/Common/src/Common.csproj
+++ b/Apps/Common/src/Common.csproj
@@ -7,6 +7,8 @@
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.1" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.5" />
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.14" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.8" />
     <PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
@@ -27,6 +29,7 @@
     <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="8.0.0" />

--- a/Apps/Common/src/Models/OpenTelemetryConfig.cs
+++ b/Apps/Common/src/Models/OpenTelemetryConfig.cs
@@ -16,11 +16,12 @@
 namespace HealthGateway.Common.Models
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using OpenTelemetry.Exporter;
 
     /// <summary>
-    /// Provides configuration data for the Notifications Settings PHSA API.
+    /// Provides configuration data for OpenTelemetry.
     /// </summary>
     public class OpenTelemetryConfig
     {
@@ -28,6 +29,11 @@ namespace HealthGateway.Common.Models
         /// Gets or sets a value indicating whether Open Telemetry is enabled.
         /// </summary>
         public bool Enabled { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the names of activity sources to monitor.
+        /// </summary>
+        public IList<string> Sources { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the name to use for the service.
@@ -61,12 +67,12 @@ namespace HealthGateway.Common.Models
         public OtlpExportProtocol ExportProtocol { get; set; } = OtlpExportProtocol.HttpProtobuf;
 
         /// <summary>
-        /// Gets or sets a value indicating whether  OpenTelemetry console export for tracing, default to false.
+        /// Gets or sets a value indicating whether the console exporter for tracing is enabled, default to false.
         /// </summary>
         public bool TraceConsoleExporterEnabled { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether OpenTelemetry console export for metrics, default to false.
+        /// Gets or sets a value indicating whether the console exporter for metrics is enabled, default to false.
         /// </summary>
         public bool MetricsConsoleExporterEnabled { get; set; }
     }

--- a/Apps/Common/src/Models/OpenTelemetryConfig.cs
+++ b/Apps/Common/src/Models/OpenTelemetryConfig.cs
@@ -43,7 +43,12 @@ namespace HealthGateway.Common.Models
         /// Gets or sets the path prefixes that tracing will ignore.
         /// </summary>
         [SuppressMessage("Performance", "CA1819:Properties should not return arrays", Justification = "Configuration Binding")]
-        public string[] IgnorePathPrefixes { get; set; } = Array.Empty<string>();
+        public string[] IgnorePathPrefixes { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets the connection string for exporting to Azure Monitor.
+        /// </summary>
+        public string AzureConnectionString { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets OpenTelemetry collector endpoint.

--- a/Apps/Encounter/src/Startup.cs
+++ b/Apps/Encounter/src/Startup.cs
@@ -106,6 +106,7 @@ namespace HealthGateway.Encounter
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
             this.startupConfig.UseRest(app);
         }
     }

--- a/Apps/Encounter/src/appsettings.json
+++ b/Apps/Encounter/src/appsettings.json
@@ -80,12 +80,16 @@
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [
+            "RestHospitalVisitDelegate",
+            "RestMspVisitDelegate",
             "EncounterService",
-            "RestMSPVisitDelegate",
-            "PatientService",
-            "ClientRegistriesDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService"
         ],
         "ServiceName": "EncounterService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/GatewayApi/src/Startup.cs
+++ b/Apps/GatewayApi/src/Startup.cs
@@ -165,6 +165,7 @@ namespace HealthGateway.GatewayApi
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app, false);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
             this.startupConfig.UseRest(app);
 
             DisableTraceMethod(app);

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -81,10 +81,20 @@
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [
-            "PatientService",
+            "PatientDetailsService",
+            "WebAlertService",
+
+            "PatientQueryStrategy",
             "ClientRegistriesDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "CDogsDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService",
+            "PersonalAccountsService"
         ],
         "ServiceName": "GatewayApi",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/Immunization/src/Startup.cs
+++ b/Apps/Immunization/src/Startup.cs
@@ -103,6 +103,7 @@ namespace HealthGateway.Immunization
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
             this.startupConfig.UseRest(app);
         }
     }

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -68,10 +68,14 @@
         "Enabled": false,
         "Sources": [
             "RestImmunizationDelegate",
-            "PatientService",
-            "ClientRegistriesDelegate",
+            "RestVaccineStatusDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService"
         ],
         "ServiceName": "ImmunizationService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -163,6 +163,7 @@ namespace HealthGateway.JobScheduler
             this.startupConfig.UseHttp(app);
             this.startupConfig.UseContentSecurityPolicy(app);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
 
             app.UseEndpoints(
                 endpoints =>

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -59,12 +59,7 @@
     },
     "OpenTelemetry": {
         "Enabled": false,
-        "Sources": [
-            "PatientService",
-            "ClientRegistriesDelegate",
-            "DbAuditLogger",
-            "RedisAuditLogger"
-        ],
+        "Sources": ["RestNotificationSettingsDelegate"],
         "ServiceName": "JobScheduler",
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,

--- a/Apps/Laboratory/src/Startup.cs
+++ b/Apps/Laboratory/src/Startup.cs
@@ -104,6 +104,7 @@ namespace HealthGateway.Laboratory
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
             this.startupConfig.UseRest(app);
         }
     }

--- a/Apps/Laboratory/src/appsettings.json
+++ b/Apps/Laboratory/src/appsettings.json
@@ -26,9 +26,7 @@
         ]
     },
     "RequestLogging": {
-        "ExcludedPaths": [
-            "/health"
-        ]
+        "ExcludedPaths": ["/health"]
     },
     "OpenIdConnect": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
@@ -65,18 +63,19 @@
         "Enabled": false,
         "Sources": [
             "RestLaboratoryDelegate",
-            "PatientService",
-            "ClientRegistriesDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService"
         ],
         "ServiceName": "LaboratoryService",
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",
-        "IgnorePathPrefixes": [
-            "/health"
-        ]
+        "IgnorePathPrefixes": ["/health"]
     },
     "Authorization": {
         "MaxDependentAge": "12"

--- a/Apps/Medication/src/Delegates/SalesforceMedicationRequestDelegate.cs
+++ b/Apps/Medication/src/Delegates/SalesforceMedicationRequestDelegate.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.Medication.Delegates
     using HealthGateway.Common.AccessManagement.Authentication.Models;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Delegates;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Medication.Api;
     using HealthGateway.Medication.Models;
@@ -72,7 +71,7 @@ namespace HealthGateway.Medication.Delegates
             this.clientCredentialsRequest = new() { TokenUri = config.TokenUri, Parameters = config.ClientAuthentication };
         }
 
-        private static ActivitySource Source { get; } = new(nameof(ClientRegistriesDelegate));
+        private static ActivitySource Source { get; } = new(nameof(SalesforceMedicationRequestDelegate));
 
         /// <inheritdoc/>
         public async Task<RequestResult<IList<MedicationRequest>>> GetMedicationRequestsAsync(string phn, CancellationToken ct = default)

--- a/Apps/Medication/src/Startup.cs
+++ b/Apps/Medication/src/Startup.cs
@@ -125,6 +125,7 @@ namespace HealthGateway.Medication
             this.startupConfig.UseSwagger(app);
             this.startupConfig.UseHttp(app);
             this.startupConfig.UseAuth(app);
+            this.startupConfig.EnrichTracing(app);
             this.startupConfig.UseRest(app);
         }
     }

--- a/Apps/Medication/src/appsettings.json
+++ b/Apps/Medication/src/appsettings.json
@@ -26,9 +26,7 @@
         ]
     },
     "RequestLogging": {
-        "ExcludedPaths": [
-            "/health"
-        ]
+        "ExcludedPaths": ["/health"]
     },
     "OpenIdConnect": {
         "Authority": "https://loginproxy.gov.bc.ca/auth/realms/health-gateway-gold",
@@ -91,20 +89,22 @@
     "OpenTelemetry": {
         "Enabled": false,
         "Sources": [
+            "RestMedicationStatementDelegate",
+            "SalesforceMedicationRequestDelegate",
             "RestMedicationStatementService",
-            "PatientService",
-            "ClientRegistriesDelegate",
-            "MedicationRequestService",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService"
         ],
         "ServiceName": "MedicationService",
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,
         "ZipkinUri": "",
-        "IgnorePathPrefixes": [
-            "/health"
-        ]
+        "IgnorePathPrefixes": ["/health"]
     },
     "AuthCache": {
         "TokenCacheExpireMinutes": "20"

--- a/Apps/Patient/src/Program.cs
+++ b/Apps/Patient/src/Program.cs
@@ -90,6 +90,7 @@ namespace HealthGateway.Patient
             SwaggerDoc.UseSwagger(app, logger);
             HttpWeb.UseHttp(app, logger, configuration, environment, false, false);
             Auth.UseAuth(app, logger);
+            Observability.EnrichTracing(app, configuration);
             HttpWeb.UseRest(app, logger);
 
             await app.RunAsync();

--- a/Apps/Patient/src/appsettings.json
+++ b/Apps/Patient/src/appsettings.json
@@ -64,9 +64,17 @@
         "Enabled": false,
         "Sources": [
             "PatientService",
+
+            "PatientQueryStrategy",
             "ClientRegistriesDelegate",
+
             "DbAuditLogger",
-            "RedisAuditLogger"
+            "RedisAuditLogger",
+            "RestTokenSwapDelegate",
+            "ClientRegistriesDelegate",
+            "AccessTokenService",
+            "PatientService",
+            "PersonalAccountsService"
         ],
         "ServiceName": "PatientService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/WebClient/src/Server/Startup.cs
+++ b/Apps/WebClient/src/Server/Startup.cs
@@ -140,6 +140,7 @@ namespace HealthGateway.WebClient.Server
                 });
 
             this.startupConfig.UseHttp(app);
+            this.startupConfig.EnrichTracing(app);
 
             app.UseEndpoints(
                 endpoints =>
@@ -148,11 +149,7 @@ namespace HealthGateway.WebClient.Server
                     endpoints.MapControllerRoute("default", "{controller}/{action=Index}/{id?}");
                 });
 
-            app.UseSpa(
-                spa =>
-                {
-                    spa.Options.SourcePath = "ClientApp";
-                });
+            app.UseSpa(spa => { spa.Options.SourcePath = "ClientApp"; });
         }
 
         private static void DisableTraceMethod(IApplicationBuilder app)

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -109,12 +109,7 @@
     "PermissionPolicy": "camera=(self)",
     "OpenTelemetry": {
         "Enabled": false,
-        "Sources": [
-            "PatientService",
-            "ClientRegistriesDelegate",
-            "DbAuditLogger",
-            "RedisAuditLogger"
-        ],
+        "Sources": [],
         "ServiceName": "WebClient",
         "TraceConsoleExporterEnabled": false,
         "ZipkinEnabled": false,


### PR DESCRIPTION
# Implements [AB#16831](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16831)

## Description

- configures logging and telemetry for Azure Monitor (Application Insights)
- enriches tracing with additional request properties when available
  - `User`: the ID/HDID of the user making the request
  - `Subject`: the HDID of the resource owner
- update lists of activity sources used in each project to output telemetry for all Activity operations

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
