### PR TITLE
Use local time offset to ensure DST is applied correctly for AB#16861.

### DIFF
--- a/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
@@ -277,6 +277,8 @@ namespace HealthGateway.Admin.Tests.Services
         [Fact]
         public void TestMapperAdminUserProfileViewFromAdminUserProfile()
         {
+            TimeSpan localTimeOffset = DateFormatter.GetLocalTimeOffset(Configuration, DateTime.UtcNow);
+
             AdminUserProfile adminUserProfile = new()
             {
                 AdminUserProfileId = Guid.NewGuid(),
@@ -288,7 +290,7 @@ namespace HealthGateway.Admin.Tests.Services
             {
                 AdminUserProfileId = adminUserProfile.AdminUserProfileId,
                 UserId = null,
-                LastLoginDateTime = adminUserProfile.LastLoginDateTime,
+                LastLoginDateTime = adminUserProfile.LastLoginDateTime.AddMinutes(localTimeOffset.TotalMinutes),
                 Username = adminUserProfile.Username,
                 Email = null,
                 FirstName = null,
@@ -301,8 +303,8 @@ namespace HealthGateway.Admin.Tests.Services
             Assert.Equal(expected.AdminUserProfileId, actual.AdminUserProfileId);
             Assert.Equal(expected.UserId, actual.UserId);
             Assert.NotNull(actual.LastLoginDateTime);
-            Assert.Equal(DateTimeKind.Unspecified, actual.LastLoginDateTime.Value.Kind);
-            Assert.Equal(expected.LastLoginDateTime, DateFormatter.SpecifyLocal(actual.LastLoginDateTime.Value, Configuration));
+            Assert.Equal(DateTimeKind.Utc, actual.LastLoginDateTime.Value.Kind);
+            Assert.Equal(expected.LastLoginDateTime, actual.LastLoginDateTime.Value);
             Assert.Equal(expected.Username, actual.Username);
             Assert.Equal(expected.Email, actual.Email);
             Assert.Equal(expected.FirstName, actual.FirstName);

--- a/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
+++ b/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
@@ -78,7 +78,18 @@ namespace HealthGateway.Admin.Tests.Services
             // Arrange
             const int inactiveDays = 3;
             DateTime today = DateTime.UtcNow.Date;
-            IList<AdminUserProfile> inactiveUserProfiles = GenerateInactiveUserProfiles(today);
+            IList<AdminUserProfile> activeUserProfiles =
+            [
+                GenerateAdminUserProfile(AdminUsername1, today.AddDays(-1)),
+                GenerateAdminUserProfile(SupportUsername1, today.AddDays(-2)),
+            ];
+
+            IList<AdminUserProfile> inactiveUserProfiles =
+            [
+                GenerateAdminUserProfile(AdminUsername2, today.AddDays(-3)),
+                GenerateAdminUserProfile(SupportUsername2, today.AddDays(-4)),
+            ];
+
             List<UserRepresentation> keycloakAdminUsers = GenerateKeycloakAdminUsers();
             List<UserRepresentation> keycloakSupportUsers = GenerateKeycloakSupportUsers();
             TimeSpan localTimeOffset = DateFormatter.GetLocalTimeOffset(Configuration, DateTime.UtcNow);
@@ -97,7 +108,7 @@ namespace HealthGateway.Admin.Tests.Services
                     : null,
             };
 
-            IInactiveUserService service = await SetupGetInactiveUsersMock(today, adminUserErrorExists, supportUserErrorExists);
+            IInactiveUserService service = await SetupInactiveUsersMock(inactiveDays, activeUserProfiles, inactiveUserProfiles, adminUserErrorExists, supportUserErrorExists);
 
             // Act
             RequestResult<List<AdminUserProfileView>> actual = await service.GetInactiveUsersAsync(inactiveDays);
@@ -201,15 +212,6 @@ namespace HealthGateway.Admin.Tests.Services
             ];
         }
 
-        private static IList<AdminUserProfile> GenerateInactiveUserProfiles(DateTime today)
-        {
-            return
-            [
-                GenerateAdminUserProfile(AdminUsername2, today.AddDays(-3)),
-                GenerateAdminUserProfile(SupportUsername2, today.AddDays(-4)),
-            ];
-        }
-
         private static UserRepresentation GenerateUserRepresentation(Guid userId, string username, string firstName, string lastName, string email, string roles)
         {
             return new()
@@ -236,19 +238,14 @@ namespace HealthGateway.Admin.Tests.Services
                 .Build();
         }
 
-        private static async Task<IInactiveUserService> SetupGetInactiveUsersMock(DateTime today, bool adminUserErrorExists, bool supportUserErrorExists)
+        private static async Task<IInactiveUserService> SetupInactiveUsersMock(
+            int inactiveDays,
+            IList<AdminUserProfile> activeUserProfiles,
+            IList<AdminUserProfile> inactiveUserProfiles,
+            bool adminUserErrorExists,
+            bool supportUserErrorExists)
         {
-            const int inactiveDays = 3;
-
             JwtModel jwt = GenerateJwt();
-
-            IList<AdminUserProfile> activeUserProfiles =
-            [
-                GenerateAdminUserProfile(AdminUsername1, today.AddDays(-1)),
-                GenerateAdminUserProfile(SupportUsername1, today.AddDays(-2)),
-            ];
-
-            IList<AdminUserProfile> inactiveUserProfiles = GenerateInactiveUserProfiles(today);
 
             List<UserRepresentation> keycloakAdminUsers = GenerateKeycloakAdminUsers();
 


### PR DESCRIPTION
# Fixes [AB#16861](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16861)

## Description

Fixed mapper to use local time offset to ensure correct timezone including daylight savings time is being used.  TimeZoneInfo.ConvertTimeFromUtc was returning a date that was still using daylight savings time even though daylight savings time has passed.

**Unit Tests:**

<img width="1231" alt="Screenshot 2024-11-06 at 2 13 57 PM" src="https://github.com/user-attachments/assets/3ac94ada-003d-4627-a929-3d4145a5e9bd">

**UTC: 5:26:13 PM:**

<img width="777" alt="Screenshot 2024-11-06 at 1 33 43 PM" src="https://github.com/user-attachments/assets/297ca470-6514-460b-8e38-1e60fdf95022">

**PST: 9:26:13 AM:**

<img width="1122" alt="Screenshot 2024-11-06 at 1 33 58 PM" src="https://github.com/user-attachments/assets/d0d4d8bf-b293-4d71-8637-3591e866dae0">

Sonar passed:

https://dev.azure.com/qslvic/Health%20Gateway/_build/results?buildId=43591&view=results

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
