### PR TITLE
Sonar Warnings for Dot Net 9 for AB#16872

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,15 @@ indent_size = 2
 # All Rules are enabled with default severity.
 # Rules with IsEnabledByDefault = false are force-enabled with default severity.
 
+# CA1515 Suppress "Because an application's API isn't typically referenced from outside the assembly, types can be made internal"
+dotnet_diagnostic.ca1515.severity = none
+
+# IDE0290 Suppress "Use primary constructor"
+dotnet_diagnostic.IDE0290.severity = none
+
+# IDE0160 Suppress "Convert to block scoped namespace"
+dotnet_diagnostic.IDE0160.severity = none
+
 # S101: Types should be named in PascalCase
 dotnet_diagnostic.s101.severity = none
 

--- a/Apps/AccountDataAccess/src/Audit/AuditRepository.cs
+++ b/Apps/AccountDataAccess/src/Audit/AuditRepository.cs
@@ -25,19 +25,9 @@ namespace HealthGateway.AccountDataAccess.Audit
     /// <summary>
     /// Handle audit data.
     /// </summary>
-    public class AuditRepository : IAuditRepository
+    /// <param name="agentAuditDelegate">The injected agent audit delegate.</param>
+    public class AuditRepository(IAgentAuditDelegate agentAuditDelegate) : IAuditRepository
     {
-        private readonly IAgentAuditDelegate agentAuditDelegate;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="AuditRepository"/> class.
-        /// </summary>
-        /// <param name="agentAuditDelegate">The injected agent audit delegate.</param>
-        public AuditRepository(IAgentAuditDelegate agentAuditDelegate)
-        {
-            this.agentAuditDelegate = agentAuditDelegate;
-        }
-
         private static ActivitySource ActivitySource { get; } = new(typeof(AuditRepository).FullName);
 
         /// <inheritdoc/>
@@ -50,7 +40,7 @@ namespace HealthGateway.AccountDataAccess.Audit
                 activity?.AddBaggage("AuditGroup", query.Group.ToString());
             }
 
-            return await this.agentAuditDelegate.GetAgentAuditsAsync(query.Hdid, query.Group, ct);
+            return await agentAuditDelegate.GetAgentAuditsAsync(query.Hdid, query.Group, ct);
         }
     }
 }

--- a/Apps/AccountDataAccess/src/Patient/Address.cs
+++ b/Apps/AccountDataAccess/src/Patient/Address.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.AccountDataAccess.Patient
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Represents an address.
@@ -26,7 +25,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <summary>
         /// Gets or sets the street lines.
         /// </summary>
-        public IEnumerable<string> StreetLines { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> StreetLines { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the city name.

--- a/Apps/AccountDataAccess/src/Patient/PatientMappings.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientMappings.cs
@@ -38,7 +38,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         private static Name ExtractPreferredName(PatientIdentity patientIdentity)
         {
             string preferredName = StringManipulator.JoinWithoutBlanks(
-                new[] { patientIdentity.PreferredFirstName, patientIdentity.PreferredSecondName, patientIdentity.PreferredThirdName });
+                [patientIdentity.PreferredFirstName, patientIdentity.PreferredSecondName, patientIdentity.PreferredThirdName]);
 
             return new()
             {
@@ -50,7 +50,7 @@ namespace HealthGateway.AccountDataAccess.Patient
         private static Name ExtractLegalName(PatientIdentity patientIdentity)
         {
             string legalName = StringManipulator.JoinWithoutBlanks(
-                new[] { patientIdentity.LegalFirstName, patientIdentity.LegalSecondName, patientIdentity.LegalThirdName });
+                [patientIdentity.LegalFirstName, patientIdentity.LegalSecondName, patientIdentity.LegalThirdName]);
 
             return new()
             {
@@ -64,7 +64,7 @@ namespace HealthGateway.AccountDataAccess.Patient
             if (ShouldReturnHomeAddress(patientIdentity))
             {
                 IEnumerable<string> streetLines = StringManipulator.ExcludeBlanks(
-                    new[] { patientIdentity.HomeAddressStreetOne, patientIdentity.HomeAddressStreetTwo, patientIdentity.HomeAddressStreetThree });
+                    [patientIdentity.HomeAddressStreetOne, patientIdentity.HomeAddressStreetTwo, patientIdentity.HomeAddressStreetThree]);
 
                 return new()
                 {
@@ -84,7 +84,7 @@ namespace HealthGateway.AccountDataAccess.Patient
             if (ShouldReturnPostalAddress(patientIdentity))
             {
                 IEnumerable<string> streetLines = StringManipulator.ExcludeBlanks(
-                    new[] { patientIdentity.MailAddressStreetOne, patientIdentity.MailAddressStreetTwo, patientIdentity.MailAddressStreetThree });
+                    [patientIdentity.MailAddressStreetOne, patientIdentity.MailAddressStreetTwo, patientIdentity.MailAddressStreetThree]);
 
                 return new()
                 {

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidEmpiStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidEmpiStrategy.cs
@@ -25,32 +25,21 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     /// <summary>
     /// Strategy implementation for EMPI hdid patient data source with or without cache.
     /// </summary>
-    internal class HdidEmpiStrategy : PatientQueryStrategy
+    /// <param name="configuration">The injected configuration.</param>
+    /// <param name="cacheProvider">The injected cache provider.</param>
+    /// <param name="clientRegistriesDelegate">The injected client registries delegate.</param>
+    /// <param name="logger">The injected logger.</param>
+    internal class HdidEmpiStrategy(
+        IConfiguration configuration,
+        ICacheProvider cacheProvider,
+        IClientRegistriesDelegate clientRegistriesDelegate,
+        ILogger<HdidEmpiStrategy> logger) : PatientQueryStrategy(configuration, cacheProvider, logger)
     {
-        private readonly IClientRegistriesDelegate clientRegistriesDelegate;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HdidEmpiStrategy"/> class.
-        /// </summary>
-        /// <param name="configuration">The injected configuration.</param>
-        /// <param name="cacheProvider">The injected cache provider.</param>
-        /// <param name="clientRegistriesDelegate">The injected client registries delegate.</param>
-        /// <param name="logger">The injected logger.</param>
-        public HdidEmpiStrategy(
-            IConfiguration configuration,
-            ICacheProvider cacheProvider,
-            IClientRegistriesDelegate clientRegistriesDelegate,
-            ILogger<HdidEmpiStrategy> logger)
-            : base(configuration, cacheProvider, logger)
-        {
-            this.clientRegistriesDelegate = clientRegistriesDelegate;
-        }
-
         /// <inheritdoc/>
         public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
             PatientModel patient = (request.UseCache ? await this.GetFromCacheAsync(request.Identifier, PatientIdentifierType.Hdid, ct) : null) ??
-                                   await this.clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation, ct);
+                                   await clientRegistriesDelegate.GetDemographicsAsync(OidType.Hdid, request.Identifier, request.DisabledValidation, ct);
 
             await this.CachePatientAsync(patient, request.DisabledValidation, ct);
             return patient;

--- a/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/HdidPhsaStrategy.cs
@@ -30,31 +30,18 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     /// <summary>
     /// Strategy implementation for PHSA phn patient data source with or without cache.
     /// </summary>
-    internal class HdidPhsaStrategy : PatientQueryStrategy
+    /// <param name="configuration">The injected configuration.</param>
+    /// <param name="cacheProvider">The injected cache provider.</param>
+    /// <param name="patientIdentityApi">The injected patient identity api. </param>
+    /// <param name="logger">The injected logger.</param>
+    /// <param name="mapper">The injected mapper.</param>
+    internal class HdidPhsaStrategy(
+        IConfiguration configuration,
+        ICacheProvider cacheProvider,
+        IPatientIdentityApi patientIdentityApi,
+        ILogger<HdidPhsaStrategy> logger,
+        IMapper mapper) : PatientQueryStrategy(configuration, cacheProvider, logger)
     {
-        private readonly IPatientIdentityApi patientIdentityApi;
-        private readonly IMapper mapper;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="HdidPhsaStrategy"/> class.
-        /// </summary>
-        /// <param name="configuration">The injected configuration.</param>
-        /// <param name="cacheProvider">The injected cache provider.</param>
-        /// <param name="patientIdentityApi">The injected patient identity api. </param>
-        /// <param name="logger">The injected logger.</param>
-        /// <param name="mapper">The injected mapper.</param>
-        public HdidPhsaStrategy(
-            IConfiguration configuration,
-            ICacheProvider cacheProvider,
-            IPatientIdentityApi patientIdentityApi,
-            ILogger<HdidPhsaStrategy> logger,
-            IMapper mapper)
-            : base(configuration, cacheProvider, logger)
-        {
-            this.patientIdentityApi = patientIdentityApi;
-            this.mapper = mapper;
-        }
-
         /// <inheritdoc/>
         public override async Task<PatientModel> GetPatientAsync(PatientRequest request, CancellationToken ct = default)
         {
@@ -65,8 +52,8 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
                 try
                 {
                     this.GetLogger().LogDebug("Retrieving patient from PHSA");
-                    PatientIdentity result = await this.patientIdentityApi.GetPatientIdentityAsync(request.Identifier, ct);
-                    patient = this.mapper.Map<PatientModel>(result);
+                    PatientIdentity result = await patientIdentityApi.GetPatientIdentityAsync(request.Identifier, ct);
+                    patient = mapper.Map<PatientModel>(result);
                 }
                 catch (ApiException e) when (e.StatusCode == HttpStatusCode.NotFound)
                 {

--- a/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryContext.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryContext.cs
@@ -21,22 +21,9 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     /// <summary>
     /// The Context defines the interface of interest to clients.
     /// </summary>
-    internal class PatientQueryContext
+    /// <param name="patientQueryStrategy">The implemented request to use.</param>
+    internal class PatientQueryContext(PatientQueryStrategy patientQueryStrategy)
     {
-        // The Context maintains a reference to one of the Strategy objects. The
-        // Context does not know the concrete class of a request. It should
-        // work with all strategies via the Strategy interface.
-        private readonly PatientQueryStrategy patientQueryStrategy;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatientQueryContext"/> class.
-        /// </summary>
-        /// <param name="patientQueryStrategy">The implemented request to use.</param>
-        public PatientQueryContext(PatientQueryStrategy patientQueryStrategy)
-        {
-            this.patientQueryStrategy = patientQueryStrategy;
-        }
-
         /// <summary>
         /// Returns patient from the specified source in the patient request.
         /// </summary>
@@ -45,7 +32,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         /// <returns>The patient model.</returns>
         public async Task<PatientModel> GetPatientAsync(PatientRequest patientRequest, CancellationToken ct = default)
         {
-            return await this.patientQueryStrategy.GetPatientAsync(patientRequest, ct);
+            return await patientQueryStrategy.GetPatientAsync(patientRequest, ct);
         }
     }
 }

--- a/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryFactory.cs
+++ b/Apps/AccountDataAccess/src/Patient/Strategy/PatientQueryFactory.cs
@@ -21,19 +21,9 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
     /// <summary>
     /// Factory for <see cref="PatientQueryStrategy"/> instances.
     /// </summary>
-    internal class PatientQueryFactory
+    /// <param name="serviceProvider">The injected service provider.</param>
+    internal class PatientQueryFactory(IServiceProvider serviceProvider)
     {
-        private readonly IServiceProvider serviceProvider;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="PatientQueryFactory"/> class.
-        /// </summary>
-        /// <param name="serviceProvider">The injected service provider.</param>
-        public PatientQueryFactory(IServiceProvider serviceProvider)
-        {
-            this.serviceProvider = serviceProvider;
-        }
-
         /// <summary>
         /// Returns an instance of the requested <see cref="PatientQueryStrategy"/> class.
         /// </summary>
@@ -42,7 +32,7 @@ namespace HealthGateway.AccountDataAccess.Patient.Strategy
         public PatientQueryStrategy GetPatientQueryStrategy(string strategy)
         {
             Type type = Type.GetType(strategy) ?? throw new ArgumentException($"Invalid strategy type {strategy}");
-            return (PatientQueryStrategy)this.serviceProvider.GetRequiredService(type);
+            return (PatientQueryStrategy)serviceProvider.GetRequiredService(type);
         }
     }
 }

--- a/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
+++ b/Apps/AccountDataAccess/test/unit/ClientRegistriesDelegateTests.cs
@@ -478,21 +478,18 @@ namespace AccountDataAccessTest
 
         private static II[] GenerateId(bool shouldReturnEmpty = false, string? extension = null, string? oidType = null, bool displayable = true)
         {
-            if (shouldReturnEmpty)
-            {
-                return [];
-            }
-
-            return
-            [
-                new II
-                {
-                    root = oidType ?? HdidOidType,
-                    extension = oidType == null || (oidType == HdidOidType && extension == null) ? Hdid
-                        : oidType == PhnOidType && extension == null ? Phn : extension,
-                    displayable = displayable,
-                },
-            ];
+            return shouldReturnEmpty
+                ? []
+                :
+                [
+                    new II
+                    {
+                        root = oidType ?? HdidOidType,
+                        extension = oidType == null || (oidType == HdidOidType && extension == null) ? Hdid
+                            : oidType == PhnOidType && extension == null ? Phn : extension,
+                        displayable = displayable,
+                    },
+                ];
         }
 
         private static HCIM_IN_GetDemographicsResponsePerson GenerateIdentifiedPerson(
@@ -507,7 +504,9 @@ namespace AccountDataAccessTest
             return new HCIM_IN_GetDemographicsResponsePerson
             {
                 deceasedInd = new BL
-                    { value = deceasedInd },
+                {
+                    value = deceasedInd,
+                },
                 id = GenerateId(shouldReturnEmpty, extension, oidType),
                 name = names.ToArray(),
                 birthTime = new TS

--- a/Apps/AccountDataAccess/test/unit/PatientMappingsTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientMappingsTests.cs
@@ -86,9 +86,15 @@ namespace AccountDataAccessTest
                 ResponseCode = string.Empty,
                 IsDeceased = true,
                 CommonName = new Name
-                    { GivenName = expectedCommonGivenName, Surname = PhsaPreferredLastName },
+                {
+                    GivenName = expectedCommonGivenName,
+                    Surname = PhsaPreferredLastName,
+                },
                 LegalName = new Name
-                    { GivenName = expectedLegalGivenName, Surname = PhsaLegalLastName },
+                {
+                    GivenName = expectedLegalGivenName,
+                    Surname = PhsaLegalLastName,
+                },
                 PhysicalAddress = new Address
                 {
                     StreetLines =
@@ -173,9 +179,15 @@ namespace AccountDataAccessTest
                 ResponseCode = string.Empty,
                 IsDeceased = true,
                 CommonName = new Name
-                    { GivenName = expectedCommonGivenName, Surname = expectedCommonSurname },
+                {
+                    GivenName = expectedCommonGivenName,
+                    Surname = expectedCommonSurname,
+                },
                 LegalName = new Name
-                    { GivenName = expectedLegalGivenName, Surname = expectedLegalSurname },
+                {
+                    GivenName = expectedLegalGivenName,
+                    Surname = expectedLegalSurname,
+                },
                 PhysicalAddress = null,
                 PostalAddress = null,
             };

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -303,7 +303,7 @@ namespace AccountDataAccessTest
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -330,10 +330,12 @@ namespace AccountDataAccessTest
 
             if (changeFeedEnabled)
             {
-                IEnumerable<MessageEnvelope> events = new MessageEnvelope[]
-                {
-                    new(new DataSourcesBlockedEvent(blockedAccess.Hdid, GetDataSourceValues(blockedAccess.DataSources)), blockedAccess.Hdid),
-                };
+                IEnumerable<MessageEnvelope> events =
+                [
+                    new(
+                        new DataSourcesBlockedEvent(blockedAccess.Hdid, GetDataSourceValues(blockedAccess.DataSources)),
+                        blockedAccess.Hdid),
+                ];
                 messageSender.Setup(ms => ms.SendAsync(events, It.IsAny<CancellationToken>()));
             }
 

--- a/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/CacheProviderTests.cs
@@ -87,7 +87,7 @@ namespace AccountDataAccessTest.Strategy
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -105,7 +105,7 @@ namespace AccountDataAccessTest.Strategy
                     s => s.GetDemographicsAsync(
                         It.Is<OidType>(x => x == OidType.Hdid),
                         It.Is<string>(x => x == Hdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patient);
 

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidAllStrategyTests.cs
@@ -98,9 +98,15 @@ namespace AccountDataAccessTest.Strategy
                 ResponseCode = string.Empty,
                 IsDeceased = false,
                 CommonName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
+                {
+                    GivenName = string.Empty,
+                    Surname = string.Empty,
+                },
                 LegalName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
+                {
+                    GivenName = string.Empty,
+                    Surname = string.Empty,
+                },
             };
 
             PatientIdentity patientIdentity = new()
@@ -146,7 +152,7 @@ namespace AccountDataAccessTest.Strategy
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -169,7 +175,7 @@ namespace AccountDataAccessTest.Strategy
                         s => s.GetDemographicsAsync(
                             It.Is<OidType>(x => x == OidType.Hdid),
                             It.Is<string>(x => x == Hdid),
-                            It.Is<bool>(x => x == false),
+                            It.Is<bool>(x => !x),
                             It.IsAny<CancellationToken>()))
                     .ReturnsAsync(patient);
             }
@@ -192,7 +198,7 @@ namespace AccountDataAccessTest.Strategy
                     s => s.GetDemographicsAsync(
                         It.Is<OidType>(x => x == OidType.Hdid),
                         It.Is<string>(x => x == PhsaHdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .Throws(new CommunicationException("Unit test PHSA get patient identity."));
 
@@ -219,7 +225,7 @@ namespace AccountDataAccessTest.Strategy
                     s => s.GetDemographicsAsync(
                         It.Is<OidType>(x => x == OidType.Hdid),
                         It.Is<string>(x => x == PhsaHdidNotFound),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .Throws(new CommunicationException("Unit test PHSA get patient identity. NotFound"));
 

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidEmpiStrategyTests.cs
@@ -77,7 +77,7 @@ namespace AccountDataAccessTest.Strategy
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -100,7 +100,7 @@ namespace AccountDataAccessTest.Strategy
                         s => s.GetDemographicsAsync(
                             It.Is<OidType>(x => x == OidType.Hdid),
                             It.Is<string>(x => x == Hdid),
-                            It.Is<bool>(x => x == false),
+                            It.Is<bool>(x => !x),
                             It.IsAny<CancellationToken>()))
                     .ReturnsAsync(patient);
             }

--- a/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/HdidPhsaStrategyTests.cs
@@ -63,9 +63,15 @@ namespace AccountDataAccessTest.Strategy
                 ResponseCode = string.Empty,
                 IsDeceased = false,
                 CommonName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
+                {
+                    GivenName = string.Empty,
+                    Surname = string.Empty,
+                },
                 LegalName = new Name
-                    { GivenName = string.Empty, Surname = string.Empty },
+                {
+                    GivenName = string.Empty,
+                    Surname = string.Empty,
+                },
             };
 
             (HdidPhsaStrategy strategy, Mock<ICacheProvider> cacheProvider) = SetupPatientMockForGetPatient(useCache, expected);
@@ -110,7 +116,7 @@ namespace AccountDataAccessTest.Strategy
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 

--- a/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
+++ b/Apps/AccountDataAccess/test/unit/Strategy/PhnEmpiStrategyTests.cs
@@ -104,7 +104,7 @@ namespace AccountDataAccessTest.Strategy
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -127,7 +127,7 @@ namespace AccountDataAccessTest.Strategy
                         s => s.GetDemographicsAsync(
                             It.Is<OidType>(x => x == OidType.Phn),
                             It.Is<string>(x => x == Phn),
-                            It.Is<bool>(x => x == false),
+                            It.Is<bool>(x => !x),
                             It.IsAny<CancellationToken>()))
                     .ReturnsAsync(patient);
             }

--- a/Apps/Admin/Client/Components/Delegation/DelegateTable.razor.cs
+++ b/Apps/Admin/Client/Components/Delegation/DelegateTable.razor.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Client.Components.Delegation
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
@@ -49,6 +50,7 @@ namespace HealthGateway.Admin.Client.Components.Delegation
 
         private IEnumerable<DelegateRow> Rows => this.Data.Select(d => new DelegateRow(d));
 
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         private static Color GetStatusColor(DelegationStatus status)
         {
             return status switch
@@ -73,11 +75,9 @@ namespace HealthGateway.Admin.Client.Components.Delegation
                 this.DateOfBirth = model.Birthdate;
                 this.PersonalHealthNumber = model.PersonalHealthNumber;
                 this.Address = AddressUtility.GetAddressAsSingleLine(model.PhysicalAddress ?? model.PostalAddress);
-                this.DelegationStatus = model.DelegationStatus switch
-                {
-                    DelegationStatus.Unknown => DelegationStatus.Allowed,
-                    _ => model.DelegationStatus,
-                };
+                this.DelegationStatus = model.DelegationStatus == DelegationStatus.Unknown
+                    ? DelegationStatus.Allowed
+                    : model.DelegationStatus;
                 this.ToBeRemoved = model.StagedDelegationStatus == DelegationStatus.Disallowed;
             }
 

--- a/Apps/Admin/Client/Pages/AgentAccessPage.razor.cs
+++ b/Apps/Admin/Client/Pages/AgentAccessPage.razor.cs
@@ -40,17 +40,13 @@ public partial class AgentAccessPage : FluxorComponent
 
     private static Func<string, string?> ValidateQueryParameter => parameter =>
     {
-        if (string.IsNullOrWhiteSpace(parameter))
-        {
-            return "Search parameter is required";
-        }
+        string? lengthValidationResult = StringManipulator.StripWhitespace(parameter).Length < 3
+            ? "Query must contain at least 3 characters"
+            : null;
 
-        if (StringManipulator.StripWhitespace(parameter).Length < 3)
-        {
-            return "Query must contain at least 3 characters";
-        }
-
-        return null;
+        return string.IsNullOrWhiteSpace(parameter)
+            ? "Search parameter is required"
+            : lengthValidationResult;
     };
 
     [Inject]

--- a/Apps/Admin/Client/Pages/BetaAccessPage.razor.cs
+++ b/Apps/Admin/Client/Pages/BetaAccessPage.razor.cs
@@ -36,17 +36,13 @@ namespace HealthGateway.Admin.Client.Pages
     {
         private static Func<string, string?> ValidateQueryParameter => parameter =>
         {
-            if (string.IsNullOrWhiteSpace(parameter))
-            {
-                return "Email is required";
-            }
+            string? emailValidationResult = !NaiveEmailValidator.IsValid(StringManipulator.StripWhitespace(parameter))
+                ? "Invalid email format"
+                : null;
 
-            if (!NaiveEmailValidator.IsValid(StringManipulator.StripWhitespace(parameter)))
-            {
-                return "Invalid email format";
-            }
-
-            return null;
+            return string.IsNullOrWhiteSpace(parameter)
+                ? "Email is required"
+                : emailValidationResult;
         };
 
         [Inject]

--- a/Apps/Admin/Client/Pages/DashboardPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DashboardPage.razor.cs
@@ -134,24 +134,19 @@ public partial class DashboardPage : FluxorComponent
         }
     }
 
-    private IEnumerable<DailyDataRow> TableData
-    {
-        get
-        {
-            return this.DailyUsageCounts.UserRegistrations.Select(x => new DailyDataRow { Date = x.Key, UserRegistrations = x.Value })
-                .Concat(this.DailyUsageCounts.UserLogins.Select(x => new DailyDataRow { Date = x.Key, UserLogins = x.Value }))
-                .Concat(this.DailyUsageCounts.DependentRegistrations.Select(x => new DailyDataRow { Date = x.Key, DependentRegistrations = x.Value }))
-                .GroupBy(x => x.Date)
-                .Select(
-                    g => new DailyDataRow
-                    {
-                        Date = g.Key,
-                        UserRegistrations = g.Sum(x => x.UserRegistrations),
-                        UserLogins = g.Sum(x => x.UserLogins),
-                        DependentRegistrations = g.Sum(x => x.DependentRegistrations),
-                    });
-        }
-    }
+    private IEnumerable<DailyDataRow> TableData =>
+        this.DailyUsageCounts.UserRegistrations.Select(x => new DailyDataRow { Date = x.Key, UserRegistrations = x.Value })
+            .Concat(this.DailyUsageCounts.UserLogins.Select(x => new DailyDataRow { Date = x.Key, UserLogins = x.Value }))
+            .Concat(this.DailyUsageCounts.DependentRegistrations.Select(x => new DailyDataRow { Date = x.Key, DependentRegistrations = x.Value }))
+            .GroupBy(x => x.Date)
+            .Select(
+                g => new DailyDataRow
+                {
+                    Date = g.Key,
+                    UserRegistrations = g.Sum(x => x.UserRegistrations),
+                    UserLogins = g.Sum(x => x.UserLogins),
+                    DependentRegistrations = g.Sum(x => x.DependentRegistrations),
+                });
 
     /// <inheritdoc/>
     protected override void OnInitialized()

--- a/Apps/Admin/Client/Pages/DelegationPage.razor.cs
+++ b/Apps/Admin/Client/Pages/DelegationPage.razor.cs
@@ -43,17 +43,13 @@ namespace HealthGateway.Admin.Client.Pages
 
         private static Func<string, string?> ValidateQueryParameter => parameter =>
         {
-            if (string.IsNullOrWhiteSpace(parameter))
-            {
-                return "PHN is required";
-            }
+            string? phnValidationResult = !PhnValidator.Validate(StringManipulator.StripWhitespace(parameter)).IsValid
+                ? "Invalid PHN"
+                : null;
 
-            if (!PhnValidator.Validate(StringManipulator.StripWhitespace(parameter)).IsValid)
-            {
-                return "Invalid PHN";
-            }
-
-            return null;
+            return string.IsNullOrWhiteSpace(parameter)
+                ? "PHN is required"
+                : phnValidationResult;
         };
 
         [Inject]

--- a/Apps/Admin/Client/Pages/LoginPage.razor.cs
+++ b/Apps/Admin/Client/Pages/LoginPage.razor.cs
@@ -16,6 +16,7 @@
 
 namespace HealthGateway.Admin.Client.Pages;
 
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Components;
@@ -52,7 +53,29 @@ public partial class LoginPage : ComponentBase
         AuthenticationState authState = await this.AuthenticationStateProvider.GetAuthenticationStateAsync();
         if (authState.User.Identity is { IsAuthenticated: true })
         {
-            this.NavigationManager.NavigateTo(this.ReturnPath ?? "/", replace: true);
+            // Validate ReturnPath to ensure it's a safe URL
+            string safeReturnPath = ValidateReturnPath(this.ReturnPath);
+
+            // Perform the navigation
+            this.NavigationManager.NavigateTo(safeReturnPath, true);
         }
+    }
+
+    private static string ValidateReturnPath(string? returnPath)
+    {
+        // Ensure the return path is not null or whitespace
+        if (!string.IsNullOrWhiteSpace(returnPath) &&
+            Uri.TryCreate(returnPath, UriKind.Relative, out Uri? validatedUri))
+        {
+            // Normalize the path and ensure it starts with "/"
+            string normalizedPath = validatedUri.ToString();
+            if (normalizedPath.StartsWith('/'))
+            {
+                return normalizedPath;
+            }
+        }
+
+        // Fallback to the default safe path
+        return "/";
     }
 }

--- a/Apps/Admin/Client/Services/DateConversionService.cs
+++ b/Apps/Admin/Client/Services/DateConversionService.cs
@@ -32,23 +32,19 @@ namespace HealthGateway.Admin.Client.Services
         /// <inheritdoc/>
         public DateTime? ConvertFromUtc(DateTime? utcDateTime, bool returnNowIfNull = false)
         {
-            if (utcDateTime != null)
-            {
-                return this.ConvertFromUtc(utcDateTime.Value);
-            }
-
-            if (returnNowIfNull)
-            {
-                return this.ConvertFromUtc(DateTime.UtcNow);
-            }
-
-            return null;
+            DateTime? dateTimeToConvert = GetDateTimeToConvert(utcDateTime, returnNowIfNull);
+            return dateTimeToConvert.HasValue ? this.ConvertFromUtc(dateTimeToConvert.Value) : null;
         }
 
         /// <inheritdoc/>
         public string ConvertToShortFormatFromUtc(DateTime? utcDateTime, string fallbackString = "-")
         {
             return utcDateTime == null ? fallbackString : DateFormatter.ToShortDateAndTime(this.ConvertFromUtc(utcDateTime.Value));
+        }
+
+        private static DateTime? GetDateTimeToConvert(DateTime? utcDateTime, bool returnNowIfNull)
+        {
+            return utcDateTime ?? (returnNowIfNull ? DateTime.UtcNow : null);
         }
     }
 }

