### PR TITLE
Reorganize unit test mock data setup for AB#16851 

### DIFF
--- a/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
+++ b/Apps/AccountDataAccess/src/Patient/ClientRegistriesDelegate.cs
@@ -26,7 +26,6 @@ namespace HealthGateway.AccountDataAccess.Patient
     using FluentValidation;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.ErrorHandling;
-    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.ErrorHandling.Exceptions;
     using Microsoft.Extensions.Logging;
     using ServiceReference;

--- a/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/AuditRepositoryTests.cs
@@ -31,11 +31,11 @@ namespace AccountDataAccessTest
         private const string Hdid = "abc123";
 
         /// <summary>
-        /// GetDemographics by PHN - happy path.
+        /// GetDemographics - happy path.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetDemographicsByPhn()
+        public async Task ShouldGetDemographics()
         {
             // Arrange
             AgentAudit audit = new()
@@ -53,7 +53,7 @@ namespace AccountDataAccessTest
             // Act
             IEnumerable<AgentAudit> actual = await auditRepository.HandleAsync(query);
 
-            // Verify
+            // Assert
             IEnumerable<AgentAudit> collection = actual.ToList();
             Assert.Single(collection);
             collection.Single().ShouldDeepEqual(agentAudits.Single());

--- a/Apps/AccountDataAccess/test/unit/PatientMappingsTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientMappingsTests.cs
@@ -73,11 +73,9 @@ namespace AccountDataAccessTest
             const string delimiter = " ";
 
             // Arrange
-            string expectedCommonGivenName = $"{PhsaPreferredFirstName}{delimiter}{PhsaPreferredThirdName}";
-            string expectedCommonSurname = PhsaPreferredLastName;
+            const string expectedCommonGivenName = $"{PhsaPreferredFirstName}{delimiter}{PhsaPreferredThirdName}";
 
-            string expectedLegalGivenName = $"{PhsaLegalFirstName}{delimiter}{PhsaLegalSecondName}{delimiter}{PhsaLegalThirdName}";
-            string expectedLegalSurname = PhsaLegalLastName;
+            const string expectedLegalGivenName = $"{PhsaLegalFirstName}{delimiter}{PhsaLegalSecondName}{delimiter}{PhsaLegalThirdName}";
 
             PatientModel expectedPatient = new()
             {
@@ -88,9 +86,9 @@ namespace AccountDataAccessTest
                 ResponseCode = string.Empty,
                 IsDeceased = true,
                 CommonName = new Name
-                    { GivenName = expectedCommonGivenName, Surname = expectedCommonSurname },
+                    { GivenName = expectedCommonGivenName, Surname = PhsaPreferredLastName },
                 LegalName = new Name
-                    { GivenName = expectedLegalGivenName, Surname = expectedLegalSurname },
+                    { GivenName = expectedLegalGivenName, Surname = PhsaLegalLastName },
                 PhysicalAddress = new Address
                 {
                     StreetLines =
@@ -149,7 +147,7 @@ namespace AccountDataAccessTest
             // Act
             PatientModel actual = Mapper.Map<PatientModel>(patientIdentity);
 
-            // Verify
+            // Assert
             actual.ShouldDeepEqual(expectedPatient);
         }
 
@@ -194,7 +192,7 @@ namespace AccountDataAccessTest
             // Act
             PatientModel actual = Mapper.Map<PatientModel>(patientIdentity);
 
-            // Verify
+            // Assert
             actual.ShouldDeepEqual(expectedPatient);
         }
     }

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -66,13 +66,35 @@ namespace AccountDataAccessTest
         public async Task ShouldQueryAsync(PatientDetailSource source, bool useHdid, bool useCache)
         {
             // Arrange
-            QueryMock mock = SetupQueryMock(source, useHdid, useCache);
+            PatientModel patient = new()
+            {
+                Phn = Phn,
+                Hdid = Hdid,
+            };
+
+            PatientIdentity patientIdentity = new()
+            {
+                Phn = Phn,
+                HdId = Hdid,
+            };
+
+            PatientModel expected = source == PatientDetailSource.Phsa && !useCache
+                ? Mapper.Map<PatientIdentity, PatientModel>(patientIdentity)
+                : patient;
+
+            PatientDetailsQuery patientDetailsQuery = new(
+                Hdid: useHdid ? Hdid : null,
+                Phn: !useHdid ? Phn : null,
+                Source: source,
+                UseCache: useCache);
+
+            IPatientRepository patientRepository = SetupQueryMock(patient, patientIdentity);
 
             // Act
-            PatientQueryResult actual = await mock.PatientRepository.QueryAsync(mock.PatientDetailsQuery, CancellationToken.None);
+            PatientQueryResult actual = await patientRepository.QueryAsync(patientDetailsQuery, CancellationToken.None);
 
             // Assert
-            actual.Item.ShouldDeepEqual(mock.Expected);
+            actual.Item.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -96,11 +118,20 @@ namespace AccountDataAccessTest
             }
 
             CancellationToken ct = cancellationTokenSource.Token;
-            QueryThrowsInvalidOperationExceptionMock mock = SetupQueryThrowsInvalidOperationExceptionMock(hdid, phn, ct);
+
+            PatientDetailsQuery patientDetailsQuery = new(
+                Hdid: hdid,
+                Phn: phn,
+                Source: PatientDetailSource.Empi,
+                UseCache: true);
+
+            string expected = ct.IsCancellationRequested ? "cancellation was requested" : "Must specify either Hdid or Phn to query patient details";
+
+            IPatientRepository patientRepository = SetupQueryThrowsInvalidOperationExceptionMock();
 
             // Act and Assert
-            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => mock.PatientRepository.QueryAsync(mock.PatientDetailsQuery, ct));
-            Assert.Equal(mock.Expected, exception.Message);
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => patientRepository.QueryAsync(patientDetailsQuery, ct));
+            Assert.Equal(expected, exception.Message);
         }
 
         /// <summary>
@@ -121,33 +152,52 @@ namespace AccountDataAccessTest
         public async Task ShouldBlockAccessAsync(bool changeFeedEnabled, bool datasourceExist)
         {
             // Arrange
-            BlockAccessMock mock = SetupBlockAccessMock(changeFeedEnabled, datasourceExist);
+            const string reason = "Unit Test Block Access";
+            bool commit = !changeFeedEnabled;
+            HashSet<DataSource> dataSources = datasourceExist ? [DataSource.Immunization, DataSource.Medication] : [];
+
+            BlockedAccess blockedAccess = new()
+            {
+                Hdid = Hdid,
+                DataSources = dataSources,
+            };
+
+            AgentAudit audit = new()
+            {
+                Hdid = Hdid,
+                Reason = reason,
+                OperationCode = AuditOperation.ChangeDataSourceAccess,
+                GroupCode = AuditGroup.BlockedAccess,
+            };
+
+            BlockAccessCommand command = new(Hdid, dataSources, reason);
+            (IPatientRepository repository, Mock<IBlockedAccessDelegate> blockedAccessDelegateMock, Mock<IMessageSender> messageSenderMock) = SetupBlockAccessMock(blockedAccess, changeFeedEnabled);
 
             // Act
-            await mock.PatientRepository.BlockAccessAsync(mock.Command);
+            await repository.BlockAccessAsync(command);
 
             // Verify
-            mock.BlockedAccessDelegate.Verify(
+            blockedAccessDelegateMock.Verify(
                 d => d.UpdateBlockedAccessAsync(
-                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(mock.BlockedAccess, ba)),
-                    It.Is<AgentAudit>(aa => AssertAgentAudit(mock.Audit, aa)),
-                    mock.Commit,
+                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(blockedAccess, ba)),
+                    It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa)),
+                    commit,
                     It.IsAny<CancellationToken>()),
                 datasourceExist ? Times.Once : Times.Never);
 
-            mock.BlockedAccessDelegate.Verify(
+            blockedAccessDelegateMock.Verify(
                 d => d.DeleteBlockedAccessAsync(
-                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(mock.BlockedAccess, ba)),
-                    It.Is<AgentAudit>(aa => AssertAgentAudit(mock.Audit, aa)),
-                    mock.Commit,
+                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(blockedAccess, ba)),
+                    It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa)),
+                    commit,
                     It.IsAny<CancellationToken>()),
                 !datasourceExist ? Times.Once : Times.Never);
 
