### PR TITLE
Skip test due to PHSA bad test data for AB#16863

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/dependent/report.js
+++ b/Testing/functional/tests/cypress/integration/e2e/dependent/report.js
@@ -252,7 +252,8 @@ describe("Reports", () => {
         );
     });
 
-    it("Validate Special Authority Report", () => {
+    // test should be skipped until PHSA fixes test data for this dependent
+    it.skip("Validate Special Authority Report", () => {
         const hdid = specialAuthorityDependent.hdid;
 
         const cardSelector = getCardSelector(hdid);

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/dependent.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/dependent.js
@@ -308,7 +308,9 @@ describe("Dependent Timeline Datasets", () => {
         disabledDatasetShouldNotBePresent(Dataset.DiagnosticImaging);
         disabledDependentDatasetShouldNotBePresent(Dataset.DiagnosticImaging);
     });
-    it("Validate Special Authority requests on dependent timeline", () => {
+
+    // test should be skipped until PHSA fixes test data for this dependent
+    it.skip("Validate Special Authority requests on dependent timeline", () => {
         enabledDatasetShouldBePresent(
             Dataset.SpecialAuthorityRequest,
             authorizedSpecialAuthorityDependentHdid


### PR DESCRIPTION
# Fixes [AB#16863](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16863)

## Description

Due to bad data (no data to be precise)  from PHSA the following functional tests are failing:

* e2e/dependent/report.js - Validate Special Authority Report
* e2e/timeline/dependent.js - Validate Special Authority requests on dependent timeline

As a result, the files have been edited to skip those tests until test data has been restored.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