--- a/Apps/Admin/Client/Utils/BreakpointUtility.cs
+++ b/Apps/Admin/Client/Utils/BreakpointUtility.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Utils
 {
+    using System.Diagnostics.CodeAnalysis;
     using MudBlazor;
 
     /// <summary>
@@ -59,6 +60,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// A string containing the override code for the breakpoint or null if the breakpoint has no associated override
         /// code.
         /// </returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string? GetOverrideCode(this Breakpoint breakpoint)
         {
             return breakpoint switch

--- a/Apps/Admin/Client/Utils/FormattingUtility.cs
+++ b/Apps/Admin/Client/Utils/FormattingUtility.cs
@@ -15,6 +15,7 @@
 // -------------------------------------------------------------------------
 namespace HealthGateway.Admin.Client.Utils
 {
+    using System.Diagnostics.CodeAnalysis;
     using HealthGateway.Admin.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
@@ -55,6 +56,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// </summary>
         /// <param name="status">The communication status to format.</param>
         /// <returns>A string formatted for display.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string FormatCommunicationStatus(CommunicationStatus status)
         {
             return status switch
@@ -69,6 +71,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// </summary>
         /// <param name="communicationType">The communication type to format.</param>
         /// <returns>A string formatted for display.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string FormatCommunicationType(CommunicationType? communicationType)
         {
             return communicationType switch
@@ -85,6 +88,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// </summary>
         /// <param name="dataSource">The data source to format.</param>
         /// <returns>A string formatted for display.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string FormatDataSource(DataSource dataSource)
         {
             return dataSource switch
@@ -110,6 +114,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// </summary>
         /// <param name="identityProvider">The identity provider to format.</param>
         /// <returns>A string formatted for display.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string FormatKeycloakIdentityProvider(KeycloakIdentityProvider identityProvider)
         {
             return identityProvider switch
@@ -125,6 +130,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// </summary>
         /// <param name="status">The patient status to format.</param>
         /// <returns>A string formatted for display.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string FormatPatientStatus(PatientStatus status)
         {
             return status switch
@@ -141,6 +147,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// </summary>
         /// <param name="queryType">The query type to format.</param>
         /// <returns>A string formatted for display.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static string FormatPatientQueryType(PatientQueryType queryType)
         {
             return queryType switch

--- a/Apps/Admin/Client/Utils/StoreUtility.cs
+++ b/Apps/Admin/Client/Utils/StoreUtility.cs
@@ -48,32 +48,7 @@ namespace HealthGateway.Admin.Client.Utils
         /// <returns>The generated <see cref="RequestError"/>.</returns>
         public static RequestError FormatRequestError(Exception? exception, RequestResultError? resultError = null)
         {
-            if (resultError is not null)
-            {
-                return new()
-                {
-                    Message = resultError.ResultMessage,
-                    Details = new()
-                    {
-                        { "errorCode", resultError.ErrorCode },
-                        { "traceId", resultError.TraceId },
-                        { "actionCode", resultError.ActionCodeValue ?? string.Empty },
-                    },
-                };
-            }
-
-            if (exception is not null)
-            {
-                return new()
-                {
-                    Message = exception.Message,
-                };
-            }
-
-            return new()
-            {
-                Message = "Unknown error",
-            };
+            return resultError is not null ? CreateRequestError(resultError) : CreateRequestError(exception);
         }
 
         /// <summary>
@@ -99,6 +74,28 @@ namespace HealthGateway.Admin.Client.Utils
                 new PatientSupportActions.LoadAction { QueryType = patientQueryType, QueryString = patientQueryString, ShouldNavigateToPatientDetails = shouldNavigateToPatientDetails });
             await SessionUtility.SetSessionStorageItem(jsRuntime, SessionUtility.SupportQueryType, patientQueryType.ToString());
             await SessionUtility.SetSessionStorageItem(jsRuntime, SessionUtility.SupportQueryString, patientQueryString);
+        }
+
+        private static RequestError CreateRequestError(RequestResultError resultError)
+        {
+            return new()
+            {
+                Message = resultError.ResultMessage,
+                Details = new()
+                {
+                    { "errorCode", resultError.ErrorCode },
+                    { "traceId", resultError.TraceId },
+                    { "actionCode", resultError.ActionCodeValue ?? string.Empty },
+                },
+            };
+        }
+
+        private static RequestError CreateRequestError(Exception? exception)
+        {
+            return new()
+            {
+                Message = exception?.Message ?? "Unknown error",
+            };
         }
     }
 }

--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Admin.Server.Controllers
 {
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
@@ -41,6 +42,7 @@ namespace HealthGateway.Admin.Server.Controllers
     [Route("v{version:apiVersion}/api/[controller]")]
     [Produces("application/json")]
     [Authorize(Roles = "AdminUser,AdminReviewer,SupportUser")]
+    [SuppressMessage("Major Code Smell", "S6960:This controller has multiple responsibilities and could be split into 2 smaller controllers", Justification = "Team decision")]
     public class SupportController(ICovidSupportService covidSupportService, ISupportService supportService) : ControllerBase
     {
         /// <summary>

--- a/Apps/Admin/Server/Delegates/RestImmunizationAdminDelegate.cs
+++ b/Apps/Admin/Server/Delegates/RestImmunizationAdminDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Delegates
 {
     using System;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -47,6 +48,7 @@ namespace HealthGateway.Admin.Server.Delegates
         private static ActivitySource ActivitySource { get; } = new(typeof(RestImmunizationAdminDelegate).FullName);
 
         /// <inheritdoc/>
+        [SuppressMessage("Style", "IDE0046:Simplify 'if' statement", Justification = "Team decision")]
         public async Task<VaccineDetails> GetVaccineDetailsWithRetriesAsync(string phn, string accessToken, bool refresh = false, CancellationToken ct = default)
         {
             using Activity? activity = ActivitySource.StartActivity();

--- a/Apps/Admin/Server/Delegates/RestVaccineStatusDelegate.cs
+++ b/Apps/Admin/Server/Delegates/RestVaccineStatusDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Delegates
 {
     using System;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Server.Api;
@@ -42,6 +43,7 @@ namespace HealthGateway.Admin.Server.Delegates
         private static ActivitySource ActivitySource { get; } = new(typeof(RestVaccineStatusDelegate).FullName);
 
         /// <inheritdoc/>
+        [SuppressMessage("Style", "IDE0046:Simplify 'if' statement", Justification = "Team decision")]
         public async Task<PhsaResult<VaccineStatusResult>> GetVaccineStatusWithRetriesAsync(string phn, DateTime dateOfBirth, string accessToken, CancellationToken ct = default)
         {
             using Activity? activity = ActivitySource.StartActivity();

--- a/Apps/Admin/Server/MapProfiles/BetaFeatureProfile.cs
+++ b/Apps/Admin/Server/MapProfiles/BetaFeatureProfile.cs
@@ -16,12 +16,14 @@
 namespace HealthGateway.Admin.Server.MapProfiles
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using AutoMapper;
     using HealthGateway.Admin.Common.Constants;
 
     /// <summary>
     /// An AutoMapper profile class which defines mapping between DB and UI Models.
     /// </summary>
+    [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
     public class BetaFeatureProfile : Profile
     {
         /// <summary>

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -67,7 +67,7 @@ namespace HealthGateway.Admin.Server.Services
             IList<BlockedAccess> records = await blockedAccessDelegate.GetAllAsync(ct);
             return records
                 .Where(r => r.DataSources.Count > 0)
-                .Select(r => new BlockedAccessRecord(r.Hdid, r.DataSources.ToList()));
+                .Select(r => new BlockedAccessRecord(r.Hdid, [.. r.DataSources]));
         }
     }
 }

--- a/Apps/Admin/Server/Services/CovidSupportService.cs
+++ b/Apps/Admin/Server/Services/CovidSupportService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Admin.Server.Services
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.AccountDataAccess.Patient;
@@ -89,15 +90,10 @@ namespace HealthGateway.Admin.Server.Services
         private async Task<VaccineStatusResult> GetVaccineStatusResultAsync(string phn, DateTime birthdate, string accessToken, CancellationToken ct)
         {
             PhsaResult<VaccineStatusResult> phsaResult = await vaccineStatusDelegate.GetVaccineStatusWithRetriesAsync(phn, birthdate, accessToken, ct);
-
-            if (phsaResult.Result == null)
-            {
-                throw new NotFoundException(ErrorMessages.CannotGetVaccineStatus);
-            }
-
-            return phsaResult.Result;
+            return phsaResult.Result ?? throw new NotFoundException(ErrorMessages.CannotGetVaccineStatus);
         }
 
+        [SuppressMessage("Style", "IDE0046:Simplify 'if' statement", Justification = "Team decision")]
         private VaccinationStatus GetVaccinationStatus(VaccineStatusResult result)
         {
             logger.LogDebug("Vaccination Status Indicator: {VaccinationStatusIndicator}", result.StatusIndicator);
@@ -118,6 +114,7 @@ namespace HealthGateway.Admin.Server.Services
             };
         }
 
+        [SuppressMessage("Style", "IDE0046:Simplify 'if' statement", Justification = "Team decision")]
         private async Task<VaccineProofResponse> GetVaccineProofAsync(VaccinationStatus vaccinationStatus, string qrCode, CancellationToken ct)
         {
             VaccineProofRequest request = new()
@@ -127,6 +124,7 @@ namespace HealthGateway.Admin.Server.Services
             };
 
             RequestResult<VaccineProofResponse> vaccineProof = await vaccineProofDelegate.GenerateAsync(this.vaccineCardConfig.PrintTemplate, request, ct);
+
             if (vaccineProof.ResultStatus != ResultType.Success || vaccineProof.ResourcePayload == null)
             {
                 throw new NotFoundException(vaccineProof.ResultError?.ResultMessage ?? ErrorMessages.CannotGetVaccineProof);

--- a/Apps/Admin/Server/Services/DelegationService.cs
+++ b/Apps/Admin/Server/Services/DelegationService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Admin.Server.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -211,13 +212,7 @@ namespace HealthGateway.Admin.Server.Services
         public async Task<AgentAction> UnprotectDependentAsync(string dependentHdid, string reason, CancellationToken ct = default)
         {
             string authenticatedUserId = authenticationDelegate.FetchAuthenticatedUserId() ?? UserId.DefaultUser;
-            Dependent? dependent = await delegationDelegate.GetDependentAsync(dependentHdid, true, ct);
-
-            if (dependent == null)
-            {
-                throw new NotFoundException($"Dependent not found for hdid: {dependentHdid}");
-            }
-
+            Dependent dependent = await delegationDelegate.GetDependentAsync(dependentHdid, true, ct) ?? throw new NotFoundException($"Dependent not found for hdid: {dependentHdid}");
             dependent.Protected = false;
             dependent.UpdatedBy = authenticatedUserId;
             dependent.AllowedDelegations = [];
@@ -253,6 +248,7 @@ namespace HealthGateway.Admin.Server.Services
             return mappingService.MapToAgentAction(agentAudit);
         }
 
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         private static void ValidatePatientResult(RequestResult<PatientModel> patientResult)
         {
             switch (patientResult)

--- a/Apps/Admin/Server/Services/InactiveUserService.cs
+++ b/Apps/Admin/Server/Services/InactiveUserService.cs
@@ -158,19 +158,17 @@ public class InactiveUserService : IInactiveUserService
     private void AddInactiveUser(
         List<AdminUserProfileView> inactiveUsers,
         IEnumerable<AdminUserProfile> activeUserProfiles,
-        ICollection<UserRepresentation> identityAccessUsers,
+        List<UserRepresentation> identityAccessUsers,
         IdentityAccessRole role)
     {
         this.logger.LogDebug("Keycloak {Role} count: {Count}...", role, identityAccessUsers.Count);
 
         // Filter identities from keycloak where inactive (database) user's username does not match keycloak user's username
         // and active (database) user's username does not match keycloak users username
-        IEnumerable<AdminUserProfileView> adminUserProfiles = identityAccessUsers
-            .Where(x1 => inactiveUsers.TrueForAll(x2 => x1.Username != x2.Username) && activeUserProfiles.All(x2 => x1.Username != x2.Username))
-            .Select(user => this.mappingService.MapToAdminUserProfileView(user));
-
-        foreach (AdminUserProfileView adminUserProfile in adminUserProfiles)
+        foreach (UserRepresentation user in identityAccessUsers
+                     .Where(x1 => inactiveUsers.TrueForAll(x2 => x1.Username != x2.Username) && activeUserProfiles.All(x2 => x1.Username != x2.Username)))
         {
+            AdminUserProfileView adminUserProfile = this.mappingService.MapToAdminUserProfileView(user);
             adminUserProfile.RealmRoles = role.ToString();
             inactiveUsers.Add(adminUserProfile);
         }

--- a/Apps/Admin/Server/Services/UserFeedbackService.cs
+++ b/Apps/Admin/Server/Services/UserFeedbackService.cs
@@ -103,7 +103,7 @@ namespace HealthGateway.Admin.Server.Services
         {
             IEnumerable<AdminTag> adminTags = await adminTagDelegate.GetAllAsync(ct);
 
-            IList<AdminTagView> adminTagViews = adminTags.Select(mappingService.MapToAdminTagView).ToList();
+            List<AdminTagView> adminTagViews = adminTags.Select(mappingService.MapToAdminTagView).ToList();
 
             return new RequestResult<IList<AdminTagView>>
             {

--- a/Apps/Admin/Tests/Delegates/RestImmunizationAdminDelegateTests.cs
+++ b/Apps/Admin/Tests/Delegates/RestImmunizationAdminDelegateTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Tests.Delegates
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Common.Models.CovidSupport;
@@ -190,7 +189,7 @@ namespace HealthGateway.Admin.Tests.Delegates
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/Admin/Tests/Delegates/RestVaccineStatusDelegateTests.cs
+++ b/Apps/Admin/Tests/Delegates/RestVaccineStatusDelegateTests.cs
@@ -18,7 +18,6 @@ namespace HealthGateway.Admin.Tests.Delegates
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Admin.Server.Api;
@@ -151,7 +150,7 @@ namespace HealthGateway.Admin.Tests.Delegates
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -132,9 +132,9 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IBlockedAccessDelegate>? blockedAccessDelegateMock = null,
             Mock<IPatientRepository>? patientRepositoryMock = null)
         {
-            delegationDelegateMock = delegationDelegateMock ?? new();
-            blockedAccessDelegateMock = blockedAccessDelegateMock ?? new();
-            patientRepositoryMock = patientRepositoryMock ?? new();
+            delegationDelegateMock ??= new();
+            blockedAccessDelegateMock ??= new();
+            patientRepositoryMock ??= new();
 
             return new AdminReportService(
                 delegationDelegateMock.Object,

--- a/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AgentAccessServiceTests.cs
@@ -236,8 +236,8 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IAuthenticationDelegate>? authenticationDelegateMock = null,
             Mock<IKeycloakAdminApi>? keycloakAdminApiMock = null)
         {
-            authenticationDelegateMock = authenticationDelegateMock ?? new();
-            keycloakAdminApiMock = keycloakAdminApiMock ?? new();
+            authenticationDelegateMock ??= new();
+            keycloakAdminApiMock ??= new();
 
             return new AgentAccessService(
                 authenticationDelegateMock.Object,

--- a/Apps/Admin/Tests/Services/BetaFeatureServiceTests.cs
+++ b/Apps/Admin/Tests/Services/BetaFeatureServiceTests.cs
@@ -285,7 +285,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -358,8 +358,8 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IUserProfileDelegate>? profileDelegateMock = null,
             Mock<IBetaFeatureAccessDelegate>? betaFeatureAccessDelegateMock = null)
         {
-            profileDelegateMock = profileDelegateMock ?? new();
-            betaFeatureAccessDelegateMock = betaFeatureAccessDelegateMock ?? new();
+            profileDelegateMock ??= new();
+            betaFeatureAccessDelegateMock ??= new();
 
             return new BetaFeatureService(
                 profileDelegateMock.Object,

--- a/Apps/Admin/Tests/Services/CommunicationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CommunicationServiceTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Tests.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
@@ -306,7 +305,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/Admin/Tests/Services/ConfigurationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/ConfigurationServiceTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Admin.Tests.Services
 {
     using System.Collections.Generic;
-    using System.Linq;
     using HealthGateway.Admin.Common.Models;
     using HealthGateway.Admin.Server.Services;
     using Microsoft.Extensions.Configuration;
@@ -61,7 +60,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CovidSupportServiceTests.cs
@@ -18,7 +18,6 @@ namespace HealthGateway.Admin.Tests.Services
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.AccountDataAccess.Patient;
@@ -553,7 +552,7 @@ namespace HealthGateway.Admin.Tests.Services
                 PersonalHealthNumber = Phn,
                 MailAddress = new()
                 {
-                    StreetLines = new[] { "9105 ROTTERDAM PLACE" },
+                    StreetLines = ["9105 ROTTERDAM PLACE"],
                     City = "VANCOUVER",
                     Country = string.Empty,
                     PostalCode = "V3X 4J5",
@@ -659,7 +658,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/CsvExportServiceTests.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Admin.Tests.Services
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
@@ -354,7 +353,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -366,12 +365,12 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IInactiveUserService>? inactiveUserServiceMock = null,
             Mock<IFeedbackDelegate>? feedbackDelegateMock = null)
         {
-            profileDelegateMock = profileDelegateMock ?? new();
-            commentDelegateMock = commentDelegateMock ?? new();
-            noteDelegateMock = noteDelegateMock ?? new();
-            ratingDelegateMock = ratingDelegateMock ?? new();
-            inactiveUserServiceMock = inactiveUserServiceMock ?? new();
-            feedbackDelegateMock = feedbackDelegateMock ?? new();
+            profileDelegateMock ??= new();
+            commentDelegateMock ??= new();
+            noteDelegateMock ??= new();
+            ratingDelegateMock ??= new();
+            inactiveUserServiceMock ??= new();
+            feedbackDelegateMock ??= new();
 
             return new CsvExportService(
                 Configuration,

--- a/Apps/Admin/Tests/Services/DashboardServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DashboardServiceTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Tests.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
@@ -55,7 +54,7 @@ namespace HealthGateway.Admin.Tests.Services
                 Dependents = dependentCount,
             };
 
-            IDashboardService service = SetupGetAllTimeCountsMock(userProfileCount, closedUserProfileCount, dependentCount);
+            IDashboardService service = SetupDashboardServiceForAllTimeCounts(userProfileCount, closedUserProfileCount, dependentCount);
 
             // Act
             AllTimeCounts actual = await service.GetAllTimeCountsAsync();
@@ -104,7 +103,7 @@ namespace HealthGateway.Admin.Tests.Services
                 DependentRegistrations = new SortedDictionary<DateOnly, int>(dependentRegistrationCounts),
             };
 
-            IDashboardService service = SetupDailyUsageCountsMock(userRegistrationCounts, userLoginCounts, dependentRegistrationCounts);
+            IDashboardService service = SetupDashboardServiceForDailyUsageCounts(userRegistrationCounts, userLoginCounts, dependentRegistrationCounts);
 
             // Act
             DailyUsageCounts actual = await service.GetDailyUsageCountsAsync(startDate, endDate);
@@ -128,7 +127,7 @@ namespace HealthGateway.Admin.Tests.Services
             const int userCount = 10;
             const int expected = 10;
 
-            IDashboardService service = SetupGetRecurringUserCountMock(dayCount, userCount);
+            IDashboardService service = SetupDashboardServiceForRecurringUserCount(dayCount, userCount);
 
             // Act
             int actual = await service.GetRecurringUserCountAsync(dayCount, startDate, endDate);
@@ -156,7 +155,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             AppLoginCounts expected = new(webCount, mobileCount + androidCount + iosCount, androidCount, iosCount, salesforceCount);
 
-            IDashboardService service = SetupGetAppLoginCountsMock(webCount, mobileCount, androidCount, iosCount, salesforceCount);
+            IDashboardService service = SetupDashboardServiceForAppLoginCounts(webCount, mobileCount, androidCount, iosCount, salesforceCount);
 
             // Act
             AppLoginCounts actual = await service.GetAppLoginCountsAsync(startDate, endDate);
@@ -185,7 +184,7 @@ namespace HealthGateway.Admin.Tests.Services
                 { "5", fiveStarCount },
             };
 
-            IDashboardService service = SetupGetRatingsSummaryMock(threeStarCount, fiveStarCount);
+            IDashboardService service = SetupDashboardServiceForRatingsSummary(threeStarCount, fiveStarCount);
 
             // Act
             IDictionary<string, int> actual = await service.GetRatingsSummaryAsync(startDate, endDate);
@@ -206,8 +205,9 @@ namespace HealthGateway.Admin.Tests.Services
             DateOnly startDatePlus5Years = startDate.AddYears(5);
             DateOnly endDate = new(2024, 1, 15);
 
-            const int startDateAge = 14;
-            const int startDatePlus5YearsAge = 9;
+            int currentYear = DateTime.UtcNow.Year;
+            int startDateAge = currentYear - startDate.Year;
+            int startDatePlus5YearsAge = currentYear - startDatePlus5Years.Year;
             const int startDateAgeCount = 5;
             const int startDatePlus5YearsAgeCount = 1;
 
@@ -217,7 +217,7 @@ namespace HealthGateway.Admin.Tests.Services
                 { startDatePlus5YearsAge, startDatePlus5YearsAgeCount },
             };
 
-            IDashboardService service = SetupGetAgeCountsMock(startDate, startDatePlus5Years, startDateAgeCount, startDatePlus5YearsAgeCount);
+            IDashboardService service = SetupDashboardServiceForAgeCounts(startDate, startDatePlus5Years, startDateAgeCount, startDatePlus5YearsAgeCount);
 
             // Act
             IDictionary<int, int> actual = await service.GetAgeCountsAsync(startDate, endDate);
@@ -235,7 +235,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -255,7 +255,7 @@ namespace HealthGateway.Admin.Tests.Services
                 ratingDelegateMock.Object);
         }
 
-        private static IDashboardService SetupGetAllTimeCountsMock(int userProfileCount, int closedUserProfileCount, int dependentCount)
+        private static IDashboardService SetupDashboardServiceForAllTimeCounts(int userProfileCount, int closedUserProfileCount, int dependentCount)
         {
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             userProfileDelegateMock.Setup(s => s.GetUserProfileCountAsync(It.IsAny<CancellationToken>())).ReturnsAsync(userProfileCount);
@@ -267,7 +267,7 @@ namespace HealthGateway.Admin.Tests.Services
             return GetDashboardService(dependentDelegateMock, userProfileDelegateMock);
         }
 
-        private static IDashboardService SetupDailyUsageCountsMock(
+        private static IDashboardService SetupDashboardServiceForDailyUsageCounts(
             IDictionary<DateOnly, int> userRegistrationCounts,
             IDictionary<DateOnly, int> userLoginCounts,
             IDictionary<DateOnly, int> dependentRegistrationCounts)
@@ -284,7 +284,7 @@ namespace HealthGateway.Admin.Tests.Services
             return GetDashboardService(dependentDelegateMock, userProfileDelegateMock);
         }
 
-        private static IDashboardService SetupGetRecurringUserCountMock(int dayCount, int userCount)
+        private static IDashboardService SetupDashboardServiceForRecurringUserCount(int dayCount, int userCount)
         {
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             userProfileDelegateMock.Setup(s => s.GetRecurringUserCountAsync(dayCount, It.IsAny<DateTimeOffset>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
@@ -293,7 +293,7 @@ namespace HealthGateway.Admin.Tests.Services
             return GetDashboardService(userProfileDelegateMock: userProfileDelegateMock);
         }
 
-        private static IDashboardService SetupGetAppLoginCountsMock(int webCount, int mobileCount, int androidCount, int iosCount, int salesforceCount)
+        private static IDashboardService SetupDashboardServiceForAppLoginCounts(int webCount, int mobileCount, int androidCount, int iosCount, int salesforceCount)
         {
             IDictionary<UserLoginClientType, int> lastLoginClientCounts = new Dictionary<UserLoginClientType, int>
             {
@@ -311,7 +311,7 @@ namespace HealthGateway.Admin.Tests.Services
             return GetDashboardService(userProfileDelegateMock: userProfileDelegateMock);
         }
 
-        private static IDashboardService SetupGetRatingsSummaryMock(int threeStarCount, int fiveStarCount)
+        private static IDashboardService SetupDashboardServiceForRatingsSummary(int threeStarCount, int fiveStarCount)
         {
             IDictionary<string, int> summary = new Dictionary<string, int>
             {
@@ -326,7 +326,7 @@ namespace HealthGateway.Admin.Tests.Services
             return GetDashboardService(ratingDelegateMock: ratingsDelegateMock);
         }
 
-        private static IDashboardService SetupGetAgeCountsMock(DateOnly startDate, DateOnly startDatePlus5Years, int startDateAgeCount, int startDatePlus5YearsAgeCount)
+        private static IDashboardService SetupDashboardServiceForAgeCounts(DateOnly startDate, DateOnly startDatePlus5Years, int startDateAgeCount, int startDatePlus5YearsAgeCount)
         {
             IDictionary<int, int> yearOfBirthCounts = new Dictionary<int, int>
             {

--- a/Apps/Admin/Tests/Services/DelegationServiceTests.cs
+++ b/Apps/Admin/Tests/Services/DelegationServiceTests.cs
@@ -575,7 +575,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -844,7 +844,7 @@ namespace HealthGateway.Admin.Tests.Services
 
             delegationDelegate.Setup(p => p.GetDependentAsync(resourceOwnerHdid, true, CancellationToken.None)).ReturnsAsync(dependent);
 
-            messageSender = messageSender ?? new();
+            messageSender ??= new();
 
             return new(
                 GetIConfigurationRoot(isChangeFeedEnabled),

--- a/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
+++ b/Apps/Admin/Tests/Services/InactiveUserServiceTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Admin.Tests.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
@@ -234,7 +233,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -148,11 +148,11 @@ namespace HealthGateway.Admin.Tests.Services
             IList<MessagingVerification> messagingVerifications = GenerateMessagingVerifications(SmsNumber, Email);
             VaccineDetails vaccineDetails = GenerateVaccineDetails(GenerateVaccineDose());
             AgentAuditQuery auditQuery = new(Hdid);
-            IEnumerable<AgentAudit> agentAudits = new[] { GenerateAgentAudit() };
-            IEnumerable<DataSource> blockedDataSources = new[]
-            {
+            IEnumerable<AgentAudit> agentAudits = [GenerateAgentAudit()];
+            IEnumerable<DataSource> blockedDataSources =
+            [
                 DataSource.Immunization,
-            };
+            ];
             ResourceDelegateQuery resourceDelegateQuery = new() { ByDelegateHdid = patientQuery.Hdid, IncludeDependent = true };
             ResourceDelegateQueryResult resourceDelegateQueryResult = GenerateResourceDelegatesForDelegate(patientQuery.Hdid, [Hdid2]);
             PatientDetailsQuery dependentPatientQuery =

--- a/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
+++ b/Apps/Admin/Tests/Services/UserFeedbackServiceTests.cs
@@ -429,7 +429,7 @@ namespace HealthGateway.Admin.Tests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -438,9 +438,9 @@ namespace HealthGateway.Admin.Tests.Services
             Mock<IAdminTagDelegate>? adminTagDelegateMock = null,
             Mock<IUserProfileDelegate>? userProfileDelegateMock = null)
         {
-            feedbackDelegateMock = feedbackDelegateMock ?? new();
-            adminTagDelegateMock = adminTagDelegateMock ?? new();
-            userProfileDelegateMock = userProfileDelegateMock ?? new();
+            feedbackDelegateMock ??= new();
+            adminTagDelegateMock ??= new();
+            userProfileDelegateMock ??= new();
 
             return new UserFeedbackService(
                 new Mock<ILogger<UserFeedbackService>>().Object,

--- a/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
+++ b/Apps/ClinicalDocument/src/Services/ClinicalDocumentService.cs
@@ -94,7 +94,7 @@ namespace HealthGateway.ClinicalDocument.Services
                     this.logger.LogDebug("Retrieving clinical documents");
                     PhsaHealthDataResponse apiResponse = await this.clinicalDocumentsApi.GetClinicalDocumentRecordsAsync(pid, ct);
 
-                    IList<ClinicalDocumentRecord> clinicalDocuments = apiResponse.Data.Select(this.mappingService.MapToClinicalDocumentRecord).ToList();
+                    List<ClinicalDocumentRecord> clinicalDocuments = apiResponse.Data.Select(this.mappingService.MapToClinicalDocumentRecord).ToList();
                     requestResult.ResultStatus = ResultType.Success;
                     requestResult.ResourcePayload = clinicalDocuments;
                     requestResult.TotalResultCount = clinicalDocuments.Count;

--- a/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
+++ b/Apps/Common/src/AccessManagement/Authentication/AuthenticationDelegate.cs
@@ -217,13 +217,13 @@ namespace HealthGateway.Common.AccessManagement.Authentication
         private async Task<JwtModel?> ClientCredentialsGrantAsync(ClientCredentialsRequest request, CancellationToken ct)
         {
             ClientCredentialsRequestParameters parameters = request.Parameters;
-            IEnumerable<KeyValuePair<string?, string?>> oauthParams = new[]
-            {
-                new KeyValuePair<string?, string?>("client_id", parameters.ClientId),
-                new KeyValuePair<string?, string?>("client_secret", parameters.ClientSecret),
-                new KeyValuePair<string?, string?>("audience", parameters.Audience),
-                new KeyValuePair<string?, string?>("grant_type", "client_credentials"),
-            };
+            IEnumerable<KeyValuePair<string?, string?>> oauthParams =
+            [
+                new("client_id", parameters.ClientId),
+                new("client_secret", parameters.ClientSecret),
+                new("audience", parameters.Audience),
+                new("grant_type", "client_credentials"),
+            ];
             using FormUrlEncodedContent content = new(oauthParams);
             return await this.AuthenticateAsync(request.TokenUri, content, ct);
         }

--- a/Apps/Common/src/AspNetConfiguration/Modules/Audit.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Audit.cs
@@ -37,7 +37,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// <param name="configuration">The configuration to use.</param>
         public static void ConfigureAuditServices(IServiceCollection services, ILogger logger, IConfiguration configuration)
         {
-            services.AddMvc(options => options.Filters.Add(typeof(AuditFilter)));
+            services.AddMvc(options => options.Filters.Add<AuditFilter>());
 
             bool redisAuditing = configuration.GetValue("RedisAuditing", false);
             if (redisAuditing)

--- a/Apps/Common/src/AspNetConfiguration/Modules/Auth.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Auth.cs
@@ -58,6 +58,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
         /// <param name="services">The services collection provider.</param>
         /// <param name="logger">The logger to use.</param>
         /// <param name="configuration">The configuration to use for values.</param>
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Parameter kept for future extensibility")]
         public static void ConfigureAuthorizationServices(IServiceCollection services, ILogger logger, IConfiguration configuration)
         {
             logger.LogDebug("ConfigureAuthorizationServices...");

--- a/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
@@ -43,17 +43,18 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
             logger.LogDebug("Sensitive Data Logging is enabled: {IsSensitiveDataLoggingEnabled}", isSensitiveDataLoggingEnabled);
 
             services.AddEntityFrameworkNpgsql();
-            services.AddSingleton(_ =>
-            {
-                NpgsqlDataSourceBuilder dataSourceBuilder = new(configuration.GetConnectionString("GatewayConnection"));
-                dataSourceBuilder.EnableDynamicJson();
-                return dataSourceBuilder.Build();
-            });
+            services.AddSingleton(
+                _ =>
+                {
+                    NpgsqlDataSourceBuilder dataSourceBuilder = new(configuration.GetConnectionString("GatewayConnection"));
+                    dataSourceBuilder.EnableDynamicJson();
+                    return dataSourceBuilder.Build();
+                });
 
             services.AddDbContextPool<GatewayDbContext>(
                 (sp, options) =>
                 {
-                    var ds = sp.GetRequiredService<NpgsqlDataSource>();
+                    NpgsqlDataSource ds = sp.GetRequiredService<NpgsqlDataSource>();
                     options.UseInternalServiceProvider(sp);
                     options.UseNpgsql(
                         ds,

--- a/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/HttpWeb.cs
@@ -291,11 +291,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
 
                     if (context.File.Name == "blazor.boot.json")
                     {
-                        if (context.Context.Response.Headers.ContainsKey("blazor-environment"))
-                        {
-                            context.Context.Response.Headers.Remove("blazor-environment");
-                        }
-
+                        context.Context.Response.Headers.Remove("blazor-environment");
                         context.Context.Response.Headers.Append("blazor-environment", environment.EnvironmentName);
                     }
                 },

--- a/Apps/Common/src/AspNetConfiguration/Modules/Observability.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Observability.cs
@@ -277,10 +277,23 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
 
         private static bool IsWildcardMatch(PathString requestPath, string path)
         {
-            return requestPath.HasValue &&
-                   (path.StartsWith('*')
-                       ? requestPath.Value!.EndsWith(path.Replace("*", string.Empty, StringComparison.InvariantCultureIgnoreCase), StringComparison.InvariantCultureIgnoreCase)
-                       : requestPath.Equals(path, StringComparison.InvariantCultureIgnoreCase));
+            if (!requestPath.HasValue)
+            {
+                return false;
+            }
+
+            string requestPathValue = requestPath.Value!;
+
+            return path switch
+            {
+                _ when path.EndsWith('*') => requestPathValue.StartsWith(
+                    path.TrimEnd('*'),
+                    StringComparison.InvariantCultureIgnoreCase),
+                _ when path.StartsWith('*') => requestPathValue.EndsWith(
+                    path.TrimStart('*'),
+                    StringComparison.InvariantCultureIgnoreCase),
+                _ => requestPath.Equals(path, StringComparison.InvariantCultureIgnoreCase),
+            };
         }
     }
 }

--- a/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
@@ -59,7 +59,11 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                         // Note: As per reading we do not have to dispose of the certificate.
                         string? clientCertificatePath = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Path");
                         string? certificatePassword = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Password");
+#pragma warning disable SYSLIB0057
+
+                        // Using the obsolete X509Certificate2 constructor
                         X509Certificate2 clientRegistriesCertificate = new(File.ReadAllBytes(clientCertificatePath), certificatePassword);
+#pragma warning restore SYSLIB0057
                         client.ClientCredentials.ClientCertificate.Certificate = clientRegistriesCertificate;
                         client.Endpoint.EndpointBehaviors.Add(s.GetService<IEndpointBehavior>());
                         client.ClientCredentials.ServiceCertificate.SslCertificateAuthentication =

--- a/Apps/Common/src/AspNetConfiguration/ProgramConfiguration.cs
+++ b/Apps/Common/src/AspNetConfiguration/ProgramConfiguration.cs
@@ -84,7 +84,7 @@ namespace HealthGateway.Common.AspNetConfiguration
                 .Enrich.FromLogContext()
                 .CreateBootstrapLogger();
 
-            using var factory = new SerilogLoggerFactory(Log.Logger);
+            using SerilogLoggerFactory factory = new(Log.Logger);
             return factory.CreateLogger("Startup");
         }
     }

--- a/Apps/Common/src/Constants/OidType.cs
+++ b/Apps/Common/src/Constants/OidType.cs
@@ -50,23 +50,19 @@ namespace HealthGateway.Common.Constants
         /// <param name="lhs">The first type to compare, or null.</param>
         /// <param name="rhs">The second type to compare, or null.</param>
         [ExcludeFromCodeCoverage]
-        public static bool operator ==(OidType lhs, OidType rhs)
+        public static bool operator ==(OidType? lhs, OidType? rhs)
         {
-            // Check for null on left side.
-            if (ReferenceEquals(lhs, null))
+            // Use ReferenceEquals to check for null equality.
+            if (ReferenceEquals(lhs, rhs))
             {
-                if (ReferenceEquals(rhs, null))
-                {
-                    // null == null = true.
-                    return true;
-                }
-
-                // Only the left side is null.
-                return false;
+                return true;
             }
 
-            // Equals handles case of null on right side.
-            return lhs.Equals(rhs);
+            // If lhs is null, return false (rhs is not null at this point).
+            return lhs is not null &&
+
+                   // Delegate to Equals for further comparison.
+                   lhs.Equals(rhs);
         }
 
         /// <summary>
@@ -109,13 +105,9 @@ namespace HealthGateway.Common.Constants
         [ExcludeFromCodeCoverage]
         public override bool Equals(object? obj)
         {
-            // Check for null and compare run-time types.
-            if (obj == null || !this.GetType().Equals(obj.GetType()))
-            {
-                return false;
-            }
-
-            return this.Equals((OidType)obj);
+            // Use 'is' to check for null and type compatibility, then delegate to the strongly-typed Equals method.
+            return obj is OidType other &&
+                   this.Equals(other);
         }
 
         /// <summary>

--- a/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
+++ b/Apps/Common/src/Delegates/ClientRegistriesDelegate.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.Common.Delegates
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.ServiceModel;
@@ -129,51 +130,91 @@ namespace HealthGateway.Common.Delegates
 
         private static HCIM_IN_GetDemographicsRequest CreateRequest(OidType oidType, string identifierValue, string clientIp)
         {
-            HCIM_IN_GetDemographics request = new();
-            request.id = new II { root = "2.16.840.1.113883.3.51.1.1.1", extension = DateTimeOffset.Now.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) };
-            request.creationTime = new TS { value = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture) };
-            request.versionCode = new CS { code = "V3PR1" };
-            request.interactionId = new II { root = "2.16.840.1.113883.3.51.1.1.2", extension = "HCIM_IN_GetDemographics" };
-            request.processingCode = new CS { code = "P" };
-            request.processingModeCode = new CS { code = "T" };
-            request.acceptAckCode = new CS { code = "NE" };
-
-            request.receiver = new MCCI_MT000100Receiver { typeCode = "RCV" };
-            request.receiver.device = new MCCI_MT000100Device { determinerCode = Instance, classCode = "DEV" };
-            request.receiver.device.id = new II { root = "2.16.840.1.113883.3.51.1.1.4", extension = clientIp };
-            request.receiver.device.asAgent = new MCCI_MT000100Agent { classCode = "AGNT" };
-            request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
-            request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
-            request.receiver.device.asAgent.representedOrganization.id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HCIM" };
-
-            request.sender = new MCCI_MT000100Sender { typeCode = "SND" };
-            request.sender.device = new MCCI_MT000100Device { determinerCode = Instance, classCode = "DEV" };
-            request.sender.device.id = new II { root = "2.16.840.1.113883.3.51.1.1.5", extension = "MOH_CRS" };
-            request.sender.device.asAgent = new MCCI_MT000100Agent { classCode = "AGNT" };
-            request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
-            request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" };
-            request.sender.device.asAgent.representedOrganization.id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HGWAY" };
-
-            request.controlActProcess = new HCIM_IN_GetDemographicsQUQI_MT020001ControlActProcess { classCode = "ACCM", moodCode = "EVN" };
-            request.controlActProcess.effectiveTime = new IVL_TS { value = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture) };
-            request.controlActProcess.dataEnterer = new QUQI_MT020001DataEnterer { typeCode = "CST", time = null, typeId = null };
-            request.controlActProcess.dataEnterer.assignedPerson = new COCT_MT090100AssignedPerson { classCode = "ENT" };
-
-            request.controlActProcess.dataEnterer.assignedPerson.id = new II { root = "2.16.840.1.113883.3.51.1.1.7", extension = "HLTHGTWAY" };
-
-            request.controlActProcess.queryByParameter = new HCIM_IN_GetDemographicsQUQI_MT020001QueryByParameter();
-            request.controlActProcess.queryByParameter.queryByParameterPayload = new HCIM_IN_GetDemographicsQueryByParameterPayload();
-            request.controlActProcess.queryByParameter.queryByParameterPayload.personid = new HCIM_IN_GetDemographicsPersonid();
-            request.controlActProcess.queryByParameter.queryByParameterPayload.personid.value = new II
+            HCIM_IN_GetDemographics request = new()
             {
-                root = oidType.ToString(),
-                extension = identifierValue,
-                assigningAuthorityName = "LCTZ_IAS",
+                id = new II { root = "2.16.840.1.113883.3.51.1.1.1", extension = DateTimeOffset.Now.ToUnixTimeMilliseconds().ToString(CultureInfo.InvariantCulture) },
+                creationTime = new TS { value = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture) },
+                versionCode = new CS { code = "V3PR1" },
+                interactionId = new II { root = "2.16.840.1.113883.3.51.1.1.2", extension = "HCIM_IN_GetDemographics" },
+                processingCode = new CS { code = "P" },
+                processingModeCode = new CS { code = "T" },
+                acceptAckCode = new CS { code = "NE" },
+                receiver = new MCCI_MT000100Receiver
+                {
+                    typeCode = "RCV",
+                    device = new MCCI_MT000100Device
+                    {
+                        determinerCode = Instance, classCode = "DEV",
+                        id = new II { root = "2.16.840.1.113883.3.51.1.1.4", extension = clientIp },
+                        asAgent = new MCCI_MT000100Agent
+                        {
+                            classCode = "AGNT",
+                            representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" },
+                        },
+                    },
+                },
+            };
+
+            request.receiver.device.asAgent.representedOrganization = new MCCI_MT000100Organization
+            {
+                determinerCode = Instance, classCode = "ORG",
+                id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HCIM" },
+            };
+
+            request.sender = new MCCI_MT000100Sender
+            {
+                typeCode = "SND",
+                device = new MCCI_MT000100Device
+                {
+                    determinerCode = Instance, classCode = "DEV",
+                    id = new II { root = "2.16.840.1.113883.3.51.1.1.5", extension = "MOH_CRS" },
+                    asAgent = new MCCI_MT000100Agent
+                    {
+                        classCode = "AGNT",
+                        representedOrganization = new MCCI_MT000100Organization { determinerCode = Instance, classCode = "ORG" },
+                    },
+                },
+            };
+            request.sender.device.asAgent.representedOrganization = new MCCI_MT000100Organization
+            {
+                determinerCode = Instance, classCode = "ORG",
+                id = new II { root = "2.16.840.1.113883.3.51.1.1.3", extension = "HGWAY" },
+            };
+
+            request.controlActProcess = new HCIM_IN_GetDemographicsQUQI_MT020001ControlActProcess
+            {
+                classCode = "ACCM", moodCode = "EVN",
+                effectiveTime = new IVL_TS { value = DateTime.Now.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture) },
+                dataEnterer = new QUQI_MT020001DataEnterer
+                {
+                    typeCode = "CST", time = null, typeId = null,
+                    assignedPerson = new COCT_MT090100AssignedPerson
+                    {
+                        classCode = "ENT",
+                        id = new II { root = "2.16.840.1.113883.3.51.1.1.7", extension = "HLTHGTWAY" },
+                    },
+                },
+                queryByParameter = new HCIM_IN_GetDemographicsQUQI_MT020001QueryByParameter
+                {
+                    queryByParameterPayload = new HCIM_IN_GetDemographicsQueryByParameterPayload
+                    {
+                        personid = new HCIM_IN_GetDemographicsPersonid
+                        {
+                            value = new II
+                            {
+                                root = oidType.ToString(),
+                                extension = identifierValue,
+                                assigningAuthorityName = "LCTZ_IAS",
+                            },
+                        },
+                    },
+                },
             };
 
             return new HCIM_IN_GetDemographicsRequest(request);
         }
 
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         private static Address? MapAddress(AD? address)
         {
             if (address?.Items == null)
@@ -399,7 +440,7 @@ namespace HealthGateway.Common.Delegates
 
         private bool PopulateIdentifiers(HCIM_IN_GetDemographicsResponseIdentifiedPerson retrievedPerson, PatientModel patient)
         {
-            II? identifiedPersonId = Array.Find(retrievedPerson.identifiedPerson.id ?? Array.Empty<II>(), x => x.root == OidType.Phn.ToString());
+            II? identifiedPersonId = Array.Find(retrievedPerson.identifiedPerson.id ?? [], x => x.root == OidType.Phn.ToString());
             if (identifiedPersonId == null)
             {
                 this.logger.LogWarning("The Client Registry returned a person without a PHN");
@@ -409,7 +450,7 @@ namespace HealthGateway.Common.Delegates
                 patient.PersonalHealthNumber = identifiedPersonId.extension;
             }
 
-            II? subjectId = Array.Find(retrievedPerson.id ?? Array.Empty<II>(), x => x.displayable && x.root == OidType.Hdid.ToString());
+            II? subjectId = Array.Find(retrievedPerson.id ?? [], x => x.displayable && x.root == OidType.Hdid.ToString());
             if (subjectId == null)
             {
                 this.logger.LogWarning("The Client Registry returned a person without an HDID");

--- a/Apps/Common/src/Delegates/HmacHashDelegate.cs
+++ b/Apps/Common/src/Delegates/HmacHashDelegate.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Common.Delegates
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Security.Cryptography;
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Models;
@@ -53,6 +54,8 @@ namespace HealthGateway.Common.Delegates
         /// <param name="prf">The pseudorandom function to use for the hash.</param>
         /// <param name="iterations">The number of iterations to process over the hash.</param>
         /// <returns>The hash object.</returns>
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public static HmacHash HmacHash(
             string? key,
             byte[] salt,
@@ -69,19 +72,12 @@ namespace HealthGateway.Common.Delegates
             {
                 // The key is not null, so we can generate a hash
                 // Calculate the length in bytes of the hash given the function size
-                int hashLength;
-                switch (prf)
+                int hashLength = prf switch
                 {
-                    case KeyDerivationPrf.HMACSHA1:
-                        hashLength = 20;
-                        break;
-                    case KeyDerivationPrf.HMACSHA256:
-                        hashLength = 32;
-                        break;
-                    default:
-                        hashLength = 64;
-                        break;
-                }
+                    KeyDerivationPrf.HMACSHA1 => 20,
+                    KeyDerivationPrf.HMACSHA256 => 32,
+                    _ => 64,
+                };
 
                 retHash.Salt = Convert.ToBase64String(salt);
                 retHash.Hash = Convert.ToBase64String(KeyDerivation.Pbkdf2(key, salt, prf, iterations, hashLength));

--- a/Apps/Common/src/Delegates/VaccineProofDelegate.cs
+++ b/Apps/Common/src/Delegates/VaccineProofDelegate.cs
@@ -64,6 +64,7 @@ namespace HealthGateway.Common.Delegates
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Style", "IDE0072:Populate swtich", Justification = "Team decision")]
         public async Task<RequestResult<VaccineProofResponse>> MailAsync(VaccineProofTemplate vaccineProofTemplate, VaccineProofRequest request, Address address, CancellationToken ct = default)
         {
             RequestResult<VaccineProofResponse> retVal = new()
@@ -134,6 +135,7 @@ namespace HealthGateway.Common.Delegates
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         public async Task<RequestResult<VaccineProofResponse>> GenerateAsync(VaccineProofTemplate vaccineProofTemplate, VaccineProofRequest request, CancellationToken ct = default)
         {
             RequestResult<VaccineProofResponse> retVal = new()
@@ -192,6 +194,7 @@ namespace HealthGateway.Common.Delegates
 
         /// <inheritdoc/>
         [SuppressMessage("Design", "CA1031:Do not catch general exception types", Justification = "Prevent exception propagation")]
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         public async Task<RequestResult<ReportModel>> GetAssetAsync(Uri assetUri, CancellationToken ct = default)
         {
             RequestResult<ReportModel> retVal = new()
@@ -258,6 +261,7 @@ namespace HealthGateway.Common.Delegates
         }
 
         // ReSharper disable once CognitiveComplexity
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         private async Task<RequestResult<T>> PostAsync<T>(string endpointString, StringContent httpContent, CancellationToken ct)
             where T : class
         {

--- a/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
+++ b/Apps/Common/src/ErrorHandling/ExceptionUtilities.cs
@@ -110,7 +110,8 @@ namespace HealthGateway.Common.ErrorHandling
                 return new { e.Message, e.StackTrace };
             }
 
-            return new { e.Message, e.StackTrace, InnerException = FormatExceptionDetails(e.InnerException, maxDepth - 1) };
+            object? innerExceptionDetails = FormatExceptionDetails(e.InnerException, maxDepth - 1);
+            return new { e.Message, e.StackTrace, InnerException = innerExceptionDetails };
         }
     }
 }

--- a/Apps/Common/src/Services/CommunicationService.cs
+++ b/Apps/Common/src/Services/CommunicationService.cs
@@ -141,6 +141,7 @@ namespace HealthGateway.Common.Services
         /// </summary>
         /// <param name="communicationType">The CommunicationType to retrieve the key for.</param>
         /// <returns>The key for the cache associated with the given CommunicationType.</returns>
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         internal static string GetCacheKey(CommunicationType communicationType)
         {
             return communicationType switch

--- a/Apps/Common/src/Swagger/ConfigureSwaggerGenOptions.cs
+++ b/Apps/Common/src/Swagger/ConfigureSwaggerGenOptions.cs
@@ -43,8 +43,10 @@ namespace HealthGateway.Common.Swagger
             IApiVersionDescriptionProvider versionDescriptionProvider,
             IOptions<SwaggerSettings> swaggerSettings)
         {
-            Debug.Assert(versionDescriptionProvider != null, $"{nameof(versionDescriptionProvider)} != null");
-            Debug.Assert(swaggerSettings != null, $"{nameof(swaggerSettings)} != null");
+#pragma warning disable S3236
+            Debug.Assert(versionDescriptionProvider != null, "The versionDescriptionProvider parameter cannot be null.");
+            Debug.Assert(swaggerSettings != null, "The swaggerSettings parameter cannot be null.");
+#pragma warning restore CSHARP_S3236
 
             this.provider = versionDescriptionProvider;
             this.settings = swaggerSettings.Value;

--- a/Apps/Common/src/Swagger/ConfigureSwaggerGenOptions.cs
+++ b/Apps/Common/src/Swagger/ConfigureSwaggerGenOptions.cs
@@ -46,7 +46,7 @@ namespace HealthGateway.Common.Swagger
 #pragma warning disable S3236
             Debug.Assert(versionDescriptionProvider != null, "The versionDescriptionProvider parameter cannot be null.");
             Debug.Assert(swaggerSettings != null, "The swaggerSettings parameter cannot be null.");
-#pragma warning restore CSHARP_S3236
+#pragma warning restore S3236
 
             this.provider = versionDescriptionProvider;
             this.settings = swaggerSettings.Value;

--- a/Apps/Common/src/Swagger/ConfigureSwaggerUiOptions.cs
+++ b/Apps/Common/src/Swagger/ConfigureSwaggerUiOptions.cs
@@ -40,7 +40,7 @@ namespace HealthGateway.Common.Swagger
 #pragma warning disable S3236
             Debug.Assert(versionDescriptionProvider != null, "The versionDescriptionProvider parameter cannot be null.");
             Debug.Assert(settings != null, "The settings parameter cannot be null.");
-#pragma warning restore CSHARP_S3236
+#pragma warning restore S3236
             this.provider = versionDescriptionProvider;
             this.settings = settings.Value;
         }

--- a/Apps/Common/src/Swagger/ConfigureSwaggerUiOptions.cs
+++ b/Apps/Common/src/Swagger/ConfigureSwaggerUiOptions.cs
@@ -37,9 +37,10 @@ namespace HealthGateway.Common.Swagger
         /// <param name="settings">settings.</param>
         public ConfigureSwaggerUiOptions(IApiVersionDescriptionProvider versionDescriptionProvider, IOptions<SwaggerSettings> settings)
         {
-            Debug.Assert(versionDescriptionProvider != null, $"{nameof(versionDescriptionProvider)} != null");
-            Debug.Assert(settings != null, $"{nameof(versionDescriptionProvider)} != null");
-
+#pragma warning disable S3236
+            Debug.Assert(versionDescriptionProvider != null, "The versionDescriptionProvider parameter cannot be null.");
+            Debug.Assert(settings != null, "The settings parameter cannot be null.");
+#pragma warning restore CSHARP_S3236
             this.provider = versionDescriptionProvider;
             this.settings = settings.Value;
         }

--- a/Apps/Common/src/Swagger/SwaggerDefaultValues.cs
+++ b/Apps/Common/src/Swagger/SwaggerDefaultValues.cs
@@ -46,10 +46,7 @@ namespace HealthGateway.Common.Swagger
                     ApiParameterDescription description = context.ApiDescription.ParameterDescriptions.First(p => p.Name == parameter.Name);
                     ApiParameterRouteInfo? routeInfo = description.RouteInfo;
 
-                    if (parameter.Description == null)
-                    {
-                        parameter.Description = description.ModelMetadata?.Description;
-                    }
+                    parameter.Description ??= description.ModelMetadata?.Description;
 
                     if (routeInfo == null)
                     {

--- a/Apps/Common/src/Utils/Odr/OdrAuthorizationHandler.cs
+++ b/Apps/Common/src/Utils/Odr/OdrAuthorizationHandler.cs
@@ -52,7 +52,12 @@ namespace HealthGateway.Common.Utils.Odr
             if (odrConfig.ClientCertificate?.Enabled == true)
             {
                 byte[] certificateData = File.ReadAllBytes(odrConfig.ClientCertificate?.Path);
+
+#pragma warning disable SYSLIB0057
+
+                // Using the obsolete X509Certificate2 constructor
                 this.ClientCertificates.Add(new X509Certificate2(certificateData, odrConfig.ClientCertificate?.Password));
+#pragma warning restore SYSLIB0057
             }
         }
 

--- a/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
+++ b/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
@@ -36,8 +36,8 @@ namespace HealthGateway.Common.Utils
         /// <inheritdoc/>
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            Type? actualType = this.FindType(typeToConvert, ref reader)
-                               ?? throw new JsonException($"serialized json doesn't have a {this.Discriminator} property");
+            Type actualType = this.FindType(typeToConvert, ref reader)
+                              ?? throw new JsonException($"serialized json doesn't have a {this.Discriminator} property");
 
             return (T)(JsonSerializer.Deserialize(ref reader, actualType, options)
                        ?? throw new JsonException($"failed to deserialize type {actualType.Name}"));

--- a/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
+++ b/Apps/Common/src/Utils/PolymorphicJsonConverter.cs
@@ -36,12 +36,8 @@ namespace HealthGateway.Common.Utils
         /// <inheritdoc/>
         public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            Type? actualType = this.FindType(typeToConvert, ref reader);
-
-            if (actualType == null)
-            {
-                throw new JsonException($"serialized json doesn't have a {this.Discriminator} property");
-            }
+            Type? actualType = this.FindType(typeToConvert, ref reader)
+                               ?? throw new JsonException($"serialized json doesn't have a {this.Discriminator} property");
 
             return (T)(JsonSerializer.Deserialize(ref reader, actualType, options)
                        ?? throw new JsonException($"failed to deserialize type {actualType.Name}"));

--- a/Apps/Common/src/Utils/SerializationHelper.cs
+++ b/Apps/Common/src/Utils/SerializationHelper.cs
@@ -64,12 +64,14 @@ public static class SerializationHelper
     {
         if (obj == null)
         {
-            return Array.Empty<byte>();
+            return [];
         }
 
-        return serializeUsingActualType
+        byte[] serializedData = serializeUsingActualType
             ? SerializeUsingConcreteType(obj, options)
             : SerializeUsingGenericType(obj, options);
+
+        return serializedData;
     }
 
     private static byte[] SerializeUsingConcreteType<T>(T obj, JsonSerializerOptions? options = null)

--- a/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authentication/AuthenticationDelegateTests.cs
@@ -223,10 +223,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authentication
             {
                 User = new ClaimsPrincipal(
                     new ClaimsIdentity(
-                        new Claim[]
-                        {
+                        [
                             new("azp", clientAzp),
-                        },
+                        ],
                         "token")),
             };
             Mock<IHttpContextAccessor> mockHttpContextAccessor = new();

--- a/Apps/Common/test/unit/AccessManagement/Authorization/PersonalAccessHandlerTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authorization/PersonalAccessHandlerTests.cs
@@ -50,9 +50,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -80,7 +80,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            NameAuthorizationRequirement[] requirements = { new(username) };
+            NameAuthorizationRequirement[] requirements = [new(username)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -104,9 +104,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -131,7 +131,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -156,9 +156,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -186,7 +186,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -211,9 +211,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -242,7 +242,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read, FhirSubjectLookupMethod.Parameter) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read, FhirSubjectLookupMethod.Parameter)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -267,8 +267,8 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -321,9 +321,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -351,7 +351,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -376,10 +376,10 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string scopes = "user/Patient.read";
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
-                new Claim(GatewayClaims.Scope, scopes),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
+                new(GatewayClaims.Scope, scopes),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -407,7 +407,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -432,9 +432,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -462,7 +462,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Write) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Write)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -487,10 +487,10 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string scopes = "user/Patient.write";
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
-                new Claim(GatewayClaims.Scope, scopes),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
+                new(GatewayClaims.Scope, scopes),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -518,7 +518,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Write) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Write)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -543,9 +543,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -573,7 +573,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<PersonalAccessHandler> logger = loggerFactory.CreateLogger<PersonalAccessHandler>();
 
             PersonalAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Write) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Write)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 

--- a/Apps/Common/test/unit/AccessManagement/Authorization/SystemDelegatedAccessHandlerTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authorization/SystemDelegatedAccessHandlerTests.cs
@@ -49,9 +49,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Hdid, hdid),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Hdid, hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -79,7 +79,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<SystemDelegatedAccessHandler> logger = loggerFactory.CreateLogger<SystemDelegatedAccessHandler>();
 
             SystemDelegatedAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            NameAuthorizationRequirement[] requirements = { new(username) };
+            NameAuthorizationRequirement[] requirements = [new(username)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -104,9 +104,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string scopes = "system/Patient.read";
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Scope, scopes),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Scope, scopes),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -134,7 +134,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<SystemDelegatedAccessHandler> logger = loggerFactory.CreateLogger<SystemDelegatedAccessHandler>();
 
             SystemDelegatedAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read, supportsSystemDelegation: false) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read, supportsSystemDelegation: false)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -159,9 +159,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string scopes = string.Empty;
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Scope, scopes),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Scope, scopes),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -189,7 +189,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<SystemDelegatedAccessHandler> logger = loggerFactory.CreateLogger<SystemDelegatedAccessHandler>();
 
             SystemDelegatedAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -213,8 +213,8 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string username = "User Name";
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -242,7 +242,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<SystemDelegatedAccessHandler> logger = loggerFactory.CreateLogger<SystemDelegatedAccessHandler>();
 
             SystemDelegatedAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -267,9 +267,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string scopes = "system/Patient.read";
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Scope, scopes),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Scope, scopes),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -297,7 +297,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<SystemDelegatedAccessHandler> logger = loggerFactory.CreateLogger<SystemDelegatedAccessHandler>();
 
             SystemDelegatedAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -322,9 +322,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             string scopes = "system/Patient.write";
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, username),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim(GatewayClaims.Scope, scopes),
+                new(ClaimTypes.Name, username),
+                new(ClaimTypes.NameIdentifier, userId),
+                new(GatewayClaims.Scope, scopes),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -352,7 +352,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             ILogger<SystemDelegatedAccessHandler> logger = loggerFactory.CreateLogger<SystemDelegatedAccessHandler>();
 
             SystemDelegatedAccessHandler authHandler = new(logger, httpContextAccessorMock.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Write) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Write)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 

--- a/Apps/Common/test/unit/AccessManagement/Authorization/UserDelegatedAccessHandlerTests.cs
+++ b/Apps/Common/test/unit/AccessManagement/Authorization/UserDelegatedAccessHandlerTests.cs
@@ -18,7 +18,6 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Linq;
     using System.Security.Claims;
     using System.Threading;
     using System.Threading.Tasks;
@@ -73,7 +72,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
                 httpContextAccessorMock.Object,
                 new Mock<IPatientService>().Object,
                 new Mock<IResourceDelegateDelegate>().Object);
-            NameAuthorizationRequirement[] requirements = { new(this.username) };
+            NameAuthorizationRequirement[] requirements = [new(this.username)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -118,7 +117,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
                 httpContextAccessorMock.Object,
                 new Mock<IPatientService>().Object,
                 new Mock<IResourceDelegateDelegate>().Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -148,7 +147,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
                 httpContextAccessorMock.Object,
                 new Mock<IPatientService>().Object,
                 new Mock<IResourceDelegateDelegate>().Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read, supportsUserDelegation: false) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read, supportsUserDelegation: false)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -177,7 +176,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
                 httpContextAccessorMock.Object,
                 new Mock<IPatientService>().Object,
                 new Mock<IResourceDelegateDelegate>().Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Patient, FhirAccessType.Read) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Patient, FhirAccessType.Read)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -227,7 +226,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
                 httpContextAccessorMock.Object,
                 mockPatientService.Object,
                 mockDependentDelegate.Object);
