### PR TITLE
Replace dotcover with opencover for Sonar coverage for AB#16906

### DIFF
--- a/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
+++ b/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
@@ -12,6 +12,10 @@
         <AdditionalFiles Include="..\..\..\stylecop.json" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
+++ b/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
@@ -21,6 +21,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="DeepEqual" Version="5.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Apps/Admin/Tests/Admin.Tests.csproj
+++ b/Apps/Admin/Tests/Admin.Tests.csproj
@@ -7,6 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
@@ -16,10 +24,6 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="XunitXml.TestLogger" Version="5.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Apps/Admin/Tests/Admin.Tests.csproj
+++ b/Apps/Admin/Tests/Admin.Tests.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
+++ b/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
@@ -10,6 +10,10 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
+++ b/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Apps/Common/test/unit/CommonTests.csproj
+++ b/Apps/Common/test/unit/CommonTests.csproj
@@ -10,6 +10,10 @@
         <AdditionalFiles Include="..\..\..\stylecop.json" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Apps/CommonData/test/unit/CommonDataTests.csproj
+++ b/Apps/CommonData/test/unit/CommonDataTests.csproj
@@ -10,6 +10,10 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/CommonUi/test/unit/CommonUiTests.csproj
+++ b/Apps/CommonUi/test/unit/CommonUiTests.csproj
@@ -10,6 +10,10 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/Database/test/unit/DatabaseTests.csproj
+++ b/Apps/Database/test/unit/DatabaseTests.csproj
@@ -20,6 +20,10 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/Encounter/test/unit/EncounterTests.csproj
+++ b/Apps/Encounter/test/unit/EncounterTests.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Apps/Encounter/test/unit/EncounterTests.csproj
+++ b/Apps/Encounter/test/unit/EncounterTests.csproj
@@ -15,6 +15,10 @@
     <None Remove="Mock\**" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
+++ b/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
+++ b/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
@@ -10,6 +10,10 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/Immunization/test/unit/ImmunizationTests.csproj
+++ b/Apps/Immunization/test/unit/ImmunizationTests.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Apps/Immunization/test/unit/ImmunizationTests.csproj
+++ b/Apps/Immunization/test/unit/ImmunizationTests.csproj
@@ -15,6 +15,10 @@
     <None Remove="Mock\**" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/Laboratory/test/unit/LaboratoryTests.csproj
+++ b/Apps/Laboratory/test/unit/LaboratoryTests.csproj
@@ -10,6 +10,10 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/Laboratory/test/unit/LaboratoryTests.csproj
+++ b/Apps/Laboratory/test/unit/LaboratoryTests.csproj
@@ -19,6 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Apps/Medication/test/unit/MedicationTests.csproj
+++ b/Apps/Medication/test/unit/MedicationTests.csproj
@@ -11,6 +11,10 @@
     <AdditionalFiles Include="..\..\..\stylecop.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/Medication/test/unit/MedicationTests.csproj
+++ b/Apps/Medication/test/unit/MedicationTests.csproj
@@ -20,6 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />

--- a/Apps/Patient/src/Patient.csproj
+++ b/Apps/Patient/src/Patient.csproj
@@ -21,8 +21,4 @@
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
-    </ItemGroup>
-
 </Project>

--- a/Apps/Patient/src/Patient.csproj
+++ b/Apps/Patient/src/Patient.csproj
@@ -21,4 +21,8 @@
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
+    </ItemGroup>
+
 </Project>

--- a/Apps/Patient/test/unit/PatientTests.csproj
+++ b/Apps/Patient/test/unit/PatientTests.csproj
@@ -19,6 +19,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="DeepEqual" Version="5.1.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.18.4" />

--- a/Apps/Patient/test/unit/PatientTests.csproj
+++ b/Apps/Patient/test/unit/PatientTests.csproj
@@ -10,6 +10,10 @@
         <AdditionalFiles Include="..\..\..\stylecop.json" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
+++ b/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
@@ -19,6 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
+++ b/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
@@ -11,6 +11,10 @@
         <AdditionalFiles Include="..\..\..\stylecop.json" />
     </ItemGroup>
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>

--- a/Apps/WebClient/test/unit/WebClientTests.csproj
+++ b/Apps/WebClient/test/unit/WebClientTests.csproj
@@ -17,6 +17,10 @@
     <None Remove="Assets\featuretoggleconfig.json" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Apps/WebClient/test/unit/WebClientTests.csproj
