### PR TITLE
Remove push to no longer existing silver environment for AB#16862.

### DIFF
--- a/Tools/BaseImage/azure/build.yaml
+++ b/Tools/BaseImage/azure/build.yaml
@@ -41,13 +41,3 @@ steps:
       tags: |
         $(Build.BuildNumber)
         latest
-
-  - bash: |
-      set -e
-      oc login --token=$(OpenShiftToken) --server=$(OpenShiftUri)
-      oc project $(SilverLicense)-tools
-      oc tag $(App.Name):latest $(App.Name):previous
-      docker tag $(DockerRepo)/$(App.Name):$(Build.BuildNumber) $(ImageRegistry)/$(SilverLicense)-tools/$(App.Name):latest
-      docker login $(ImageRegistry) --username=azure --password=$(OpenShiftToken)
-      docker push $(ImageRegistry)/$(SilverLicense)-tools/$(App.Name):latest
-    displayName: Push Image to OpenShift


### PR DESCRIPTION
# Fixes [AB#16862](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16862)

## Description

Silver Openshift Environment has been decommissioned.  Removed reference to Silver in Base Image build yaml.

See [Successful Run](https://dev.azure.com/qslvic/Health%20Gateway/_build/results?buildId=43576&view=results)

Note: OWASP ZAP pipeline error fixed by editing pipeline's bash scripts.  See [Successful Run](https://dev.azure.com/qslvic/Health%20Gateway/_build/results?buildId=43581&view=results)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