-            PersonalFhirRequirement[] requirements = { new(FhirResource.Observation, FhirAccessType.Read, supportsUserDelegation: true) };
+            PersonalFhirRequirement[] requirements = [new(FhirResource.Observation, FhirAccessType.Read, supportsUserDelegation: true)];
 
             AuthorizationHandlerContext context = new(requirements, claimsPrincipal, null);
 
@@ -322,7 +321,7 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
             }
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(configDictionary.ToList())
+                .AddInMemoryCollection(configDictionary)
                 .Build();
         }
 
@@ -330,9 +329,9 @@ namespace HealthGateway.CommonTests.AccessManagement.Authorization
         {
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, this.username),
-                new Claim(ClaimTypes.NameIdentifier, this.userId),
-                new Claim(GatewayClaims.Hdid, this.hdid),
+                new(ClaimTypes.Name, this.username),
+                new(ClaimTypes.NameIdentifier, this.userId),
+                new(GatewayClaims.Hdid, this.hdid),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             return new ClaimsPrincipal(identity);

--- a/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
+++ b/Apps/Common/test/unit/Auditing/DbAuditLoggerTests.cs
@@ -58,7 +58,7 @@ namespace HealthGateway.CommonTests.Auditing
             // Arrange
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress([127, 0, 0, 1]) },
                 User = new(new ClaimsIdentity([new Claim("hdid", Hdid), new Claim("preferred_username", Idir)])),
             };
 