+++ b/Apps/WebClient/test/unit/WebClientTests.csproj
@@ -26,6 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="9.0.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Apps/sonar-config.xml
+++ b/Apps/sonar-config.xml
@@ -22,7 +22,7 @@
   <Property Name="sonar.test.inclusions">**/test/**/*Tests.cs,**/Tests/**/*Tests.cs</Property>
   <Property Name="sonar.coverage.exclusions">**/*Controller.cs,**/Models/**/*,**/Admin/Client/**/*,**/Database/**/*,**/DBMaintainer/**/*,**/JobScheduler/**/*,**/ClientApp/**/*</Property>
   <Property Name="sonar.host.url">https://sonarcloud.io</Property>
-  <Property Name="sonar.cs.dotcover.reportsPaths">**/dotCover.Output.html</Property>
+  <Property Name="sonar.cs.opencover.reportsPaths">**/coverage.opencover.xml</Property>
   <Property Name="sonar.excludeTestProjects">true</Property>
   <Property Name="sonar.scm.disabled">true</Property>
   <Property Name="sonar.sourceEncoding">UTF-8</Property>

--- a/Tools/SonarCloud/azure/build.yaml
+++ b/Tools/SonarCloud/azure/build.yaml
@@ -37,9 +37,8 @@ jobs:
           secureFile: "integration_test_secrets.json"
 
       - script: |
-          dotnet tool install --global JetBrains.dotCover.GlobalTool
           dotnet tool install --global dotnet-sonarscanner --version $(SONARSCANNER_VERSION)
-        displayName: "Install SonarScanner and dotCover"
+        displayName: "Install SonarScanner"
         enabled: true
 
       - script: |
@@ -61,11 +60,76 @@ jobs:
           set -e
           export SECRETS_PATH=$(testSecrets.secureFilePath)
           dotnet build --no-incremental
-          dotnet dotcover test --filter "Category!=IntegrationTest" --dcReportType=HTML --dcAttributeFilters=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute;
+          dotnet test \
+            --no-build \
+            --filter "Category!=IntegrationTest" \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:CoverletOutput=TestResults/coverage.opencover.xml \
+            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
+            -p:ParallelizeTestCollections=true
         displayName: "Build and Test"
         continueOnError: true
         workingDirectory: $(Build.SourcesDirectory)/Apps/
         enabled: "true"
+
+      - script: |
+          set -e
+          dotnet test \
+          Admin/Tests/Admin.Tests.csproj \
+          --no-build \
+          -p:CollectCoverage=true \
+          -p:CoverletOutputFormat=opencover \
+          -p:CoverletOutput=TestResults/coverage.opencover.xml \
+          -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
+          -p:ParallelizeTestCollections=true
+        displayName: "Run Admin.Tests with Coverage"
+        workingDirectory: $(Build.SourcesDirectory)/Apps/
+
+      - script: |
+          set -e
+          dotnet test \
+            Common/test/unit/CommonTests.csproj \
+            --no-build \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:CoverletOutput=TestResults/coverage.opencover.xml \
+            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
+            -p:ParallelizeTestCollections=true
+        displayName: "Run CommonTests with Coverage"
+        workingDirectory: $(Build.SourcesDirectory)/Apps/
+
+      - script: |
+          set -e
+          dotnet test \
+            CommonUi/test/unit/CommonUiTests.csproj \
+            --no-build \
+            --results-directory CommonUi/test/unit/TestResults \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:CoverletOutput=TestResults/coverage.opencover.xml \
+            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
+            -p:ParallelizeTestCollections=true
+        displayName: "Run CommonUiTests with Coverage"
+        workingDirectory: $(Build.SourcesDirectory)/Apps/
+
+      - script: |
+          set -e
+          dotnet test \
+            CommonData/test/unit/CommonDataTests.csproj \
+            --no-build \
+            -p:CollectCoverage=true \
+            -p:CoverletOutputFormat=opencover \
+            -p:CoverletOutput=TestResults/coverage.opencover.xml \
+            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
+            -p:ParallelizeTestCollections=true
+        displayName: "Run CommonDataTests with Coverage"
+        workingDirectory: $(Build.SourcesDirectory)/Apps/
+
+      - script: |
+          echo "Coverage file location:"
+          find $(Build.SourcesDirectory) -name "coverage.opencover.xml"
+        displayName: "Confirm location of coverage.opencover.xml"
 
       - script: |
           export DOTNET_ROLL_FORWARD=Major

