### PR TITLE
Move provincial drug load target url to github actions for AB#16886.

### DIFF
--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -182,7 +182,7 @@
         "Schedule": "45 2 * * 1-5",
         "Immediate": "false",
         "Delay": 60,
-        "Url": "https://www.health.gov.bc.ca/pharmacare/outgoing/pddf.zip",
+        "Url": "https://github.com/bcgov/MOH-FederalDrugDataFile/blob/main/pddf.zip?raw=true",
         "TargetFolder": "Resources",
         "AppName": "PROV-DRUG"
     },

--- a/Tools/Helm/Charts/healthgateway/templates/deployment.tpl
+++ b/Tools/Helm/Charts/healthgateway/templates/deployment.tpl
@@ -20,7 +20,7 @@ metadata:
     {{- $labels | trim | nindent 4 }}
     role: {{ $role }}
   annotations:
-    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"{{ $context.name }}:{{ $tag }}","namespace":"{{ $top.Values.toolsNamespace }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ $name }}\")].image","pause":"false"}]'
+    image.openshift.io/triggers: '[{"from":{"kind":"ImageStreamTag","name":"{{ $context.image.imageStreamName | default $context.name }}:{{ $tag }}","namespace":"{{ $top.Values.toolsNamespace }}"},"fieldPath":"spec.template.spec.containers[?(@.name==\"{{ $name }}\")].image","pause":"false"}]'
 spec:
   replicas: {{ $replicas }}
   revisionHistoryLimit: 10


### PR DESCRIPTION
# Fixes [AB#16886](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16886)

## Description

1. For Provincial Drug Load access provincial drug load file from [MOH-FederalDrugDataFile](https://github.com/bcgov/MOH-FederalDrugDataFile)
2. FIx Helm Template so that when new JobScheduler (Hangfire) image is released via CICD, the pod for JobScheduler (Hangfire) is rolled out again.

<img width="2532" alt="Screenshot 2025-02-21 at 3 58 52 PM" src="https://github.com/user-attachments/assets/5fac5980-9c30-4000-bdde-4b52ee57e15c" />

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