@@ -111,7 +111,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress([127, 0, 0, 1]) },
                 Response = { StatusCode = 401 },
             };
             AuditEvent expected = new()
@@ -142,7 +142,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress([127, 0, 0, 1]) },
                 Response = { StatusCode = 405 },
             };
             AuditEvent expected = new()
@@ -173,7 +173,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress([127, 0, 0, 1]) },
                 Response = { StatusCode = 500 },
             };
             AuditEvent expected = new()
@@ -205,7 +205,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress([127, 0, 0, 1]) },
             };
             AuditEvent expected = new()
             {
@@ -235,7 +235,7 @@ namespace HealthGateway.CommonTests.Auditing
         {
             DefaultHttpContext ctx = new()
             {
-                Connection = { RemoteIpAddress = new IPAddress(new byte[] { 127, 0, 0, 1 }) },
+                Connection = { RemoteIpAddress = new IPAddress([127, 0, 0, 1]) },
             };
             AuditEvent expected = new()
             {

--- a/Apps/Common/test/unit/CacheProviders/DistributedCacheProviderTests.cs
+++ b/Apps/Common/test/unit/CacheProviders/DistributedCacheProviderTests.cs
@@ -284,7 +284,7 @@ namespace HealthGateway.CommonTests.CacheProviders
                     return number;
 
                 case CacheType.ObjectType:
-                    IEnumerable<DataSource> dataSources = new[] { DataSource.Immunization };
+                    IEnumerable<DataSource> dataSources = [DataSource.Immunization];
                     return dataSources;
 
                 case CacheType.StringType:

--- a/Apps/Common/test/unit/Delegates/AesCryptoDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/AesCryptoDelegateTests.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.CommonTests.Delegates
             };
 
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
 
             AesCryptoDelegate aesDelegate = new(configuration);
@@ -92,7 +92,7 @@ namespace HealthGateway.CommonTests.Delegates
             };
 
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
 
             AesCryptoDelegate aesDelegate = new(configuration);

--- a/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/CDogsDelegateTests.cs
@@ -97,7 +97,7 @@ namespace HealthGateway.CommonTests.Delegates
 
             using HttpResponseMessage httpResponseMessage = new();
             httpResponseMessage.StatusCode = statusCode;
-            httpResponseMessage.Content = new ByteArrayContent(Array.Empty<byte>());
+            httpResponseMessage.Content = new ByteArrayContent([]);
 
             Mock<ILogger<CDogsDelegate>> mockLogger = new();
             Mock<ICDogsApi> mockCdogsApi = new();

--- a/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/ClientRegistriesDelegateTests.cs
@@ -773,21 +773,18 @@ namespace HealthGateway.CommonTests.Delegates
 
         private static II[] GenerateId(bool shouldReturnEmpty = false, string? extension = null, string? oidType = null)
         {
-            if (shouldReturnEmpty)
-            {
-                return [];
-            }
-
-            return
-            [
-                new II
-                {
-                    root = oidType ?? HdidOidType,
-                    extension = oidType == null || (oidType == HdidOidType && extension == null) ? Hdid
-                        : oidType == PhnOidType && extension == null ? Phn : extension,
-                    displayable = true,
-                },
-            ];
+            return shouldReturnEmpty
+                ? []
+                :
+                [
+                    new II
+                    {
+                        root = oidType ?? HdidOidType,
+                        extension = oidType == null || (oidType == HdidOidType && extension == null) ? Hdid
+                            : oidType == PhnOidType && extension == null ? Phn : extension,
+                        displayable = true,
+                    },
+                ];
         }
 
         private static IEnumerable<ENXP> GenerateItems(IEnumerable<EnName> givenNames, IEnumerable<EnName> familyNames)
@@ -848,7 +845,9 @@ namespace HealthGateway.CommonTests.Delegates
             return new HCIM_IN_GetDemographicsResponsePerson
             {
                 deceasedInd = new BL
-                    { value = deceasedInd },
+                {
+                    value = deceasedInd,
+                },
                 id = GenerateId(shouldReturnEmpty, extension, oidType),
                 name = names.ToArray(),
                 birthTime = new TS

--- a/Apps/Common/test/unit/Delegates/HmacHashDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/HmacHashDelegateTests.cs
@@ -54,7 +54,7 @@ namespace HealthGateway.CommonTests.Delegates
             };
 
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
 
             HmacHashDelegate hashDelegate = new(configuration);

--- a/Apps/Common/test/unit/Delegates/RestTokenSwapDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/RestTokenSwapDelegateTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.CommonTests.Delegates
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -103,7 +102,7 @@ namespace HealthGateway.CommonTests.Delegates
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(configuration.ToList())
+                .AddInMemoryCollection(configuration)
                 .Build();
         }
 

--- a/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
+++ b/Apps/Common/test/unit/Delegates/VaccineProofDelegateTests.cs
@@ -406,7 +406,7 @@ namespace HealthGateway.CommonTests.Delegates
                 TotalResultCount = 1,
             };
 
-            byte[] fileContents = { 1 };
+            byte[] fileContents = [1];
             using MemoryStream memoryStream = new(fileContents);
             using HttpResponseMessage httpResponseMessage = new();
             httpResponseMessage.StatusCode = HttpStatusCode.OK;
@@ -461,7 +461,7 @@ namespace HealthGateway.CommonTests.Delegates
         public async Task ValidateGetAssetAsyncEmptyPayload()
         {
             Uri jobUri = new($"https://localhost/{JobId}");
-            byte[] fileContents = Array.Empty<byte>();
+            byte[] fileContents = [];
             using MemoryStream memoryStream = new(fileContents);
             using HttpResponseMessage httpResponseMessage = new();
             httpResponseMessage.StatusCode = HttpStatusCode.OK;

--- a/Apps/Common/test/unit/Services/AccessTokenServiceTests.cs
+++ b/Apps/Common/test/unit/Services/AccessTokenServiceTests.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.CommonTests.Services
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.Common.AccessManagement.Authentication;
@@ -144,7 +143,7 @@ namespace HealthGateway.CommonTests.Services
             }
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(configuration.ToList())
+                .AddInMemoryCollection(configuration)
                 .Build();
         }
 

--- a/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
+++ b/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
@@ -108,9 +108,11 @@ namespace HealthGateway.CommonTests.Services
                 case Scenario.Expired:
                 case Scenario.Deleted:
                 case Scenario.DifferentCache:
-                default:
                     Assert.Equal(commResult.ResourcePayload!.Id, actualResult.ResourcePayload!.Id);
                     break;
+
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(scenario), $"Unexpected scenario: {scenario}");
             }
         }
 

--- a/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
+++ b/Apps/Common/test/unit/Services/CommunicationServiceTests.cs
@@ -77,7 +77,11 @@ namespace HealthGateway.CommonTests.Services
                 EffectiveDateTime = scenario switch
                 {
                     Scenario.Future => DateTime.UtcNow.AddDays(3),
-                    _ => DateTime.UtcNow,
+                    Scenario.Active => DateTime.UtcNow,
+                    Scenario.Expired => DateTime.UtcNow,
+                    Scenario.Deleted => DateTime.UtcNow,
+                    Scenario.DifferentCache => DateTime.UtcNow,
+                    _ => throw new ArgumentOutOfRangeException(nameof(scenario), scenario, "Unhandled scenario value"),
                 },
             };
 
@@ -100,6 +104,10 @@ namespace HealthGateway.CommonTests.Services
                     Assert.Equal(ResultType.Success, actualResult.ResultStatus);
                     break;
 