-            mock.MessageSender.Verify(
+            messageSenderMock.Verify(
                 s => s.SendAsync(
                     It.Is<IEnumerable<MessageEnvelope>>(
                         me => AssertDataSourcesBlockedEvent(
-                            mock.BlockedAccess,
+                            blockedAccess,
                             me.Select(envelope => envelope.Content as DataSourcesBlockedEvent).First())),
                     It.IsAny<CancellationToken>()),
                 changeFeedEnabled ? Times.Once : Times.Never);
@@ -157,20 +207,23 @@ namespace AccountDataAccessTest
         /// Can access data source.
         /// </summary>
         /// <param name="dataSource">The data source to check for access.</param>
+        /// <param name="useCache">The value indicating whether cache should be used or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(DataSource.Note)]
-        [InlineData(DataSource.Medication)]
-        public async Task CanAccessDataSourceAsync(DataSource dataSource)
+        [InlineData(DataSource.Note, false)]
+        [InlineData(DataSource.Medication, true)]
+        public async Task CanAccessDataSourceAsync(DataSource dataSource, bool useCache)
         {
             // Arrange
-            CanAccessDatasourceMock mock = SetupCanAccessDatasourceMock(dataSource);
+            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
+            bool expected = !dataSources.Contains(dataSource);
+            IPatientRepository patientRepository = SetupCanAccessDatasourceMock(dataSources, useCache);
 
             // Act
-            bool actual = await mock.PatientRepository.CanAccessDataSourceAsync(Hdid, mock.DataSource);
+            bool actual = await patientRepository.CanAccessDataSourceAsync(Hdid, dataSource);
 
             // Assert
-            Assert.Equal(mock.Expected, actual);
+            Assert.Equal(expected, actual);
         }
 
         /// <summary>
@@ -181,30 +234,40 @@ namespace AccountDataAccessTest
         public async Task ShouldGetBlockedAccessAsync()
         {
             // Arrange
-            GetBlockedAccessMock mock = SetupGetBlockedAccessMock();
+            BlockedAccess expected = new()
+            {
+                Hdid = Hdid,
+                DataSources = [DataSource.Immunization, DataSource.Medication],
+            };
+
+            IPatientRepository patientRepository = SetupGetBlockedAccessMock(expected);
 
             // Act
-            BlockedAccess? actual = await mock.PatientRepository.GetBlockedAccessRecordsAsync(mock.Hdid);
+            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecordsAsync(Hdid);
 
             // Verify
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
         /// Get data sources by hdid.
         /// </summary>
+        /// <param name="useCache">The value indicating whether cache should be used or not.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetDataSourcesAsync()
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task ShouldGetDataSourcesAsync(bool useCache)
         {
             // Arrange
-            GetDataSourcesMock mock = SetupGetDataSourcesMock();
+            HashSet<DataSource> expected = [DataSource.Immunization, DataSource.Medication];
+            IPatientRepository patientRepository = SetupGetDataSourcesMock(expected, useCache);
 
             // Act
-            IEnumerable<DataSource> actual = await mock.PatientRepository.GetDataSourcesAsync(mock.Hdid);
+            IEnumerable<DataSource> actual = await patientRepository.GetDataSourcesAsync(Hdid);
 
             // Verify
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static bool AssertAgentAudit(AgentAudit expected, AgentAudit actual)
@@ -249,26 +312,8 @@ namespace AccountDataAccessTest
             return dataSources.Select(ds => EnumUtility.ToEnumString(ds));
         }
 
-        private static BlockAccessMock SetupBlockAccessMock(bool changeFeedEnabled, bool datasourceExist)
+        private static BlockAccessMock SetupBlockAccessMock(BlockedAccess blockedAccess, bool changeFeedEnabled)
         {
-            const string reason = "Unit Test Block Access";
-            bool commit = !changeFeedEnabled;
-            HashSet<DataSource> dataSources = datasourceExist ? [DataSource.Immunization, DataSource.Medication] : [];
-
-            BlockedAccess blockedAccess = new()
-            {
-                Hdid = Hdid,
-                DataSources = dataSources,
-            };
-
-            AgentAudit audit = new()
-            {
-                Hdid = Hdid,
-                Reason = reason,
-                OperationCode = AuditOperation.ChangeDataSourceAccess,
-                GroupCode = AuditGroup.BlockedAccess,
-            };
-
             Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
             blockedAccessDelegate.Setup(
                     s => s.GetBlockedAccessAsync(
@@ -281,7 +326,6 @@ namespace AccountDataAccessTest
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(blockedAccess.DataSources);
 
-            BlockAccessCommand command = new(Hdid, dataSources, reason);
             Mock<IMessageSender> messageSender = new();
 
             if (changeFeedEnabled)
@@ -302,41 +346,58 @@ namespace AccountDataAccessTest
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
                 messageSender.Object);
 
-            return new(patientRepository, blockedAccessDelegate, messageSender, blockedAccess, audit, commit, command);
+            return new(patientRepository, blockedAccessDelegate, messageSender);
         }
 
-        private static CanAccessDatasourceMock SetupCanAccessDatasourceMock(DataSource dataSource)
+        private static IPatientRepository SetupCanAccessDatasourceMock(HashSet<DataSource> dataSources, bool useCache)
         {
-            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
             Mock<ICacheProvider> cacheProviderMock = new();
-            cacheProviderMock.Setup(
-                    s => s.GetOrSetAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<Func<Task<IEnumerable<DataSource>>>>(),
-                        It.IsAny<TimeSpan>(),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync(dataSources);
+            Mock<IBlockedAccessDelegate> blocedAccessDelegateMock = new();
 
-            PatientRepository patientRepository = new(
+            if (useCache)
+            {
+                cacheProviderMock.Setup(
+                        s => s.GetOrSetAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<Func<Task<IEnumerable<DataSource>>>>(),
+                            It.IsAny<TimeSpan>(),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(dataSources);
+            }
+            else
+            {
+                blocedAccessDelegateMock.Setup(
+                        s => s.GetDataSourcesAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(dataSources);
+
+                cacheProviderMock.Setup(
+                        s => s.GetOrSetAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<Func<Task<IEnumerable<DataSource>>>>(),
+                            It.IsAny<TimeSpan?>(), // TimeSpan? for consistency
+                            It.IsAny<CancellationToken>()))
+                    .Returns(
+                        (string _, Func<Task<IEnumerable<DataSource>?>> valueFactory, TimeSpan? _, CancellationToken _) =>
+                        {
+                            Task<IEnumerable<DataSource>?> task = valueFactory.Invoke();
+                            return task;
+                        });
+            }
+
+            return new PatientRepository(
                 new Mock<ILogger<PatientRepository>>().Object,
-                new Mock<IBlockedAccessDelegate>().Object,
+                blocedAccessDelegateMock.Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 cacheProviderMock.Object,
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
                 new Mock<IMessageSender>().Object);
-
-            return new(patientRepository, !dataSources.Contains(dataSource), dataSource);
         }
 
-        private static GetBlockedAccessMock SetupGetBlockedAccessMock()
+        private static IPatientRepository SetupGetBlockedAccessMock(BlockedAccess blockedAccess)
         {
-            BlockedAccess blockedAccess = new()
-            {
-                Hdid = Hdid,
-                DataSources = [DataSource.Immunization, DataSource.Medication],
-            };
-
             Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
             blockedAccessDelegate.Setup(
                     s => s.GetBlockedAccessAsync(
@@ -344,7 +405,7 @@ namespace AccountDataAccessTest
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(blockedAccess);
 
-            PatientRepository patientRepository = new(
+            return new PatientRepository(
                 new Mock<ILogger<PatientRepository>>().Object,
                 blockedAccessDelegate.Object,
                 new Mock<IAuthenticationDelegate>().Object,
@@ -352,60 +413,58 @@ namespace AccountDataAccessTest
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
                 new Mock<IMessageSender>().Object);
-
-            return new(patientRepository, blockedAccess, Hdid);
         }
 
-        private static GetDataSourcesMock SetupGetDataSourcesMock()
+        private static IPatientRepository SetupGetDataSourcesMock(HashSet<DataSource> dataSources, bool useCache)
         {
             string cacheKey = string.Format(CultureInfo.InvariantCulture, ICacheProvider.BlockedAccessCachePrefixKey, Hdid);
-            HashSet<DataSource> dataSources = [DataSource.Immunization, DataSource.Medication];
             Mock<ICacheProvider> cacheProviderMock = new();
-            cacheProviderMock.Setup(
-                    s =>
-                        s.GetOrSetAsync(
+            Mock<IBlockedAccessDelegate> blocedAccessDelegateMock = new();
+
+            if (useCache)
+            {
+                cacheProviderMock.Setup(
+                        s => s.GetOrSetAsync(
                             It.Is<string>(x => x.Contains(cacheKey)),
                             It.IsAny<Func<Task<IEnumerable<DataSource>>>>(),
                             It.IsAny<TimeSpan>(),
                             It.IsAny<CancellationToken>()))
-                .ReturnsAsync(dataSources);
+                    .ReturnsAsync(dataSources);
+            }
+            else
+            {
+                blocedAccessDelegateMock.Setup(
+                        s => s.GetDataSourcesAsync(
+                            It.IsAny<string>(),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(dataSources);
 
-            PatientRepository patientRepository = new(
+                cacheProviderMock.Setup(
+                        s => s.GetOrSetAsync(
+                            It.Is<string>(x => x.Contains(cacheKey)),
+                            It.IsAny<Func<Task<IEnumerable<DataSource>>>>(),
+                            It.IsAny<TimeSpan>(),
+                            It.IsAny<CancellationToken>()))
+                    .Returns(
+                        (string _, Func<Task<IEnumerable<DataSource>?>> valueFactory, TimeSpan? _, CancellationToken _) =>
+                        {
+                            Task<IEnumerable<DataSource>?> task = valueFactory.Invoke();
+                            return task;
+                        });
+            }
+
+            return new PatientRepository(
                 new Mock<ILogger<PatientRepository>>().Object,
-                new Mock<IBlockedAccessDelegate>().Object,
+                blocedAccessDelegateMock.Object,
                 new Mock<IAuthenticationDelegate>().Object,
                 cacheProviderMock.Object,
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
                 new Mock<IMessageSender>().Object);
-
-            return new(patientRepository, dataSources, Hdid);
         }
 
-        private static QueryMock SetupQueryMock(PatientDetailSource source, bool useHdid, bool useCache)
+        private static IPatientRepository SetupQueryMock(PatientModel patient, PatientIdentity patientIdentity)
         {
-            PatientDetailsQuery patientDetailsQuery = new(
-                Hdid: useHdid ? Hdid : null,
-                Phn: !useHdid ? Phn : null,
-                Source: source,
-                UseCache: useCache);
-
-            PatientModel patient = new()
-            {
-                Phn = Phn,
-                Hdid = Hdid,
-            };
-
-            PatientIdentity patientIdentity = new()
-            {
-                Phn = Phn,
-                HdId = Hdid,
-            };
-
-            PatientModel expected = source == PatientDetailSource.Phsa && !useCache
-                ? Mapper.Map<PatientIdentity, PatientModel>(patientIdentity)
-                : patient;
-
             ServiceCollection serviceCollection = [];
 
             Mock<ICacheProvider> cacheProviderMock = new();
@@ -464,7 +523,7 @@ namespace AccountDataAccessTest
             serviceCollection.AddScoped<HdidPhsaStrategy>(_ => hdidPhsaStrategy);
             ServiceProvider serviceProvider = serviceCollection.BuildServiceProvider();
 
-            PatientRepository patientRepository = new(
+            return new PatientRepository(
                 new Mock<ILogger<PatientRepository>>().Object,
                 new Mock<IBlockedAccessDelegate>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
@@ -472,38 +531,11 @@ namespace AccountDataAccessTest
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(serviceProvider),
                 new Mock<IMessageSender>().Object);
-
-            return new(patientRepository, expected, patientDetailsQuery);
         }
 
-        private static QueryThrowsInvalidOperationExceptionMock SetupQueryThrowsInvalidOperationExceptionMock(
-            string? hdid,
-            string? phn,
-            CancellationToken ct)
+        private static IPatientRepository SetupQueryThrowsInvalidOperationExceptionMock()
         {
-            PatientDetailsQuery patientDetailsQuery = new(
-                Hdid: hdid,
-                Phn: phn,
-                Source: PatientDetailSource.Empi,
-                UseCache: true);
-            string expected = string.Empty;
-
-            if (string.IsNullOrEmpty(hdid))
-            {
-                expected = "Must specify either Hdid or Phn to query patient details";
-            }
-
-            if (string.IsNullOrEmpty(phn))
-            {
-                expected = "Must specify either Hdid or Phn to query patient details";
-            }
-
-            if (ct.IsCancellationRequested)
-            {
-                expected = "cancellation was requested";
-            }
-
-            PatientRepository patientRepository = new(
+            return new PatientRepository(
                 new Mock<ILogger<PatientRepository>>().Object,
                 new Mock<IBlockedAccessDelegate>().Object,
                 new Mock<IAuthenticationDelegate>().Object,
@@ -511,42 +543,11 @@ namespace AccountDataAccessTest
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
                 new Mock<IMessageSender>().Object);
-
-            return new(patientRepository, expected, patientDetailsQuery);
         }
 
         private sealed record BlockAccessMock(
             PatientRepository PatientRepository,
             Mock<IBlockedAccessDelegate> BlockedAccessDelegate,
-            Mock<IMessageSender> MessageSender,
-            BlockedAccess BlockedAccess,
-            AgentAudit Audit,
-            bool Commit,
-            BlockAccessCommand Command);
-
-        private sealed record CanAccessDatasourceMock(
-            PatientRepository PatientRepository,
-            bool Expected,
-            DataSource DataSource);
-
-        private sealed record GetBlockedAccessMock(
-            PatientRepository PatientRepository,
-            BlockedAccess Expected,
-            string Hdid);
-
-        private sealed record GetDataSourcesMock(
-            PatientRepository PatientRepository,
-            IEnumerable<DataSource> Expected,
-            string Hdid);
-
-        private sealed record QueryMock(
-            PatientRepository PatientRepository,
-            PatientModel Expected,
-            PatientDetailsQuery PatientDetailsQuery);
-
-        private sealed record QueryThrowsInvalidOperationExceptionMock(
-            PatientRepository PatientRepository,
-            string Expected,
-            PatientDetailsQuery PatientDetailsQuery);
+            Mock<IMessageSender> MessageSender);
     }
 }

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -111,7 +111,7 @@ namespace AccountDataAccessTest.Strategy
                 HasDeathIndicator = false,
             };
 
-            HdidAllStrategy strategy = SetupGetPatientFromPhsaMock(patientIdentity);
+            HdidAllStrategy strategy = SetupHdidAllStrategyForGetPatientFromPhsa(patientIdentity);
 
             // Act
             PatientModel actual = await strategy.GetPatientAsync(patientRequest);
@@ -130,7 +130,7 @@ namespace AccountDataAccessTest.Strategy
             // Arrange
             PatientRequest patientRequest = new(PhsaHdidNotFound, false);
             Type expected = typeof(NotFoundException);
-            HdidAllStrategy strategy = SetupGetPatientHandlesPatientIdentityExceptionMock();
+            HdidAllStrategy strategy = SetupHdidAllStrategyForGetPatientHandlesPatientIdentityException();
 
             // Act and Assert
             await Assert.ThrowsAsync(
@@ -185,7 +185,7 @@ namespace AccountDataAccessTest.Strategy
             return new(hdidAllStrategy, cacheProvider);
         }
 
-        private static HdidAllStrategy SetupGetPatientFromPhsaMock(PatientIdentity patientIdentity)
+        private static HdidAllStrategy SetupHdidAllStrategyForGetPatientFromPhsa(PatientIdentity patientIdentity)
         {
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
             clientRegistriesDelegate.Setup(
@@ -212,7 +212,7 @@ namespace AccountDataAccessTest.Strategy
                 Mapper);
         }
 
-        private static HdidAllStrategy SetupGetPatientHandlesPatientIdentityExceptionMock()
+        private static HdidAllStrategy SetupHdidAllStrategyForGetPatientHandlesPatientIdentityException()
         {
             Mock<IClientRegistriesDelegate> clientRegistriesDelegate = new();
             clientRegistriesDelegate.Setup(

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -68,7 +68,7 @@ namespace AccountDataAccessTest.Strategy
                     { GivenName = string.Empty, Surname = string.Empty },
             };
 
-            (HdidPhsaStrategy strategy, Mock<ICacheProvider> cacheProvider) = SetupGetPatientMock(useCache, expected);
+            (HdidPhsaStrategy strategy, Mock<ICacheProvider> cacheProvider) = SetupPatientMockForGetPatient(useCache, expected);
 
             // Act
             PatientModel actual = await strategy.GetPatientAsync(patientRequest);
@@ -94,7 +94,7 @@ namespace AccountDataAccessTest.Strategy
             // Arrange
             PatientRequest patientRequest = new(PhsaHdidNotFound, false);
             Type expected = typeof(NotFoundException);
-            HdidPhsaStrategy strategy = SetupGetPatientHandlesPhsaApiExceptionMock();
+            HdidPhsaStrategy strategy = SetupHdidPhsaStrategyForGetPatientIdentityHandlesPhsaApiException();
 
             // Act and Assert
             await Assert.ThrowsAsync(
@@ -114,7 +114,7 @@ namespace AccountDataAccessTest.Strategy
                 .Build();
         }
 
-        private static PatientMock SetupGetPatientMock(bool useCache, PatientModel patient)
+        private static PatientMock SetupPatientMockForGetPatient(bool useCache, PatientModel patient)
         {
             Mock<ICacheProvider> cacheProvider = new();
             Mock<IPatientIdentityApi> patientIdentityApi = new();
@@ -154,7 +154,7 @@ namespace AccountDataAccessTest.Strategy
             return new(hdidPhsaStrategy, cacheProvider);
         }
 
-        private static HdidPhsaStrategy SetupGetPatientHandlesPhsaApiExceptionMock()
+        private static HdidPhsaStrategy SetupHdidPhsaStrategyForGetPatientIdentityHandlesPhsaApiException()
         {
             PatientModel? cachedPatient = null;
             Mock<ICacheProvider> cacheProvider = new();

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -50,21 +50,36 @@ namespace AccountDataAccessTest.Strategy
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
-        public async Task ShouldGetPatientByHdid(bool useCache)
+        public async Task ShouldGetPatient(bool useCache)
         {
             // Arrange
-            GetPatientMock mock = SetupGetPatientMock(useCache);
+            PatientRequest patientRequest = new(Hdid, useCache);
+
+            PatientModel expected = new()
+            {
+                Phn = Phn,
+                Hdid = Hdid,
+                Gender = Gender,
+                ResponseCode = string.Empty,
+                IsDeceased = false,
+                CommonName = new Name
+                    { GivenName = string.Empty, Surname = string.Empty },
+                LegalName = new Name
+                    { GivenName = string.Empty, Surname = string.Empty },
+            };
+
+            (HdidPhsaStrategy strategy, Mock<ICacheProvider> cacheProvider) = SetupGetPatientMock(useCache, expected);
 
             // Act
-            PatientModel actual = await mock.Strategy.GetPatientAsync(mock.PatientRequest);
+            PatientModel actual = await strategy.GetPatientAsync(patientRequest);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
 
             // Verify
-            mock.CacheProvider.Verify(
+            cacheProvider.Verify(
                 v => v.GetItemAsync<PatientModel>(
-                    It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{mock.PatientRequest.Identifier}"),
+                    It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{patientRequest.Identifier}"),
                     It.IsAny<CancellationToken>()),
                 useCache ? Times.AtLeastOnce : Times.Never);
         }
@@ -77,12 +92,14 @@ namespace AccountDataAccessTest.Strategy
         public async Task GetPatientIdentityHandlesPhsaApiException()
         {
             // Arrange
-            GetPatientHandlesPhsaApiExceptionMock mock = SetupGetPatientHandlesPhsaApiExceptionMock();
+            PatientRequest patientRequest = new(PhsaHdidNotFound, false);
+            Type expected = typeof(NotFoundException);
+            HdidPhsaStrategy strategy = SetupGetPatientHandlesPhsaApiExceptionMock();
 
             // Act and Assert
             await Assert.ThrowsAsync(
-                mock.ExpectedExceptionType,
-                async () => { await mock.Strategy.GetPatientAsync(mock.PatientRequest); });
+                expected,
+                async () => { await strategy.GetPatientAsync(patientRequest); });
         }
 
         private static IConfigurationRoot GetConfiguration()
@@ -97,66 +114,49 @@ namespace AccountDataAccessTest.Strategy
                 .Build();
         }
 
-        private static HdidPhsaStrategy GetHdidPhsaStrategy(IMock<ICacheProvider> cacheProvider, IMock<IPatientIdentityApi> patientIdentityApi)
+        private static PatientMock SetupGetPatientMock(bool useCache, PatientModel patient)
         {
-            return new(
+            Mock<ICacheProvider> cacheProvider = new();
+            Mock<IPatientIdentityApi> patientIdentityApi = new();
+
+            if (useCache)
+            {
+                cacheProvider.Setup(
+                        p => p.GetItemAsync<PatientModel>(
+                            It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(patient);
+            }
+            else
+            {
+                PatientIdentity patientIdentity = new()
+                {
+                    Phn = patient.Phn,
+                    HdId = patient.Hdid,
+                    Gender = patient.Gender,
+                    HasDeathIndicator = patient.IsDeceased!.Value,
+                };
+
+                patientIdentityApi.Setup(
+                        p => p.GetPatientIdentityAsync(
+                            It.Is<string>(x => x == Hdid),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(patientIdentity);
+            }
+
+            HdidPhsaStrategy hdidPhsaStrategy = new(
                 GetConfiguration(),
                 cacheProvider.Object,
                 patientIdentityApi.Object,
                 new Mock<ILogger<HdidPhsaStrategy>>().Object,
                 Mapper);
+
+            return new(hdidPhsaStrategy, cacheProvider);
         }
 
-        private static GetPatientMock SetupGetPatientMock(bool useCache)
-        {
-            PatientModel patient = new()
-            {
-                Phn = Phn,
-                Hdid = Hdid,
-                Gender = Gender,
-                ResponseCode = string.Empty,
-                IsDeceased = false,
-                CommonName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
-                LegalName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
-            };
-
-            PatientIdentity patientIdentity = new()
-            {
-                Phn = Phn,
-                HdId = Hdid,
-                Gender = Gender,
-                HasDeathIndicator = false,
-            };
-
-            PatientModel? cachedPatient = useCache ? patient : null;
-            PatientRequest patientRequest = new(Hdid, useCache);
-
-            Mock<ICacheProvider> cacheProvider = new();
-            cacheProvider.Setup(
-                    p => p.GetItemAsync<PatientModel>(
-                        It.Is<string>(x => x == $"{PatientCacheDomain}:HDID:{Hdid}"),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync(cachedPatient);
-
-            Mock<IPatientIdentityApi> patientIdentityApi = new();
-            patientIdentityApi.Setup(
-                    p => p.GetPatientIdentityAsync(
-                        It.Is<string>(x => x == Hdid),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync(patientIdentity);
-
-            HdidPhsaStrategy hdidPhsaStrategy = GetHdidPhsaStrategy(cacheProvider, patientIdentityApi);
-
-            return new(hdidPhsaStrategy, cacheProvider, patient, patientRequest);
-        }
-
-        private static GetPatientHandlesPhsaApiExceptionMock SetupGetPatientHandlesPhsaApiExceptionMock()
+        private static HdidPhsaStrategy SetupGetPatientHandlesPhsaApiExceptionMock()
         {
             PatientModel? cachedPatient = null;
-            PatientRequest patientRequest = new(PhsaHdidNotFound, false);
-
             Mock<ICacheProvider> cacheProvider = new();
             cacheProvider.Setup(
                     s => s.GetItemAsync<PatientModel>(
@@ -171,20 +171,16 @@ namespace AccountDataAccessTest.Strategy
                         It.IsAny<CancellationToken>()))
                 .Throws(RefitExceptionUtil.CreateApiException(HttpStatusCode.NotFound).Result);
 
-            HdidPhsaStrategy hdidPhsaStrategy = GetHdidPhsaStrategy(cacheProvider, patientIdentityApi);
-
-            return new(hdidPhsaStrategy, typeof(NotFoundException), patientRequest);
+            return new(
+                GetConfiguration(),
+                cacheProvider.Object,
+                patientIdentityApi.Object,
+                new Mock<ILogger<HdidPhsaStrategy>>().Object,
+                Mapper);
         }
 
-        private sealed record GetPatientMock(
+        private sealed record PatientMock(
             HdidPhsaStrategy Strategy,
-            Mock<ICacheProvider> CacheProvider,
-            PatientModel Expected,
-            PatientRequest PatientRequest);
-
-        private sealed record GetPatientHandlesPhsaApiExceptionMock(
-            HdidPhsaStrategy Strategy,
-            Type ExpectedExceptionType,
-            PatientRequest PatientRequest);
+            Mock<ICacheProvider> CacheProvider);
     }
 }

--- a/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
@@ -49,7 +49,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetCommentsAsync()
+        public async Task ShouldGetComments()
         {
             // Arrange
             Comment comment = new()
@@ -78,7 +78,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetNotesAsync()
+        public async Task ShouldGetNotes()
         {
             // Arrange
             Note note = new()
@@ -105,7 +105,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetUserProfilesAsync()
+        public async Task ShouldGetUserProfiles()
         {
             // Arrange
             UserProfile userProfile = new()
@@ -134,7 +134,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetRatingsAsync()
+        public async Task ShouldGetRatings()
         {
             // Arrange
             Rating rating = new()
@@ -162,7 +162,7 @@ namespace HealthGateway.Admin.Tests.Services
         [Theory]
         [InlineData(ResultType.Success)]
         [InlineData(ResultType.Error)]
-        public async Task ShouldGetInactiveUsersAsync(ResultType inactiveUsersResultType)
+        public async Task ShouldGetInactiveUsers(ResultType inactiveUsersResultType)
         {
             // Arrange
             RequestResult<List<AdminUserProfileView>> result = new()
@@ -198,9 +198,19 @@ namespace HealthGateway.Admin.Tests.Services
         /// <summary>
         /// Get user feedback download.
         /// </summary>
+        /// <param name="yearOfBirth">The year of birth of the user associated with the feedback.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetUserFeedbackAsync()
+        [Theory]
+        [InlineData(0)] // yearOfBirth maps to values defined in UserFeedbackCsvMap.GetAgeCohort
+        [InlineData(1927)]
+        [InlineData(1945)]
+        [InlineData(1954)]
+        [InlineData(1964)]
+        [InlineData(1980)]
+        [InlineData(1996)]
+        [InlineData(2012)]
+        [InlineData(2018)]
+        public async Task ShouldGetUserFeedback(int yearOfBirth)
         {
             // Arrange
             Guid adminTagId = Guid.NewGuid();
@@ -221,6 +231,10 @@ namespace HealthGateway.Admin.Tests.Services
                         },
                     },
                 ],
+                UserProfile = new()
+                {
+                    YearOfBirth = yearOfBirth,
+                },
             };
 
             IList<UserFeedback> userFeedbacks = [userFeedback];
@@ -240,7 +254,7 @@ namespace HealthGateway.Admin.Tests.Services
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetYearOfBirthCountsAsync()
+        public async Task ShouldGetYearOfBirthCounts()
         {
             // Arrange
             Dictionary<int, int> getResult = [];

--- a/Apps/ClinicalDocument/src/Controllers/ClinicalDocumentController.cs
+++ b/Apps/ClinicalDocument/src/Controllers/ClinicalDocumentController.cs
@@ -25,7 +25,6 @@ namespace HealthGateway.ClinicalDocument.Controllers
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Data.Models.PHSA;
-    using HealthGateway.Common.Filters;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Extensions.Logging;

--- a/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
+++ b/Apps/ClinicalDocument/test/unit/Services/ClinicalDocumentServiceTests.cs
@@ -65,8 +65,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
 
             IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(
                 expectedPhsaHealthDataResponse,
-                false,
-                canAccessDataSource,
+                canAccessDataSource: canAccessDataSource,
                 personalAccountResultType: personalAccountResultType);
 
             // Act
@@ -102,10 +101,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         public async Task ShouldGetClinicalDocumentRecordsThrowsException()
         {
             // Arrange
-            Guid id = Guid.NewGuid();
-            PhsaHealthDataResponse expectedPhsaHealthDataResponse = GetPhsaHealthDataResponse(id);
-
-            IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, true);
+            IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(throwException: true);
 
             // Act
             RequestResult<IEnumerable<ClinicalDocumentRecord>> actualResult = await clinicalDocumentService.GetRecordsAsync(It.IsAny<string>());
@@ -136,7 +132,11 @@ namespace HealthGateway.ClinicalDocumentTests.Services
             Guid id = Guid.NewGuid();
             PhsaHealthDataResponse expectedPhsaHealthDataResponse = GetPhsaHealthDataResponse(id);
 
-            IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, false, canAccessDatasource, personalAccountExists, personalAccountResultType);
+            IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(
+                expectedPhsaHealthDataResponse,
+                canAccessDataSource: canAccessDatasource,
+                personalAccountExists: personalAccountExists,
+                personalAccountResultType: personalAccountResultType);
 
             if (canAccessDatasource)
             {
@@ -182,10 +182,7 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         public async Task ShouldGetClinicalDocumentFileThrowsException()
         {
             // Arrange
-            Guid id = Guid.NewGuid();
-            PhsaHealthDataResponse expectedPhsaHealthDataResponse = GetPhsaHealthDataResponse(id);
-
-            IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(expectedPhsaHealthDataResponse, true);
+            IClinicalDocumentService clinicalDocumentService = GetClinicalDocumentService(throwException: true);
 
             // Act
             RequestResult<EncodedMedia> actualResult = await clinicalDocumentService.GetFileAsync(It.IsAny<string>(), It.IsAny<string>());
@@ -215,14 +212,14 @@ namespace HealthGateway.ClinicalDocumentTests.Services
         }
 
         private static IClinicalDocumentService GetClinicalDocumentService(
-            PhsaHealthDataResponse content,
-            bool throwException,
+            PhsaHealthDataResponse? content = null,
+            bool throwException = false,
             bool canAccessDataSource = true,
             bool personalAccountExists = true,
             ResultType? personalAccountResultType = ResultType.Success)
         {
             Mock<IClinicalDocumentsApi> clinicalDocumentApiMock = new();
-            if (!throwException)
+            if (!throwException && content != null)
             {
                 clinicalDocumentApiMock.Setup(c => c.GetClinicalDocumentRecordsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(content);
                 clinicalDocumentApiMock.Setup(c => c.GetClinicalDocumentFileAsync(It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(new EncodedMedia());

--- a/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
+++ b/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
@@ -56,14 +56,51 @@ namespace HealthGateway.CommonTests.Auditing
         public void ShouldPopulateWithHttpContext(bool useRouteValues, bool useQueryParamValues)
         {
             // Arrange
-            AuditEvent actual = new();
-            PopulateWithHttpContextMock mock = SetupPopulateWithHttpContextMock(useRouteValues, useQueryParamValues);
+            DefaultHttpContext ctx = new()
+            {
+                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                User = new(new ClaimsIdentity([new Claim("hdid", Hdid), new Claim("preferred_username", Idir)])),
+            };
+
+            if (useRouteValues)
+            {
+                ctx.Request.RouteValues = new RouteValueDictionary
+                {
+                    { "Hdid", RouteHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
+                };
+            }
+
+            if (useQueryParamValues)
+            {
+                ctx.Request.Query = new QueryCollection(
+                    new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        { "Hdid", QueryParamHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
+                    });
+            }
+
+            AuditEvent expected = new()
+            {
+                ApplicationSubject = useRouteValues ? RouteHdid : useQueryParamValues ? QueryParamHdid : Hdid,
+                ApplicationType = ApplicationType.Configuration,
+                ClientIp = "127.0.0.1",
+                CreatedBy = Hdid,
+                Trace = ctx.TraceIdentifier,
+                TransactionName = @"\",
+                TransactionResultCode = AuditTransactionResult.Success,
+                TransactionVersion = string.Empty,
+            };
+
+            Mock<ILogger<DbAuditLogger>> logger = new();
+            Mock<IWriteAuditEventDelegate> dbContext = new();
+            DbAuditLogger dbAuditLogger = new(logger.Object, dbContext.Object);
 
             // Act
-            mock.DbAuditLogger.PopulateWithHttpContext(mock.DefaultHttpContext, actual);
+            AuditEvent actual = new();
+            dbAuditLogger.PopulateWithHttpContext(ctx, actual);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -234,51 +271,5 @@ namespace HealthGateway.CommonTests.Auditing
                     It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
                 Times.Once);
         }
-
-        private static PopulateWithHttpContextMock SetupPopulateWithHttpContextMock(bool useRouteValues, bool useQueryParamValues)
-        {
-            DefaultHttpContext ctx = new()
-            {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
-                User = new(new ClaimsIdentity([new Claim("hdid", Hdid), new Claim("preferred_username", Idir)])),
-            };
-
-            if (useRouteValues)
-            {
-                ctx.Request.RouteValues = new RouteValueDictionary
-                {
-                    { "Hdid", RouteHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
-                };
-            }
-
-            if (useQueryParamValues)
-            {
-                ctx.Request.Query = new QueryCollection(
-                    new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
-                    {
-                        { "Hdid", QueryParamHdid }, // Use Hdid for hdid in HttpContextHelper to check for case insensitivity
-                    });
-            }
-
-            AuditEvent expected = new()
-            {
-                ApplicationSubject = useRouteValues ? RouteHdid : useQueryParamValues ? QueryParamHdid : Hdid,
-                ApplicationType = ApplicationType.Configuration,
-                ClientIp = "127.0.0.1",
-                CreatedBy = Hdid,
-                Trace = ctx.TraceIdentifier,
-                TransactionName = @"\",
-                TransactionResultCode = AuditTransactionResult.Success,
-                TransactionVersion = string.Empty,
-            };
-
-            Mock<ILogger<DbAuditLogger>> logger = new();
-            Mock<IWriteAuditEventDelegate> dbContext = new();
-            DbAuditLogger dbAuditLogger = new(logger.Object, dbContext.Object);
-
-            return new(dbAuditLogger, ctx, expected);
-        }
-
-        private sealed record PopulateWithHttpContextMock(DbAuditLogger DbAuditLogger, DefaultHttpContext DefaultHttpContext, AuditEvent Expected);
     }
 }

--- a/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
+++ b/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
@@ -45,17 +45,24 @@ namespace HealthGateway.CommonTests.Utils
         public void ShouldGetResourceHdid(FhirSubjectLookupMethod lookupMethod)
         {
             // Arrange
-            GetResourceHdidMock mock = SetupGetResourceHdidMock(lookupMethod);
+            string? expected = lookupMethod switch
+            {
+                FhirSubjectLookupMethod.Parameter => QueryParamHdid,
+                FhirSubjectLookupMethod.Route => RouteHdid,
+                _ => null,
+            };
+
+            Mock<HttpContext> httpContextMock = SetupGetResourceHdidMock(lookupMethod);
 
             // Act
-            string? actual = HttpContextHelper.GetResourceHdid(mock.HttpContext, lookupMethod);
+            string? actual = HttpContextHelper.GetResourceHdid(httpContextMock.Object, lookupMethod);
 
             // Assert
-            Assert.Equal(mock.Expected, actual);
+            Assert.Equal(expected, actual);
         }
 
         [SuppressMessage("ReSharper", "SwitchStatementHandlesSomeKnownEnumValuesWithDefault", Justification = "Unknown enum value expected and is handled in mock setup.")]
-        private static GetResourceHdidMock SetupGetResourceHdidMock(FhirSubjectLookupMethod lookupMethod)
+        private static Mock<HttpContext> SetupGetResourceHdidMock(FhirSubjectLookupMethod lookupMethod)
         {
             Mock<HttpRequest> httpRequestMock = new();
 
@@ -87,17 +94,7 @@ namespace HealthGateway.CommonTests.Utils
 
             Mock<HttpContext> httpContextMock = new();
             httpContextMock.Setup(s => s.Request).Returns(httpRequestMock.Object);
-
-            string? expected = lookupMethod switch
-            {
-                FhirSubjectLookupMethod.Parameter => QueryParamHdid,
-                FhirSubjectLookupMethod.Route => RouteHdid,
-                _ => null,
-            };
-
-            return new(httpContextMock.Object, expected);
+            return httpContextMock;
         }
-
-        private sealed record GetResourceHdidMock(HttpContext HttpContext, string Expected);
     }
 }

--- a/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
+++ b/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
@@ -52,7 +52,7 @@ namespace HealthGateway.CommonTests.Utils
                 _ => null,
             };
 
-            Mock<HttpContext> httpContextMock = SetupGetResourceHdidMock(lookupMethod);
+            Mock<HttpContext> httpContextMock = SetupHttpContextForGetResourceHdid(lookupMethod);
 
             // Act
             string? actual = HttpContextHelper.GetResourceHdid(httpContextMock.Object, lookupMethod);
@@ -62,7 +62,7 @@ namespace HealthGateway.CommonTests.Utils
         }
 
         [SuppressMessage("ReSharper", "SwitchStatementHandlesSomeKnownEnumValuesWithDefault", Justification = "Unknown enum value expected and is handled in mock setup.")]
-        private static Mock<HttpContext> SetupGetResourceHdidMock(FhirSubjectLookupMethod lookupMethod)
+        private static Mock<HttpContext> SetupHttpContextForGetResourceHdid(FhirSubjectLookupMethod lookupMethod)
         {
             Mock<HttpRequest> httpRequestMock = new();
 

--- a/Apps/Encounter/src/Controllers/EncounterController.cs
+++ b/Apps/Encounter/src/Controllers/EncounterController.cs
@@ -21,7 +21,6 @@ namespace HealthGateway.Encounter.Controllers
     using Asp.Versioning;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.Encounter.Models;
     using HealthGateway.Encounter.Models.PHSA;
     using HealthGateway.Encounter.Services;

--- a/Apps/GatewayApi/src/Controllers/NoteController.cs
+++ b/Apps/GatewayApi/src/Controllers/NoteController.cs
@@ -21,7 +21,6 @@ namespace HealthGateway.GatewayApi.Controllers
     using Asp.Versioning;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Services;
     using Microsoft.AspNetCore.Authorization;

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserFeedbackControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserFeedbackControllerTests.cs
@@ -126,36 +126,27 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
         public async Task ShouldCreateRating()
         {
             // Arrange
-            CreateRatingMock mock = SetupCreateRatingMock();
-
-            // Act
-            RequestResult<RatingModel> actual = await mock.Controller.CreateRating(mock.Rating, default);
-
-            // Assert
-            actual.ShouldDeepEqual(mock.Expected);
-        }
-
-        private static CreateRatingMock SetupCreateRatingMock()
-        {
             SubmitRating rating = new()
             {
                 RatingValue = 5,
                 Skip = false,
             };
 
-            RequestResult<RatingModel> result = new()
+            RequestResult<RatingModel> expected = new()
             {
                 ResultStatus = ResultType.Success,
                 ResourcePayload = new() { RatingValue = rating.RatingValue, Skip = rating.Skip },
             };
 
             Mock<IUserFeedbackService> userFeedbackServiceMock = new();
-            userFeedbackServiceMock.Setup(s => s.CreateRatingAsync(It.IsAny<SubmitRating>(), It.IsAny<CancellationToken>())).ReturnsAsync(result);
-
+            userFeedbackServiceMock.Setup(s => s.CreateRatingAsync(It.IsAny<SubmitRating>(), It.IsAny<CancellationToken>())).ReturnsAsync(expected);
             UserFeedbackController controller = new(userFeedbackServiceMock.Object);
-            return new(controller, result, rating);
-        }
 
-        private sealed record CreateRatingMock(UserFeedbackController Controller, RequestResult<RatingModel> Expected, SubmitRating Rating);
+            // Act
+            RequestResult<RatingModel> actual = await controller.CreateRating(rating, default);
+
+            // Assert
+            actual.ShouldDeepEqual(expected);
+        }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/ApplicationSettingsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/ApplicationSettingsServiceTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System;
-    using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.CacheProviders;
@@ -40,21 +39,21 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(true)]
         [InlineData(false)]
         [Theory]
-        public async Task ShouldGetLatestTourChangeDateTimeAsync(bool useCache)
+        public async Task ShouldGetLatestTourChangeDateTime(bool useCache)
         {
             // Arrange
-            GetLatestTourChangeDateTimeMock mock = SetupGetLatestTourChangeDateTimeMock(useCache);
+            DateTime expected = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+            IApplicationSettingsService service = SetupGetLatestTourChangeDateTimeMock(useCache, expected);
 
             // Act
-            DateTime? actual = await mock.ApplicationSettingsService.GetLatestTourChangeDateTimeAsync();
+            DateTime? actual = await service.GetLatestTourChangeDateTimeAsync();
 
             // Assert
-            Assert.Equal(mock.Expected, actual);
+            Assert.Equal(expected, actual);
         }
 
-        private static GetLatestTourChangeDateTimeMock SetupGetLatestTourChangeDateTimeMock(bool useCache)
+        private static IApplicationSettingsService SetupGetLatestTourChangeDateTimeMock(bool useCache, DateTime latestTourDate)
         {
-            DateTime latestTourDate = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
             string cacheKey = $"{TourApplicationSettings.Application}:{TourApplicationSettings.Component}:{TourApplicationSettings.LatestChangeDateTime}";
 
             ApplicationSetting applicationSetting = new()
@@ -102,13 +101,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         });
             }
 
-            IApplicationSettingsService applicationSettingsService = new ApplicationSettingsService(
+            return new ApplicationSettingsService(
                 applicationSettingsDelegateMock.Object,
                 cacheProviderMock.Object);
-
-            return new(applicationSettingsService, DateTime.Parse(applicationSetting.Value, CultureInfo.InvariantCulture).ToUniversalTime());
         }
-
-        private sealed record GetLatestTourChangeDateTimeMock(IApplicationSettingsService ApplicationSettingsService, DateTime? Expected);
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/ApplicationSettingsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/ApplicationSettingsServiceTests.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             // Arrange
             DateTime expected = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-            IApplicationSettingsService service = SetupGetLatestTourChangeDateTimeMock(useCache, expected);
+            IApplicationSettingsService service = SetupApplicationSettingsServiceForGetLatestTourChangeDateTime(useCache, expected);
 
             // Act
             DateTime? actual = await service.GetLatestTourChangeDateTimeAsync();
@@ -52,7 +52,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Assert.Equal(expected, actual);
         }
 
-        private static IApplicationSettingsService SetupGetLatestTourChangeDateTimeMock(bool useCache, DateTime latestTourDate)
+        private static IApplicationSettingsService SetupApplicationSettingsServiceForGetLatestTourChangeDateTime(bool useCache, DateTime latestTourDate)
         {
             string cacheKey = $"{TourApplicationSettings.Application}:{TourApplicationSettings.Component}:{TourApplicationSettings.LatestChangeDateTime}";
 

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -18,7 +18,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.Constants;
@@ -331,7 +330,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Times expectedQueueEmailCalls = isHdidMonitored && isAdminEmailAddressPopulated ? Times.Once() : Times.Never();
             mockEmailQueueService
-                .Verify(m => m.QueueNewEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), expectedQueueEmailCalls);
+                .Verify(
+                    m => m.QueueNewEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+                    expectedQueueEmailCalls);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Services.Test/GatewayApiCommunicationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/GatewayApiCommunicationServiceTests.cs
@@ -112,6 +112,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             actual.ShouldDeepEqual(expected);
         }
 
+        private static IGatewayApiCommunicationService GetGatewayApiCommunicationService(Mock<ICommunicationService> communicationServiceMock)
+        {
+            return new GatewayApiCommunicationService(communicationServiceMock.Object, MappingService);
+        }
+
         private static IGatewayApiCommunicationService SetupGetActiveCommunicationMock(
             Guid id,
             string text,
@@ -134,7 +139,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             communicationServiceMock.Setup(s => s.GetActiveCommunicationAsync(It.Is<Common.Data.Constants.CommunicationType>(x => x == sourceCommunicationType), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
-            return new GatewayApiCommunicationService(communicationServiceMock.Object, MappingService);
+            return GetGatewayApiCommunicationService(communicationServiceMock);
         }
 
         private static IGatewayApiCommunicationService SetupGetActiveCommunicationReturnsErrorMock(string errorMessage)
@@ -152,7 +157,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             communicationServiceMock.Setup(s => s.GetActiveCommunicationAsync(It.IsAny<Common.Data.Constants.CommunicationType>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(requestResult);
 
-            return new GatewayApiCommunicationService(communicationServiceMock.Object, MappingService);
+            return GetGatewayApiCommunicationService(communicationServiceMock);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/GatewayApiCommunicationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/GatewayApiCommunicationServiceTests.cs
@@ -103,7 +103,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     ResultMessage = errorMessage,
                 },
             };
-            IGatewayApiCommunicationService service = SetupGetActiveCommunicationReturnsErrorMock(errorMessage);
+            IGatewayApiCommunicationService service = SetupGatewayApiCommunicationServiceForGetActiveCommunicationReturnsError(errorMessage);
 
             // Act
             RequestResult<CommunicationModel> actual = await service.GetActiveCommunicationAsync(CommunicationType.Banner);
@@ -142,7 +142,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetGatewayApiCommunicationService(communicationServiceMock);
         }
 
-        private static IGatewayApiCommunicationService SetupGetActiveCommunicationReturnsErrorMock(string errorMessage)
+        private static IGatewayApiCommunicationService SetupGatewayApiCommunicationServiceForGetActiveCommunicationReturnsError(string errorMessage)
         {
             RequestResult<Communication?> requestResult = new()
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/LegalAgreementServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/LegalAgreementServiceTests.cs
@@ -73,7 +73,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     },
             };
 
-            ILegalAgreementService service = SetupGetActiveTermsOfServiceMock(legalAgreement);
+            ILegalAgreementService service = SetupLegalAgreementServiceForGetActiveLegalAgreementId(legalAgreement);
 
             // Act
             RequestResult<TermsOfServiceModel> actual = await service.GetActiveTermsOfServiceAsync();
@@ -105,7 +105,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 }
                 : null;
 
-            ILegalAgreementService service = SetupGetActiveTermsOfServiceMock(legalAgreement);
+            ILegalAgreementService service = SetupLegalAgreementServiceForGetActiveLegalAgreementId(legalAgreement);
 
             // Act
             Guid? actual = await service.GetActiveLegalAgreementId(LegalAgreementType.TermsOfService);
@@ -114,7 +114,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             actual.ShouldDeepEqual(expected);
         }
 
-        private static ILegalAgreementService SetupGetActiveTermsOfServiceMock(LegalAgreement legalAgreement)
+        private static ILegalAgreementService SetupLegalAgreementServiceForGetActiveLegalAgreementId(LegalAgreement legalAgreement)
         {
             Mock<ILegalAgreementDelegate> legalAgreementDelegateMock = new();
             legalAgreementDelegateMock.Setup(

--- a/Apps/GatewayApi/test/unit/Services.Test/LegalAgreementServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/LegalAgreementServiceV2Tests.cs
@@ -48,7 +48,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Arrange
             LegalAgreement? legalAgreement = GenerateLegalAgreement();
             TermsOfServiceModel expected = MappingService.MapToTermsOfServiceModel(legalAgreement);
-            ILegalAgreementServiceV2 service = SetupGetActiveTermsOfServiceMock(legalAgreement);
+            ILegalAgreementServiceV2 service = SetupLegalAgreementServiceV2ForGetActiveLegalAgreementId(legalAgreement);
 
             // Act
             TermsOfServiceModel actual = await service.GetActiveTermsOfServiceAsync();
@@ -66,7 +66,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             // Arrange
             LegalAgreement? legalAgreement = null; // This will cause a DatabaseException to be thrown.
-            ILegalAgreementServiceV2 service = SetupGetActiveTermsOfServiceMock(legalAgreement);
+            ILegalAgreementServiceV2 service = SetupLegalAgreementServiceV2ForGetActiveLegalAgreementId(legalAgreement);
             Type expected = typeof(DatabaseException);
 
             // Act and Assert
@@ -88,7 +88,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Arrange
             LegalAgreement? legalAgreement = GenerateLegalAgreement(legalAgreementFound);
             Guid? expected = legalAgreement?.Id;
-            ILegalAgreementServiceV2 service = SetupGetActiveTermsOfServiceMock(legalAgreement);
+            ILegalAgreementServiceV2 service = SetupLegalAgreementServiceV2ForGetActiveLegalAgreementId(legalAgreement);
 
             // Act
             Guid? actual = await service.GetActiveLegalAgreementId(LegalAgreementType.TermsOfService);
@@ -110,7 +110,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 : null;
         }
 
-        private static ILegalAgreementServiceV2 SetupGetActiveTermsOfServiceMock(LegalAgreement? legalAgreement)
+        private static ILegalAgreementServiceV2 SetupLegalAgreementServiceV2ForGetActiveLegalAgreementId(LegalAgreement? legalAgreement)
         {
             Mock<ILegalAgreementDelegate> legalAgreementDelegateMock = new();
             legalAgreementDelegateMock.Setup(

--- a/Apps/GatewayApi/test/unit/Services.Test/PatientDetailsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/PatientDetailsServiceTests.cs
@@ -141,6 +141,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
         }
 
+        private static IPatientDetailsService GetPatientDetailsService(Mock<IPatientRepository> patientRepositoryMock)
+        {
+            return new PatientDetailsService(
+                MappingService,
+                new Mock<ILogger<PatientDetailsService>>().Object,
+                patientRepositoryMock.Object);
+        }
+
         private static IPatientDetailsService SetupGetPatientMock(PatientModel patientModel, string identifier, PatientIdentifierType identifierType)
         {
             PatientDetailsQuery query = identifierType == PatientIdentifierType.Hdid
@@ -156,10 +164,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patientQueryResult);
 
-            return new PatientDetailsService(
-                MappingService,
-                new Mock<ILogger<PatientDetailsService>>().Object,
-                patientRepositoryMock.Object);
+            return GetPatientDetailsService(patientRepositoryMock);
         }
 
         private static IPatientDetailsService SetupGetPatientThrowsInvalidDataExceptionMock(
@@ -179,10 +184,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patientQueryResult);
 
-            return new PatientDetailsService(
-                MappingService,
-                new Mock<ILogger<PatientDetailsService>>().Object,
-                patientRepositoryMock.Object);
+            return GetPatientDetailsService(patientRepositoryMock);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/PatientDetailsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/PatientDetailsServiceTests.cs
@@ -60,7 +60,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 CommonName = patient.CommonName,
                 LegalName = patient.LegalName,
             };
-            IPatientDetailsService service = SetupGetPatientMock(patient, identifier, identifierType);
+            IPatientDetailsService service = SetupPatientDetailsServiceForGetPatient(patient, identifier, identifierType);
 
             // Act
             PatientDetails actual = await service.GetPatientAsync(identifier, identifierType);
@@ -91,7 +91,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             bool legalNameExists)
         {
             // Arrange
-            IPatientDetailsService service = SetupGetPatientThrowsInvalidDataExceptionMock(hdidExists, phnExists, commonNameExists, legalNameExists);
+            IPatientDetailsService service = SetupPatientDetailsServiceForGetPatientThrowsInvalidDataException(hdidExists, phnExists, commonNameExists, legalNameExists);
             bool shouldThrowException = (!hdidExists && !phnExists) || (!commonNameExists && !legalNameExists);
 
             // Act and Assert
@@ -149,7 +149,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 patientRepositoryMock.Object);
         }
 
-        private static IPatientDetailsService SetupGetPatientMock(PatientModel patientModel, string identifier, PatientIdentifierType identifierType)
+        private static IPatientDetailsService SetupPatientDetailsServiceForGetPatient(PatientModel patientModel, string identifier, PatientIdentifierType identifierType)
         {
             PatientDetailsQuery query = identifierType == PatientIdentifierType.Hdid
                 ? new PatientDetailsQuery(Hdid: identifier, Source: PatientDetailSource.Empi, UseCache: true)
@@ -167,7 +167,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetPatientDetailsService(patientRepositoryMock);
         }
 
-        private static IPatientDetailsService SetupGetPatientThrowsInvalidDataExceptionMock(
+        private static IPatientDetailsService SetupPatientDetailsServiceForGetPatientThrowsInvalidDataException(
             bool hdidExists,
             bool phnExists,
             bool commonNameExists,

--- a/Apps/GatewayApi/test/unit/Services.Test/RegistrationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/RegistrationServiceTests.cs
@@ -150,7 +150,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Profile = new(Hdid, Guid.NewGuid(), requestedSmsNumber, EmailAddress),
             };
 
-            IRegistrationService service = SetupCreateUserProfileThrowsExceptionMock(
+            IRegistrationService service = SetupRegistrationServiceForCreateUserProfileThrowsException(
                 requestedSmsNumber,
                 minPatientAge,
                 patientAge,
@@ -488,7 +488,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 jobServiceMock);
         }
 
-        private static IRegistrationService SetupCreateUserProfileThrowsExceptionMock(
+        private static IRegistrationService SetupRegistrationServiceForCreateUserProfileThrowsException(
             string? requestedSmsNumber,
             int minPatientAge,
             int patientAge,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
@@ -178,6 +178,29 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return cryptoDelegateMock;
         }
 
+        private static IUserFeedbackService GetUserFeedbackService(
+            Mock<IFeedbackDelegate>? feedbackDelegateMock = null,
+            Mock<IRatingDelegate>? ratingDelegateMock = null,
+            Mock<IUserProfileDelegate>? userProfileDelegateMock = null,
+            Mock<IBackgroundJobClient>? backgroundJobClientMock = null,
+            Mock<IAuthenticationDelegate>? authenticationDelegateMock = null)
+        {
+            feedbackDelegateMock ??= new();
+            ratingDelegateMock ??= new();
+            userProfileDelegateMock ??= new();
+            backgroundJobClientMock ??= new();
+            authenticationDelegateMock ??= new();
+
+            return new UserFeedbackService(
+                new Mock<ILogger<UserFeedbackService>>().Object,
+                feedbackDelegateMock.Object,
+                ratingDelegateMock.Object,
+                userProfileDelegateMock.Object,
+                backgroundJobClientMock.Object,
+                MappingService,
+                authenticationDelegateMock.Object);
+        }
+
         private static IUserFeedbackService SetupCreateRatingMock(DbResult<Rating> dbResult, SubmitRating createRating)
         {
             Mock<IRatingDelegate> ratingDelegateMock = new();
@@ -187,14 +210,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
-            return new UserFeedbackService(
-                new Mock<ILogger<UserFeedbackService>>().Object,
-                new Mock<IFeedbackDelegate>().Object,
-                ratingDelegateMock.Object,
-                new Mock<IUserProfileDelegate>().Object,
-                new Mock<IBackgroundJobClient>().Object,
-                MappingService,
-                new Mock<IAuthenticationDelegate>().Object);
+            return GetUserFeedbackService(ratingDelegateMock: ratingDelegateMock);
         }
 
         private static IUserFeedbackService SetupCreateUserFeedbackMock(DbResult<UserFeedback> dbResult, UserFeedback createUserFeedback)
@@ -226,14 +242,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.FetchAuthenticatedUserClientType())
                 .Returns(DefaultClientType);
 
-            return new UserFeedbackService(
-                new Mock<ILogger<UserFeedbackService>>().Object,
-                userFeedbackDelegateMock.Object,
-                new Mock<IRatingDelegate>().Object,
-                userProfileDelegateMock.Object,
-                new Mock<IBackgroundJobClient>().Object,
-                MappingService,
-                authenticationDelegateMock.Object);
+            return GetUserFeedbackService(
+                userFeedbackDelegateMock,
+                userProfileDelegateMock: userProfileDelegateMock,
+                authenticationDelegateMock: authenticationDelegateMock);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserFeedbackServiceTests.cs
@@ -83,7 +83,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 ResourcePayload = new() { Id = ratingId, RatingValue = rating.RatingValue, Skip = rating.Skip },
             };
 
-            IUserFeedbackService service = SetupCreateRatingMock(createRatingResult, createRating);
+            IUserFeedbackService service = SetupUserFeedbackServiceForCreateRating(createRatingResult, createRating);
 
             // Act
             RequestResult<RatingModel> actual = await service.CreateRatingAsync(createRating);
@@ -124,7 +124,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 },
             };
 
-            IUserFeedbackService service = SetupCreateRatingMock(createRatingResult, createRating);
+            IUserFeedbackService service = SetupUserFeedbackServiceForCreateRating(createRatingResult, createRating);
 
             // Act
             RequestResult<RatingModel> actual = await service.CreateRatingAsync(createRating);
@@ -160,7 +160,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Status = DbStatusCode.Created,
             };
 
-            IUserFeedbackService service = SetupCreateUserFeedbackMock(expected, createUserFeedback);
+            IUserFeedbackService service = SetupUserFeedbackServiceForCreateUserFeedback(expected, createUserFeedback);
 
             // Act
             DbResult<UserFeedback> actual = await service.CreateUserFeedbackAsync(feedback, Hdid);
@@ -201,7 +201,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 authenticationDelegateMock.Object);
         }
 
-        private static IUserFeedbackService SetupCreateRatingMock(DbResult<Rating> dbResult, SubmitRating createRating)
+        private static IUserFeedbackService SetupUserFeedbackServiceForCreateRating(DbResult<Rating> dbResult, SubmitRating createRating)
         {
             Mock<IRatingDelegate> ratingDelegateMock = new();
             ratingDelegateMock.Setup(
@@ -213,7 +213,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetUserFeedbackService(ratingDelegateMock: ratingDelegateMock);
         }
 
-        private static IUserFeedbackService SetupCreateUserFeedbackMock(DbResult<UserFeedback> dbResult, UserFeedback createUserFeedback)
+        private static IUserFeedbackService SetupUserFeedbackServiceForCreateUserFeedback(DbResult<UserFeedback> dbResult, UserFeedback createUserFeedback)
         {
             UserProfile profile = new()
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
@@ -43,69 +43,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         private static readonly IGatewayApiMappingService MappingService = new GatewayApiMappingService(MapperUtil.InitializeAutoMapper(), new Mock<ICryptoDelegate>().Object);
 
         /// <summary>
-        /// CreateUserPreferenceAsync call.
+        /// CreateUserPreferenceAsync.
         /// </summary>
-        /// <param name="dBStatusCode">dBStatusCode.</param>
+        /// <param name="dbStatusCode">dBStatusCode.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
         [InlineData(DbStatusCode.Created)]
         [InlineData(DbStatusCode.Error)]
-        public async Task ShouldCreateUserPreferenceAsync(DbStatusCode dBStatusCode)
+        public async Task ShouldCreateUserPreference(DbStatusCode dbStatusCode)
         {
             // Arrange
-            CreateUserPreferenceMock mock = SetupCreateUserPreferenceMock(dBStatusCode);
-
-            // Act
-            RequestResult<UserPreferenceModel> actual = await mock.Service.CreateUserPreferenceAsync(mock.UserPreferenceModel);
-
-            // Assert
-            actual.ShouldDeepEqual(mock.Expected);
-        }
-
-        /// <summary>
-        /// UpdateUserPreferenceAsync call.
-        /// </summary>
-        /// <param name="dBStatusCode">dBStatusCode.</param>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Theory]
-        [InlineData(DbStatusCode.Updated)]
-        [InlineData(DbStatusCode.Error)]
-        public async Task ShouldUpdateUserPreferenceAsync(DbStatusCode dBStatusCode)
-        {
-            // Arrange
-            UpdateUserPreferenceMock mock = SetupUpdateUserPreferenceMock(dBStatusCode);
-
-            // Act
-            RequestResult<UserPreferenceModel> actual = await mock.Service.UpdateUserPreferenceAsync(mock.UserPreferenceModel);
-
-            // Assert
-            actual.ShouldDeepEqual(mock.Expected);
-        }
-
-        /// <summary>
-        /// GetUserPreferenceAsync call.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetUserPreferencesAsync()
-        {
-            // Arrange
-            GetUserPreferenceMock mock = SetupGetUserPreferenceMock();
-
-            // Act
-            Dictionary<string, UserPreferenceModel> actual = await mock.Service.GetUserPreferencesAsync(mock.Hdid);
-
-            // Assert
-            actual.ShouldDeepEqual(mock.Expected);
-        }
-
-        private static IUserPreferenceService GetUserPreferenceService(IMock<IUserPreferenceDelegate> userPreferenceDelegateMock)
-        {
-            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
-        }
-
-        private static UserPreferenceMock SetupUserPreferenceMock(DbStatusCode action, DbStatusCode dbStatusCode)
-        {
             UserPreferenceModel userPreferenceModel = new()
             {
                 HdId = Hdid,
@@ -115,7 +62,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             UserPreference userPreference = MappingService.MapToUserPreference(userPreferenceModel);
 
-            DbResult<UserPreference> dbResult = new()
+            DbResult<UserPreference> createUserPreferenceResult = new()
             {
                 Payload = userPreference,
                 Status = dbStatusCode,
@@ -124,8 +71,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             RequestResult<UserPreferenceModel> expected = new()
             {
-                ResultStatus = dbStatusCode == action ? ResultType.Success : ResultType.Error,
-                ResourcePayload = dbStatusCode == action ? userPreferenceModel : null,
+                ResultStatus = dbStatusCode == DbStatusCode.Created ? ResultType.Success : ResultType.Error,
+                ResourcePayload = dbStatusCode == DbStatusCode.Created ? userPreferenceModel : null,
                 ResultError = dbStatusCode == DbStatusCode.Error
                     ? new()
                     {
@@ -135,35 +82,72 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     : null,
             };
 
-            return new(expected, userPreference, dbResult, userPreferenceModel);
+            IUserPreferenceService service = SetupCreateUserPreferenceMock(createUserPreferenceResult, userPreference);
+
+            // Act
+            RequestResult<UserPreferenceModel> actual = await service.CreateUserPreferenceAsync(userPreferenceModel);
+
+            // Assert
+            actual.ShouldDeepEqual(expected);
         }
 
-        private static CreateUserPreferenceMock SetupCreateUserPreferenceMock(DbStatusCode dbStatusCode)
+        /// <summary>
+        /// UpdateUserPreferenceAsync.
+        /// </summary>
+        /// <param name="dbStatusCode">dBStatusCode.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(DbStatusCode.Updated)]
+        [InlineData(DbStatusCode.Error)]
+        public async Task ShouldUpdateUserPreference(DbStatusCode dbStatusCode)
         {
-            UserPreferenceMock mock = SetupUserPreferenceMock(DbStatusCode.Created, dbStatusCode);
-            Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
-            userPreferenceDelegateMock.Setup(
-                    s => s.CreateUserPreferenceAsync(It.Is<UserPreference>(x => x.Preference == mock.UserPreference.Preference), It.Is<bool>(x => x == true), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(mock.DbResult);
+            // Arrange
+            UserPreferenceModel userPreferenceModel = new()
+            {
+                HdId = Hdid,
+                Preference = "TutorialPopover",
+                Value = "mocked value",
+            };
 
-            IUserPreferenceService service = GetUserPreferenceService(userPreferenceDelegateMock);
-            return new(service, mock.Expected, mock.UserPreferenceModel);
+            UserPreference userPreference = MappingService.MapToUserPreference(userPreferenceModel);
+
+            DbResult<UserPreference> updateUserPreferenceResult = new()
+            {
+                Payload = userPreference,
+                Status = dbStatusCode,
+                Message = dbStatusCode == DbStatusCode.Error ? "DB Error" : string.Empty,
+            };
+
+            RequestResult<UserPreferenceModel> expected = new()
+            {
+                ResultStatus = dbStatusCode == DbStatusCode.Updated ? ResultType.Success : ResultType.Error,
+                ResourcePayload = dbStatusCode == DbStatusCode.Updated ? userPreferenceModel : null,
+                ResultError = dbStatusCode == DbStatusCode.Error
+                    ? new()
+                    {
+                        ResultMessage = "DB Error",
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                    }
+                    : null,
+            };
+
+            IUserPreferenceService service = SetupUpdateUserPreferenceMock(updateUserPreferenceResult, userPreference);
+
+            // Act
+            RequestResult<UserPreferenceModel> actual = await service.UpdateUserPreferenceAsync(userPreferenceModel);
+
+            // Assert
+            actual.ShouldDeepEqual(expected);
         }
 
-        private static UpdateUserPreferenceMock SetupUpdateUserPreferenceMock(DbStatusCode dbStatusCode)
+        /// <summary>
+        /// GetUserPreferenceAsync.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ShouldGetUserPreferences()
         {
-            UserPreferenceMock mock = SetupUserPreferenceMock(DbStatusCode.Updated, dbStatusCode);
-            Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
-            userPreferenceDelegateMock.Setup(
-                    s => s.UpdateUserPreferenceAsync(It.Is<UserPreference>(x => x.Preference == mock.UserPreference.Preference), It.Is<bool>(x => x == true), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(mock.DbResult);
-
-            IUserPreferenceService service = GetUserPreferenceService(userPreferenceDelegateMock);
-            return new(service, mock.Expected, mock.UserPreferenceModel);
-        }
-
-        private static GetUserPreferenceMock SetupGetUserPreferenceMock()
-        {
+            // Arrange
             UserPreference userPreference = new()
             {
                 HdId = Hdid,
@@ -174,25 +158,49 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             List<UserPreference> preferences = [userPreference];
             Dictionary<string, UserPreferenceModel> expected = preferences.Select(MappingService.MapToUserPreferenceModel).ToDictionary(x => x.Preference, x => x);
 
+            IUserPreferenceService service = SetupGetUserPreferenceMock(preferences);
+
+            // Act
+            Dictionary<string, UserPreferenceModel> actual = await service.GetUserPreferencesAsync(Hdid);
+
+            // Assert
+            actual.ShouldDeepEqual(expected);
+        }
+
+        private static IUserPreferenceService SetupCreateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference userPreference)
+        {
+            Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
+            userPreferenceDelegateMock.Setup(
+                    s => s.CreateUserPreferenceAsync(
+                        It.Is<UserPreference>(x => x.Preference == userPreference.Preference),
+                        It.Is<bool>(x => x == true),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbResult);
+
+            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
+        }
+
+        private static IUserPreferenceService SetupUpdateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference userPreference)
+        {
+            Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
+            userPreferenceDelegateMock.Setup(
+                    s => s.UpdateUserPreferenceAsync(
+                        It.Is<UserPreference>(x => x.Preference == userPreference.Preference),
+                        It.Is<bool>(x => x == true),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbResult);
+
+            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
+        }
+
+        private static IUserPreferenceService SetupGetUserPreferenceMock(List<UserPreference> preferences)
+        {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(
                     s => s.GetUserPreferencesAsync(It.Is<string>(x => x == Hdid), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(preferences);
 
-            IUserPreferenceService service = GetUserPreferenceService(userPreferenceDelegateMock);
-            return new(service, expected, Hdid);
+            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
         }
-
-        private sealed record UserPreferenceMock(
-            RequestResult<UserPreferenceModel> Expected,
-            UserPreference UserPreference,
-            DbResult<UserPreference> DbResult,
-            UserPreferenceModel UserPreferenceModel);
-
-        private sealed record CreateUserPreferenceMock(IUserPreferenceService Service, RequestResult<UserPreferenceModel> Expected, UserPreferenceModel UserPreferenceModel);
-
-        private sealed record UpdateUserPreferenceMock(IUserPreferenceService Service, RequestResult<UserPreferenceModel> Expected, UserPreferenceModel UserPreferenceModel);
-
-        private sealed record GetUserPreferenceMock(IUserPreferenceService Service, Dictionary<string, UserPreferenceModel> Expected, string Hdid);
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
@@ -82,7 +82,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     : null,
             };
 
-            IUserPreferenceService service = SetupCreateUserPreferenceMock(createUserPreferenceResult, userPreference);
+            IUserPreferenceService service = SetupUserPreferenceServiceForCreateUserPreference(createUserPreferenceResult, userPreference);
 
             // Act
             RequestResult<UserPreferenceModel> actual = await service.CreateUserPreferenceAsync(userPreferenceModel);
@@ -131,7 +131,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     : null,
             };
 
-            IUserPreferenceService service = SetupUpdateUserPreferenceMock(updateUserPreferenceResult, userPreference);
+            IUserPreferenceService service = SetupUserPreferenceServiceForUpdateUserPreference(updateUserPreferenceResult, userPreference);
 
             // Act
             RequestResult<UserPreferenceModel> actual = await service.UpdateUserPreferenceAsync(userPreferenceModel);
@@ -158,7 +158,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             List<UserPreference> preferences = [userPreference];
             Dictionary<string, UserPreferenceModel> expected = preferences.Select(MappingService.MapToUserPreferenceModel).ToDictionary(x => x.Preference, x => x);
 
-            IUserPreferenceService service = SetupGetUserPreferenceMock(preferences);
+            IUserPreferenceService service = SetupUserPreferenceServiceForGetUserPreference(preferences);
 
             // Act
             Dictionary<string, UserPreferenceModel> actual = await service.GetUserPreferencesAsync(Hdid);
@@ -175,7 +175,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 new Mock<ILogger<UserPreferenceService>>().Object);
         }
 
-        private static IUserPreferenceService SetupCreateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference userPreference)
+        private static IUserPreferenceService SetupUserPreferenceServiceForCreateUserPreference(DbResult<UserPreference> dbResult, UserPreference userPreference)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(
@@ -188,7 +188,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
-        private static IUserPreferenceService SetupUpdateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference userPreference)
+        private static IUserPreferenceService SetupUserPreferenceServiceForUpdateUserPreference(DbResult<UserPreference> dbResult, UserPreference userPreference)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(
@@ -201,7 +201,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
-        private static IUserPreferenceService SetupGetUserPreferenceMock(List<UserPreference> preferences)
+        private static IUserPreferenceService SetupUserPreferenceServiceForGetUserPreference(List<UserPreference> preferences)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
@@ -167,6 +167,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             actual.ShouldDeepEqual(expected);
         }
 
+        private static IUserPreferenceService GetUserPreferenceService(IMock<IUserPreferenceDelegate> userPreferenceDelegateMock)
+        {
+            return new UserPreferenceService(
+                userPreferenceDelegateMock.Object,
+                MappingService,
+                new Mock<ILogger<UserPreferenceService>>().Object);
+        }
+
         private static IUserPreferenceService SetupCreateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference userPreference)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
@@ -177,7 +185,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
-            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
+            return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
         private static IUserPreferenceService SetupUpdateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference userPreference)
@@ -190,7 +198,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
-            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
+            return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
         private static IUserPreferenceService SetupGetUserPreferenceMock(List<UserPreference> preferences)
@@ -200,7 +208,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetUserPreferencesAsync(It.Is<string>(x => x == Hdid), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(preferences);
 
-            return new UserPreferenceService(userPreferenceDelegateMock.Object, MappingService, new Mock<ILogger<UserPreferenceService>>().Object);
+            return GetUserPreferenceService(userPreferenceDelegateMock);
         }
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Status = DbStatusCode.Created,
             };
 
-            IUserPreferenceServiceV2 service = SetupCreateUserPreferenceMock(dbResult, createUserPreference);
+            IUserPreferenceServiceV2 service = SetupUserPreferenceServiceForCreateUserPreference(dbResult, createUserPreference);
 
             // Act
             UserPreferenceModel actual = await service.CreateUserPreferenceAsync(Hdid, expected);
@@ -85,7 +85,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Message = "DB Error",
             };
 
-            IUserPreferenceServiceV2 service = SetupCreateUserPreferenceMock(expected, createUserPreference);
+            IUserPreferenceServiceV2 service = SetupUserPreferenceServiceForCreateUserPreference(expected, createUserPreference);
 
             // Act and Assert
             DatabaseException actual = await Assert.ThrowsAsync<DatabaseException>(
@@ -110,7 +110,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Status = DbStatusCode.Updated,
             };
 
-            IUserPreferenceServiceV2 service = SetupUpdateUserPreferenceMock(dbResult, updateUserPreference);
+            IUserPreferenceServiceV2 service = SetupUserPreferenceServiceForUpdateUserPreference(dbResult, updateUserPreference);
 
             // Act
             UserPreferenceModel actual = await service.UpdateUserPreferenceAsync(Hdid, expected);
@@ -137,7 +137,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Message = "DB Error",
             };
 
-            IUserPreferenceServiceV2 service = SetupUpdateUserPreferenceMock(expected, updateUserPreference);
+            IUserPreferenceServiceV2 service = SetupUserPreferenceServiceForUpdateUserPreference(expected, updateUserPreference);
 
             // Act and Assert
             DatabaseException actual = await Assert.ThrowsAsync<DatabaseException>(
@@ -155,7 +155,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Arrange
             List<UserPreference> preferences = [GenerateUserPreference()];
             Dictionary<string, UserPreferenceModel> expected = preferences.Select(MappingService.MapToUserPreferenceModel).ToDictionary(x => x.Preference, x => x);
-            IUserPreferenceServiceV2 service = SetupGetUserPreferencesMock(preferences);
+            IUserPreferenceServiceV2 service = SetupUserPreferenceServiceForGetUserPreference(preferences);
 
             // Act
             Dictionary<string, UserPreferenceModel> actual = await service.GetUserPreferencesAsync(Hdid);
@@ -194,7 +194,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
         }
 
-        private static IUserPreferenceServiceV2 SetupCreateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference createUserPreference)
+        private static IUserPreferenceServiceV2 SetupUserPreferenceServiceForCreateUserPreference(DbResult<UserPreference> dbResult, UserPreference createUserPreference)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(
@@ -214,7 +214,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
-        private static IUserPreferenceServiceV2 SetupUpdateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference updateUserPreference)
+        private static IUserPreferenceServiceV2 SetupUserPreferenceServiceForUpdateUserPreference(DbResult<UserPreference> dbResult, UserPreference updateUserPreference)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
 
@@ -228,7 +228,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
-        private static IUserPreferenceServiceV2 SetupGetUserPreferencesMock(List<UserPreference> preferences)
+        private static IUserPreferenceServiceV2 SetupUserPreferenceServiceForGetUserPreference(List<UserPreference> preferences)
         {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
@@ -42,18 +42,26 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         private static readonly IGatewayApiMappingService MappingService = new GatewayApiMappingService(MapperUtil.InitializeAutoMapper(), new Mock<ICryptoDelegate>().Object);
 
         /// <summary>
-        /// CreateUserPreferenceAsync call.
+        /// CreateUserPreferenceAsync.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldCreateUserPreferenceAsync()
+        public async Task ShouldCreateUserPreference()
         {
             // Arrange
             UserPreferenceModel expected = GenerateUserPreferenceModel();
-            UserPreferenceMock mock = SetupUserPreferenceMock(DbStatusCode.Created);
+            UserPreference createUserPreference = MappingService.MapToUserPreference(expected);
+
+            DbResult<UserPreference> dbResult = new()
+            {
+                Payload = createUserPreference,
+                Status = DbStatusCode.Created,
+            };
+
+            IUserPreferenceServiceV2 service = SetupCreateUserPreferenceMock(dbResult, createUserPreference);
 
             // Act
-            UserPreferenceModel actual = await mock.Service.CreateUserPreferenceAsync(mock.Hdid, mock.UserPreferenceModel);
+            UserPreferenceModel actual = await service.CreateUserPreferenceAsync(Hdid, expected);
 
             // Assert
             actual.ShouldDeepEqual(expected);
@@ -67,11 +75,22 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task CreateUserPreferenceAsyncThrowsException()
         {
             // Arrange
-            UserPreferenceMock mock = SetupUserPreferenceMock(DbStatusCode.Error);
+            UserPreferenceModel userPreferenceModel = GenerateUserPreferenceModel();
+            UserPreference createUserPreference = MappingService.MapToUserPreference(userPreferenceModel);
+
+            DbResult<UserPreference> expected = new()
+            {
+                Payload = createUserPreference,
+                Status = DbStatusCode.Error,
+                Message = "DB Error",
+            };
+
+            IUserPreferenceServiceV2 service = SetupCreateUserPreferenceMock(expected, createUserPreference);
 
             // Act and Assert
-            await Assert.ThrowsAsync<DatabaseException>(
-                async () => { await mock.Service.CreateUserPreferenceAsync(mock.Hdid, mock.UserPreferenceModel); });
+            DatabaseException actual = await Assert.ThrowsAsync<DatabaseException>(
+                async () => { await service.CreateUserPreferenceAsync(Hdid, userPreferenceModel); });
+            Assert.Equal(expected.Message, actual.Message);
         }
 
         /// <summary>
@@ -83,10 +102,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             // Arrange
             UserPreferenceModel expected = GenerateUserPreferenceModel();
-            UserPreferenceMock mock = SetupUserPreferenceMock(DbStatusCode.Updated);
+            UserPreference updateUserPreference = MappingService.MapToUserPreference(expected);
+
+            DbResult<UserPreference> dbResult = new()
+            {
+                Payload = updateUserPreference,
+                Status = DbStatusCode.Updated,
+            };
+
+            IUserPreferenceServiceV2 service = SetupUpdateUserPreferenceMock(dbResult, updateUserPreference);
 
             // Act
-            UserPreferenceModel actual = await mock.Service.UpdateUserPreferenceAsync(mock.Hdid, mock.UserPreferenceModel);
+            UserPreferenceModel actual = await service.UpdateUserPreferenceAsync(Hdid, expected);
 
             // Assert
             actual.ShouldDeepEqual(expected);
@@ -100,27 +127,38 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task UpdateUserPreferenceAsyncThrowsDatabaseException()
         {
             // Arrange
-            UserPreferenceMock mock = SetupUserPreferenceMock(DbStatusCode.Error);
+            UserPreferenceModel userPreferenceModel = GenerateUserPreferenceModel();
+            UserPreference updateUserPreference = MappingService.MapToUserPreference(userPreferenceModel);
+
+            DbResult<UserPreference> expected = new()
+            {
+                Payload = updateUserPreference,
+                Status = DbStatusCode.Error,
+                Message = "DB Error",
+            };
+
+            IUserPreferenceServiceV2 service = SetupUpdateUserPreferenceMock(expected, updateUserPreference);
 
             // Act and Assert
-            await Assert.ThrowsAsync<DatabaseException>(
-                async () => { await mock.Service.UpdateUserPreferenceAsync(mock.Hdid, mock.UserPreferenceModel); });
+            DatabaseException actual = await Assert.ThrowsAsync<DatabaseException>(
+                async () => { await service.UpdateUserPreferenceAsync(Hdid, userPreferenceModel); });
+            Assert.Equal(expected.Message, actual.Message);
         }
 
         /// <summary>
-        /// GetUserPreferenceAsync call.
+        /// GetUserPreferenceAsync.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldGetUserPreferencesAsync()
+        public async Task ShouldGetUserPreferences()
         {
             // Arrange
             List<UserPreference> preferences = [GenerateUserPreference()];
             Dictionary<string, UserPreferenceModel> expected = preferences.Select(MappingService.MapToUserPreferenceModel).ToDictionary(x => x.Preference, x => x);
-            UserPreferencesMock mock = SetupUserPreferencesMock();
+            IUserPreferenceServiceV2 service = SetupGetUserPreferencesMock(preferences);
 
             // Act
-            Dictionary<string, UserPreferenceModel> actual = await mock.Service.GetUserPreferencesAsync(mock.Hdid);
+            Dictionary<string, UserPreferenceModel> actual = await service.GetUserPreferencesAsync(Hdid);
 
             // Assert
             actual.ShouldDeepEqual(expected);
@@ -151,60 +189,59 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 HdId = Hdid,
                 Preference = "TutorialPopover",
                 Value = "mocked value",
+                CreatedBy = Hdid,
+                UpdatedBy = Hdid,
             };
         }
 
-        private static UserPreferenceMock SetupUserPreferenceMock(DbStatusCode dbStatusCode)
+        private static IUserPreferenceServiceV2 SetupCreateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference createUserPreference)
         {
-            UserPreferenceModel userPreferenceModel = GenerateUserPreferenceModel();
-            UserPreference userPreference = MappingService.MapToUserPreference(userPreferenceModel);
-
-            DbResult<UserPreference> dbResult = new()
-            {
-                Payload = userPreference,
-                Status = dbStatusCode,
-                Message = dbStatusCode == DbStatusCode.Error ? "DB Error" : string.Empty,
-            };
-
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(
                     s => s.CreateUserPreferenceAsync(
-                        It.Is<UserPreference>(x => x.Preference == userPreference.Preference),
+                        It.Is<UserPreference>(x => x.Preference == createUserPreference.Preference),
                         It.Is<bool>(x => x == true),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
             userPreferenceDelegateMock.Setup(
                     s => s.UpdateUserPreferenceAsync(
-                        It.Is<UserPreference>(x => x.Preference == userPreference.Preference),
+                        It.Is<UserPreference>(x => x.Preference == createUserPreference.Preference),
                         It.Is<bool>(x => x == true),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
-            IUserPreferenceServiceV2 service = GetUserPreferenceService(userPreferenceDelegateMock);
-
-            return new UserPreferenceMock(service, Hdid, userPreferenceModel);
+            return new UserPreferenceServiceV2(
+                userPreferenceDelegateMock.Object,
+                MappingService,
+                new Mock<ILogger<UserPreferenceServiceV2>>().Object);
         }
 
-        private static UserPreferencesMock SetupUserPreferencesMock()
+        private static IUserPreferenceServiceV2 SetupUpdateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference updateUserPreference)
         {
-            List<UserPreference> preferences = [GenerateUserPreference()];
+            Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
+
+            userPreferenceDelegateMock.Setup(
+                    s => s.UpdateUserPreferenceAsync(
+                        It.Is<UserPreference>(x => x.Preference == updateUserPreference.Preference),
+                        It.Is<bool>(x => x == true),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(dbResult);
+
+            return new UserPreferenceServiceV2(
+                userPreferenceDelegateMock.Object,
+                MappingService,
+                new Mock<ILogger<UserPreferenceServiceV2>>().Object);
+        }
+
+        private static IUserPreferenceServiceV2 SetupGetUserPreferencesMock(List<UserPreference> preferences)
+        {
             Mock<IUserPreferenceDelegate> userPreferenceDelegateMock = new();
             userPreferenceDelegateMock.Setup(
                     s => s.GetUserPreferencesAsync(It.Is<string>(x => x == Hdid), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(preferences);
 
-            IUserPreferenceServiceV2 service = GetUserPreferenceService(userPreferenceDelegateMock);
-            return new(service, Hdid);
+            return GetUserPreferenceService(userPreferenceDelegateMock);
         }
-
-        private sealed record UserPreferenceMock(
-            IUserPreferenceServiceV2 Service,
-            string Hdid,
-            UserPreferenceModel UserPreferenceModel);
-
-        private sealed record UserPreferencesMock(
-            IUserPreferenceServiceV2 Service,
-            string Hdid);
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
@@ -211,10 +211,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
-            return new UserPreferenceServiceV2(
-                userPreferenceDelegateMock.Object,
-                MappingService,
-                new Mock<ILogger<UserPreferenceServiceV2>>().Object);
+            return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
         private static IUserPreferenceServiceV2 SetupUpdateUserPreferenceMock(DbResult<UserPreference> dbResult, UserPreference updateUserPreference)
@@ -228,10 +225,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
-            return new UserPreferenceServiceV2(
-                userPreferenceDelegateMock.Object,
-                MappingService,
-                new Mock<ILogger<UserPreferenceServiceV2>>().Object);
+            return GetUserPreferenceService(userPreferenceDelegateMock);
         }
 
         private static IUserPreferenceServiceV2 SetupGetUserPreferencesMock(List<UserPreference> preferences)

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileModelServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileModelServiceTests.cs
@@ -93,7 +93,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 BlockedDataSources = blockedDataSources,
             };
 
-            IUserProfileModelService service = SetupBuildUserProfileModelMock(
+            IUserProfileModelService service = SetupUserProfileModelServiceForBuildUserProfileModel(
                 currentDateTime,
                 blockedDataSources,
                 tourChangeDateIsLatest);
@@ -289,7 +289,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return userProfileDelegateMock;
         }
 
-        private static IUserProfileModelService SetupBuildUserProfileModelMock(
+        private static IUserProfileModelService SetupUserProfileModelServiceForBuildUserProfileModel(
             DateTime currentDateTime,
             IEnumerable<DataSource> blockedDataSources,
             bool tourChangeDateIsLatest = true)

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -202,7 +202,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
             };
 
-            IUserProfileService service = SetupUpdateAcceptedTermsMock(updateResult, userProfile);
+            IUserProfileService service = SetupUserProfileServiceForUpdateAcceptedTerms(updateResult, userProfile);
 
             RequestResult<UserProfileModel> expected = new()
             {
@@ -501,7 +501,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 ? Times.Once()
                 : Times.Never();
 
-            (IUserProfileService service, Mock<IEmailQueueService> emailQueueServiceMock) = SetupCloseUerProfileMock(updateUserProfileResult, readUserProfile);
+            (IUserProfileService service, Mock<IEmailQueueService> emailQueueServiceMock) = SetupCloseUserProfileMock(updateUserProfileResult, readUserProfile);
 
             // Act
             RequestResult<UserProfileModel> actual = await service.CloseUserProfileAsync(Hdid, userId);
@@ -686,7 +686,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 ResultError = patientResult.ResultError,
             };
 
-            IUserProfileService service = SetupValidateMinimumAgeMock(minAge, patientResult);
+            IUserProfileService service = SetupUserProfileServiceForValidateMinimumAge(minAge, patientResult);
 
             // Act
             RequestResult<bool> actual = await service.ValidateMinimumAgeAsync(Hdid);
@@ -722,7 +722,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 ResultError = patientResult.ResultError,
             };
 
-            IUserProfileService service = SetupValidateMinimumAgeMock(minAge, patientResult);
+            IUserProfileService service = SetupUserProfileServiceForValidateMinimumAge(minAge, patientResult);
 
             // Act
             RequestResult<bool> actual = await service.ValidateMinimumAgeAsync(Hdid);
@@ -1044,7 +1044,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new(service, userProfileDelegateMock);
         }
 
-        private static IUserProfileService SetupUpdateAcceptedTermsMock(DbResult<UserProfile?> updateResult, UserProfile? userProfile)
+        private static IUserProfileService SetupUserProfileServiceForUpdateAcceptedTerms(DbResult<UserProfile?> updateResult, UserProfile? userProfile)
         {
             Guid latestTermsOfServiceId = Guid.NewGuid();
             DateTime latestTourDate = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
@@ -1099,7 +1099,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 patientRepositoryMock: patientRepositoryMock);
         }
 
-        private static CloseUserProfileMock SetupCloseUerProfileMock(
+        private static CloseUserProfileMock SetupCloseUserProfileMock(
             DbResult<UserProfile> updateResult,
             UserProfile? readUserProfile)
         {
@@ -1221,7 +1221,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new(service, emailQueueServiceMock);
         }
 
-        private static IUserProfileService SetupValidateMinimumAgeMock(int minAge, RequestResult<PatientModel> patientResult)
+        private static IUserProfileService SetupUserProfileServiceForValidateMinimumAge(int minAge, RequestResult<PatientModel> patientResult)
         {
             Mock<IPatientService> patientServiceMock = new();
             patientServiceMock.Setup(

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -812,7 +812,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 HasTourUpdated = tourChangeDateIsLatest,
                 LastLoginDateTime = lastLoginDateTimes[0],
                 LastLoginDateTimes = [.. lastLoginDateTimes],
-                BetaFeatures = new List<GatewayApi.Constants.BetaFeature> { GatewayApi.Constants.BetaFeature.Salesforce },
+                BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
             };
         }
 
@@ -929,7 +929,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             string? smsNumber = null,
             IList<UserProfileHistory>? userProfileHistoryList = null)
         {
-            userProfileHistoryList ??= new List<UserProfileHistory>();
+            userProfileHistoryList ??= [];
 
             Guid latestTermsOfServiceId = Guid.NewGuid();
             DateTime currentUtcDate = DateTime.UtcNow.Date;

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -54,6 +54,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
     public class UserProfileServiceTests
     {
         private const string Email = "user@HealthGateway.ca";
+        private const string InvalidSmsNumber = "0000000000";
+        private const string SmsNumber = "2505556000";
+        private const string SmsVerificationCode = "12345";
 
         private static readonly IGatewayApiMappingService MappingService = new GatewayApiMappingService(MapperUtil.InitializeAutoMapper(), new Mock<ICryptoDelegate>().Object);
         private static readonly string Hdid = Guid.NewGuid().ToString();
@@ -82,25 +85,69 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             bool tourChangeDateIsLatest)
         {
             // Arrange
-            GetUserProfileMock mock = SetupGetUserProfileMock(
+            const int patientAge = 15;
+            const int minPatientAge = 10;
+            DateTime currentUtcDate = DateTime.UtcNow.Date;
+            string? smsNumber = smsIsVerified ? SmsNumber : null;
+            string? email = emailIsVerified ? Email : null;
+
+            DateTime jwtAuthTime = jwtAuthTimeIsDifferent
+                ? currentUtcDate.AddHours(1)
+                : currentUtcDate;
+
+            IList<UserProfileHistory> userProfileHistoryList =
+            [
+                GenerateUserProfileHistory(currentUtcDate, 1),
+                GenerateUserProfileHistory(currentUtcDate, 2),
+            ];
+
+            DateTime[] lastLoginDateTimes =
+            [
+                jwtAuthTimeIsDifferent ? jwtAuthTime : currentUtcDate,
+                userProfileHistoryList[0].LastLoginDateTime,
+                userProfileHistoryList[1].LastLoginDateTime,
+            ];
+
+            RequestResult<UserProfileModel> expected = new()
+            {
+                ResourcePayload = userProfileExists
+                    ? GenerateUserProfileModel(
+                        email,
+                        emailIsVerified,
+                        smsIsVerified,
+                        smsNumber,
+                        tourChangeDateIsLatest,
+                        lastLoginDateTimes)
+                    : new(),
+                ResultStatus = ResultType.Success,
+            };
+
+            Times expectedTimesUpdateUserProfile = jwtAuthTimeIsDifferent
+                ? Times.Once()
+                : Times.Never();
+
+            (IUserProfileService service, Mock<IUserProfileDelegate> userProfileDelegateMock) = SetupGetUserProfileMock(
+                patientAge,
+                minPatientAge,
                 userProfileExists,
-                jwtAuthTimeIsDifferent,
-                emailIsVerified,
-                smsIsVerified,
-                tourChangeDateIsLatest);
+                tourChangeDateIsLatest,
+                email: email,
+                smsNumber: smsNumber,
+                userProfileHistoryList: userProfileHistoryList);
 
             // Act
-            RequestResult<UserProfileModel> actual = await mock.Service.GetUserProfileAsync(mock.Hdid, mock.JwtAuthTime);
+            RequestResult<UserProfileModel> actual = await service.GetUserProfileAsync(Hdid, jwtAuthTime);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected.Result);
+            actual.ShouldDeepEqual(expected);
 
-            mock.UserProfileDelegateMock.Verify(
+            // Verify
+            userProfileDelegateMock.Verify(
                 v => v.UpdateAsync(
                     It.IsAny<UserProfile>(),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesUpdateUserProfile);
+                expectedTimesUpdateUserProfile);
         }
 
         /// <summary>
@@ -111,13 +158,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task GetUserProfileThrowsNotImplementedException()
         {
             // Arrange
-            GetUserProfileMock mock = SetupGetUserProfileMock(validBetaFeature: false);
+            DateTime jwtAuthTime = DateTime.UtcNow.Date;
+            const BetaFeature betaFeature = (BetaFeature)999;
+            string expected = $"Mapping for {betaFeature} is not implemented";
+            (IUserProfileService service, Mock<IUserProfileDelegate> _) = SetupGetUserProfileMock(betaFeature: (BetaFeature)999);
 
             // Act and Assert
-            AutoMapperMappingException exception = await Assert.ThrowsAsync<AutoMapperMappingException>(() => mock.Service.GetUserProfileAsync(mock.Hdid, mock.JwtAuthTime));
+            AutoMapperMappingException exception = await Assert.ThrowsAsync<AutoMapperMappingException>(() => service.GetUserProfileAsync(Hdid, jwtAuthTime));
             Assert.NotNull(exception.InnerException);
             Assert.IsType<NotImplementedException>(exception.InnerException);
-            Assert.Equal(mock.Expected.ExceptionMessage, exception.InnerException.Message);
+            Assert.Equal(expected, exception.InnerException.Message);
         }
 
         /// <summary>
@@ -131,16 +181,60 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(DbStatusCode.Updated, false)] // Cannot update because user profile does not exist
         [InlineData(DbStatusCode.Concurrency, true)] // Cannot update due to database error
         [InlineData(DbStatusCode.Error, true)] // Cannot update due to database error
-        public async Task ShouldUpdateAcceptedTermsAsync(DbStatusCode updatedStatus, bool userProfileExists)
+        public async Task ShouldUpdateAcceptedTerms(DbStatusCode updatedStatus, bool userProfileExists)
         {
             // Arrange
-            UpdateAcceptedTermsMock mock = SetupUpdateAcceptedTermsMock(updatedStatus, userProfileExists);
+            DateTime lastLoginDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+
+            UserProfile? userProfile = userProfileExists
+                ? new()
+                {
+                    HdId = Hdid,
+                    TermsOfServiceId = TermsOfServiceGuid,
+                    LastLoginDateTime = lastLoginDateTime,
+                }
+                : null;
+
+            DbResult<UserProfile?> updateResult = new()
+            {
+                Payload = userProfile,
+                Status = updatedStatus,
+                Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
+            };
+
+            IUserProfileService service = SetupUpdateAcceptedTermsMock(updateResult, userProfile);
+
+            RequestResult<UserProfileModel> expected = new()
+            {
+                ResourcePayload = updateResult.Status == DbStatusCode.Updated && userProfileExists
+                    ? new UserProfileModel
+                    {
+                        HdId = userProfile!.HdId,
+                        TermsOfServiceId = TermsOfServiceGuid,
+                        AcceptedTermsOfService = true,
+                        HasTermsOfServiceUpdated = true,
+                        LastLoginDateTime = lastLoginDateTime,
+                        HasTourUpdated = false,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
+                    }
+                    : null,
+                ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
+                    ? ResultType.Error
+                    : ResultType.Success,
+                ResultError = updateResult.Status != DbStatusCode.Updated || !userProfileExists
+                    ? new()
+                    {
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                        ResultMessage = !userProfileExists ? "Unable to retrieve user profile" : "Unable to update the terms of service: DB Error",
+                    }
+                    : null,
+            };
 
             // Act
-            RequestResult<UserProfileModel> actual = await mock.Service.UpdateAcceptedTermsAsync(mock.Hdid, mock.TermsOfServiceId);
+            RequestResult<UserProfileModel> actual = await service.UpdateAcceptedTermsAsync(Hdid, TermsOfServiceGuid);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -162,7 +256,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(DbStatusCode.Created, false, false, true, true, true, ResultType.Error)] // Cannot insert due to get patient error
         [InlineData(DbStatusCode.Concurrency, false, false, true, true, false, ResultType.Error)] // Cannot insert due to database error
         [InlineData(DbStatusCode.Error, false, false, true, true, false, ResultType.Error)] // Cannot insert due to database error
-        public async Task ShouldICreateUserProfileAsync(
+        public async Task ShouldCreateUserProfile(
             DbStatusCode insertedStatus,
             bool accountsFeedEnabled,
             bool notificationsFeedEnabled,
@@ -172,52 +266,158 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             ResultType expectedResultStatus)
         {
             // Arrange
-            CreateUserProfileMock mock = SetupCreateUserProfileMock(
-                insertedStatus,
-                accountsFeedEnabled,
-                notificationsFeedEnabled,
-                smsIsValid,
-                patientAgeIsValid,
-                patientErrorExists,
-                expectedResultStatus);
+            const int minPatientAge = 10;
+            const string jwtEmail = "user@healthgateway.ca";
+            const string requestedEmail = "user@healthgateway.ca";
+            string requestedSms = smsIsValid ? SmsNumber : InvalidSmsNumber;
+            int patientAge = patientAgeIsValid ? minPatientAge : minPatientAge - 1;
+            DateTime currentUtcDate = DateTime.UtcNow.Date;
+            DateTime birthDate = currentUtcDate.AddYears(-patientAge).Date;
+
+            PatientModel patientModel = GeneratePatientModel(birthDate);
+            RequestResult<PatientModel> patientResult = GeneratePatientResult(patientErrorExists, patientModel);
+            UserProfile userProfile = GenerateUserProfile(currentUtcDate);
+            DbResult<UserProfile> insertResult = new()
+            {
+                Payload = userProfile,
+                Status = insertedStatus,
+                Message = insertedStatus != DbStatusCode.Created ? "DB ERROR" : string.Empty,
+            };
+
+            CreateUserRequest createUserRequest = new()
+            {
+                Profile = new(patientModel.HdId, Guid.NewGuid(), requestedSms, requestedEmail),
+            };
+
+            RequestResult<UserProfileModel> expected = new()
+            {
+                ResourcePayload = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
+                    ? new UserProfileModel
+                    {
+                        HdId = userProfile.HdId,
+                        TermsOfServiceId = TermsOfServiceGuid,
+                        Email = requestedEmail,
+                        AcceptedTermsOfService = true,
+                        IsEmailVerified = true,
+                        SmsNumber = requestedSms,
+                        HasTermsOfServiceUpdated = true,
+                        HasTourUpdated = false,
+                        LastLoginDateTime = currentUtcDate,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
+                    }
+                    : null,
+                ResultStatus = expectedResultStatus,
+                ResultError = !IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
+                    ? GetResultError(patientResult.ResultError, smsIsValid, patientAgeIsValid, insertResult.Message)
+                    : null,
+            };
+
+            Times expectedTimesSendEmail = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
+                ? Times.Once()
+                : Times.Never();
+            Times expectedTimesSendAccountsFeed = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid) && accountsFeedEnabled
+                ? Times.Once()
+                : Times.Never();
+            Times expectedTimesSendNotificationFeed = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid) && notificationsFeedEnabled
+                ? Times.Once()
+                : Times.Never();
+            Times expectedTimesQueueNotificationSettings = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
+                ? Times.Once()
+                : Times.Never();
+
+            (IUserProfileService service, Mock<IUserEmailService> userEmailServiceMock, Mock<INotificationSettingsService> notificationSettingsServiceMock, Mock<IMessageSender> messageSenderMock) =
+                SetupCreateUserProfileMock(
+                    accountsFeedEnabled,
+                    notificationsFeedEnabled,
+                    minPatientAge,
+                    requestedSms,
+                    patientResult,
+                    insertResult);
 
             // Act
-            RequestResult<UserProfileModel> actual = await mock.Service.CreateUserProfileAsync(
-                mock.CreateUserRequest,
-                mock.JwtAuthTime,
-                mock.JwtEmailAddress);
+            RequestResult<UserProfileModel> actual = await service.CreateUserProfileAsync(
+                createUserRequest,
+                DateTime.Today,
+                jwtEmail);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected.Result);
+            actual.ShouldDeepEqual(expected);
 
-            mock.UserEmailServiceMock.Verify(
+            // Verify
+            userEmailServiceMock.Verify(
                 v => v.CreateUserEmailAsync(
-                    It.Is<string>(x => x == mock.CreateUserRequest.Profile.HdId),
-                    It.Is<string>(x => x == mock.CreateUserRequest.Profile.Email),
-                    It.Is<bool>(x => x == mock.Expected.Result.ResourcePayload!.IsEmailVerified),
+                    It.Is<string>(x => x == createUserRequest.Profile.HdId),
+                    It.Is<string>(x => x == createUserRequest.Profile.Email),
+                    It.Is<bool>(x => x == expected.ResourcePayload!.IsEmailVerified),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesSendEmail);
+                expectedTimesSendEmail);
 
-            mock.MessageSenderMock.Verify(
+            messageSenderMock.Verify(
                 v => v.SendAsync(
                     It.Is<IEnumerable<MessageEnvelope>>(
                         envelopes => envelopes.First().Content is AccountCreatedEvent),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesSendAccountCreatedEvent);
+                expectedTimesSendAccountsFeed);
 
-            mock.MessageSenderMock.Verify(
+            messageSenderMock.Verify(
                 v => v.SendAsync(
                     It.Is<IEnumerable<MessageEnvelope>>(
                         envelopes => envelopes.First().Content is NotificationChannelVerifiedEvent),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesSendNotificationChannelVerifiedEvent);
+                expectedTimesSendNotificationFeed);
 
-            mock.NotificationSettingsServiceMock.Verify(
+            notificationSettingsServiceMock.Verify(
                 v => v.QueueNotificationSettingsAsync(
                     It.IsAny<NotificationSettingsRequest>(),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesQueueNotificationSettings);
+                expectedTimesQueueNotificationSettings);
+            return;
+
+            static RequestResultError GetResultError(
+                RequestResultError? patientResultError,
+                bool smsIsValid,
+                bool patientAgeIsValid,
+                string insertResultMessage)
+            {
+                if (patientResultError != null)
+                {
+                    return patientResultError;
+                }
+
+                if (!smsIsValid)
+                {
+                    return new RequestResultError
+                    {
+                        ErrorCode = ErrorTranslator.InternalError(ErrorType.SmsInvalid),
+                        ResultMessage = "Profile values entered are invalid",
+                    };
+                }
+
+                if (!patientAgeIsValid)
+                {
+                    return new RequestResultError
+                    {
+                        ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState),
+                        ResultMessage = "Patient under minimum age",
+                    };
+                }
+
+                return new RequestResultError
+                {
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                    ResultMessage = insertResultMessage,
+                };
+            }
+
+            static bool IsInsertSuccessful(
+                DbStatusCode insertStatus,
+                bool patientErrorExists,
+                bool smsIsValid,
+                bool patientAgeIsValid)
+            {
+                return insertStatus == DbStatusCode.Created && !patientErrorExists && smsIsValid && patientAgeIsValid;
+            }
         }
 
         /// <summary>
@@ -236,22 +436,88 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldCloseUserProfile(DbStatusCode updatedStatus, bool userProfileExists, bool profileClosed)
         {
             // Arrange
-            CloseUserProfileMock mock = SetupCloseUerProfileMock(updatedStatus, userProfileExists, profileClosed);
+            Guid userId = Guid.NewGuid();
+            DateTime closedDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+            DateTime lastLoginDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+
+            UserProfile? readUserProfile = userProfileExists
+                ? new()
+                {
+                    HdId = Hdid,
+                    TermsOfServiceId = TermsOfServiceGuid,
+                    ClosedDateTime = profileClosed ? closedDateTime : null,
+                    LastLoginDateTime = lastLoginDateTime,
+                    Email = "user@healthgateway.ca",
+                }
+                : null;
+
+            UserProfile updatedUserProfile = new()
+            {
+                HdId = Hdid,
+                TermsOfServiceId = TermsOfServiceGuid,
+                ClosedDateTime = closedDateTime,
+                LastLoginDateTime = lastLoginDateTime,
+                IdentityManagementId = userId,
+                Email = readUserProfile?.Email,
+            };
+
+            DbResult<UserProfile> updateUserProfileResult = new()
+            {
+                Payload = updatedUserProfile,
+                Status = updatedStatus,
+                Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
+            };
+
+            RequestResult<UserProfileModel> expected = new()
+            {
+                ResourcePayload = profileClosed || (updateUserProfileResult.Status == DbStatusCode.Updated && userProfileExists)
+                    ? new UserProfileModel
+                    {
+                        HdId = updatedUserProfile.HdId,
+                        TermsOfServiceId = updatedUserProfile.TermsOfServiceId,
+                        AcceptedTermsOfService = true,
+                        HasTermsOfServiceUpdated = true,
+                        LastLoginDateTime = updatedUserProfile.LastLoginDateTime,
+                        HasTourUpdated = false,
+                        IsEmailVerified = true,
+                        Email = updatedUserProfile.Email,
+                        ClosedDateTime = updatedUserProfile.ClosedDateTime,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
+                    }
+                    : null,
+                ResultStatus = updateUserProfileResult.Status != DbStatusCode.Updated || !userProfileExists
+                    ? ResultType.Error
+                    : ResultType.Success,
+                ResultError = updateUserProfileResult.Status != DbStatusCode.Updated || !userProfileExists
+                    ? new()
+                    {
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                        ResultMessage = !userProfileExists ? ErrorMessages.UserProfileNotFound : updateUserProfileResult.Message,
+                    }
+                    : null,
+            };
+
+            Times expectedTimesSendEmail = userProfileExists && updatedStatus == DbStatusCode.Updated && !profileClosed
+                ? Times.Once()
+                : Times.Never();
+
+            (IUserProfileService service, Mock<IEmailQueueService> emailQueueServiceMock) = SetupCloseUerProfileMock(updateUserProfileResult, readUserProfile);
 
             // Act
-            RequestResult<UserProfileModel> actual = await mock.Service.CloseUserProfileAsync(mock.Hdid, mock.UserId);
+            RequestResult<UserProfileModel> actual = await service.CloseUserProfileAsync(Hdid, userId);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected.Result);
+            actual.ShouldDeepEqual(expected);
 
-            mock.EmailQueueServiceMock.Verify(
+            // Verify
+            emailQueueServiceMock.Verify(
                 v => v.QueueNewEmailAsync(
                     It.IsAny<string>(),
                     It.Is<string>(x => x == EmailTemplateName.AccountClosedTemplate),
                     It.IsAny<Dictionary<string, string>>(),
                     It.Is<bool>(x => x == true),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesSendEmail);
+                expectedTimesSendEmail);
         }
 
         /// <summary>
@@ -270,22 +536,87 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldRecoverUserProfile(DbStatusCode updatedStatus, bool userProfileExists, bool profileClosed)
         {
             // Arrange
-            RecoverUserProfileMock mock = SetupRecoverUserProfileMock(updatedStatus, userProfileExists, profileClosed);
+            DateTime closedDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+            DateTime lastLoginDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
+
+            UserProfile? readUserProfile = userProfileExists
+                ? new()
+                {
+                    HdId = Hdid,
+                    TermsOfServiceId = TermsOfServiceGuid,
+                    ClosedDateTime = profileClosed ? closedDateTime : null,
+                    LastLoginDateTime = lastLoginDateTime,
+                    Email = Email,
+                }
+                : null;
+
+            UserProfile updatedUserProfile = new()
+            {
+                HdId = Hdid,
+                TermsOfServiceId = TermsOfServiceGuid,
+                ClosedDateTime = null,
+                IdentityManagementId = null,
+                LastLoginDateTime = lastLoginDateTime,
+                Email = readUserProfile?.Email,
+            };
+
+            DbResult<UserProfile> updateResult = new()
+            {
+                Payload = updatedUserProfile,
+                Status = updatedStatus,
+                Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
+            };
+
+            RequestResult<UserProfileModel> expected = new()
+            {
+                ResourcePayload = !profileClosed || (updateResult.Status == DbStatusCode.Updated && userProfileExists)
+                    ? new UserProfileModel
+                    {
+                        HdId = updatedUserProfile.HdId,
+                        TermsOfServiceId = updatedUserProfile.TermsOfServiceId,
+                        AcceptedTermsOfService = true,
+                        HasTermsOfServiceUpdated = true,
+                        LastLoginDateTime = updatedUserProfile.LastLoginDateTime,
+                        HasTourUpdated = false,
+                        IsEmailVerified = true,
+                        Email = updatedUserProfile.Email,
+                        ClosedDateTime = updatedUserProfile.ClosedDateTime,
+                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
+                    }
+                    : null,
+                ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
+                    ? ResultType.Error
+                    : ResultType.Success,
+                ResultError = updateResult.Status != DbStatusCode.Updated || !userProfileExists
+                    ? new()
+                    {
+                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
+                        ResultMessage = !userProfileExists ? ErrorMessages.UserProfileNotFound : updateResult.Message,
+                    }
+                    : null,
+            };
+
+            Times expectedTimesSendEmail = userProfileExists && updatedStatus == DbStatusCode.Updated && profileClosed
+                ? Times.Once()
+                : Times.Never();
+
+            (IUserProfileService service, Mock<IEmailQueueService> emailQueueServiceMock) = SetupRecoverUserProfileMock(updateResult, readUserProfile);
 
             // Act
-            RequestResult<UserProfileModel> actual = await mock.Service.RecoverUserProfileAsync(mock.Hdid);
+            RequestResult<UserProfileModel> actual = await service.RecoverUserProfileAsync(Hdid);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected.Result);
+            actual.ShouldDeepEqual(expected);
 
-            mock.EmailQueueServiceMock.Verify(
+            // Verify
+            emailQueueServiceMock.Verify(
                 v => v.QueueNewEmailAsync(
                     It.IsAny<string>(),
                     It.Is<string>(x => x == EmailTemplateName.AccountRecoveredTemplate),
                     It.IsAny<Dictionary<string, string>>(),
                     It.Is<bool>(x => x == true),
                     It.IsAny<CancellationToken>()),
-                mock.Expected.TimesSendEmail);
+                expectedTimesSendEmail);
         }
 
         /// <summary>
@@ -296,16 +627,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData("3345678901")]
         [InlineData("2507001000")]
         [Theory]
-        public async Task PhoneNumberShouldBeValidAsync(string phoneNumber)
+        public async Task PhoneNumberShouldBeValid(string phoneNumber)
         {
             // Arrange
-            PhoneNumberShouldBeValidMock mock = SetupPhoneNumberShouldBeValidMock(phoneNumber, true);
+            IUserProfileService service = GetUserProfileService(configurationRoot: GetIConfiguration());
 
             // Act
-            bool actual = await mock.Service.IsPhoneNumberValidAsync(mock.PhoneNumber);
+            bool actual = await service.IsPhoneNumberValidAsync(phoneNumber);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected);
+            Assert.True(actual);
         }
 
         /// <summary>
@@ -316,16 +647,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData("xxx3277465")]
         [InlineData("abc")]
         [Theory]
-        public async Task PhoneNumberShouldNotBeValidAsync(string phoneNumber)
+        public async Task PhoneNumberShouldNotBeValid(string phoneNumber)
         {
             // Arrange
-            PhoneNumberShouldBeValidMock mock = SetupPhoneNumberShouldBeValidMock(phoneNumber, false);
+            IUserProfileService service = GetUserProfileService(configurationRoot: GetIConfiguration());
 
             // Act
-            bool actual = await mock.Service.IsPhoneNumberValidAsync(mock.PhoneNumber);
+            bool actual = await service.IsPhoneNumberValidAsync(phoneNumber);
 
             // Assert
-            Assert.Equal(mock.Expected, actual);
+            Assert.False(actual);
         }
 
         /// <summary>
@@ -339,16 +670,29 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(19, 19, false)]
         [InlineData(20, 19, false)]
         [Theory]
-        public async Task ShouldValidateValidMinimumAgeAsync(int age, int minAge, bool patientErrorExists)
+        public async Task ShouldValidateValidMinimumAge(int age, int minAge, bool patientErrorExists)
         {
             // Arrange
-            ValidateMinimumAgeMock mock = SetupValidateMinimumAgeMock(age, minAge, patientErrorExists, true);
+            DateTime currentUtcDate = DateTime.UtcNow;
+            DateTime birthDate = currentUtcDate.AddYears(-age).Date;
+
+            PatientModel patientModel = GeneratePatientModel(birthDate);
+            RequestResult<PatientModel> patientResult = GeneratePatientResult(patientErrorExists, patientModel);
+
+            RequestResult<bool> expected = new()
+            {
+                ResourcePayload = true,
+                ResultStatus = patientResult.ResultStatus,
+                ResultError = patientResult.ResultError,
+            };
+
+            IUserProfileService service = SetupValidateMinimumAgeMock(minAge, patientResult);
 
             // Act
-            RequestResult<bool> actual = await mock.Service.ValidateMinimumAgeAsync(mock.Age);
+            RequestResult<bool> actual = await service.ValidateMinimumAgeAsync(Hdid);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -362,16 +706,29 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(18, 19, false)]
         [InlineData(19, 19, true)]
         [Theory]
-        public async Task ShouldValidateInvalidMinimumAgeAsync(int age, int minAge, bool patientErrorExists)
+        public async Task ShouldValidateInvalidMinimumAge(int age, int minAge, bool patientErrorExists)
         {
             // Arrange
-            ValidateMinimumAgeMock mock = SetupValidateMinimumAgeMock(age, minAge, patientErrorExists, false);
+            DateTime currentUtcDate = DateTime.UtcNow;
+            DateTime birthDate = currentUtcDate.AddYears(-age).Date;
+
+            PatientModel patientModel = GeneratePatientModel(birthDate);
+            RequestResult<PatientModel> patientResult = GeneratePatientResult(patientErrorExists, patientModel);
+
+            RequestResult<bool> expected = new()
+            {
+                ResourcePayload = false,
+                ResultStatus = patientResult.ResultStatus,
+                ResultError = patientResult.ResultError,
+            };
+
+            IUserProfileService service = SetupValidateMinimumAgeMock(minAge, patientResult);
 
             // Act
-            RequestResult<bool> actual = await mock.Service.ValidateMinimumAgeAsync(mock.Age);
+            RequestResult<bool> actual = await service.ValidateMinimumAgeAsync(Hdid);
 
             // Assert
-            actual.ShouldDeepEqual(mock.Expected);
+            actual.ShouldDeepEqual(expected);
         }
 
         private static PatientModel GeneratePatientModel(DateTime birthDate)
@@ -434,6 +791,31 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
         }
 
+        private static UserProfileModel GenerateUserProfileModel(
+            string email,
+            bool emailIsVerified,
+            bool smsIsVerified,
+            string smsNumber,
+            bool tourChangeDateIsLatest,
+            DateTime[] lastLoginDateTimes)
+        {
+            return new UserProfileModel
+            {
+                HdId = Hdid,
+                TermsOfServiceId = TermsOfServiceGuid,
+                Email = email,
+                AcceptedTermsOfService = true,
+                IsEmailVerified = emailIsVerified,
+                IsSmsNumberVerified = smsIsVerified,
+                SmsNumber = smsNumber,
+                HasTermsOfServiceUpdated = true,
+                HasTourUpdated = tourChangeDateIsLatest,
+                LastLoginDateTime = lastLoginDateTimes[0],
+                LastLoginDateTimes = [.. lastLoginDateTimes],
+                BetaFeatures = new List<GatewayApi.Constants.BetaFeature> { GatewayApi.Constants.BetaFeature.Salesforce },
+            };
+        }
+
         private static IConfigurationRoot GetIConfiguration(
             int minPatientAge = 12,
             int profileHistoryRecordLimit = 2,
@@ -454,43 +836,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         }
 
         private static CreateUserProfileMock SetupCreateUserProfileMock(
-            DbStatusCode insertedStatus,
             bool accountsFeedEnabled,
             bool notificationsFeedEnabled,
-            bool smsIsValid,
-            bool patientAgeIsValid,
-            bool patientErrorExists,
-            ResultType expectedResultStatus)
+            int minPatientAge,
+            string smsNumber,
+            RequestResult<PatientModel> patientResult,
+            DbResult<UserProfile> insertResult)
         {
-            const int minPatientAge = 10;
-            const string jwtEmail = "user@healthgateway.ca";
-            const string requestedEmail = "user@healthgateway.ca";
-            const string smsVerificationCode = "12345";
-            string requestedSms = smsIsValid ? "2505556000" : "0000000000";
-            int patientAge = patientAgeIsValid ? minPatientAge : minPatientAge - 1;
-
-            Guid latestTermsOfServiceId = Guid.NewGuid();
-            DateTime currentUtcDate = DateTime.UtcNow.Date;
-            DateTime birthDate = currentUtcDate.AddYears(-patientAge).Date;
-
-            PatientModel patientModel = GeneratePatientModel(birthDate);
-
-            CreateUserRequest createUserRequest = new()
-            {
-                Profile = new(patientModel.HdId, Guid.NewGuid(), requestedSms, requestedEmail),
-            };
-
-            RequestResult<PatientModel> patientResult = GeneratePatientResult(patientErrorExists, patientModel);
-
-            UserProfile userProfile = GenerateUserProfile(currentUtcDate);
-
-            DbResult<UserProfile> insertResult = new()
-            {
-                Payload = userProfile,
-                Status = insertedStatus,
-                Message = insertedStatus != DbStatusCode.Created ? "DB ERROR" : string.Empty,
-            };
-
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             userProfileDelegateMock.Setup(
                     s => s.InsertUserProfileAsync(
@@ -522,15 +874,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             MessagingVerification messagingVerification = new()
             {
                 Id = Guid.NewGuid(),
-                SmsNumber = createUserRequest.Profile.SmsNumber,
-                SmsValidationCode = smsVerificationCode,
+                SmsNumber = smsNumber,
+                SmsValidationCode = SmsVerificationCode,
             };
 
             Mock<IUserSmsService> userSmsServiceMock = new();
             userSmsServiceMock.Setup(
                     s => s.CreateUserSmsAsync(
                         It.Is<string>(x => x == Hdid),
-                        It.Is<string>(x => x == createUserRequest.Profile.SmsNumber),
+                        It.Is<string>(x => x == smsNumber),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(messagingVerification);
 
@@ -539,13 +891,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetActiveLegalAgreementId(
                         It.Is<LegalAgreementType>(x => x == LegalAgreementType.TermsOfService),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(latestTermsOfServiceId);
+                .ReturnsAsync(Guid.NewGuid());
 
             Mock<IApplicationSettingsService> applicationSettingsServiceMock = new();
             applicationSettingsServiceMock.Setup(
                     s => s.GetLatestTourChangeDateTimeAsync(
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(currentUtcDate);
+                .ReturnsAsync(DateTime.UtcNow.Date);
 
             IConfigurationRoot configuration = GetIConfiguration(
                 minPatientAge,
@@ -564,123 +916,28 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 applicationSettingsServiceMock: applicationSettingsServiceMock,
                 messageSenderMock: messageSenderMock);
 
-            RequestResult<UserProfileModel> userProfileModelResult = new()
-            {
-                ResourcePayload = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
-                    ? new UserProfileModel
-                    {
-                        HdId = userProfile.HdId,
-                        TermsOfServiceId = TermsOfServiceGuid,
-                        Email = requestedEmail,
-                        AcceptedTermsOfService = true,
-                        IsEmailVerified = true,
-                        SmsNumber = requestedSms,
-                        HasTermsOfServiceUpdated = true,
-                        HasTourUpdated = false,
-                        LastLoginDateTime = currentUtcDate,
-                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
-                    }
-                    : null,
-                ResultStatus = expectedResultStatus,
-                ResultError = !IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
-                    ? GetResultError(patientResult.ResultError, smsIsValid, patientAgeIsValid, insertResult.Message)
-                    : null,
-            };
-
-            Times timesSendEmail = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
-                ? Times.Once()
-                : Times.Never();
-            Times timesSendAccountsFeed = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid) && accountsFeedEnabled
-                ? Times.Once()
-                : Times.Never();
-            Times timesSendNotificationFeed = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid) && notificationsFeedEnabled
-                ? Times.Once()
-                : Times.Never();
-            Times timesQueueNotificationSettings = IsInsertSuccessful(insertedStatus, patientErrorExists, smsIsValid, patientAgeIsValid)
-                ? Times.Once()
-                : Times.Never();
-
-            CreatedUserProfileResult expected = new(userProfileModelResult, timesSendEmail, timesSendAccountsFeed, timesSendNotificationFeed, timesQueueNotificationSettings);
-            return new(service, userEmailServiceMock, notificationSettingsServiceMock, messageSenderMock, expected, createUserRequest, DateTime.Today, jwtEmail);
-
-            static RequestResultError GetResultError(
-                RequestResultError? patientResultError,
-                bool smsIsValid,
-                bool patientAgeIsValid,
-                string insertResultMessage)
-            {
-                if (patientResultError != null)
-                {
-                    return patientResultError;
-                }
-
-                if (!smsIsValid)
-                {
-                    return new RequestResultError
-                    {
-                        ErrorCode = ErrorTranslator.InternalError(ErrorType.SmsInvalid),
-                        ResultMessage = "Profile values entered are invalid",
-                    };
-                }
-
-                if (!patientAgeIsValid)
-                {
-                    return new RequestResultError
-                    {
-                        ErrorCode = ErrorTranslator.InternalError(ErrorType.InvalidState),
-                        ResultMessage = "Patient under minimum age",
-                    };
-                }
-
-                return new RequestResultError
-                {
-                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
-                    ResultMessage = insertResultMessage,
-                };
-            }
-
-            static bool IsInsertSuccessful(
-                DbStatusCode insertStatus,
-                bool patientErrorExists,
-                bool smsIsValid,
-                bool patientAgeIsValid)
-            {
-                return insertStatus == DbStatusCode.Created && !patientErrorExists && smsIsValid && patientAgeIsValid;
-            }
+            return new(service, userEmailServiceMock, notificationSettingsServiceMock, messageSenderMock);
         }
 
-        private static GetUserProfileMock SetupGetUserProfileMock(
+        private static UserProfileMock SetupGetUserProfileMock(
+            int patientAge = 15,
+            int minPatientAge = 10,
             bool userProfileExists = true,
-            bool jwtAuthTimeIsDifferent = true,
-            bool emailIsVerified = true,
-            bool smsIsVerified = true,
             bool tourChangeDateIsLatest = true,
-            bool validBetaFeature = true)
+            BetaFeature betaFeature = BetaFeature.Salesforce,
+            string? email = null,
+            string? smsNumber = null,
+            IList<UserProfileHistory>? userProfileHistoryList = null)
         {
-            const int patientAge = 15;
-            const int minPatientAge = 10;
-            string? smsNumber = smsIsVerified ? "2505556000" : null;
-            string? email = emailIsVerified ? Email : null;
+            userProfileHistoryList ??= new List<UserProfileHistory>();
 
             Guid latestTermsOfServiceId = Guid.NewGuid();
             DateTime currentUtcDate = DateTime.UtcNow.Date;
             DateTime birthDate = currentUtcDate.AddYears(-patientAge).Date;
 
-            DateTime jwtAuthTime = jwtAuthTimeIsDifferent
-                ? currentUtcDate.AddHours(1)
-                : currentUtcDate;
-
             DateTime latestTourChangeDateTime = tourChangeDateIsLatest
                 ? currentUtcDate
                 : currentUtcDate.AddDays(-5);
-
-            BetaFeature betaFeature = validBetaFeature
-                ? BetaFeature.Salesforce
-                : (BetaFeature)999; // An invalid database beta feature value will not map to a valid ui beta feature value
-
-            string betaFeatureMappingErrorMessage = !validBetaFeature
-                ? $"Mapping for {betaFeature} is not implemented"
-                : string.Empty;
 
             UserProfile? userProfile = userProfileExists
                 ? GenerateUserProfile(currentUtcDate, email: email, smsNumber: smsNumber, betaFeature: betaFeature)
@@ -710,12 +967,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.Is<bool>(x => x == false),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patientResult);
-
-            IList<UserProfileHistory> userProfileHistoryList =
-            [
-                GenerateUserProfileHistory(currentUtcDate, 1),
-                GenerateUserProfileHistory(currentUtcDate, 2),
-            ];
 
             userProfileDelegateMock.Setup(
                     s => s.GetUserProfileHistoryListAsync(
@@ -790,53 +1041,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 applicationSettingsServiceMock: applicationSettingsServiceMock,
                 messageSenderMock: messageSenderMock);
 
-            RequestResult<UserProfileModel> userProfileModelResult = new()
-            {
-                ResourcePayload = userProfileExists
-                    ? new UserProfileModel
-                    {
-                        HdId = Hdid,
-                        TermsOfServiceId = TermsOfServiceGuid,
-                        Email = email,
-                        AcceptedTermsOfService = true,
-                        IsEmailVerified = emailIsVerified,
-                        IsSmsNumberVerified = smsIsVerified,
-                        SmsNumber = smsNumber,
-                        HasTermsOfServiceUpdated = true,
-                        HasTourUpdated = tourChangeDateIsLatest,
-                        LastLoginDateTime = jwtAuthTimeIsDifferent ? jwtAuthTime : currentUtcDate,
-                        LastLoginDateTimes =
-                        [
-                            jwtAuthTimeIsDifferent ? jwtAuthTime : currentUtcDate,
-                            userProfileHistoryList[0].LastLoginDateTime,
-                            userProfileHistoryList[1].LastLoginDateTime,
-                        ],
-                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
-                    }
-                    : new(),
-                ResultStatus = ResultType.Success,
-            };
-
-            Times timesUpdateUserProfile = jwtAuthTimeIsDifferent
-                ? Times.Once()
-                : Times.Never();
-
-            GetUserProfileResult expected = new(userProfileModelResult, timesUpdateUserProfile, betaFeatureMappingErrorMessage);
-            return new(service, userProfileDelegateMock, expected, Hdid, jwtAuthTime);
+            return new(service, userProfileDelegateMock);
         }
 
-        private static UpdateAcceptedTermsMock SetupUpdateAcceptedTermsMock(DbStatusCode updatedStatus, bool userProfileExists)
+        private static IUserProfileService SetupUpdateAcceptedTermsMock(DbResult<UserProfile?> updateResult, UserProfile? userProfile)
         {
             Guid latestTermsOfServiceId = Guid.NewGuid();
             DateTime latestTourDate = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-            DateTime lastLoginDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-
-            UserProfile userProfile = new()
-            {
-                HdId = Hdid,
-                TermsOfServiceId = TermsOfServiceGuid,
-                LastLoginDateTime = lastLoginDateTime,
-            };
 
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             userProfileDelegateMock.Setup(
@@ -844,21 +1055,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.Is<string>(x => x == Hdid),
                         It.Is<bool>(x => x == false),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(userProfileExists ? userProfile : null);
-
-            DbResult<UserProfile> updateResult = new()
-            {
-                Payload = userProfile,
-                Status = updatedStatus,
-                Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
-            };
+                .ReturnsAsync(userProfile);
 
             userProfileDelegateMock.Setup(
                     s => s.UpdateAsync(
                         It.Is<UserProfile>(x => x.HdId == Hdid),
                         It.Is<bool>(x => x == true),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(updateResult);
+                .ReturnsAsync(updateResult!);
 
             Mock<ILegalAgreementService> legalAgreementServiceMock = new();
             legalAgreementServiceMock.Setup(
@@ -885,72 +1089,22 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetDataSourcesAsync(
                         It.Is<string>(x => x == Hdid),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Enumerable.Empty<DataSource>());
+                .ReturnsAsync([]);
 
-            IUserProfileService service = GetUserProfileService(
+            return GetUserProfileService(
                 userProfileDelegateMock: userProfileDelegateMock,
                 legalAgreementServiceMock: legalAgreementServiceMock,
                 userPreferenceServiceMock: userPreferenceServiceMock,
                 applicationSettingsServiceMock: applicationSettingsServiceMock,
                 patientRepositoryMock: patientRepositoryMock);
-
-            RequestResult<UserProfileModel> expected = new()
-            {
-                ResourcePayload = updateResult.Status == DbStatusCode.Updated && userProfileExists
-                    ? new UserProfileModel
-                    {
-                        HdId = userProfile.HdId,
-                        TermsOfServiceId = TermsOfServiceGuid,
-                        AcceptedTermsOfService = true,
-                        HasTermsOfServiceUpdated = true,
-                        LastLoginDateTime = lastLoginDateTime,
-                        HasTourUpdated = false,
-                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
-                    }
-                    : null,
-                ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
-                    ? ResultType.Error
-                    : ResultType.Success,
-                ResultError = updateResult.Status != DbStatusCode.Updated || !userProfileExists
-                    ? new()
-                    {
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
-                        ResultMessage = !userProfileExists ? "Unable to retrieve user profile" : "Unable to update the terms of service: DB Error",
-                    }
-                    : null,
-            };
-
-            return new(service, expected, Hdid, TermsOfServiceGuid);
         }
 
-        private static CloseUserProfileMock SetupCloseUerProfileMock(DbStatusCode updatedStatus, bool userProfileExists, bool profileClosed)
+        private static CloseUserProfileMock SetupCloseUerProfileMock(
+            DbResult<UserProfile> updateResult,
+            UserProfile? readUserProfile)
         {
-            Guid userId = Guid.NewGuid();
             Guid latestTermsOfServiceId = Guid.NewGuid();
             DateTime latestTourDate = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-            DateTime closedDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-            DateTime lastLoginDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-
-            UserProfile? readUserProfile = userProfileExists
-                ? new()
-                {
-                    HdId = Hdid,
-                    TermsOfServiceId = TermsOfServiceGuid,
-                    ClosedDateTime = profileClosed ? closedDateTime : null,
-                    LastLoginDateTime = lastLoginDateTime,
-                    Email = "user@healthgateway.ca",
-                }
-                : null;
-
-            UserProfile updatedUserProfile = new()
-            {
-                HdId = Hdid,
-                TermsOfServiceId = TermsOfServiceGuid,
-                ClosedDateTime = closedDateTime,
-                LastLoginDateTime = lastLoginDateTime,
-                IdentityManagementId = userId,
-                Email = readUserProfile?.Email,
-            };
 
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             userProfileDelegateMock.Setup(
@@ -960,13 +1114,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readUserProfile);
 
-            DbResult<UserProfile> updateResult = new()
-            {
-                Payload = updatedUserProfile,
-                Status = updatedStatus,
-                Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
-            };
-
             userProfileDelegateMock.Setup(
                     s => s.UpdateAsync(
                         It.Is<UserProfile>(x => x.HdId == Hdid),
@@ -999,7 +1146,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetDataSourcesAsync(
                         It.Is<string>(x => x == Hdid),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Enumerable.Empty<DataSource>());
+                .ReturnsAsync([]);
 
             Mock<IEmailQueueService> emailQueueServiceMock = new();
 
@@ -1011,69 +1158,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 applicationSettingsServiceMock: applicationSettingsServiceMock,
                 patientRepositoryMock: patientRepositoryMock);
 
-            RequestResult<UserProfileModel> userProfileModel = new()
-            {
-                ResourcePayload = profileClosed || (updateResult.Status == DbStatusCode.Updated && userProfileExists)
-                    ? new UserProfileModel
-                    {
-                        HdId = updatedUserProfile.HdId,
-                        TermsOfServiceId = updatedUserProfile.TermsOfServiceId,
-                        AcceptedTermsOfService = true,
-                        HasTermsOfServiceUpdated = true,
-                        LastLoginDateTime = updatedUserProfile.LastLoginDateTime,
-                        HasTourUpdated = false,
-                        IsEmailVerified = true,
-                        Email = updatedUserProfile.Email,
-                        ClosedDateTime = updatedUserProfile.ClosedDateTime,
-                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
-                    }
-                    : null,
-                ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
-                    ? ResultType.Error
-                    : ResultType.Success,
-                ResultError = updateResult.Status != DbStatusCode.Updated || !userProfileExists
-                    ? new()
-                    {
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
-                        ResultMessage = !userProfileExists ? ErrorMessages.UserProfileNotFound : updateResult.Message,
-                    }
-                    : null,
-            };
-
-            Times timesSendEmail = userProfileExists && updatedStatus == DbStatusCode.Updated && !profileClosed
-                ? Times.Once()
-                : Times.Never();
-            UserProfileModelResult expected = new(userProfileModel, timesSendEmail);
-            return new(service, emailQueueServiceMock, expected, Hdid, userId);
+            return new(service, emailQueueServiceMock);
         }
 
-        private static RecoverUserProfileMock SetupRecoverUserProfileMock(DbStatusCode updatedStatus, bool userProfileExists, bool profileClosed)
+        private static RecoverUserProfileMock SetupRecoverUserProfileMock(DbResult<UserProfile> updateResult, UserProfile? readUserProfile)
         {
             Guid latestTermsOfServiceId = Guid.NewGuid();
             DateTime latestTourDate = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-            DateTime closedDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-            DateTime lastLoginDateTime = new(2024, 4, 15, 0, 0, 0, DateTimeKind.Utc);
-
-            UserProfile? readUserProfile = userProfileExists
-                ? new()
-                {
-                    HdId = Hdid,
-                    TermsOfServiceId = TermsOfServiceGuid,
-                    ClosedDateTime = profileClosed ? closedDateTime : null,
-                    LastLoginDateTime = lastLoginDateTime,
-                    Email = "user@healthgateway.ca",
-                }
-                : null;
-
-            UserProfile updatedUserProfile = new()
-            {
-                HdId = Hdid,
-                TermsOfServiceId = TermsOfServiceGuid,
-                ClosedDateTime = null,
-                IdentityManagementId = null,
-                LastLoginDateTime = lastLoginDateTime,
-                Email = readUserProfile?.Email,
-            };
 
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             userProfileDelegateMock.Setup(
@@ -1082,13 +1173,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.Is<bool>(x => x == false),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readUserProfile);
-
-            DbResult<UserProfile> updateResult = new()
-            {
-                Payload = updatedUserProfile,
-                Status = updatedStatus,
-                Message = updatedStatus != DbStatusCode.Updated ? "DB ERROR" : string.Empty,
-            };
 
             userProfileDelegateMock.Setup(
                     s => s.UpdateAsync(
@@ -1122,7 +1206,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetDataSourcesAsync(
                         It.Is<string>(x => x == Hdid),
                         It.IsAny<CancellationToken>()))
-                .ReturnsAsync(Enumerable.Empty<DataSource>());
+                .ReturnsAsync([]);
 
             Mock<IEmailQueueService> emailQueueServiceMock = new();
 
@@ -1134,56 +1218,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 applicationSettingsServiceMock: applicationSettingsServiceMock,
                 patientRepositoryMock: patientRepositoryMock);
 
-            RequestResult<UserProfileModel> userProfileModel = new()
-            {
-                ResourcePayload = !profileClosed || (updateResult.Status == DbStatusCode.Updated && userProfileExists)
-                    ? new UserProfileModel
-                    {
-                        HdId = updatedUserProfile.HdId,
-                        TermsOfServiceId = updatedUserProfile.TermsOfServiceId,
-                        AcceptedTermsOfService = true,
-                        HasTermsOfServiceUpdated = true,
-                        LastLoginDateTime = updatedUserProfile.LastLoginDateTime,
-                        HasTourUpdated = false,
-                        IsEmailVerified = true,
-                        Email = updatedUserProfile.Email,
-                        ClosedDateTime = updatedUserProfile.ClosedDateTime,
-                        BetaFeatures = [GatewayApi.Constants.BetaFeature.Salesforce],
-                    }
-                    : null,
-                ResultStatus = updateResult.Status != DbStatusCode.Updated || !userProfileExists
-                    ? ResultType.Error
-                    : ResultType.Success,
-                ResultError = updateResult.Status != DbStatusCode.Updated || !userProfileExists
-                    ? new()
-                    {
-                        ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.Database),
-                        ResultMessage = !userProfileExists ? ErrorMessages.UserProfileNotFound : updateResult.Message,
-                    }
-                    : null,
-            };
-
-            Times timesSendEmail = userProfileExists && updatedStatus == DbStatusCode.Updated && profileClosed
-                ? Times.Once()
-                : Times.Never();
-            UserProfileModelResult expected = new(userProfileModel, timesSendEmail);
-            return new(service, emailQueueServiceMock, expected, Hdid);
+            return new(service, emailQueueServiceMock);
         }
 
-        private static PhoneNumberShouldBeValidMock SetupPhoneNumberShouldBeValidMock(string phoneNumber, bool valid)
+        private static IUserProfileService SetupValidateMinimumAgeMock(int minAge, RequestResult<PatientModel> patientResult)
         {
-            IUserProfileService service = GetUserProfileService(configurationRoot: GetIConfiguration());
-            return new(service, valid, phoneNumber);
-        }
-
-        private static ValidateMinimumAgeMock SetupValidateMinimumAgeMock(int age, int minAge, bool patientErrorExists, bool validAge)
-        {
-            DateTime currentUtcDate = DateTime.UtcNow;
-            DateTime birthDate = currentUtcDate.AddYears(-age).Date;
-
-            PatientModel patientModel = GeneratePatientModel(birthDate);
-            RequestResult<PatientModel> patientResult = GeneratePatientResult(patientErrorExists, patientModel);
-
             Mock<IPatientService> patientServiceMock = new();
             patientServiceMock.Setup(
                     s => s.GetPatientAsync(
@@ -1193,16 +1232,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patientResult);
 
-            RequestResult<bool> expected = new()
-            {
-                ResourcePayload = validAge,
-                ResultStatus = patientResult.ResultStatus,
-                ResultError = patientResult.ResultError,
-            };
-
             IConfigurationRoot configuration = GetIConfiguration(minAge);
-            IUserProfileService service = GetUserProfileService(configurationRoot: configuration, patientServiceMock: patientServiceMock);
-            return new(service, expected, age.ToString(CultureInfo.InvariantCulture));
+            return GetUserProfileService(configurationRoot: configuration, patientServiceMock: patientServiceMock);
         }
 
         private static IUserProfileService GetUserProfileService(
@@ -1221,20 +1252,20 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IPatientRepository>? patientRepositoryMock = null,
             Mock<IMessageSender>? messageSenderMock = null)
         {
-            patientServiceMock = patientServiceMock ?? new();
-            userEmailServiceMock = userEmailServiceMock ?? new();
-            emailQueueServiceMock = emailQueueServiceMock ?? new();
-            notificationSettingsServiceMock = notificationSettingsServiceMock ?? new();
-            userSmsServiceMock = userSmsServiceMock ?? new();
-            userProfileDelegateMock = userProfileDelegateMock ?? new();
-            legalAgreementServiceMock = legalAgreementServiceMock ?? new();
-            messagingVerificationDelegateMock = messagingVerificationDelegateMock ?? new();
-            userPreferenceServiceMock = userPreferenceServiceMock ?? new();
-            configurationRoot = configurationRoot ?? GetIConfiguration();
-            authenticationDelegateMock = authenticationDelegateMock ?? new();
-            applicationSettingsServiceMock = applicationSettingsServiceMock ?? new();
-            patientRepositoryMock = patientRepositoryMock ?? new();
-            messageSenderMock = messageSenderMock ?? new();
+            patientServiceMock ??= new();
+            userEmailServiceMock ??= new();
+            emailQueueServiceMock ??= new();
+            notificationSettingsServiceMock ??= new();
+            userSmsServiceMock ??= new();
+            userProfileDelegateMock ??= new();
+            legalAgreementServiceMock ??= new();
+            messagingVerificationDelegateMock ??= new();
+            userPreferenceServiceMock ??= new();
+            configurationRoot ??= GetIConfiguration();
+            authenticationDelegateMock ??= new();
+            applicationSettingsServiceMock ??= new();
+            patientRepositoryMock ??= new();
+            messageSenderMock ??= new();
 
             return new UserProfileService(
                 new Mock<ILogger<UserProfileService>>().Object,
@@ -1260,62 +1291,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IUserProfileService Service,
             Mock<IUserEmailService> UserEmailServiceMock,
             Mock<INotificationSettingsService> NotificationSettingsServiceMock,
-            Mock<IMessageSender> MessageSenderMock,
-            CreatedUserProfileResult Expected,
-            CreateUserRequest CreateUserRequest,
-            DateTime JwtAuthTime,
-            string? JwtEmailAddress);
+            Mock<IMessageSender> MessageSenderMock);
 
-        private sealed record CreatedUserProfileResult(
-            RequestResult<UserProfileModel> Result,
-            Times TimesSendEmail,
-            Times TimesSendAccountCreatedEvent,
-            Times TimesSendNotificationChannelVerifiedEvent,
-            Times TimesQueueNotificationSettings);
-
-        private sealed record GetUserProfileMock(
+        private sealed record UserProfileMock(
             IUserProfileService Service,
-            Mock<IUserProfileDelegate> UserProfileDelegateMock,
-            GetUserProfileResult Expected,
-            string Hdid,
-            DateTime JwtAuthTime);
-
-        private sealed record GetUserProfileResult(
-            RequestResult<UserProfileModel> Result,
-            Times TimesUpdateUserProfile,
-            string ExceptionMessage);
-
-        private sealed record UpdateAcceptedTermsMock(
-            IUserProfileService Service,
-            RequestResult<UserProfileModel> Expected,
-            string Hdid,
-            Guid TermsOfServiceId);
+            Mock<IUserProfileDelegate> UserProfileDelegateMock);
 
         private sealed record CloseUserProfileMock(
             IUserProfileService Service,
-            Mock<IEmailQueueService> EmailQueueServiceMock,
-            UserProfileModelResult Expected,
-            string Hdid,
-            Guid UserId);
+            Mock<IEmailQueueService> EmailQueueServiceMock);
 
         private sealed record RecoverUserProfileMock(
             IUserProfileService Service,
-            Mock<IEmailQueueService> EmailQueueServiceMock,
-            UserProfileModelResult Expected,
-            string Hdid);
-
-        private sealed record UserProfileModelResult(
-            RequestResult<UserProfileModel> Result,
-            Times TimesSendEmail);
-
-        private sealed record PhoneNumberShouldBeValidMock(
-            IUserProfileService Service,
-            bool Expected,
-            string PhoneNumber);
-
-        private sealed record ValidateMinimumAgeMock(
-            IUserProfileService Service,
-            RequestResult<bool> Expected,
-            string Age);
+            Mock<IEmailQueueService> EmailQueueServiceMock);
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
@@ -53,7 +53,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldCloseUserProfileAsync()
+        public async Task ShouldCloseUserProfile()
         {
             // Arrange
             const string expectedEmailTemplateName = EmailTemplateName.AccountClosedTemplate;
@@ -64,7 +64,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (baseMock is CloseUserProfileMock mock)
             {
                 // Act
-                await mock.Service.CloseUserProfileAsync(mock.Hdid);
+                await mock.Service.CloseUserProfileAsync(Hdid);
 
                 // Verify
                 VerifyUserProfileUpdate(mock.UserProfileDelegateMock);
@@ -81,7 +81,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task CloseUserProfileAsyncAlreadyClosed()
+        public async Task CloseUserProfileAlreadyClosed()
         {
             // Arrange
             const string expectedEmailTemplateName = EmailTemplateName.AccountClosedTemplate;
@@ -92,7 +92,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (baseMock is CloseUserProfileMock mock)
             {
                 // Act
-                await mock.Service.CloseUserProfileAsync(mock.Hdid);
+                await mock.Service.CloseUserProfileAsync(Hdid);
 
                 // Verify
                 VerifyUserProfileUpdate(mock.UserProfileDelegateMock, Times.Never());
@@ -114,7 +114,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [Theory]
         [InlineData(false, null, typeof(NotFoundException))]
         [InlineData(true, DbStatusCode.Error, typeof(DatabaseException))]
-        public async Task CloseUserProfileAsyncThrowsException(bool userProfileExists, DbStatusCode? profileUpdateStatus, Type expectedException)
+        public async Task CloseUserProfileThrowsException(bool userProfileExists, DbStatusCode? profileUpdateStatus, Type expectedException)
         {
             // Arrange
             BaseUserProfileServiceMock baseMock = SetupCloseUserProfileMock(userProfileExists, profileUpdateStatus: profileUpdateStatus);
@@ -124,7 +124,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 // Act and Assert
                 await Assert.ThrowsAsync(
                     expectedException,
-                    async () => { await mock.Service.CloseUserProfileAsync(mock.Hdid); });
+                    async () => { await mock.Service.CloseUserProfileAsync(Hdid); });
             }
             else
             {
@@ -142,7 +142,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(true, true)] // User profile exists and jwt auth time is different
         [InlineData(true, false)] // User profile exists and jwt auth time is not different
         [InlineData(false, false)] // Cannot get profile because user profile does not exist
-        public async Task ShouldGetUserProfileAsync(
+        public async Task ShouldGetUserProfile(
             bool userProfileExists,
             bool jwtAuthTimeIsDifferent)
         {
@@ -160,11 +160,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             UserProfileMock mock = SetupUserProfileMock(
                 currentDateTime,
-                jwtAuthTime,
                 userProfileExists);
 
             // Act
-            UserProfileModel actual = await mock.Service.GetUserProfileAsync(mock.Hdid, mock.JwtAuthTime);
+            UserProfileModel actual = await mock.Service.GetUserProfileAsync(Hdid, jwtAuthTime);
 
             // Assert and Verify
             actual.ShouldDeepEqual(expected);
@@ -177,7 +176,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldRecoverUserProfileAsync()
+        public async Task ShouldRecoverUserProfile()
         {
             // Arrange
             const string expectedEmailTemplateName = EmailTemplateName.AccountRecoveredTemplate;
@@ -190,7 +189,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (baseMock is RecoverUserProfileMock mock)
             {
                 // Act
-                await mock.Service.RecoverUserProfileAsync(mock.Hdid);
+                await mock.Service.RecoverUserProfileAsync(Hdid);
 
                 // Verify
                 VerifyUserProfileUpdate(mock.UserProfileDelegateMock);
@@ -207,7 +206,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task RecoverUserProfileAsyncAlreadyRecovered()
+        public async Task RecoverUserProfileAlreadyRecovered()
         {
             // Arrange
             const string expectedEmailTemplateName = EmailTemplateName.AccountRecoveredTemplate;
@@ -218,7 +217,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (baseMock is RecoverUserProfileMock mock)
             {
                 // Act
-                await mock.Service.RecoverUserProfileAsync(mock.Hdid);
+                await mock.Service.RecoverUserProfileAsync(Hdid);
 
                 // Verify
                 VerifyUserProfileUpdate(mock.UserProfileDelegateMock, Times.Never());
@@ -240,7 +239,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(false, null, typeof(NotFoundException))]
         [InlineData(true, DbStatusCode.Error, typeof(DatabaseException))]
         [Theory]
-        public async Task RecoverUserProfileAsyncThrowsException(bool userProfileExists, DbStatusCode? profileUpdateStatus, Type expected)
+        public async Task RecoverUserProfileThrowsException(bool userProfileExists, DbStatusCode? profileUpdateStatus, Type expected)
         {
             // Arrange
             BaseUserProfileServiceMock baseMock = SetupRecoverUserProfileMock(
@@ -253,7 +252,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 // Act and Assert
                 await Assert.ThrowsAsync(
                     expected,
-                    async () => { await mock.Service.RecoverUserProfileAsync(mock.Hdid); });
+                    async () => { await mock.Service.RecoverUserProfileAsync(Hdid); });
             }
             else
             {
@@ -266,7 +265,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task ShouldUpdateAcceptedTermsAsync()
+        public async Task ShouldUpdateAcceptedTerms()
         {
             // Arrange
             BaseUserProfileServiceMock baseMock = SetupUpdateAcceptedTermsMock(DbStatusCode.Updated);
@@ -274,7 +273,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             if (baseMock is UpdateAcceptedTermsMock mock)
             {
                 // Act
-                await mock.Service.UpdateAcceptedTermsAsync(mock.Hdid, mock.TermsOfServiceId);
+                await mock.Service.UpdateAcceptedTermsAsync(Hdid, TermsOfServiceGuid);
 
                 // Verify
                 VerifyUserProfileUpdate(mock.UserProfileDelegateMock);
@@ -290,7 +289,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task UpdateAcceptedTermsAsyncThrowsDatabaseException()
+        public async Task UpdateAcceptedTermsThrowsDatabaseException()
         {
             // Arrange
             BaseUserProfileServiceMock baseMock = SetupUpdateAcceptedTermsMock(DbStatusCode.Error);
@@ -299,7 +298,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 // Act and Assert
                 await Assert.ThrowsAsync<DatabaseException>(
-                    async () => { await mock.Service.UpdateAcceptedTermsAsync(mock.Hdid, mock.TermsOfServiceId); });
+                    async () => { await mock.Service.UpdateAcceptedTermsAsync(Hdid, TermsOfServiceGuid); });
             }
             else
             {
@@ -552,12 +551,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 return new UpdateAcceptedTermsMock(
                     service,
-                    userProfileDelegateMock,
-                    Hdid,
-                    TermsOfServiceGuid);
+                    userProfileDelegateMock);
             }
 
-            return new UpdateAcceptedTermsExceptionMock(service, Hdid, TermsOfServiceGuid);
+            return new UpdateAcceptedTermsExceptionMock(service);
         }
 
         private static BaseUserProfileServiceMock SetupCloseUserProfileMock(
@@ -588,11 +585,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 return new CloseUserProfileMock(
                     service,
                     userProfileDelegateMock,
-                    jobServiceMock,
-                    Hdid);
+                    jobServiceMock);
             }
 
-            return new CloseUserProfileExceptionMock(service, Hdid);
+            return new CloseUserProfileExceptionMock(service);
         }
 
         private static BaseUserProfileServiceMock SetupRecoverUserProfileMock(
@@ -622,22 +618,20 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             {
                 if (profileUpdateStatus == DbStatusCode.Error)
                 {
-                    return new RecoverUserProfileExceptionMock(service, Hdid);
+                    return new RecoverUserProfileExceptionMock(service);
                 }
 
                 return new RecoverUserProfileMock(
                     service,
                     userProfileDelegateMock,
-                    jobServiceMock,
-                    Hdid);
+                    jobServiceMock);
             }
 
-            return new RecoverUserProfileExceptionMock(service, Hdid);
+            return new RecoverUserProfileExceptionMock(service);
         }
 
         private static UserProfileMock SetupUserProfileMock(
             DateTime currentDateTime,
-            DateTime jwtAuthTime,
             bool userProfileExists = true)
         {
             DateTime birthDate = GenerateBirthDate();
@@ -665,48 +659,36 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             return new(
                 service,
-                userProfileDelegateMock,
-                Hdid,
-                jwtAuthTime);
+                userProfileDelegateMock);
         }
 
         private abstract record BaseUserProfileServiceMock;
 
         private sealed record UserProfileMock(
             IUserProfileServiceV2 Service,
-            Mock<IUserProfileDelegate> UserProfileDelegateMock,
-            string Hdid,
-            DateTime JwtAuthTime);
+            Mock<IUserProfileDelegate> UserProfileDelegateMock);
 
         private sealed record UpdateAcceptedTermsMock(
             IUserProfileServiceV2 Service,
-            Mock<IUserProfileDelegate> UserProfileDelegateMock,
-            string Hdid,
-            Guid TermsOfServiceId) : BaseUserProfileServiceMock;
+            Mock<IUserProfileDelegate> UserProfileDelegateMock) : BaseUserProfileServiceMock;
 
         private sealed record UpdateAcceptedTermsExceptionMock(
-            IUserProfileServiceV2 Service,
-            string Hdid,
-            Guid TermsOfServiceId) : BaseUserProfileServiceMock;
+            IUserProfileServiceV2 Service) : BaseUserProfileServiceMock;
 
         private sealed record CloseUserProfileMock(
             IUserProfileServiceV2 Service,
             Mock<IUserProfileDelegate> UserProfileDelegateMock,
-            Mock<IJobService> JobServiceMock,
-            string Hdid) : BaseUserProfileServiceMock;
+            Mock<IJobService> JobServiceMock) : BaseUserProfileServiceMock;
 
         private sealed record CloseUserProfileExceptionMock(
-            IUserProfileServiceV2 Service,
-            string Hdid) : BaseUserProfileServiceMock;
+            IUserProfileServiceV2 Service) : BaseUserProfileServiceMock;
 
         private sealed record RecoverUserProfileMock(
             IUserProfileServiceV2 Service,
             Mock<IUserProfileDelegate> UserProfileDelegateMock,
-            Mock<IJobService> JobServiceMock,
-            string Hdid) : BaseUserProfileServiceMock;
+            Mock<IJobService> JobServiceMock) : BaseUserProfileServiceMock;
 
         private sealed record RecoverUserProfileExceptionMock(
-            IUserProfileServiceV2 Service,
-            string Hdid) : BaseUserProfileServiceMock;
+            IUserProfileServiceV2 Service) : BaseUserProfileServiceMock;
     }
 }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldValidateEligibility(int minPatientAge, int patientAge, bool expected)
         {
             // Arrange
-            IUserValidationService service = SetupValidateEligibilityMock(minPatientAge, patientAge);
+            IUserValidationService service = SetupUserValidationServiceForValidateEligibility(minPatientAge, patientAge);
 
             // Act
             bool actual = await service.ValidateEligibilityAsync(Hdid);
@@ -135,7 +135,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return patientDetailsServiceMock;
         }
 
-        private static IUserValidationService SetupValidateEligibilityMock(
+        private static IUserValidationService SetupUserValidationServiceForValidateEligibility(
             int minPatientAge = 0,
             int patientAge = 0)
         {

--- a/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserValidationServiceTests.cs
@@ -48,10 +48,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldValidatePhoneNumber(string phoneNumber, bool expected)
         {
             // Arrange
-            PhoneNumberValidMock mock = SetupPhoneNumberValidMock(phoneNumber);
+            IUserValidationService service = GetUserValidationService(configurationRoot: GetIConfiguration());
 
             // Act
-            bool actual = await mock.Service.IsPhoneNumberValidAsync(mock.PhoneNumber);
+            bool actual = await service.IsPhoneNumberValidAsync(phoneNumber);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -72,10 +72,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         public async Task ShouldValidateEligibility(int minPatientAge, int patientAge, bool expected)
         {
             // Arrange
-            ValidateEligibilityMock mock = SetupValidateEligibilityMock(minPatientAge, patientAge);
+            IUserValidationService service = SetupValidateEligibilityMock(minPatientAge, patientAge);
 
             // Act
-            bool actual = await mock.Service.ValidateEligibilityAsync(mock.Hdid);
+            bool actual = await service.ValidateEligibilityAsync(Hdid);
 
             // Assert
             Assert.Equal(expected, actual);
@@ -135,13 +135,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return patientDetailsServiceMock;
         }
 
-        private static PhoneNumberValidMock SetupPhoneNumberValidMock(string phoneNumber)
-        {
-            IUserValidationService service = GetUserValidationService(configurationRoot: GetIConfiguration());
-            return new(service, phoneNumber);
-        }
-
-        private static ValidateEligibilityMock SetupValidateEligibilityMock(
+        private static IUserValidationService SetupValidateEligibilityMock(
             int minPatientAge = 0,
             int patientAge = 0)
         {
@@ -152,19 +146,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             PatientDetails patientDetails = GeneratePatientDetails(birthDate: DateOnly.FromDateTime(birthDate));
             Mock<IPatientDetailsService> patientDetailsServiceMock = SetupPatientDetailsServiceMock(patientDetails);
 
-            IUserValidationService service = GetUserValidationService(
+            return GetUserValidationService(
                 configuration,
                 patientDetailsServiceMock);
-
-            return new(service, Hdid);
         }
-
-        private sealed record PhoneNumberValidMock(
-            IUserValidationService Service,
-            string PhoneNumber);
-
-        private sealed record ValidateEligibilityMock(
-            IUserValidationService Service,
-            string Hdid);
     }
 }

--- a/Apps/Immunization/src/Controllers/AuthenticatedVaccineStatusController.cs
+++ b/Apps/Immunization/src/Controllers/AuthenticatedVaccineStatusController.cs
@@ -20,7 +20,6 @@ namespace HealthGateway.Immunization.Controllers
     using Asp.Versioning;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
     using Microsoft.AspNetCore.Authorization;

--- a/Apps/Immunization/src/Controllers/ImmunizationController.cs
+++ b/Apps/Immunization/src/Controllers/ImmunizationController.cs
@@ -20,7 +20,6 @@ namespace HealthGateway.Immunization.Controllers
     using Asp.Versioning;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
     using Microsoft.AspNetCore.Authorization;

--- a/Apps/Immunization/src/Controllers/PublicVaccineStatusController.cs
+++ b/Apps/Immunization/src/Controllers/PublicVaccineStatusController.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Immunization.Controllers
     using System.Threading.Tasks;
     using Asp.Versioning;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.Immunization.Models;
     using HealthGateway.Immunization.Services;
     using Microsoft.AspNetCore.Authorization;

--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -21,7 +21,6 @@ namespace HealthGateway.Laboratory.Controllers
     using Asp.Versioning;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.Laboratory.Models;
     using HealthGateway.Laboratory.Models.PHSA;
     using HealthGateway.Laboratory.Services;

--- a/Apps/Laboratory/src/Controllers/PublicLaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/PublicLaboratoryController.cs
@@ -20,7 +20,6 @@ namespace HealthGateway.Laboratory.Controllers
     using System.Threading.Tasks;
     using Asp.Versioning;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.Filters;
     using HealthGateway.Laboratory.Models.PHSA;
     using HealthGateway.Laboratory.Services;
     using Microsoft.AspNetCore.Authorization;


### PR DESCRIPTION
# Implements [AB#16851](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16851)

## Description

Reorganize unit test setup:

- Reduce use of Record type
- Moved 'Expected' creation from Setup function back to unit test itself for clearer definition
- Moved 'Parameters' to be used when calling service or delegate or repository from Setup function back to unit test itself for clearer definition
- Moved data/object creation from Setup function back to unit test for clearer definition as to what is being used in the mock 
- Removed 'Async' from unit test name
- Created helper functions in unit tests to help reduce duplicated code
- Increased code coverage for v1 UserEmailService and UserSmsService
- Also removed imports no longer being used in code.

See latest Sonar coverage for services: https://sonarcloud.io/code?id=bcgov_healthgateway&selected=bcgov_healthgateway%3AApps

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
