### PR TITLE
Landing page updates - DHSOHG-2105 for AB#16899.

### DIFF
--- a/Apps/Landing/src/ClientApp/src/components/public/landing/LandingView.vue
+++ b/Apps/Landing/src/ClientApp/src/components/public/landing/LandingView.vue
@@ -20,7 +20,7 @@ enum PreviewDevice {
 const datasetEntryTypes: EntryType[] = [
     EntryType.Medication,
     EntryType.LabResult,
-    EntryType.Covid19TestResult,
+    EntryType.BcCancerScreening,
     EntryType.HealthVisit,
     EntryType.Immunization,
     EntryType.SpecialAuthorityRequest,
@@ -28,8 +28,6 @@ const datasetEntryTypes: EntryType[] = [
     EntryType.HospitalVisit,
     EntryType.DiagnosticImaging,
 ];
-
-const serviceEntryTypes: EntryType[] = [EntryType.BcCancerScreening];
 
 const configStore = useConfigStore();
 
@@ -66,11 +64,9 @@ const organDonorRegistrationTile = computed<InfoTile>(() => ({
     active: ConfigUtil.isServiceEnabled(ServiceName.OrganDonorRegistration),
 }));
 const servicesTiles = computed(() =>
-    [
-        proofOfVaccinationTile.value,
-        organDonorRegistrationTile.value,
-        ...serviceEntryTypes.map<InfoTile>(mapEntryTypeToTile),
-    ].filter((tile) => tile.active)
+    [proofOfVaccinationTile.value, organDonorRegistrationTile.value].filter(
+        (tile) => tile.active
+    )
 );
 const shouldDisplayServices = computed(() => servicesTiles.value.length > 0);
 const datasetTiles = computed(() =>
@@ -369,8 +365,8 @@ function selectPreviewDevice(previewDevice: PreviewDevice): void {
                         </template>
                         <template #text>
                             <p class="text-body-1">
-                                Add a quick link to the records you use the
-                                most. Filter or search to find what you need.
+                                Filter by category or search your health records
+                                to find what you need.
                             </p>
                         </template>
                     </v-card>

--- a/Apps/Landing/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/Landing/src/ClientApp/src/constants/entryType.ts
@@ -26,7 +26,7 @@ entryTypeMap.set(EntryType.Immunization, {
     type: EntryType.Immunization,
     name: "Immunizations",
     description:
-        "View immunizations you received from public health and community pharmacies and recommended vaccines.",
+        "View immunizations you received from community pharmacies or public health including COVID-19 and vaccine recommendations.",
     icon: "syringe",
 });
 
@@ -42,14 +42,6 @@ entryTypeMap.set(EntryType.LabResult, {
     name: "Lab Results",
     description: "View and download the results of your lab tests.",
     icon: "microscope",
-});
-
-entryTypeMap.set(EntryType.Covid19TestResult, {
-    type: EntryType.Covid19TestResult,
-    name: "COVID‑19 Tests",
-    description:
-        "View and download your COVID‑19 test results as soon as they are available.",
-    icon: "vial",
 });
 
 entryTypeMap.set(EntryType.HealthVisit, {
@@ -103,8 +95,6 @@ entryTypeMap.set(EntryType.BcCancerScreening, {
     name: "BC Cancer Screening",
     description:
         "View and download your notices and results as soon as they are available.",
-    logoUri: new URL("@/assets/images/services/bc-cancer.png", import.meta.url)
-        .href,
     icon: "ribbon",
 });
 


### PR DESCRIPTION
# Fixes or Implements AB#16899

## Description

[DHSOHG-2105](https://www.jira.healthcarebc.ca/browse/DHSOHG-2105)

Landing page updated:

- Remove Covid 19 tests icon and explanation from screen
- Add Cancer Screening to with Timeline logo to third position on top row
- Add new Immunizations text from Immunizations Homepage Tile
- Remove the BC Cancer copy and logo from Services section 
- ‘Find what you need’ section: Change sentence “Filter by category or search your health records to find what you need.”

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

<img width="2554" alt="Screenshot 2025-03-19 at 2 49 00 PM" src="https://github.com/user-attachments/assets/578a3d05-ec75-477e-9553-d3855fd6a61f" />

<img width="2538" alt="Screenshot 2025-03-19 at 2 49 25 PM" src="https://github.com/user-attachments/assets/4175884b-78d2-4c11-84b2-6872339f29a1" />

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