+                case Scenario.Active:
+                case Scenario.Expired:
+                case Scenario.Deleted:
+                case Scenario.DifferentCache:
                 default:
                     Assert.Equal(commResult.ResourcePayload!.Id, actualResult.ResourcePayload!.Id);
                     break;
@@ -221,6 +229,9 @@ namespace HealthGateway.CommonTests.Services
                     communication.ExpiryDateTime = DateTime.Now.AddDays(5);
                     break;
 
+                case Scenario.Active:
+                case Scenario.Deleted:
+                case Scenario.DifferentCache:
                 default:
                     communication.EffectiveDateTime = DateTime.Now;
                     communication.ExpiryDateTime = DateTime.Now.AddDays(1);
@@ -306,6 +317,9 @@ namespace HealthGateway.CommonTests.Services
                     Assert.Equal(ResultType.Success, cacheResult!.ResultStatus);
                     Assert.Equal(1, cacheResult.TotalResultCount);
                     break;
+
+                default:
+                    throw new InvalidOperationException($"Unhandled scenario: {scenario}");
             }
         }
 

--- a/Apps/Common/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PatientServiceTests.cs
@@ -227,7 +227,7 @@ namespace HealthGateway.CommonTests.Services
         }
 
         /// <summary>
-        /// GetPatient - Returns action required when identifer is null.
+        /// GetPatient - Returns action required when identifier is null.
         /// </summary>
         /// <param name="identifierType">The identifier type used to query with.</param>
         /// <returns>
@@ -297,7 +297,7 @@ namespace HealthGateway.CommonTests.Services
 
             Mock<IClientRegistriesDelegate> patientDelegateMock = new();
             IConfigurationRoot config = new ConfigurationBuilder()
-                .AddInMemoryCollection(configDictionary.ToList())
+                .AddInMemoryCollection(configDictionary)
                 .Build();
 
             patientDelegateMock.Setup(p => p.GetDemographicsByHdidAsync(It.IsAny<string>(), false, It.IsAny<CancellationToken>())).ReturnsAsync(requestResult);

--- a/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
+++ b/Apps/Common/test/unit/Services/PersonalAccountServiceTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.CommonTests.Services
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -101,7 +100,7 @@ namespace HealthGateway.CommonTests.Services
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(configuration.ToList())
+                .AddInMemoryCollection(configuration)
                 .Build();
         }
 

--- a/Apps/Common/test/unit/Utils/DateOnlyJsonConverterTests.cs
+++ b/Apps/Common/test/unit/Utils/DateOnlyJsonConverterTests.cs
@@ -55,7 +55,7 @@ namespace HealthGateway.CommonTests.Utils
                 Converters = { new DateOnlyJsonConverter() },
             };
 
-            object? actualResult = JsonSerializer.Deserialize($@"""{dateStr}""", typeof(DateOnly), options);
+            object? actualResult = JsonSerializer.Deserialize<DateOnly>($@"""{dateStr}""", options);
 
             Assert.IsType<DateOnly>(actualResult);
             Assert.True(date.Equals(actualResult));

--- a/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
+++ b/Apps/Common/test/unit/Utils/HttpContextHelperTests.cs
@@ -1,18 +1,18 @@
-//-------------------------------------------------------------------------
-// Copyright © 2019 Province of British Columbia
+// -------------------------------------------------------------------------
+//  Copyright © 2019 Province of British Columbia
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//-------------------------------------------------------------------------
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------
 namespace HealthGateway.CommonTests.Utils
 {
     using System;
@@ -61,7 +61,7 @@ namespace HealthGateway.CommonTests.Utils
             Assert.Equal(expected, actual);
         }
 
-        [SuppressMessage("ReSharper", "SwitchStatementHandlesSomeKnownEnumValuesWithDefault", Justification = "Unknown enum value expected and is handled in mock setup.")]
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         private static Mock<HttpContext> SetupHttpContextForGetResourceHdid(FhirSubjectLookupMethod lookupMethod)
         {
             Mock<HttpRequest> httpRequestMock = new();

--- a/Apps/Common/test/unit/Utils/SerializationHelperTests.cs
+++ b/Apps/Common/test/unit/Utils/SerializationHelperTests.cs
@@ -37,11 +37,11 @@ namespace HealthGateway.CommonTests.Utils
         [InlineData(typeof(string[]))]
         public void ShouldReturnDefaultOfGenericIfNoData(Type type)
         {
-            MethodInfo? deserializerRef = typeof(SerializationHelper).GetMethod(nameof(SerializationHelper.Deserialize), 2, new[] { typeof(byte[]), typeof(JsonSerializerOptions) })
+            MethodInfo? deserializerRef = typeof(SerializationHelper).GetMethod(nameof(SerializationHelper.Deserialize), 2, [typeof(byte[]), typeof(JsonSerializerOptions)])
                 ?.MakeGenericMethod(type);
             if (deserializerRef != null)
             {
-                byte[] data = Array.Empty<byte>();
+                byte[] data = [];
                 Assert.Equal(Activator.CreateInstance(type), deserializerRef.Invoke(data, null));
                 byte[]? dataNull = null;
                 Assert.Equal(Activator.CreateInstance(type), deserializerRef.Invoke(dataNull, null));
@@ -49,13 +49,13 @@ namespace HealthGateway.CommonTests.Utils
         }
 
         /// <summary>
-        /// Non generic deserialize should return default of Object? when data is or empty which is null.
+        /// Non-generic deserialize should return default of Object? when data is or empty which is null.
         /// </summary>
         [Fact]
         public void ShouldReturnNullIfNoData()
         {
             Type anyType = typeof(string);
-            byte[] data = Array.Empty<byte>();
+            byte[] data = [];
             byte[]? dataNull = null;
             Assert.Null(data.Deserialize(anyType));
             Assert.Null(dataNull.Deserialize(anyType));
@@ -89,7 +89,7 @@ namespace HealthGateway.CommonTests.Utils
         [Fact]
         public void ShouldSerializeWhetherConcreteOrGeneric()
         {
-            string anyObj = "SomeValue";
+            const string anyObj = "SomeValue";
 
             // serialize and deserialize using concrete
             byte[] serialized = anyObj.Serialize();
@@ -98,7 +98,7 @@ namespace HealthGateway.CommonTests.Utils
 
             // serialize and deserialize using generic
             byte[] serialized2 = anyObj.Serialize(false);
-            string? deserialized2 = serialized2.Deserialize(typeof(string)) as string;
+            string? deserialized2 = serialized2.Deserialize<string>();
             Assert.Equal(anyObj, deserialized2);
 
             // serialize results should be equivalent.

--- a/Apps/Common/test/unit/Utils/TimeOnlyJsonConverterTests.cs
+++ b/Apps/Common/test/unit/Utils/TimeOnlyJsonConverterTests.cs
@@ -57,7 +57,7 @@ namespace HealthGateway.CommonTests.Utils
                 Converters = { new TimeOnlyJsonConverter() },
             };
 
-            object? actualResult = JsonSerializer.Deserialize($@"""{timeStr}""", typeof(TimeOnly), options);
+            object? actualResult = JsonSerializer.Deserialize<TimeOnly>($@"""{timeStr}""", options);
 
             Assert.IsType<TimeOnly>(actualResult);
             Assert.True(time.Equals(actualResult));

--- a/Apps/Common/test/unit/Validations/VaccineStatusQueryValidatorTests.cs
+++ b/Apps/Common/test/unit/Validations/VaccineStatusQueryValidatorTests.cs
@@ -17,6 +17,7 @@
 namespace HealthGateway.CommonTests.Validations
 {
     using System;
+    using FluentValidation.Results;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Validations;
     using Xunit;
@@ -38,13 +39,14 @@ namespace HealthGateway.CommonTests.Validations
         [InlineData("2000-01-01", "2021-01-01", "", "PHN is empty")]
         public void ShouldNotBeValid(DateTime dob, DateTime dov, string phn, string reason)
         {
-            var validator = new VaccineStatusQueryValidator();
-            var validationResult = validator.Validate(new VaccineStatusQuery
-            {
-                DateOfBirth = dob,
-                DateOfVaccine = dov,
-                PersonalHealthNumber = phn,
-            });
+            VaccineStatusQueryValidator validator = new();
+            ValidationResult? validationResult = validator.Validate(
+                new VaccineStatusQuery
+                {
+                    DateOfBirth = dob,
+                    DateOfVaccine = dov,
+                    PersonalHealthNumber = phn,
+                });
 
             Assert.False(validationResult.IsValid, reason);
         }
@@ -59,13 +61,14 @@ namespace HealthGateway.CommonTests.Validations
         [InlineData("2000-01-01", "2021-01-01", "9735353315")]
         public void ShouldBeValid(DateTime dob, DateTime dov, string phn)
         {
-            var validator = new VaccineStatusQueryValidator();
-            var validationResult = validator.Validate(new VaccineStatusQuery
-            {
-                DateOfBirth = dob,
-                DateOfVaccine = dov,
-                PersonalHealthNumber = phn,
-            });
+            VaccineStatusQueryValidator validator = new();
+            ValidationResult? validationResult = validator.Validate(
+                new VaccineStatusQuery
+                {
+                    DateOfBirth = dob,
+                    DateOfVaccine = dov,
+                    PersonalHealthNumber = phn,
+                });
 
             Assert.True(validationResult.IsValid);
         }

--- a/Apps/CommonData/src/Models/Address.cs
+++ b/Apps/CommonData/src/Models/Address.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Common.Data.Models
 {
     using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Represents an address.
@@ -26,7 +25,7 @@ namespace HealthGateway.Common.Data.Models
         /// <summary>
         /// Gets or sets the street lines.
         /// </summary>
-        public IEnumerable<string> StreetLines { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> StreetLines { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the city name.

--- a/Apps/CommonData/src/Utils/AddressUtility.cs
+++ b/Apps/CommonData/src/Utils/AddressUtility.cs
@@ -240,7 +240,7 @@ namespace HealthGateway.Common.Data.Utils
             }
 
             IEnumerable<string> addressElements = address.StreetLines
-                .Concat(new[] { address.City, address.State, address.PostalCode });
+                .Concat([address.City, address.State, address.PostalCode]);
 
             if (includeCountry)
             {

--- a/Apps/CommonData/src/Utils/EnumUtility.cs
+++ b/Apps/CommonData/src/Utils/EnumUtility.cs
@@ -45,7 +45,7 @@ namespace HealthGateway.Common.Data.Utils
                     if (attr != null)
                     {
                         // if there's no EnumMember attr, use the default value
-                        enumString = attr.Value !;
+                        enumString = attr.Value!;
                     }
                 }
             }

--- a/Apps/CommonData/src/Validations/PhnValidator.cs
+++ b/Apps/CommonData/src/Validations/PhnValidator.cs
@@ -26,7 +26,7 @@ namespace HealthGateway.Common.Data.Validations
     /// </summary>
     public class PhnValidator : AbstractValidator<string?>
     {
-        private static readonly int[] PhnSigDigits = { 2, 4, 8, 5, 10, 9, 7, 3 };
+        private static readonly int[] PhnSigDigits = [2, 4, 8, 5, 10, 9, 7, 3];
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PhnValidator"/> class.
@@ -49,7 +49,7 @@ namespace HealthGateway.Common.Data.Validations
 
         private static bool IsValidInternal(string? phn)
         {
-            if (string.IsNullOrEmpty(phn) || phn.Length != 10 || !phn.All(c => char.IsDigit(c)) || phn[0] != '9')
+            if (string.IsNullOrEmpty(phn) || phn.Length != 10 || !phn.All(char.IsDigit) || phn[0] != '9')
             {
                 return false;
             }

--- a/Apps/CommonData/test/unit/Extensions/ClaimsPrincipalExtensionsTests.cs
+++ b/Apps/CommonData/test/unit/Extensions/ClaimsPrincipalExtensionsTests.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.Common.Data.Tests.Extensions
         public void ValidateToEnumString(string[] userRoles, string[] targetRoles, bool expected)
         {
             IEnumerable<Claim> claims = userRoles.Select(r => new Claim(ClaimsIdentity.DefaultRoleClaimType, r));
-            ClaimsPrincipal user = new(new[] { new ClaimsIdentity(claims) });
+            ClaimsPrincipal user = new([new ClaimsIdentity(claims)]);
 
             bool actual = user.IsInAnyRole(targetRoles);
 

--- a/Apps/CommonData/test/unit/Utils/DateFormatterTests.cs
+++ b/Apps/CommonData/test/unit/Utils/DateFormatterTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Common.Data.Tests.Utils
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using HealthGateway.Common.Data.Utils;
     using Microsoft.Extensions.Configuration;
     using Xunit;
@@ -211,7 +210,7 @@ namespace HealthGateway.Common.Data.Tests.Utils
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/CommonUi/test/unit/Utils/IJSRuntimeExtensionMethodsTests.cs
+++ b/Apps/CommonUi/test/unit/Utils/IJSRuntimeExtensionMethodsTests.cs
@@ -42,9 +42,10 @@ namespace HealthGateway.CommonUi.Tests.Utils
 
             jsRuntime.Verify(
                 a => a.InvokeAsync<IJSVoidResult>(
-                It.Is<string>(s =>
-                    s.Equals("initializeInactivityTimer",  StringComparison.OrdinalIgnoreCase)),
-                It.IsAny<object?[]?>()),
+                    It.Is<string>(
+                        s =>
+                            s.Equals("initializeInactivityTimer", StringComparison.OrdinalIgnoreCase)),
+                    It.IsAny<object?[]?>()),
                 Times.Once);
         }
     }

--- a/Apps/DBMaintainer/Apps/BCPProvDrugDBApp.cs
+++ b/Apps/DBMaintainer/Apps/BCPProvDrugDBApp.cs
@@ -120,10 +120,12 @@ namespace HealthGateway.DBMaintainer.Apps
         /// <param name="downloadedFile">Search for all download files matching this one.</param>
         protected override void RemoveOldFiles(FileDownload downloadedFile)
         {
-            List<FileDownload> oldIds = this.DrugDbContext.FileDownload
-                .Where(p => p.ProgramCode == downloadedFile.ProgramCode)
-                .Select(f => new FileDownload { Id = f.Id, ProgramCode = f.ProgramCode, Version = f.Version })
-                .ToList();
+            List<FileDownload> oldIds =
+            [
+                .. this.DrugDbContext.FileDownload
+                    .Where(p => p.ProgramCode == downloadedFile.ProgramCode)
+                    .Select(f => new FileDownload { Id = f.Id, ProgramCode = f.ProgramCode, Version = f.Version }),
+            ];
             oldIds.ForEach(s => this.Logger.LogInformation("Deleting old file downloads with id: {Id} and program code: {ProgramCode}", s.Id, s.ProgramCode));
             this.DrugDbContext.RemoveRange(oldIds);
         }
@@ -131,12 +133,7 @@ namespace HealthGateway.DBMaintainer.Apps
         private static string GetDownloadedFile(string sourceFolder, string filenamePattern)
         {
             string[] files = Directory.GetFiles(sourceFolder, filenamePattern);
-            if (files.Length > 1)
-            {
-                throw new FormatException($"The zip file contained {files.Length} CSV files, very confused.");
-            }
-
-            return files[0];
+            return files.Length > 1 ? throw new FormatException($"The zip file contained {files.Length} CSV files, very confused.") : files[0];
         }
 
         private static void ModifyPharmaCareDrug(PharmacyAssessment pharmacyAssessment, IList<PharmaCareDrug> pharmaCareDrugs)

--- a/Apps/DBMaintainer/Apps/BaseDrugApp.cs
+++ b/Apps/DBMaintainer/Apps/BaseDrugApp.cs
@@ -140,10 +140,12 @@ namespace HealthGateway.DBMaintainer.Apps
         /// <param name="downloadedFile">Search for all download files not matching this one.</param>
         protected virtual void RemoveOldFiles(FileDownload downloadedFile)
         {
-            List<FileDownload> oldIds = this.DrugDbContext.FileDownload
-                .Where(p => p.ProgramCode == downloadedFile.ProgramCode && p.Hash != downloadedFile.Hash)
-                .Select(f => new FileDownload { Id = f.Id, Version = f.Version })
-                .ToList();
+            List<FileDownload> oldIds =
+            [
+                .. this.DrugDbContext.FileDownload
+                    .Where(p => p.ProgramCode == downloadedFile.ProgramCode && p.Hash != downloadedFile.Hash)
+                    .Select(f => new FileDownload { Id = f.Id, Version = f.Version }),
+            ];
             oldIds.ForEach(s => this.Logger.LogInformation("Deleting old Download file with hash: {Hash}", s.Hash));
             this.DrugDbContext.RemoveRange(oldIds);
         }

--- a/Apps/DBMaintainer/Mappers/Converters/BooleanConverter.cs
+++ b/Apps/DBMaintainer/Mappers/Converters/BooleanConverter.cs
@@ -27,12 +27,7 @@ namespace HealthGateway.DBMaintainer.Mappers.Converters
         /// <inheritdoc/>
         public override object? ConvertFromString(string? text, IReaderRow row, MemberMapData memberMapData)
         {
-            if (TryConvertToBool(text, out bool result))
-            {
-                return result;
-            }
-
-            return null;
+            return TryConvertToBool(text, out bool result) ? result : null;
         }
 
         private static bool TryConvertToBool(string text, out bool result)

--- a/Apps/DBMaintainer/Mappers/PharmacyAssessmentMapper.cs
+++ b/Apps/DBMaintainer/Mappers/PharmacyAssessmentMapper.cs
@@ -30,7 +30,7 @@ namespace HealthGateway.DBMaintainer.Mappers
         /// Performs the mapping of read Pharmacy Assessment file to the db model.
         /// </summary>
         /// <param name="fileDownload">The fileDownload to map.</param>
-        [SuppressMessage("ReSharper", "UnusedParameter.Local", Justification = "Required by ClassMap")]
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required by ClassMap")]
         public PharmacyAssessmentMapper(FileDownload fileDownload)
         {
             this.Map(m => m.Pin).Index(0);

--- a/Apps/DBMaintainer/Mappers/PharmacyAssessmentMapper.cs
+++ b/Apps/DBMaintainer/Mappers/PharmacyAssessmentMapper.cs
@@ -31,6 +31,8 @@ namespace HealthGateway.DBMaintainer.Mappers
         /// </summary>
         /// <param name="fileDownload">The fileDownload to map.</param>
         [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required by ClassMap")]
+
+        // ReSharper disable once UnusedParameter.Local
         public PharmacyAssessmentMapper(FileDownload fileDownload)
         {
             this.Map(m => m.Pin).Index(0);

--- a/Apps/DBMaintainer/Parsers/FederalDrugProductParser.cs
+++ b/Apps/DBMaintainer/Parsers/FederalDrugProductParser.cs
@@ -241,12 +241,7 @@ namespace HealthGateway.DBMaintainer.Parsers
         private static string GetFileMatching(string sourceFolder, string fileMatch)
         {
             string[] files = Directory.GetFiles(sourceFolder, fileMatch);
-            if (files.Length > 1 || files.Length == 0)
-            {
-                throw new FormatException($"The zip file contained {files.Length} CSV files, very confused.");
-            }
-
-            return files[0];
+            return files.Length is > 1 or 0 ? throw new FormatException($"The zip file contained {files.Length} CSV files, very confused.") : files[0];
         }
     }
 }

--- a/Apps/DBMaintainer/Program.cs
+++ b/Apps/DBMaintainer/Program.cs
@@ -74,7 +74,7 @@ namespace HealthGateway.DBMaintainer
         /// </summary>
         /// <returns>The IHostBuilder.</returns>
         /// <param name="args">The set of command line arguments.</param>
-        [SuppressMessage("Usage", "CA1801:Review unused parameters", Justification = "Required for migrations")]
+        [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "Required for migrations.")]
         public static IHostBuilder CreateWebHostBuilder(string[] args)
         {
             string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Development";

--- a/Apps/Database/src/Delegates/DbBetaFeatureAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/DbBetaFeatureAccessDelegate.cs
@@ -82,7 +82,7 @@ namespace HealthGateway.Database.Delegates
 
             int totalCount = await emailQuery.CountAsync(ct);
 
-            IList<string> emailAddresses = await emailQuery
+            List<string> emailAddresses = await emailQuery
                 .OrderBy(p => p)
                 .Skip(pageIndex * pageSize)
                 .Take(pageSize)

--- a/Apps/Database/src/Wrapper/DBDelegateHelper.cs
+++ b/Apps/Database/src/Wrapper/DBDelegateHelper.cs
@@ -19,7 +19,6 @@ namespace HealthGateway.Database.Wrapper
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using HealthGateway.Database.Constants;
     using Microsoft.EntityFrameworkCore;
 
     /// <summary>
@@ -27,26 +26,6 @@ namespace HealthGateway.Database.Wrapper
     /// </summary>
     public static class DbDelegateHelper
     {
-        /// <summary>
-        /// Gets a list of DBModel records for a specific page.
-        /// </summary>
-        /// <param name="query">A query that needs to be paged.</param>
-        /// <param name="page">The starting offset for the query.</param>
-        /// <param name="pageSize">The maximum amount of rows to return.</param>
-        /// <typeparam name="T">A DBModel type.</typeparam>
-        /// <returns>A list of DBModel records wrapped in a DBResult.</returns>
-        public static DbResult<IEnumerable<T>> GetPagedDbResult<T>(IQueryable<T> query, int page, int pageSize)
-            where T : class
-        {
-            int offset = page * pageSize;
-            DbResult<IEnumerable<T>> result = new()
-            {
-                Payload = query.Skip(offset).Take(pageSize).ToList(),
-            };
-            result.Status = DbStatusCode.Read;
-            return result;
-        }
-
         /// <summary>
         /// Gets a list of DBModel records for a specific page.
         /// </summary>

--- a/Apps/Encounter/src/MapProfiles/EncounterModelProfile.cs
+++ b/Apps/Encounter/src/MapProfiles/EncounterModelProfile.cs
@@ -41,8 +41,7 @@ namespace HealthGateway.Encounter.MapProfiles
                 .ForMember(
                     dest => dest.Clinic,
                     opt => opt.MapFrom(
-                        src => new Clinic
-                            { Name = src.LocationName }))
+                        src => new Clinic { Name = src.LocationName }))
                 .AfterMap(
                     (src, dest) =>
                     {

--- a/Apps/Encounter/src/Models/PHSA/HospitalVisitResult.cs
+++ b/Apps/Encounter/src/Models/PHSA/HospitalVisitResult.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Encounter.Models.PHSA
 {
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text.Json.Serialization;
 
     /// <summary>
@@ -49,6 +48,6 @@ namespace HealthGateway.Encounter.Models.PHSA
         /// Gets or sets the list of hospital visits.
         /// </summary>
         [JsonPropertyName("hospitalVisits")]
-        public IEnumerable<HospitalVisitModel> HospitalVisits { get; set; } = Enumerable.Empty<HospitalVisitModel>();
+        public IEnumerable<HospitalVisitModel> HospitalVisits { get; set; } = [];
     }
 }

--- a/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
+++ b/Apps/Encounter/test/unit/Delegates/RestHospitalVisitDelegateTests.cs
@@ -167,7 +167,7 @@ namespace HealthGateway.EncounterTests.Delegates
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(configuration.ToList())
+                .AddInMemoryCollection(configuration)
                 .Build();
         }
     }

--- a/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceTests.cs
@@ -344,7 +344,7 @@ namespace HealthGateway.EncounterTests.Services
                 ResultStatus = ResultType.Success,
                 ResourcePayload = new PhsaResult<IEnumerable<HospitalVisit>>
                 {
-                    Result = Enumerable.Empty<HospitalVisit>(),
+                    Result = [],
                 },
                 TotalResultCount = 0,
             };
@@ -377,7 +377,7 @@ namespace HealthGateway.EncounterTests.Services
                 ResultStatus = ResultType.ActionRequired,
                 ResourcePayload = new PhsaResult<IEnumerable<HospitalVisit>>
                 {
-                    Result = Enumerable.Empty<HospitalVisit>(),
+                    Result = [],
                     LoadState = new()
                     {
                         Queued = true,
@@ -416,7 +416,7 @@ namespace HealthGateway.EncounterTests.Services
                 ResultStatus = ResultType.Error,
                 ResourcePayload = new PhsaResult<IEnumerable<HospitalVisit>>
                 {
-                    Result = Enumerable.Empty<HospitalVisit>(),
+                    Result = [],
                 },
             };
             IEncounterService service = GetEncounterService(hospitalVisitResults);

--- a/Apps/GatewayApi/src/Controllers/CommentController.cs
+++ b/Apps/GatewayApi/src/Controllers/CommentController.cs
@@ -130,12 +130,9 @@ namespace HealthGateway.GatewayApi.Controllers
         [Authorize(Policy = UserProfilePolicy.Write)]
         public async Task<ActionResult<RequestResult<UserComment>>> Delete(string hdid, [FromBody] UserComment comment, CancellationToken ct)
         {
-            if (comment.UserProfileId != hdid)
-            {
-                return new ForbidResult();
-            }
-
-            return await this.commentService.DeleteAsync(comment, ct);
+            return comment.UserProfileId != hdid
+                ? new ForbidResult()
+                : await this.commentService.DeleteAsync(comment, ct);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Controllers/PhsaController.cs
+++ b/Apps/GatewayApi/src/Controllers/PhsaController.cs
@@ -18,6 +18,7 @@ namespace HealthGateway.GatewayApi.Controllers
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -37,6 +38,7 @@ namespace HealthGateway.GatewayApi.Controllers
     [ApiVersion("1.0")]
     [Route("[controller]")]
     [ApiController]
+    [SuppressMessage("Major Code Smell", "S6960:Controllers should not have mixed responsibilities", Justification = "Team decision")]
     public class PhsaController : ControllerBase
     {
         private readonly IDependentService dependentService;

--- a/Apps/GatewayApi/src/Controllers/UserFeedbackController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserFeedbackController.cs
@@ -75,12 +75,7 @@ namespace HealthGateway.GatewayApi.Controllers
             }
 
             DbResult<UserFeedback> result = await this.userFeedbackService.CreateUserFeedbackAsync(feedback, hdid, ct);
-            if (result.Status != DbStatusCode.Created)
-            {
-                return new ConflictResult();
-            }
-
-            return new OkResult();
+            return result.Status != DbStatusCode.Created ? new ConflictResult() : new OkResult();
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -39,6 +39,7 @@ namespace HealthGateway.GatewayApi.Controllers
     [ApiVersion("1.0")]
     [Route("[controller]")]
     [ApiController]
+    [SuppressMessage("Major Code Smell", "S6960:Controllers should not have mixed responsibilities", Justification = "Team decision")]
     public class UserProfileController : ControllerBase
     {
         private readonly IAuthenticationDelegate authenticationDelegate;

--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -41,6 +41,7 @@ namespace HealthGateway.GatewayApi.Controllers
     [Route("UserProfile")]
     [ApiController]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Major Code Smell", "S6960:Controllers should not have mixed responsibilities", Justification = "Team decision")]
     public class UserProfileControllerV2 : ControllerBase
     {
         private readonly IHttpContextAccessor httpContextAccessor;
@@ -131,7 +132,7 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The requested user profile, or an empty profile if the requested profile doesn't exist.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <response code="200">Returns the requested user profile, or an empty profile if the requested profile doesn't exists.</response>
+        /// <response code="200">Returns the requested user profile, or an empty profile if the requested profile doesn't exist.</response>
         /// <response code="400">Validation error.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -415,12 +416,9 @@ namespace HealthGateway.GatewayApi.Controllers
         public async Task<ActionResult<UserPreferenceModel>> UpdateUserPreference(string hdid, [FromBody] UserPreferenceModel? userPreferenceModel, CancellationToken ct)
         {
             await new UserPreferenceModelValidator().ValidateAndThrowAsync(userPreferenceModel, ct);
-            if (!hdid.Equals(userPreferenceModel?.HdId, StringComparison.OrdinalIgnoreCase))
-            {
-                return new ForbidResult();
-            }
-
-            return await this.userPreferenceService.UpdateUserPreferenceAsync(hdid, userPreferenceModel, ct);
+            return !hdid.Equals(userPreferenceModel?.HdId, StringComparison.OrdinalIgnoreCase)
+                ? new ForbidResult()
+                : await this.userPreferenceService.UpdateUserPreferenceAsync(hdid, userPreferenceModel, ct);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Services/MessagingVerificationService.cs
+++ b/Apps/GatewayApi/src/Services/MessagingVerificationService.cs
@@ -131,8 +131,7 @@ namespace HealthGateway.GatewayApi.Services
             return
                 BitConverter
                     .ToUInt32(data)
-                    .ToString("D6", CultureInfo.InvariantCulture)
-                    .Substring(0, 6);
+                    .ToString("D6", CultureInfo.InvariantCulture)[..6];
         }
 
         private static string SanitizeSms(string smsNumber)

--- a/Apps/GatewayApi/src/Services/PatientDetailsService.cs
+++ b/Apps/GatewayApi/src/Services/PatientDetailsService.cs
@@ -52,17 +52,10 @@ namespace HealthGateway.GatewayApi.Services
 
             PatientModel patientModel = (await this.patientRepository.QueryAsync(query, ct)).Item;
 
-            if (patientModel.LegalName == null && patientModel.CommonName == null)
-            {
-                throw new InvalidDataException(ErrorMessages.InvalidServicesCard);
-            }
-
-            if (string.IsNullOrEmpty(patientModel.Hdid) && string.IsNullOrEmpty(patientModel.Phn) && !disableIdValidation)
-            {
-                throw new InvalidDataException(ErrorMessages.InvalidServicesCard);
-            }
-
-            return this.mappingService.MapToPatientDetails(patientModel);
+            return (patientModel.LegalName == null && patientModel.CommonName == null) ||
+                   (string.IsNullOrEmpty(patientModel.Hdid) && string.IsNullOrEmpty(patientModel.Phn) && !disableIdValidation)
+                ? throw new InvalidDataException(ErrorMessages.InvalidServicesCard)
+                : this.mappingService.MapToPatientDetails(patientModel);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/UserPreferenceServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserPreferenceServiceV2.cs
@@ -38,12 +38,7 @@ namespace HealthGateway.GatewayApi.Services
             UserPreference userPreference = mappingService.MapToUserPreference(userPreferenceModel);
 
             DbResult<UserPreference> dbResult = await userPreferenceDelegate.UpdateUserPreferenceAsync(userPreference, ct: ct);
-            if (dbResult.Status != DbStatusCode.Updated)
-            {
-                throw new DatabaseException(dbResult.Message);
-            }
-
-            return mappingService.MapToUserPreferenceModel(dbResult.Payload);
+            return dbResult.Status != DbStatusCode.Updated ? throw new DatabaseException(dbResult.Message) : mappingService.MapToUserPreferenceModel(dbResult.Payload);
         }
 
         /// <inheritdoc/>
@@ -55,12 +50,7 @@ namespace HealthGateway.GatewayApi.Services
             UserPreference userPreference = mappingService.MapToUserPreference(userPreferenceModel);
 
             DbResult<UserPreference> dbResult = await userPreferenceDelegate.CreateUserPreferenceAsync(userPreference, ct: ct);
-            if (dbResult.Status != DbStatusCode.Created)
-            {
-                throw new DatabaseException(dbResult.Message);
-            }
-
-            return mappingService.MapToUserPreferenceModel(dbResult.Payload);
+            return dbResult.Status != DbStatusCode.Created ? throw new DatabaseException(dbResult.Message) : mappingService.MapToUserPreferenceModel(dbResult.Payload);
         }
 
         /// <inheritdoc/>

--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -178,8 +178,7 @@ namespace HealthGateway.GatewayApi.Services
             return
                 BitConverter
                     .ToUInt32(data)
-                    .ToString("D6", CultureInfo.InvariantCulture)
-                    .Substring(0, 6);
+                    .ToString("D6", CultureInfo.InvariantCulture)[..6];
         }
 
         private static string SanitizeSms(string smsNumber)

--- a/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/DependentControllerTests.cs
@@ -197,10 +197,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IAuthenticationService> authenticationMock = new();
             AuthenticateResult authResult = AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, JwtBearerDefaults.AuthenticationScheme));
             authResult.Properties.StoreTokens(
-                new[]
-                {
-                    new AuthenticationToken { Name = "access_token", Value = token },
-                });
+            [
+                new AuthenticationToken { Name = "access_token", Value = token },
+            ]);
             authenticationMock
                 .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))
                 .ReturnsAsync(authResult);

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -555,11 +555,11 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
 
             List<Claim> claims =
             [
-                new Claim(ClaimTypes.Name, "username"),
-                new Claim(ClaimTypes.NameIdentifier, userId),
-                new Claim("hdid", hdid),
-                new Claim("auth_time", "123"),
-                new Claim("access_token", token),
+                new(ClaimTypes.Name, "username"),
+                new(ClaimTypes.NameIdentifier, userId),
+                new("hdid", hdid),
+                new("auth_time", "123"),
+                new("access_token", token),
             ];
             ClaimsIdentity identity = new(claims, "TestAuth");
             ClaimsPrincipal claimsPrincipal = new(identity);
