### PR TITLE
Change filter text to return no results for AB#16853.

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
@@ -211,10 +211,15 @@ describe("Filters", () => {
 
     it("No Records on Linear Timeline", () => {
         cy.get("[data-testid=filterDropdown]").click();
-        cy.get("[data-testid=filterTextInput]").type("xxxx");
+        cy.get("[data-testid=filterTextInput]").type(
+            "no-data-should-match-this-unique-string"
+        );
         cy.get("[data-testid=btnFilterApply]").click();
         cy.get("[data-testid=noTimelineEntriesText]").should("be.visible");
-        cy.contains("[data-testid=filter-label]", '"xxxx"')
+        cy.contains(
+            "[data-testid=filter-label]",
+            '"no-data-should-match-this-unique-string"'
+        )
             .children(".v-chip__close")
             .click();
         cy.get("[data-testid=noTimelineEntriesText]").should("not.exist");


### PR DESCRIPTION
# Fixes [AB#16853](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16853)

## Description

Test data is returning data that matches filter text. Therefore, changed filter text on functional test to return 0 records so that test can pass

See cypress tests: https://cloud.cypress.io/projects/ofnepc/runs/4663/overview?roarHideRunsWithDiffGroupsAndTags=1

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
