### PR TITLE
Implement solution for SYSLIB0057 for AB#16882

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Patient.cs
@@ -59,11 +59,8 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                         // Note: As per reading we do not have to dispose of the certificate.
                         string? clientCertificatePath = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Path");
                         string? certificatePassword = clientConfiguration.GetSection("ClientCertificate").GetValue<string>("Password");
-#pragma warning disable SYSLIB0057
-
-                        // Using the obsolete X509Certificate2 constructor
-                        X509Certificate2 clientRegistriesCertificate = new(File.ReadAllBytes(clientCertificatePath), certificatePassword);
-#pragma warning restore SYSLIB0057
+                        byte[] certificateData = File.ReadAllBytes(clientCertificatePath);
+                        X509Certificate2 clientRegistriesCertificate = X509CertificateLoader.LoadPkcs12(certificateData, certificatePassword);
                         client.ClientCredentials.ClientCertificate.Certificate = clientRegistriesCertificate;
                         client.Endpoint.EndpointBehaviors.Add(s.GetService<IEndpointBehavior>());
                         client.ClientCredentials.ServiceCertificate.SslCertificateAuthentication =

--- a/Apps/Common/src/Utils/Odr/OdrAuthorizationHandler.cs
+++ b/Apps/Common/src/Utils/Odr/OdrAuthorizationHandler.cs
@@ -52,12 +52,8 @@ namespace HealthGateway.Common.Utils.Odr
             if (odrConfig.ClientCertificate?.Enabled == true)
             {
                 byte[] certificateData = File.ReadAllBytes(odrConfig.ClientCertificate?.Path);
-
-#pragma warning disable SYSLIB0057
-
-                // Using the obsolete X509Certificate2 constructor
-                this.ClientCertificates.Add(new X509Certificate2(certificateData, odrConfig.ClientCertificate?.Password));
-#pragma warning restore SYSLIB0057
+                X509Certificate2 clientRegistriesCertificate = X509CertificateLoader.LoadPkcs12(certificateData, odrConfig.ClientCertificate?.Password);
+                this.ClientCertificates.Add(clientRegistriesCertificate);
             }
         }
 


### PR DESCRIPTION
# Implements [AB#16882](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16882)

## Description

Solution for SYSLIB0057.

X509Certificate2 clientRegistriesCertificate = new(......) is obsolete.  According to Microsoft, X509CertificateLoader should be used instead.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