@@ -572,10 +572,9 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IAuthenticationService> authenticationMock = new();
             AuthenticateResult authResult = AuthenticateResult.Success(new AuthenticationTicket(claimsPrincipal, JwtBearerDefaults.AuthenticationScheme));
             authResult.Properties.StoreTokens(
-                new[]
-                {
-                    new AuthenticationToken { Name = "access_token", Value = token },
-                });
+            [
+                new AuthenticationToken { Name = "access_token", Value = token },
+            ]);
             authenticationMock
                 .Setup(x => x.AuthenticateAsync(httpContextAccessorMock.Object.HttpContext, It.IsAny<string>()))
                 .ReturnsAsync(authResult);

--- a/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/CommentServiceTests.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Arrange
             List<Comment> comments =
             [
-                new Comment
+                new()
                 {
                     UserProfileId = Hdid,
                     ParentEntryId = ParentEntryId,
@@ -73,7 +73,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     CreatedDateTime = DateTime.Parse("2020-01-01", CultureInfo.InvariantCulture),
                 },
 
-                new Comment
+                new()
                 {
                     UserProfileId = Hdid,
                     ParentEntryId = ParentEntryId,
@@ -127,7 +127,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Arrange
             List<Comment> comments =
             [
-                new Comment
+                new()
                 {
                     UserProfileId = Hdid,
                     ParentEntryId = ParentEntryId,
@@ -342,8 +342,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             DbResult<IList<Comment>>? parentEntryCommentsDbResult = null,
             DbResult<IEnumerable<Comment>>? allCommentsDbResult = null)
         {
-            UserProfile userProfile = new()
-                { EncryptionKey = encryptionKey };
+            UserProfile userProfile = new() { EncryptionKey = encryptionKey };
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
             profileDelegateMock.Setup(s => s.GetUserProfileAsync(Hdid, It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(userProfile);

--- a/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DependentServiceTests.cs
@@ -411,7 +411,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [Fact]
         public async Task ValidateRemove()
         {
-            IList<ResourceDelegate> resourceDelegates = new[] { new ResourceDelegate { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId } };
+            IList<ResourceDelegate> resourceDelegates =
+            [
+                new()
+                    { ProfileHdid = this.mockParentHdid, ResourceOwnerHdid = this.mockHdId },
+            ];
             DbResult<ResourceDelegate> dbResult = new()
             {
                 Status = DbStatusCode.Deleted,
@@ -465,7 +469,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 .AddJsonFile("appsettings.json", true)
                 .AddJsonFile("appsettings.Development.json", true)
                 .AddJsonFile("appsettings.local.json", true)
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -502,9 +506,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
         private static RequestResult<PatientModel> SetupPatientRequestResultForInvalidPatient(ResultType resultType, string message)
         {
-            if (resultType == ResultType.ActionRequired)
-            {
-                return new()
+            return resultType == ResultType.ActionRequired
+                ? new()
                 {
                     ResultStatus = ResultType.ActionRequired,
                     ResultError = message == ErrorMessages.InvalidServicesCard
@@ -513,13 +516,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                             ActionCode = ActionType.NoHdId,
                         }
                         : null,
+                }
+                : new()
+                {
+                    ResultStatus = resultType,
                 };
-            }
-
-            return new()
-            {
-                ResultStatus = resultType,
-            };
         }
 
         private IList<ResourceDelegate> GenerateMockResourceDelegatesList()

--- a/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/NoteServiceTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading;
@@ -67,6 +68,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(DbStatusCode.Read, DbStatusCode.Deferred, DbStatusCode.Error, null, true, true)]
         [InlineData(DbStatusCode.Read, DbStatusCode.Error, null, null, true, true)]
         [InlineData(null, null, null, null, false, false)]
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         public async Task ShouldGetNotes(
             DbStatusCode? notesDbStatusCode,
             DbStatusCode? updateProfileDbStatusCode,
@@ -78,7 +80,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Arrange
             List<UserNote> expected =
             [
-                new UserNote
+                new()
                 {
                     HdId = Hdid,
                     Title = "First Note",
@@ -86,7 +88,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     CreatedDateTime = DateTime.Parse("2020-01-01", CultureInfo.InvariantCulture),
                 },
 
-                new UserNote
+                new()
                 {
                     HdId = Hdid,
                     Title = "Second Note",
@@ -95,7 +97,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 },
             ];
 
-            IList<Note> notes = expected.Select(n => Mapper.Map<UserNote, Note>(n)).ToList();
+            IList<Note> notes = expected.Select(Mapper.Map<UserNote, Note>).ToList();
             if (encryptionKey != null)
             {
                 foreach (Note note in notes)
@@ -203,8 +205,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 }
                 : null;
 
-            UserProfile userProfile = new()
-                { EncryptionKey = encryptionKey };
+            UserProfile userProfile = new() { EncryptionKey = encryptionKey };
 
             NoteService service = GetNoteService(userProfile: userProfile, noteDbResult: noteDbResult);
 
@@ -256,8 +257,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 }
                 : null;
 
-            UserProfile userProfile = new()
-                { EncryptionKey = encryptionKey };
+            UserProfile userProfile = new() { EncryptionKey = encryptionKey };
 
             NoteService service = GetNoteService(userProfile: userProfile, noteDbResult: noteDbResult);
 
@@ -309,8 +309,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 }
                 : null;
 
-            UserProfile userProfile = new()
-                { EncryptionKey = encryptionKey };
+            UserProfile userProfile = new() { EncryptionKey = encryptionKey };
 
             NoteService service = GetNoteService(userProfile: userProfile, noteDbResult: noteDbResult);
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -210,7 +210,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <summary>
         /// ValidateEmailAsync - invalid invite.
         /// </summary>
-        /// <param name="hdid">The hdid associated with the verification by invite key..</param>
+        /// <param name="hdid">The hdid associated with the verification by invite key.</param>
         /// <param name="validated">The last verification for user Validated value.</param>
         /// <param name="deleted">The last verification's Deleted value.</param>
         /// <param name="userProfileExists">
@@ -317,7 +317,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
@@ -280,7 +280,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             messagingVerificationDelegateMock.Verify(
                 s => s.UpdateAsync(
                     It.Is<MessagingVerification>(
-                        mv => mv.Validated == false &&
+                        mv => !mv.Validated &&
                               mv.VerificationAttempts == 1),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()),
@@ -291,8 +291,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         {
             messagingVerificationDelegateMock.Verify(
                 s => s.UpdateAsync(
-                    It.Is<MessagingVerification>(
-                        mv => mv.Validated == true),
+                    It.Is<MessagingVerification>(mv => mv.Validated),
                     It.IsAny<bool>(),
                     It.IsAny<CancellationToken>()),
                 times ?? Times.Once());
@@ -496,8 +495,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                             It.IsAny<bool>(),
                             It.IsAny<CancellationToken>()))
                     .ReturnsAsync(
-                        new DbResult<UserProfile>
-                            { Status = dbUpdateStatus.Value });
+                        new DbResult<UserProfile> { Status = dbUpdateStatus.Value });
             }
 
             return userProfileDelegateMock;

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceTests.cs
@@ -179,7 +179,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userPreferenceDelegateMock.Setup(
                     s => s.CreateUserPreferenceAsync(
                         It.Is<UserPreference>(x => x.Preference == userPreference.Preference),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
@@ -192,7 +192,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userPreferenceDelegateMock.Setup(
                     s => s.UpdateUserPreferenceAsync(
                         It.Is<UserPreference>(x => x.Preference == userPreference.Preference),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserPreferenceServiceV2Tests.cs
@@ -198,14 +198,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userPreferenceDelegateMock.Setup(
                     s => s.CreateUserPreferenceAsync(
                         It.Is<UserPreference>(x => x.Preference == createUserPreference.Preference),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
             userPreferenceDelegateMock.Setup(
                     s => s.UpdateUserPreferenceAsync(
                         It.Is<UserPreference>(x => x.Preference == createUserPreference.Preference),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 
@@ -219,7 +219,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userPreferenceDelegateMock.Setup(
                     s => s.UpdateUserPreferenceAsync(
                         It.Is<UserPreference>(x => x.Preference == updateUserPreference.Preference),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(dbResult);
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Linq;
     using System.Threading;
@@ -256,6 +257,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(DbStatusCode.Created, false, false, true, true, true, ResultType.Error)] // Cannot insert due to get patient error
         [InlineData(DbStatusCode.Concurrency, false, false, true, true, false, ResultType.Error)] // Cannot insert due to database error
         [InlineData(DbStatusCode.Error, false, false, true, true, false, ResultType.Error)] // Cannot insert due to database error
+        [SuppressMessage("Style", "IDE0046: 'if' statement can be simplified", Justification = "Team decision")]
         public async Task ShouldCreateUserProfile(
             DbStatusCode insertedStatus,
             bool accountsFeedEnabled,
@@ -515,7 +517,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     It.IsAny<string>(),
                     It.Is<string>(x => x == EmailTemplateName.AccountClosedTemplate),
                     It.IsAny<Dictionary<string, string>>(),
-                    It.Is<bool>(x => x == true),
+                    It.Is<bool>(x => x),
                     It.IsAny<CancellationToken>()),
                 expectedTimesSendEmail);
         }
@@ -614,7 +616,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     It.IsAny<string>(),
                     It.Is<string>(x => x == EmailTemplateName.AccountRecoveredTemplate),
                     It.IsAny<Dictionary<string, string>>(),
-                    It.Is<bool>(x => x == true),
+                    It.Is<bool>(x => x),
                     It.IsAny<CancellationToken>()),
                 expectedTimesSendEmail);
         }
@@ -831,7 +833,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 
@@ -856,7 +858,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetPatientAsync(
                         It.Is<string>(x => x == Hdid),
                         It.Is<PatientIdentifierType>(x => x == PatientIdentifierType.Hdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patientResult);
 
@@ -947,7 +949,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userProfileDelegateMock.Setup(
                     s => s.GetUserProfileAsync(
                         It.Is<string>(x => x == Hdid),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(userProfile);
 
@@ -964,7 +966,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     s => s.GetPatientAsync(
                         It.Is<string>(x => x == Hdid),
                         It.Is<PatientIdentifierType>(x => x == PatientIdentifierType.Hdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(patientResult);
 
@@ -1053,14 +1055,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userProfileDelegateMock.Setup(
                     s => s.GetUserProfileAsync(
                         It.Is<string>(x => x == Hdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(userProfile);
 
             userProfileDelegateMock.Setup(
                     s => s.UpdateAsync(
                         It.Is<UserProfile>(x => x.HdId == Hdid),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(updateResult!);
 
@@ -1110,14 +1112,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userProfileDelegateMock.Setup(
                     s => s.GetUserProfileAsync(
                         It.Is<string>(x => x == Hdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readUserProfile);
 
             userProfileDelegateMock.Setup(
                     s => s.UpdateAsync(
                         It.Is<UserProfile>(x => x.HdId == Hdid),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(updateResult);
 
@@ -1170,14 +1172,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             userProfileDelegateMock.Setup(
                     s => s.GetUserProfileAsync(
                         It.Is<string>(x => x == Hdid),
-                        It.Is<bool>(x => x == false),
+                        It.Is<bool>(x => !x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readUserProfile);
 
             userProfileDelegateMock.Setup(
                     s => s.UpdateAsync(
                         It.Is<UserProfile>(x => x.HdId == Hdid),
-                        It.Is<bool>(x => x == true),
+                        It.Is<bool>(x => x),
                         It.IsAny<CancellationToken>()))
                 .ReturnsAsync(updateResult);
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
@@ -547,14 +548,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IUserProfileServiceV2 service = GetUserProfileService(
                 userProfileDelegateMock: userProfileDelegateMock);
 
-            if (profileUpdateStatus == DbStatusCode.Updated)
-            {
-                return new UpdateAcceptedTermsMock(
+            return profileUpdateStatus == DbStatusCode.Updated
+                ? new UpdateAcceptedTermsMock(
                     service,
-                    userProfileDelegateMock);
-            }
-
-            return new UpdateAcceptedTermsExceptionMock(service);
+                    userProfileDelegateMock)
+                : new UpdateAcceptedTermsExceptionMock(service);
         }
 
         private static BaseUserProfileServiceMock SetupCloseUserProfileMock(
@@ -580,17 +578,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 authenticationDelegateMock: authenticationDelegateMock,
                 jobServiceMock: jobServiceMock);
 
-            if (closedDateTime != null || profileUpdateStatus == DbStatusCode.Updated)
-            {
-                return new CloseUserProfileMock(
+            return closedDateTime != null || profileUpdateStatus == DbStatusCode.Updated
+                ? new CloseUserProfileMock(
                     service,
                     userProfileDelegateMock,
-                    jobServiceMock);
-            }
-
-            return new CloseUserProfileExceptionMock(service);
+                    jobServiceMock)
+                : new CloseUserProfileExceptionMock(service);
         }
 
+        [SuppressMessage("Style", "IDE0046: 'if' statement can be simplified", Justification = "Team decision")]
         private static BaseUserProfileServiceMock SetupRecoverUserProfileMock(
             bool userProfileExists = true,
             DateTime? profileClosedDateTime = null,
@@ -616,15 +612,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             if (userProfileExists)
             {
-                if (profileUpdateStatus == DbStatusCode.Error)
-                {
-                    return new RecoverUserProfileExceptionMock(service);
-                }
-
-                return new RecoverUserProfileMock(
-                    service,
-                    userProfileDelegateMock,
-                    jobServiceMock);
+                return profileUpdateStatus == DbStatusCode.Error
+                    ? new RecoverUserProfileExceptionMock(service)
+                    : new RecoverUserProfileMock(service, userProfileDelegateMock, jobServiceMock);
             }
 
             return new RecoverUserProfileExceptionMock(service);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -335,7 +335,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             };
 
             return new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
     }

--- a/Apps/Immunization/src/Services/ImmunizationService.cs
+++ b/Apps/Immunization/src/Services/ImmunizationService.cs
@@ -61,28 +61,26 @@ namespace HealthGateway.Immunization.Services
             }
 
             RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = await this.immunizationDelegate.GetImmunizationsAsync(hdid, ct);
-            if (delegateResult.ResultStatus == ResultType.Success)
-            {
-                return new RequestResult<ImmunizationResult>
+
+            return delegateResult.ResultStatus == ResultType.Success
+                ? new RequestResult<ImmunizationResult>
                 {
                     ResultStatus = delegateResult.ResultStatus,
                     ResourcePayload = new ImmunizationResult
                     {
                         LoadState = this.mappingService.MapToLoadStateModel(delegateResult.ResourcePayload!.LoadState),
                         Immunizations = delegateResult.ResourcePayload!.Result!.ImmunizationViews.Select(this.mappingService.MapToImmunizationEvent).ToList(),
-                        Recommendations = this.mappingService.MapToImmunizationRecommendations(delegateResult.ResourcePayload.Result.Recommendations).ToList(),
+                        Recommendations = this.mappingService.MapToImmunizationRecommendations(delegateResult.ResourcePayload.Result.Recommendations),
                     },
                     PageIndex = delegateResult.PageIndex,
                     PageSize = delegateResult.PageSize,
                     TotalResultCount = delegateResult.TotalResultCount,
+                }
+                : new RequestResult<ImmunizationResult>
+                {
+                    ResultStatus = delegateResult.ResultStatus,
+                    ResultError = delegateResult.ResultError,
                 };
-            }
-
-            return new RequestResult<ImmunizationResult>
-            {
-                ResultStatus = delegateResult.ResultStatus,
-                ResultError = delegateResult.ResultError,
-            };
         }
     }
 }

--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Immunization.Services
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using FluentValidation.Results;
@@ -237,6 +238,7 @@ namespace HealthGateway.Immunization.Services
             return retVal;
         }
 
+        [SuppressMessage("Style", "IDE0072:Switch expression should be exhaustive", Justification = "Team decision")]
         private async Task<RequestResult<VaccineStatus>> GetVaccineStatusFromDelegateAsync(VaccineStatusQuery query, string accessToken, string? phn = null, CancellationToken ct = default)
         {
             RequestResult<VaccineStatus> retVal = new()

--- a/Apps/Immunization/src/Services/VaccineStatusService.cs
+++ b/Apps/Immunization/src/Services/VaccineStatusService.cs
@@ -238,7 +238,7 @@ namespace HealthGateway.Immunization.Services
             return retVal;
         }
 
-        [SuppressMessage("Style", "IDE0072:Switch expression should be exhaustive", Justification = "Team decision")]
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         private async Task<RequestResult<VaccineStatus>> GetVaccineStatusFromDelegateAsync(VaccineStatusQuery query, string accessToken, string? phn = null, CancellationToken ct = default)
         {
             RequestResult<VaccineStatus> retVal = new()

--- a/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
+++ b/Apps/Immunization/test/unit/Delegates.Test/ImmunizationDelegateTests.cs
@@ -113,7 +113,7 @@ namespace HealthGateway.ImmunizationTests.Delegates.Test
                 .AddJsonFile("appsettings.json", true)
                 .AddJsonFile("appsettings.Development.json", true)
                 .AddJsonFile("appsettings.local.json", true)
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
         }
 

--- a/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/VaccineStatusServiceTests.cs
@@ -75,7 +75,10 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
                     LoadState = new PhsaLoadState
-                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    {
+                        RefreshInProgress = false,
+                        BackOffMilliseconds = 500,
+                    },
                     Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
@@ -159,7 +162,10 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
                     LoadState = new PhsaLoadState
-                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    {
+                        RefreshInProgress = false,
+                        BackOffMilliseconds = 500,
+                    },
                     Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
@@ -246,7 +252,10 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
                     LoadState = new PhsaLoadState
-                        { RefreshInProgress = true, BackOffMilliseconds = 500 },
+                    {
+                        RefreshInProgress = true,
+                        BackOffMilliseconds = 500,
+                    },
                     Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
@@ -339,7 +348,10 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
                     LoadState = new PhsaLoadState
-                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    {
+                        RefreshInProgress = false,
+                        BackOffMilliseconds = 500,
+                    },
                     Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",
@@ -454,7 +466,10 @@ namespace HealthGateway.ImmunizationTests.Services.Test
                 ResourcePayload = new PhsaResult<VaccineStatusResult>
                 {
                     LoadState = new PhsaLoadState
-                        { RefreshInProgress = false, BackOffMilliseconds = 500 },
+                    {
+                        RefreshInProgress = false,
+                        BackOffMilliseconds = 500,
+                    },
                     Result = new VaccineStatusResult
                     {
                         FirstName = "Bob",

--- a/Apps/JobScheduler/src/Controllers/JobSchedulerController.cs
+++ b/Apps/JobScheduler/src/Controllers/JobSchedulerController.cs
@@ -57,12 +57,8 @@ namespace HealthGateway.JobScheduler.Controllers
 
             this.logger.LogDebug(@"Redirecting to dashboard");
             string basePath = this.httpContextAccessor.HttpContext?.Request.PathBase.Value ?? string.Empty;
-            if (this.Url.IsLocalUrl(basePath))
-            {
-                return new RedirectResult($"{basePath}/");
-            }
+            return this.Url.IsLocalUrl(basePath) ? new RedirectResult($"{basePath}/") : new RedirectResult("/");
 
-            return new RedirectResult("/");
 #pragma warning restore CA1303 //Restore literal warning
         }
 
@@ -75,11 +71,10 @@ namespace HealthGateway.JobScheduler.Controllers
         public IActionResult Logout()
         {
             return new SignOutResult(
-                new[]
-                {
-                    OpenIdConnectDefaults.AuthenticationScheme,
-                    CookieAuthenticationDefaults.AuthenticationScheme,
-                });
+            [
+                OpenIdConnectDefaults.AuthenticationScheme,
+                CookieAuthenticationDefaults.AuthenticationScheme,
+            ]);
         }
 
         /// <summary>

--- a/Apps/JobScheduler/src/Tasks/FinalizeIncompleteUserRegistrations.cs
+++ b/Apps/JobScheduler/src/Tasks/FinalizeIncompleteUserRegistrations.cs
@@ -72,7 +72,7 @@ namespace HealthGateway.JobScheduler.Tasks
             DateTime extendedStartDateTime = StartDateTime.AddMinutes(-5);
             DateTime extendedHotfixDateTime = HotfixDateTime.AddMinutes(5);
 
-            IList<UserProfile> profiles = await dbContext.UserProfile
+            List<UserProfile> profiles = await dbContext.UserProfile
                 .AsNoTracking()
                 .Where(p => p.CreatedDateTime > extendedStartDateTime && p.CreatedDateTime < extendedHotfixDateTime)
                 .ToListAsync(ct);
@@ -90,7 +90,7 @@ namespace HealthGateway.JobScheduler.Tasks
             DateTime extendedHotfixDateTime = HotfixDateTime.AddMinutes(-5);
 
             int iteration = 0;
-            IList<UserProfile> profiles;
+            List<UserProfile> profiles;
             do
             {
                 profiles = await dbContext.UserProfile
@@ -128,7 +128,7 @@ namespace HealthGateway.JobScheduler.Tasks
             DateTime extendedStartDateTime = StartDateTime.AddMinutes(-5);
 
             int iteration = 0;
-            IList<UserProfile> profiles;
+            List<UserProfile> profiles;
             do
             {
                 profiles = await dbContext.UserProfile

--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -36,6 +36,7 @@ namespace HealthGateway.Laboratory.Controllers
     [Route("[controller]")]
     [ApiController]
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("SonarLint", "S6960:This controller has multiple responsibilities and could be split into 2 smaller controllers", Justification = "Team decision")]
     public class LaboratoryController : ControllerBase
     {
         private readonly ILaboratoryService labService;

--- a/Apps/Laboratory/src/Delegates/MockLaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/MockLaboratoryDelegate.cs
@@ -43,7 +43,7 @@ namespace HealthGateway.Laboratory.Delegates
             };
             List<PhsaCovid19Order> mockData =
             [
-                new PhsaCovid19Order
+                new()
                 {
                     Id = Guid.Parse("612d31e5-12e1-451f-a475-58d6b0a8f007"),
                     Phn = "9735352542",
@@ -56,8 +56,8 @@ namespace HealthGateway.Laboratory.Delegates
                     MessageId = "20200770000196",
                     AdditionalData = string.Empty,
                     ReportAvailable = true,
-                    Covid19Tests = new PhsaCovid19Test[]
-                    {
+                    Covid19Tests =
+                    [
                         new()
                         {
                             Id = Guid.Parse("dee12642-fb2c-481f-9ae4-c672b045b2b1"),
@@ -76,7 +76,7 @@ namespace HealthGateway.Laboratory.Delegates
                                 "This test targets the RdRP and E gene regions of COVID‑19 virus (2019-nCoV) and has not been fully validated.",
                             ],
                         },
-                    },
+                    ],
                 },
             ];
 

--- a/Apps/Laboratory/src/Delegates/RestLaboratoryDelegate.cs
+++ b/Apps/Laboratory/src/Delegates/RestLaboratoryDelegate.cs
@@ -72,6 +72,8 @@ namespace HealthGateway.Laboratory.Delegates
             {
                 this.logger.LogDebug("Retrieving COVID-19 test results");
                 PhsaResult<List<PhsaCovid19Order>> response = await this.laboratoryApi.GetCovid19OrdersAsync(hdid, this.labConfig.FetchSize, bearerToken, ct);
+
+                // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
                 retVal.ResourcePayload = response ?? new() { Result = [] };
                 retVal.TotalResultCount = retVal.ResourcePayload.Result!.Count;
                 retVal.ResultStatus = ResultType.Success;
@@ -150,6 +152,8 @@ namespace HealthGateway.Laboratory.Delegates
             {
                 this.logger.LogDebug("Retrieving laboratory orders");
                 PhsaResult<PhsaLaboratorySummary> response = await this.laboratoryApi.GetPlisLaboratorySummaryAsync(hdid, bearerToken, ct);
+
+                // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
                 retVal.ResourcePayload = response ?? new() { Result = new() };
                 retVal.TotalResultCount = retVal.ResourcePayload.Result!.LabOrderCount;
                 retVal.ResultStatus = ResultType.Success;

--- a/Apps/Laboratory/src/Models/Covid19Order.cs
+++ b/Apps/Laboratory/src/Models/Covid19Order.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Laboratory.Models
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text.Json.Serialization;
 
     /// <summary>
@@ -95,6 +94,6 @@ namespace HealthGateway.Laboratory.Models
         /// Gets or sets the collection of COVID-19 tests.
         /// </summary>
         [JsonPropertyName("labResults")]
-        public IEnumerable<Covid19Test> Covid19Tests { get; set; } = Enumerable.Empty<Covid19Test>();
+        public IEnumerable<Covid19Test> Covid19Tests { get; set; } = [];
     }
 }

--- a/Apps/Laboratory/src/Models/Covid19OrderResult.cs
+++ b/Apps/Laboratory/src/Models/Covid19OrderResult.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Laboratory.Models;
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -43,5 +42,5 @@ public class Covid19OrderResult
     /// Gets or sets the collection of COVID-19 laboratory orders.
     /// </summary>
     [JsonPropertyName("orders")]
-    public IEnumerable<Covid19Order> Covid19Orders { get; set; } = Enumerable.Empty<Covid19Order>();
+    public IEnumerable<Covid19Order> Covid19Orders { get; set; } = [];
 }

--- a/Apps/Laboratory/src/Models/LaboratoryOrder.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrder.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.Laboratory.Models;
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -89,5 +88,5 @@ public class LaboratoryOrder
     /// Gets or sets the collection of laboratory tests.
     /// </summary>
     [JsonPropertyName("laboratoryTests")]
-    public IEnumerable<LaboratoryTest> LaboratoryTests { get; set; } = Enumerable.Empty<LaboratoryTest>();
+    public IEnumerable<LaboratoryTest> LaboratoryTests { get; set; } = [];
 }

--- a/Apps/Laboratory/src/Models/LaboratoryOrderResult.cs
+++ b/Apps/Laboratory/src/Models/LaboratoryOrderResult.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Laboratory.Models;
 
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.Json.Serialization;
 
 /// <summary>
@@ -49,5 +48,5 @@ public class LaboratoryOrderResult
     /// Gets or sets the collection of laboratory orders.
     /// </summary>
     [JsonPropertyName("orders")]
-    public IEnumerable<LaboratoryOrder> LaboratoryOrders { get; set; } = Enumerable.Empty<LaboratoryOrder>();
+    public IEnumerable<LaboratoryOrder> LaboratoryOrders { get; set; } = [];
 }

--- a/Apps/Laboratory/src/Services/LabTestKitService.cs
+++ b/Apps/Laboratory/src/Services/LabTestKitService.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Laboratory.Services
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Net;
     using System.Net.Http;
@@ -127,6 +128,7 @@ namespace HealthGateway.Laboratory.Services
             return result;
         }
 
+        [SuppressMessage("Style", "IDE0010:Populate switch", Justification = "Team decision")]
         private static RequestResult<T> ProcessResponse<T>(T payload, HttpStatusCode responseStatusCode)
         {
             RequestResult<T> requestResult = InitializeResult(payload);

--- a/Apps/Laboratory/src/Services/LaboratoryService.cs
+++ b/Apps/Laboratory/src/Services/LaboratoryService.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Laboratory.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -73,6 +74,7 @@ namespace HealthGateway.Laboratory.Services
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Style", "IDE0046:'if' statement can be simplified", Justification = "Team decision")]
         public async Task<RequestResult<Covid19OrderResult>> GetCovid19OrdersAsync(string hdid, int pageIndex = 0, CancellationToken ct = default)
         {
             if (!await this.patientRepository.CanAccessDataSourceAsync(hdid, DataSource.Covid19TestResult, ct))
@@ -107,23 +109,21 @@ namespace HealthGateway.Laboratory.Services
                     "Refresh in progress");
             }
 
-            if (delegateResult.ResultStatus != ResultType.Success)
-            {
-                return RequestResultFactory.Error<Covid19OrderResult>(delegateResult.ResultError);
-            }
-
-            return RequestResultFactory.Success(
-                new Covid19OrderResult
-                {
-                    Covid19Orders = delegateResult.ResourcePayload?.Result?.Select(this.mappingService.MapToCovid19Order).ToList() ?? [],
-                    Loaded = true,
-                },
-                delegateResult.TotalResultCount,
-                delegateResult.PageIndex,
-                delegateResult.PageSize);
+            return delegateResult.ResultStatus != ResultType.Success
+                ? RequestResultFactory.Error<Covid19OrderResult>(delegateResult.ResultError)
+                : RequestResultFactory.Success(
+                    new Covid19OrderResult
+                    {
+                        Covid19Orders = delegateResult.ResourcePayload?.Result?.Select(this.mappingService.MapToCovid19Order).ToList() ?? [],
+                        Loaded = true,
+                    },
+                    delegateResult.TotalResultCount,
+                    delegateResult.PageIndex,
+                    delegateResult.PageSize);
         }
 
         /// <inheritdoc/>
+        [SuppressMessage("Style", "IDE0046:'if' statement can be simplified", Justification = "Team decision")]
         public async Task<RequestResult<LaboratoryOrderResult>> GetLaboratoryOrdersAsync(string hdid, CancellationToken ct = default)
         {
             if (!await this.patientRepository.CanAccessDataSourceAsync(hdid, DataSource.LabResult, ct))
@@ -163,21 +163,18 @@ namespace HealthGateway.Laboratory.Services
                     "Refresh in progress");
             }
 
-            if (delegateResult.ResultStatus != ResultType.Success)
-            {
-                return RequestResultFactory.Error<LaboratoryOrderResult>(delegateResult.ResultError);
-            }
-
-            return RequestResultFactory.Success(
-                new LaboratoryOrderResult
-                {
-                    LaboratoryOrders = delegateResult.ResourcePayload?.Result?.LabOrders?.Select(this.mappingService.MapToLaboratoryOrder).ToList() ?? [],
-                    Loaded = !(loadState?.RefreshInProgress ?? false),
-                    Queued = loadState?.Queued ?? false,
-                },
-                delegateResult.TotalResultCount,
-                delegateResult.PageIndex,
-                delegateResult.PageSize);
+            return delegateResult.ResultStatus != ResultType.Success
+                ? RequestResultFactory.Error<LaboratoryOrderResult>(delegateResult.ResultError)
+                : RequestResultFactory.Success(
+                    new LaboratoryOrderResult
+                    {
+                        LaboratoryOrders = delegateResult.ResourcePayload?.Result?.LabOrders?.Select(this.mappingService.MapToLaboratoryOrder).ToList() ?? [],
+                        Loaded = !(loadState?.RefreshInProgress ?? false),
+                        Queued = loadState?.Queued ?? false,
+                    },
+                    delegateResult.TotalResultCount,
+                    delegateResult.PageIndex,
+                    delegateResult.PageSize);
         }
 
         /// <inheritdoc/>

--- a/Apps/Medication/src/Services/MedicationRequestService.cs
+++ b/Apps/Medication/src/Services/MedicationRequestService.cs
@@ -66,27 +66,25 @@ namespace HealthGateway.Medication.Services
 
             // Retrieve the phn
             RequestResult<PatientModel> patientResult = await this.patientService.GetPatientAsync(hdid, ct: ct);
-            if (patientResult.ResultStatus == ResultType.Success && patientResult.ResourcePayload != null)
+            if (patientResult is { ResultStatus: ResultType.Success, ResourcePayload: not null })
             {
                 PatientModel patient = patientResult.ResourcePayload;
                 RequestResult<IList<MedicationRequest>> delegateResult = await this.medicationRequestDelegate.GetMedicationRequestsAsync(patient.PersonalHealthNumber, ct);
-                if (delegateResult.ResultStatus == ResultType.Success)
-                {
-                    return new RequestResult<IList<MedicationRequest>>
+
+                return delegateResult.ResultStatus == ResultType.Success
+                    ? new RequestResult<IList<MedicationRequest>>
                     {
                         ResultStatus = delegateResult.ResultStatus,
                         ResourcePayload = delegateResult.ResourcePayload,
                         PageIndex = delegateResult.PageIndex,
                         PageSize = delegateResult.PageSize,
                         TotalResultCount = delegateResult.TotalResultCount,
+                    }
+                    : new RequestResult<IList<MedicationRequest>>
+                    {
+                        ResultStatus = delegateResult.ResultStatus,
+                        ResultError = delegateResult.ResultError,
                     };
-                }
-
-                return new RequestResult<IList<MedicationRequest>>
-                {
-                    ResultStatus = delegateResult.ResultStatus,
-                    ResultError = delegateResult.ResultError,
-                };
             }
 
             return new RequestResult<IList<MedicationRequest>>

--- a/Apps/Patient/src/Controllers/PatientController.cs
+++ b/Apps/Patient/src/Controllers/PatientController.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Patient.Controllers
 {
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
     using System.Threading.Tasks;
     using Asp.Versioning;
@@ -33,6 +34,7 @@ namespace HealthGateway.Patient.Controllers
     [Route("[controller]")]
     [ApiController]
     [Authorize]
+    [SuppressMessage("SonarLint", "S6960:This controller has multiple responsibilities and could be split into 2 smaller controllers", Justification = "Team Decision")]
     public class PatientController : ControllerBase
     {
         /// <summary>

--- a/Apps/Patient/src/Controllers/PatientDataController.cs
+++ b/Apps/Patient/src/Controllers/PatientDataController.cs
@@ -64,7 +64,7 @@ namespace HealthGateway.Patient.Controllers
         [ProducesResponseType(StatusCodes.Status502BadGateway, Type = typeof(ProblemDetails))]
         public async Task<ActionResult<PatientDataResponse>> Get(string hdid, [FromQuery] PatientDataType[] patientDataTypes, CancellationToken ct)
         {
-            ValidateGetRequest(hdid, patientDataTypes);
+            ValidateRequest(hdid, patientDataTypes);
             PatientDataQuery query = new(hdid, patientDataTypes);
             return await this.patientDataService.QueryAsync(query, ct);
         }
@@ -86,13 +86,13 @@ namespace HealthGateway.Patient.Controllers
         [ProducesResponseType(StatusCodes.Status502BadGateway, Type = typeof(ProblemDetails))]
         public async Task<ActionResult<PatientFileResponse>> GetFile(string hdid, string fileId, CancellationToken ct)
         {
-            ValidateGetFileRequest(hdid, fileId);
+            ValidateFileRequest(hdid, fileId);
             PatientFileQuery query = new(hdid, fileId);
             return await this.patientDataService.QueryAsync(query, ct) ??
                    throw new NotFoundException($"file {fileId} not found");
         }
 
-        private static void ValidateGetRequest(string hdid, PatientDataType[] patientDataTypes)
+        private static void ValidateRequest(string hdid, PatientDataType[] patientDataTypes)
         {
             if (string.IsNullOrEmpty(hdid))
             {
@@ -105,7 +105,7 @@ namespace HealthGateway.Patient.Controllers
             }
         }
 
-        private static void ValidateGetFileRequest(string hdid, string fileId)
+        private static void ValidateFileRequest(string hdid, string fileId)
         {
             if (string.IsNullOrEmpty(hdid))
             {

--- a/Apps/Patient/src/Services/PatientDataService.cs
+++ b/Apps/Patient/src/Services/PatientDataService.cs
@@ -51,7 +51,7 @@ namespace HealthGateway.Patient.Services
             IList<PatientDataType> unblockedPatientDataTypes = await this.GetUnblockedPatientDataTypesAsync(query.Hdid, query.PatientDataTypes, ct);
             if (!unblockedPatientDataTypes.Any())
             {
-                return new PatientDataResponse(Enumerable.Empty<PatientData>());
+                return new PatientDataResponse([]);
             }
 
             Guid pid = await this.ResolvePidFromHdidAsync(query.Hdid, ct);

--- a/Apps/Patient/src/Services/PatientService.cs
+++ b/Apps/Patient/src/Services/PatientService.cs
@@ -57,7 +57,12 @@ namespace HealthGateway.Patient.Services
                 : new PatientDetailsQuery(identifier, Source: PatientDetailSource.All, UseCache: true);
 
             PatientModel patientDetails = (await this.patientRepository.QueryAsync(query, ct)).Item;
+            this.ValidatePatientDetails(patientDetails, disableIdValidation);
+            return this.mappingService.MapToPatientDetails(patientDetails);
+        }
 
+        private void ValidatePatientDetails(PatientModel patientDetails, bool disableIdValidation)
+        {
             if (patientDetails.IsDeceased == true)
             {
                 this.logger.LogWarning("Patient is deceased");
@@ -73,8 +78,6 @@ namespace HealthGateway.Patient.Services
             {
                 throw new InvalidDataException(ErrorMessages.InvalidServicesCard);
             }
-
-            return this.mappingService.MapToPatientDetails(patientDetails);
         }
     }
 }

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -60,9 +60,9 @@ namespace HealthGateway.PatientTests.Services
             };
 
             PatientData[] data =
-            {
+            [
                 organDonorRegistration,
-            };
+            ];
 
             PatientDataResponse response = new(data);
 
@@ -95,9 +95,9 @@ namespace HealthGateway.PatientTests.Services
             };
 
             PatientData[] data =
-            {
+            [
                 diagnosticImagingExam,
-            };
+            ];
 
             PatientDataResponse response = new(data);
 
@@ -142,7 +142,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, MappingService);
 
-            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, new[] { PatientDataType.OrganDonorRegistrationStatus }), CancellationToken.None)
+            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, [PatientDataType.OrganDonorRegistrationStatus]), CancellationToken.None)
                 ;
 
             if (canAccessDataSource)
@@ -184,7 +184,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, MappingService);
 
-            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, new[] { PatientDataType.BcCancerScreening }), CancellationToken.None)
+            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, [PatientDataType.BcCancerScreening]), CancellationToken.None)
                 ;
 
             if (canAccessDataSource)
