### PR TITLE
FIx HPA naming bug for AB#16890.

### DIFF
--- a/Tools/Helm/Charts/healthgateway/templates/hpa.tpl
+++ b/Tools/Helm/Charts/healthgateway/templates/hpa.tpl
@@ -3,7 +3,7 @@
 {{- $top := index . 0 -}}
 {{- $context := index . 1 -}}
 {{- if or (or (not (hasKey $context "scaling")) (not (hasKey $context.scaling "enabled"))) ($context.scaling).enabled -}}
-    {{- $name := printf "%s-%s-deployment" $top.Release.Name $context.name -}}
+    {{- $name := printf "%s-%s" $top.Release.Name $context.name -}}
     {{- $namespace := $top.Values.namespace | default $top.Release.Namespace -}}
     {{- $labels := include "standard.labels" $top -}}
     {{- $minReplicas := ($context.scaling).hpaMinReplicas | default $top.Values.scaling.hpaMinReplicas | required "hpaMinReplicas required" -}}


### PR DESCRIPTION
# Fixes [AB#16890](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16890)

## Description

Fixes Helm HPA template for incorrectly naming HPA by accidentally adding an additional "-deployment".

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

No

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