--- a/Tools/SonarCloud/azure/build.yaml
+++ b/Tools/SonarCloud/azure/build.yaml
@@ -42,6 +42,11 @@ jobs:
         enabled: true
 
       - script: |
+          echo "Cleaning up old coverage reports..."
+          find $(Build.SourcesDirectory) -name "coverage.opencover.xml" -delete
+        displayName: "Clean previous coverage files"
+
+      - script: |
           set -e
           export DOTNET_ROLL_FORWARD=Major
           export SONAR_SCANNER_OPTS="-Xmx3072m"
@@ -66,69 +71,15 @@ jobs:
             -p:CollectCoverage=true \
             -p:CoverletOutputFormat=opencover \
             -p:CoverletOutput=TestResults/coverage.opencover.xml \
-            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
-            -p:ParallelizeTestCollections=true
+            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute
         displayName: "Build and Test"
         continueOnError: true
         workingDirectory: $(Build.SourcesDirectory)/Apps/
         enabled: "true"
 
       - script: |
-          set -e
-          dotnet test \
-          Admin/Tests/Admin.Tests.csproj \
-          --no-build \
-          -p:CollectCoverage=true \
-          -p:CoverletOutputFormat=opencover \
-          -p:CoverletOutput=TestResults/coverage.opencover.xml \
-          -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
-          -p:ParallelizeTestCollections=true
-        displayName: "Run Admin.Tests with Coverage"
-        workingDirectory: $(Build.SourcesDirectory)/Apps/
-
-      - script: |
-          set -e
-          dotnet test \
-            Common/test/unit/CommonTests.csproj \
-            --no-build \
-            -p:CollectCoverage=true \
-            -p:CoverletOutputFormat=opencover \
-            -p:CoverletOutput=TestResults/coverage.opencover.xml \
-            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
-            -p:ParallelizeTestCollections=true
-        displayName: "Run CommonTests with Coverage"
-        workingDirectory: $(Build.SourcesDirectory)/Apps/
-
-      - script: |
-          set -e
-          dotnet test \
-            CommonUi/test/unit/CommonUiTests.csproj \
-            --no-build \
-            --results-directory CommonUi/test/unit/TestResults \
-            -p:CollectCoverage=true \
-            -p:CoverletOutputFormat=opencover \
-            -p:CoverletOutput=TestResults/coverage.opencover.xml \
-            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
-            -p:ParallelizeTestCollections=true
-        displayName: "Run CommonUiTests with Coverage"
-        workingDirectory: $(Build.SourcesDirectory)/Apps/
-
-      - script: |
-          set -e
-          dotnet test \
-            CommonData/test/unit/CommonDataTests.csproj \
-            --no-build \
-            -p:CollectCoverage=true \
-            -p:CoverletOutputFormat=opencover \
-            -p:CoverletOutput=TestResults/coverage.opencover.xml \
-            -p:ExcludeByAttribute=System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute \
-            -p:ParallelizeTestCollections=true
-        displayName: "Run CommonDataTests with Coverage"
-        workingDirectory: $(Build.SourcesDirectory)/Apps/
-
-      - script: |
           echo "Coverage file location:"
-          find $(Build.SourcesDirectory) -name "coverage.opencover.xml"
+          find $(Build.SourcesDirectory) -name "coverage.opencover.xml" -exec ls -lh --time-style=long-iso {} \;
         displayName: "Confirm location of coverage.opencover.xml"
 
       - script: |


### PR DESCRIPTION
# Fixes [AB#16906](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16906)

## Description

JetBrains [DotCover Global Tool has been deprecated](https://youtrack.jetbrains.com/issue/DCVR-12422/JetBrains.dotCover.GlobalTool-2023.3.x-unavailable-on-nuget.org).  As a result, Sonar Coverage pipeline job was updated to use [Coverlet integration with MSBuild](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/MSBuildIntegration.md). Using Coverlet meant easy access to package via nuget install and could be done more easily via build scripts.

There was also a 'Coverlet.Core.Exceptions.CecilAssemblyResolutionException: AssemblyResolutionException for 'Microsoft.AspNetCore.Cryptography.KeyDerivation, Version=9.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' warning that had to be addressed. To fix this issue was to add reference for KeyDerivation to each *Test project was accessing it via a common project.  [Known issue.](https://github.com/coverlet-coverage/coverlet/blob/master/Documentation/KnownIssues.md#failed-to-resolve-assembly-during-instrumentation)

[Pipeline Results](https://dev.azure.com/qslvic/Health%20Gateway/_build/results?buildId=45663&view=results)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