@@ -230,8 +230,7 @@ namespace HealthGateway.PatientTests.Services
 
             PatientDataService sut = new(patientDataRepository.Object, patientRepository.Object, personalAccountService.Object, MappingService);
 
-            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, new[] { PatientDataType.DiagnosticImaging }), CancellationToken.None)
-                ;
+            PatientDataResponse result = await sut.QueryAsync(new PatientDataQuery(this.hdid, [PatientDataType.DiagnosticImaging]), CancellationToken.None);
 
             if (canAccessDataSource)
             {

--- a/Apps/Patient/test/unit/Services/PatientServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientServiceTests.cs
@@ -126,7 +126,8 @@ namespace HealthGateway.PatientTests.Services
             return errorMessage switch
             {
                 ErrorMessages.ClientRegistryReturnedDeceasedPerson => CreatePatient(deceased: true),
-                ErrorMessages.InvalidServicesCard => commonNameExists == false ? CreatePatient(commonNameExists: false, legalNameExists: false) : CreatePatient(string.Empty, string.Empty),
+                ErrorMessages.InvalidServicesCard =>
+                    commonNameExists ? CreatePatient(string.Empty, string.Empty) : CreatePatient(commonNameExists: false, legalNameExists: false),
                 ErrorMessages.PhnInvalid => CreatePatient(),
                 _ => CreatePatient(commonNameExists: commonNameExists, legalNameExists: legalNameExists),
             };

--- a/Apps/PatientDataAccess/src/PatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/PatientDataRepository.cs
@@ -31,7 +31,6 @@ namespace HealthGateway.PatientDataAccess
     /// </summary>
     /// <param name="patientApi">The patient API to use.</param>
     /// <param name="mapper">The injected mapper.</param>
-    [SuppressMessage("Style", "IDE0072:Switch expression should be exhaustive", Justification = "Team decision")]
     internal class PatientDataRepository(IPatientApi patientApi, IMapper mapper) : IPatientDataRepository
     {
         /// <summary>
@@ -51,6 +50,7 @@ namespace HealthGateway.PatientDataAccess
             };
         }
 
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         private static string? MapHealthOptionsCategories(HealthCategory category)
         {
             return category switch
@@ -60,6 +60,7 @@ namespace HealthGateway.PatientDataAccess
             };
         }
 
+        [SuppressMessage("Style", "IDE0072:Populate switch", Justification = "Team decision")]
         private static string? MapHealthDataCategories(HealthCategory category)
         {
             return category switch

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -47,11 +47,11 @@ namespace PatientDataAccessTests
 
             patientApi
                 .Setup(api => api.GetHealthOptionsAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new HealthOptionsResult(new HealthOptionsMetadata(), new[] { phsaOrganDonorRegistrationResponse }));
+                .ReturnsAsync(new HealthOptionsResult(new HealthOptionsMetadata(), [phsaOrganDonorRegistrationResponse]));
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.OrganDonorRegistrationStatus }), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.OrganDonorRegistrationStatus]), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.OrganDonorRegistration
@@ -81,14 +81,11 @@ namespace PatientDataAccessTests
                 .ReturnsAsync(
                     new HealthDataResult(
                         new HealthDataMetadata(),
-                        new[]
-                        {
-                            bcCancerScreening,
-                        }));
+                        [bcCancerScreening]));
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.BcCancerScreening }), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.BcCancerScreening]), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.BcCancerScreening exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.BcCancerScreening>();
@@ -121,14 +118,11 @@ namespace PatientDataAccessTests
                 .ReturnsAsync(
                     new HealthDataResult(
                         new HealthDataMetadata(),
-                        new[]
-                        {
-                            phsaDiagnosticImageExam,
-                        }));
+                        [phsaDiagnosticImageExam]));
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging }), CancellationToken.None);
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.DiagnosticImaging]), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.DiagnosticImagingExam exam = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.DiagnosticImagingExam>();
@@ -159,11 +153,11 @@ namespace PatientDataAccessTests
 
             patientApi
                 .Setup(api => api.GetHealthDataAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new HealthDataResult(new HealthDataMetadata(), new HealthDataEntry[] { phsaDiagnosticImageExam, bcCancerScreening }));
+                .ReturnsAsync(new HealthDataResult(new HealthDataMetadata(), [phsaDiagnosticImageExam, bcCancerScreening]));
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, new[] { HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening }), CancellationToken.None)
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening]), CancellationToken.None)
                 ;
 
             result.ShouldNotBeNull();

--- a/Apps/WebClient/src/ClientApp/src/ioc/container.ts
+++ b/Apps/WebClient/src/ClientApp/src/ioc/container.ts
@@ -6,8 +6,8 @@ interface IContainer {
 }
 
 class Container implements IContainer {
-    private mappings = new Map<Identifier, (c: Container) => any>();
-    private cachedMappings = new Map<Identifier, any>();
+    private readonly mappings = new Map<Identifier, (c: Container) => any>();
+    private readonly cachedMappings = new Map<Identifier, any>();
 
     public set<T>(key: Identifier, factory: (c: Container) => T): void {
         this.mappings.set(key, factory);

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/bcCancerScreeningTimelineEntry.ts
@@ -17,7 +17,7 @@ export default class BcCancerScreeningTimelineEntry extends TimelineEntry {
     public fileName!: string;
     public eventText!: string;
 
-    private getComments: (entryId: string) => UserComment[] | null;
+    private readonly getComments: (entryId: string) => UserComment[] | null;
 
     public constructor(
         model: BcCancerScreening,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/clinicalDocumentTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/clinicalDocumentTimelineEntry.ts
@@ -11,7 +11,7 @@ export default class ClinicalDocumentTimelineEntry extends TimelineEntry {
     public documentType: string;
     public facilityName: string;
     public discipline: string;
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: ClinicalDocument,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/covid19TestResultTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/covid19TestResultTimelineEntry.ts
@@ -25,7 +25,7 @@ export default class Covid19TestResultTimelineEntry extends TimelineEntry {
 
     public tests: Covid19TestData[];
 
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: Covid19LaboratoryOrder,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/diagnosticImagingTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/diagnosticImagingTimelineEntry.ts
@@ -16,7 +16,7 @@ export default class DiagnosticImagingTimelineEntry extends TimelineEntry {
     public fileId: string | undefined;
     public examDate: StringISODate;
 
-    private getComments: (entryId: string) => UserComment[] | null;
+    private readonly getComments: (entryId: string) => UserComment[] | null;
 
     public constructor(
         model: DiagnosticImagingExam,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/healthVisitTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/healthVisitTimelineEntry.ts
@@ -12,7 +12,7 @@ export default class HealthVisitTimelineEntry extends TimelineEntry {
     public specialtyDescription: string;
     public clinic: ClinicViewModel;
     public showRollOffWarning: boolean;
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: Encounter,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/hospitalVisitTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/hospitalVisitTimelineEntry.ts
@@ -15,7 +15,7 @@ export default class HospitalVisitTimelineEntry extends TimelineEntry {
     public admitDateTime: DateWrapper;
     public endDateTime?: DateWrapper;
 
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: HospitalVisit,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/labResultTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/labResultTimelineEntry.ts
@@ -21,7 +21,7 @@ export default class LabResultTimelineEntry extends TimelineEntry {
 
     public tests: LaboratoryTestViewModel[];
 
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: LaboratoryOrder,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/medicationTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/medicationTimelineEntry.ts
@@ -19,7 +19,7 @@ export default class MedicationTimelineEntry extends TimelineEntry {
     public prescriptionProvided?: boolean;
     public redirectedToHealthCareProvider?: boolean;
 
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: MedicationStatement,

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/noteTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/noteTimelineEntry.ts
@@ -11,7 +11,7 @@ export default class NoteTimelineEntry extends TimelineEntry {
     public title: string;
     public hdid: string;
     public version?: number;
-    private static maxSumaryLength = 40;
+    private static readonly maxSumaryLength = 40;
 
     public constructor(model: UserNote) {
         super(

--- a/Apps/WebClient/src/ClientApp/src/models/timeline/specialAuthorityRequestTimelineEntry.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/timeline/specialAuthorityRequestTimelineEntry.ts
@@ -13,7 +13,7 @@ export default class SpecialAuthorityRequestTimelineEntry extends TimelineEntry 
     public expiryDate?: DateWrapper;
     public referenceNumber: string;
 
-    private getComments: (entyId: string) => UserComment[] | null;
+    private readonly getComments: (entyId: string) => UserComment[] | null;
 
     public constructor(
         model: MedicationRequest,

--- a/Apps/WebClient/src/ClientApp/src/services/httpDelegate.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/httpDelegate.ts
@@ -5,7 +5,7 @@ import { HttpError } from "@/models/errors";
 import { IHttpDelegate, ILogger } from "@/services/interfaces";
 
 export class HttpDelegate implements IHttpDelegate {
-    private logger;
+    private readonly logger;
 
     constructor(logger: ILogger) {
         this.logger = logger;

--- a/Apps/WebClient/src/ClientApp/src/services/restAuthService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restAuthService.ts
@@ -8,11 +8,11 @@ import { IAuthenticationService, ILogger } from "@/services/interfaces";
 const REFRESH_CUSHION = 30;
 
 export class RestAuthenticationService implements IAuthenticationService {
-    private logger;
-    private keycloak;
-    private scope!: string;
-    private logonCallback!: string;
-    private logoutCallback!: string;
+    private readonly logger;
+    private readonly keycloak;
+    private readonly scope!: string;
+    private readonly logonCallback!: string;
+    private readonly logoutCallback!: string;
 
     // RestAuthenticationService.GetService() should be called instead of using the constructor directly.
     constructor(

--- a/Apps/WebClient/src/ClientApp/src/services/restClinicalDocumentService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restClinicalDocumentService.ts
@@ -16,10 +16,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestClinicalDocumentService implements IClinicalDocumentService {
     private readonly BASE_URI = "ClinicalDocument";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restCommunicationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restCommunicationService.ts
@@ -12,9 +12,9 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestCommunicationService implements ICommunicationService {
     private readonly BASE_URI: string = "Communication";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restConfigService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restConfigService.ts
@@ -5,10 +5,10 @@ import { IConfigService, IHttpDelegate, ILogger } from "@/services/interfaces";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestConfigService implements IConfigService {
-    private logger;
+    private readonly logger;
     private readonly CONFIG_BASE_URI: string = "configuration";
-    private http;
-    private baseUri = import.meta.env.VITE_WEB_CLIENT_BASE_URI || "/";
+    private readonly http;
+    private readonly baseUri = import.meta.env.VITE_WEB_CLIENT_BASE_URI || "/";
 
     constructor(logger: ILogger, httpDelegate: IHttpDelegate) {
         this.logger = logger;

--- a/Apps/WebClient/src/ClientApp/src/services/restDependentService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restDependentService.ts
@@ -14,10 +14,10 @@ import RequestResultUtil from "@/utility/requestResultUtil";
 
 export class RestDependentService implements IDependentService {
     private readonly DEPENDENT_BASE_URI: string = "UserProfile";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restEncounterService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restEncounterService.ts
@@ -15,10 +15,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestEncounterService implements IEncounterService {
     private readonly ENCOUNTER_BASE_URI: string = "Encounter";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restHospitalVisitService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restHospitalVisitService.ts
@@ -15,10 +15,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestHospitalVisitService implements IHospitalVisitService {
     private readonly HOSPITAL_VISIT_BASE_URI: string = "Encounter";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restImmunizationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restImmunizationService.ts
@@ -15,10 +15,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestImmunizationService implements IImmunizationService {
     private readonly IMMS_BASE_URI: string = "Immunization";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restLaboratoryService.ts
@@ -19,11 +19,11 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestLaboratoryService implements ILaboratoryService {
     private readonly LABORATORY_BASE_URI: string = "Laboratory";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
-    private isCovid19Enabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
+    private readonly isCovid19Enabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restMedicationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restMedicationService.ts
@@ -16,10 +16,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestMedicationService implements IMedicationService {
     private readonly BASE_URI: string = "MedicationStatement";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restNotificationService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restNotificationService.ts
@@ -11,10 +11,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestNotificationService implements INotificationService {
     private readonly NOTIFICATION_BASE_URI: string = "Notification";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restPatientDataService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPatientDataService.ts
@@ -39,9 +39,9 @@ export const entryTypeToPatientDataTypeMap: Map<EntryType, PatientDataType> =
 
 export class RestPatientDataService implements IPatientDataService {
     private readonly BASE_URI = "PatientData";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPatientService.ts
@@ -7,9 +7,9 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestPatientService implements IPatientService {
     private readonly PATIENT_BASE_URI: string = "Patient";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restPcrTestService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restPcrTestService.ts
@@ -11,10 +11,10 @@ import RequestResultUtil from "@/utility/requestResultUtil";
 export class RestPcrTestService implements IPcrTestService {
     private readonly LABORATORY_BASE_URI: string = "Laboratory";
     private readonly PUBLIC_LABORATORY_BASE_URI: string = "PublicLaboratory";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restReportService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restReportService.ts
@@ -9,9 +9,9 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestReportService implements IReportService {
     private readonly REPORT_BASE_URI: string = "Report";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restSpecialAuthorityService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restSpecialAuthorityService.ts
@@ -15,10 +15,10 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestSpecialAuthorityService implements ISpecialAuthorityService {
     private readonly SPECIAL_AUTHORITY_BASE_URI: string = "MedicationRequest";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restTrackingService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restTrackingService.ts
@@ -4,7 +4,7 @@ import { ILogger, ITrackingService } from "@/services/interfaces";
 declare let window: SnowplowWindow;
 
 export class RestTrackingService implements ITrackingService {
-    private logger;
+    private readonly logger;
 
     constructor(logger: ILogger) {
         this.logger = logger;

--- a/Apps/WebClient/src/ClientApp/src/services/restUserCommentService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserCommentService.ts
@@ -15,10 +15,10 @@ import RequestResultUtil from "@/utility/requestResultUtil";
 
 export class RestUserCommentService implements IUserCommentService {
     private readonly USER_COMMENT_BASE_URI: string = "UserProfile";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restUserFeedback.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserFeedback.ts
@@ -11,9 +11,9 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestUserFeedbackService implements IUserFeedbackService {
     private readonly USER_FEEDBACK_BASE_URI: string = "UserFeedback";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restUserNoteService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserNoteService.ts
@@ -17,10 +17,10 @@ import RequestResultUtil from "@/utility/requestResultUtil";
 
 export class RestUserNoteService implements IUserNoteService {
     private readonly USER_NOTE_BASE_URI: string = "Note";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
@@ -19,9 +19,9 @@ export class RestUserProfileService implements IUserProfileService {
         "application/json; charset=utf-8";
     private readonly CONTENT_TYPE: string = "Content-Type";
     private readonly USER_PROFILE_BASE_URI: string = "UserProfile";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileServiceV2.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileServiceV2.ts
@@ -18,9 +18,9 @@ export class RestUserProfileServiceV2 implements IUserProfileService {
     private readonly CONTENT_TYPE: string = "Content-Type";
     private readonly USER_PROFILE_BASE_URI: string = "UserProfile";
     private readonly API_VERSION: string = "2.0";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restUserRatingService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserRatingService.ts
@@ -11,9 +11,9 @@ import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestUserRatingService implements IUserRatingService {
     private readonly USER_RATING_BASE_URI: string = "UserFeedback/Rating";
-    private logger;
-    private http;
-    private baseUri;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/services/restVaccinationStatusService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restVaccinationStatusService.ts
@@ -18,10 +18,10 @@ export class RestVaccinationStatusService implements IVaccinationStatusService {
         "PublicVaccineStatus";
     private readonly AUTHENTICATED_VACCINATION_STATUS_BASE_URI: string =
         "AuthenticatedVaccineStatus";
-    private logger;
-    private http;
-    private baseUri;
-    private isEnabled;
+    private readonly logger;
+    private readonly http;
+    private readonly baseUri;
+    private readonly isEnabled;
 
     constructor(
         logger: ILogger,

--- a/Apps/WebClient/src/ClientApp/src/utility/idleDetector.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/idleDetector.ts
@@ -13,11 +13,13 @@ export class IdleDetector {
     ];
     private readonly idleTimer: ReliableTimer;
     private enabled = false;
-    private notifyActiveThrottled = throttle(1000, () => this.notifyActive());
+    private readonly notifyActiveThrottled = throttle(1000, () =>
+        this.notifyActive()
+    );
 
     constructor(
-        private isIdleCallback: (timeIdle: number) => void,
-        private timeBeforeIdle: number,
+        private readonly isIdleCallback: (timeIdle: number) => void,
+        private readonly timeBeforeIdle: number,
         startEnabled: boolean
     ) {
         this.idleTimer = new ReliableTimer(

--- a/Apps/WebClient/src/ClientApp/src/utility/reliableTimer.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/reliableTimer.ts
@@ -3,7 +3,10 @@ export class ReliableTimer {
     private timeoutId?: ReturnType<typeof setTimeout>;
     private startingTimestamp?: number;
 
-    constructor(private callback: () => void, private duration: number) {
+    constructor(
+        private readonly callback: () => void,
+        private readonly duration: number
+    ) {
         if (duration < this.interval) {
             throw new Error(`Duration must be at least ${this.interval}ms`);
         }

--- a/Apps/WebClient/src/ClientApp/src/utility/validationUtil.ts
+++ b/Apps/WebClient/src/ClientApp/src/utility/validationUtil.ts
@@ -79,6 +79,6 @@ export default abstract class ValidationUtil {
         predicate: boolean,
         validatorObject: object
     ) {
-        return predicate ? validatorObject : {};
+        return (predicate && validatorObject) || {};
     }
 }

--- a/Apps/WebClient/src/Server/Models/MobileConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/MobileConfiguration.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.WebClient.Server.Models
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
 
     /// <summary>
     /// Configuration data to be used by the Health Gateway Mobile App.
@@ -35,16 +34,16 @@ namespace HealthGateway.WebClient.Server.Models
         /// <summary>
         /// Gets or sets the collection of enabled datasets.
         /// </summary>
-        public IEnumerable<string> Datasets { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> Datasets { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the collection of enabled datasets for dependents.
         /// </summary>
-        public IEnumerable<string> DependentDatasets { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> DependentDatasets { get; set; } = [];
 
         /// <summary>
         /// Gets or sets the collection of enabled services.
         /// </summary>
-        public IEnumerable<string> Services { get; set; } = Enumerable.Empty<string>();
+        public IEnumerable<string> Services { get; set; } = [];
     }
 }

--- a/Apps/WebClient/test/unit/Controllers/RobotsControllerTests.cs
+++ b/Apps/WebClient/test/unit/Controllers/RobotsControllerTests.cs
@@ -17,7 +17,6 @@ namespace HealthGateway.WebClientTests.Controllers
 {
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Net.Mime;
     using System.Threading.Tasks;
     using DeepEqual.Syntax;
@@ -73,7 +72,7 @@ namespace HealthGateway.WebClientTests.Controllers
             };
 
             IConfigurationRoot configuration = new ConfigurationBuilder()
-                .AddInMemoryCollection(myConfiguration.ToList())
+                .AddInMemoryCollection(myConfiguration)
                 .Build();
 
             using RobotsController controller = new(configuration);

--- a/Apps/WebClient/test/unit/Services/ConfigurationServiceTests.cs
+++ b/Apps/WebClient/test/unit/Services/ConfigurationServiceTests.cs
@@ -81,8 +81,8 @@ namespace HealthGateway.WebClientTests.Services
                     "myhealthbc://*"),
                 2)
             {
-                Datasets = new[]
-                {
+                Datasets =
+                [
                     "bcCancerScreening",
                     "clinicalDocument",
                     "covid19TestResult",
@@ -94,9 +94,9 @@ namespace HealthGateway.WebClientTests.Services
                     "medication",
                     "note",
                     "specialAuthorityRequest",
-                },
-                DependentDatasets = new[]
-                {
+                ],
+                DependentDatasets =
+                [
                     "bcCancerScreening",
                     "clinicalDocument",
                     "covid19TestResult",
@@ -107,12 +107,12 @@ namespace HealthGateway.WebClientTests.Services
                     "labResult",
                     "medication",
                     "specialAuthorityRequest",
-                },
-                Services = new[]
-                {
+                ],
+                Services =
+                [
                     "organDonorRegistration",
                     "healthConnectRegistry",
-                },
+                ],
             };
 
             MobileConfiguration actualResult = await this.service.GetMobileConfigurationAsync();
@@ -176,8 +176,8 @@ namespace HealthGateway.WebClientTests.Services
                         { "Logout", new Uri("https://localhost/logout") },
                     },
                 },
-                IdentityProviders = new[]
-                {
+                IdentityProviders =
+                [
                     new IdentityProviderConfiguration
                     {
                         Id = "Id",
@@ -186,7 +186,7 @@ namespace HealthGateway.WebClientTests.Services
                         Hint = "Hint",
                         Disabled = true,
                     },
-                },
+                ],
                 WebClient = new WebClientConfiguration
                 {
                     LogLevel = "LogLevel",
@@ -207,23 +207,10 @@ namespace HealthGateway.WebClientTests.Services
                             new HomepageSettings(true, true),
                             new NotificationCentreSettings(true),
                             new TimelineSettings(true),
-                            new DatasetSettings[]
-                            {
-                                new("bcCancerScreening", true),
-                                new("clinicalDocument", true),
-                                new("covid19TestResult", true),
-                                new("diagnosticImaging", true),
-                                new("healthVisit", true),
-                                new("hospitalVisit", true),
-                                new("immunization", true),
-                                new("labResult", true),
-                                new("medication", true),
-                                new("note", true),
-                                new("specialAuthorityRequest", true),
-                            },
+                            GetFeatureDatasetSettings(),
                             new Covid19Settings(true, new PublicCovid19Settings(true), new ProofOfVaccinationSettings(false)),
-                            new DependentsSettings(true, true, new DatasetSettings[] { new("note", false) }),
-                            new ServicesSettings(true, new ServiceSetting[] { new("organDonorRegistration", true), new("healthConnectRegistry", true) }))
+                            new DependentsSettings(true, true, [new("note", false)]),
+                            new ServicesSettings(true, [new("organDonorRegistration", true), new("healthConnectRegistry", true)]))
                         : null,
                 },
                 ServiceEndpoints = new Dictionary<string, Uri>
@@ -233,6 +220,15 @@ namespace HealthGateway.WebClientTests.Services
                     },
                 },
             };
+        }
+
+        private static DatasetSettings[] GetFeatureDatasetSettings()
+        {
+            return
+            [
+                new("bcCancerScreening", true), new("clinicalDocument", true), new("covid19TestResult", true), new("diagnosticImaging", true), new("healthVisit", true),
+                new("hospitalVisit", true), new("immunization", true), new("labResult", true), new("medication", true), new("note", true), new("specialAuthorityRequest", true),
+            ];
         }
     }
 }

--- a/Apps/sonar-config.xml
+++ b/Apps/sonar-config.xml
@@ -17,7 +17,8 @@
 
 -->
 <SonarQubeAnalysisProperties xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns="http://www.sonarsource.com/msbuild/integration/2015/1">
-  <Property Name="sonar.exclusions">**/node_modules/**/*,**/wwwroot/**/*,**/ClientApp/public/**/*,**/Startup.cs</Property>
+  <Property Name="sonar.sources">$(Build.SourcesDirectory)/Apps</Property>
+  <Property Name="sonar.exclusions">**/node_modules/**/*,**/wwwroot/**/*,**/ClientApp/public/**/*,**/Startup.cs,**/Testing/**,**/Tools/**</Property>
   <Property Name="sonar.test.inclusions">**/test/**/*Tests.cs,**/Tests/**/*Tests.cs</Property>
   <Property Name="sonar.coverage.exclusions">**/*Controller.cs,**/Models/**/*,**/Admin/Client/**/*,**/Database/**/*,**/DBMaintainer/**/*,**/JobScheduler/**/*,**/ClientApp/**/*</Property>
   <Property Name="sonar.host.url">https://sonarcloud.io</Property>

--- a/Tools/SonarCloud/azure/build.yaml
+++ b/Tools/SonarCloud/azure/build.yaml
@@ -51,8 +51,6 @@ jobs:
             /k:bcgov_healthgateway \
             /n:HealthGateway \
             /d:sonar.token="$(SonarToken)" \
-            /d:sonar.sources=$(Build.SourcesDirectory)/Apps \
-            /d:sonar.exclusions="**/node_modules/**,**/Testing/**,**/Tools/**" \
             /s:$(Build.SourcesDirectory)/Apps/sonar-config.xml
         displayName: "Begin Static Code Analysis"
         continueOnError: true

--- a/Tools/SonarCloud/azure/build.yaml
+++ b/Tools/SonarCloud/azure/build.yaml
@@ -51,6 +51,8 @@ jobs:
             /k:bcgov_healthgateway \
             /n:HealthGateway \
             /d:sonar.token="$(SonarToken)" \
+            /d:sonar.sources=$(Build.SourcesDirectory)/Apps \
+            /d:sonar.exclusions="**/node_modules/**,**/Testing/**,**/Tools/**" \
             /s:$(Build.SourcesDirectory)/Apps/sonar-config.xml
         displayName: "Begin Static Code Analysis"
         continueOnError: true


### PR DESCRIPTION
# Implements [AB#16872](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16872)

## Description

Address Sonar warnings after Dot Net 9 upgrade.

- Update pipeline job to scan only Apps but not node_modules, Testing and Tools [commit](08955c9510f20fde5555c028b08b2184a9e16bfc)
- Disabled CA1515 Suppress "Because an application's API isn't typically referenced from outside the assembly, types can be made internal"  [commit](08955c9510f20fde5555c028b08b2184a9e16bfc)
- Disabled IDE0290 Suppress "Use primary constructor" [commit](08955c9510f20fde5555c028b08b2184a9e16bfc)
- Disabled IDE0160 Suppress "Convert to block scoped namespace" [commit](08955c9510f20fde5555c028b08b2184a9e16bfc)
- applied changes as per dot net 9 standards

- PatientDataRepository => suppress populate switch warning [commit](abcdd240383fe1d255f2a9182aa975f9c7ca113b)
- Auth.cs => suppressed sonar warning for unused parameter [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- Observability => suppressed rider warnings [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- Patient => suppressed SYSLIB0057 warning for certificate as dot net 9 new certificate does not accept password  [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- ClientRegistryDelegate => suppress populate switch warning [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- HmacHash => suppress populate switch warning [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- VaccineProofDelegate => suppress populate switch warning [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- CommunicationService => suppress populate switch warning [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- ConfigureSwaggerGenOptions => suppress warning on debug assert  [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- ConfigureSwaggerUiOptions => suppress warning on debug assert  [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- OdrAuthorizationHandler => suppressed SYSLIB0057 warning for certificate as dot net 9 new certificate does not accept password  [commit](cee4da29a990e0e7f4bcb621973ea61c12f1859d)
- Laboratory => suppressed simplify if, switch and controller should be split. Reason too complex to change
- Patient => suppressed controller should be split [commit](6c997923fb1ed436a2d93385d9cd1e9c55e04322)
- Admin => suppressed populate switch warning [commit](157573a07a65b7893e80cae5cc9cfd448879ef54)

Note: reasoning for suppressing switch changes was due to logic re-write and/or handling
Note: reasoning for suppressing simplify if was due to readability as existing if structure was easier than using ternary operator or in some cases having to re-write by using helper methods

Remaining sonar issues are false positives and will be updated in Sonar.  There are format issues that do not appear to be issues i.e.,  Copyright removed and added but sonar believes there is an issue.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
