### PR TITLE
Disable PCR Lab Test Kit for AB#16912.

### DIFF
--- a/Apps/Common/src/Filters/AvailabilityFilter.cs
+++ b/Apps/Common/src/Filters/AvailabilityFilter.cs
@@ -1,0 +1,51 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.Common.Filters
+{
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Configuration;
+
+    /// <summary>
+    /// The availability middleware class.
+    /// Determines if an action should be disabled via config.
+    /// </summary>
+    /// <param name="configuration">The injected configuration.</param>
+    public class AvailabilityFilter(IConfiguration configuration) : IAsyncActionFilter
+    {
+        /// <inheritdoc/>
+        public async Task OnActionExecutionAsync(ActionExecutingContext context, ActionExecutionDelegate next)
+        {
+            RouteValueDictionary routeValues = context.HttpContext.Request.RouteValues;
+            string controllerDisabledKey = @$"{nameof(AvailabilityFilter)}:{routeValues["controller"]}";
+            bool controllerDisabled = configuration.GetValue<bool>(controllerDisabledKey);
+            string actionDisabledKey = @$"{controllerDisabledKey}:{routeValues["action"]}";
+            bool actionDisabled = configuration.GetValue<bool>(actionDisabledKey);
+            if (controllerDisabled || actionDisabled)
+            {
+                context.Result = new StatusCodeResult(StatusCodes.Status503ServiceUnavailable);
+            }
+            else
+            {
+                // Executes the action (Controller method)
+                await next();
+            }
+        }
+    }
+}

--- a/Apps/Common/test/unit/Filters/AvailabilityFilterTests.cs
+++ b/Apps/Common/test/unit/Filters/AvailabilityFilterTests.cs
@@ -1,0 +1,161 @@
+//-------------------------------------------------------------------------
+// Copyright © 2019 Province of British Columbia
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//-------------------------------------------------------------------------
+namespace HealthGateway.CommonTests.Filters
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using HealthGateway.Common.Filters;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Microsoft.AspNetCore.Mvc.Controllers;
+    using Microsoft.AspNetCore.Mvc.Filters;
+    using Microsoft.AspNetCore.Routing;
+    using Microsoft.Extensions.Configuration;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for the AvailabilityFilter.
+    /// </summary>
+    public class AvailabilityFilterTests
+    {
+        /// <summary>
+        /// Verifies that when the controller is explicitly disabled in configuration,
+        /// the filter returns a 503 Service Unavailable response and does not proceed to execute the action.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+        [Fact]
+        public async Task OnActionExecutionReturns50WhenControllerIsDisabled()
+        {
+            // Arrange
+            IConfiguration configuration = GetConfiguration(isLaboratoryFiltered: true);
+            ActionExecutingContext context = CreateContext("Laboratory", "AddLabTestKit");
+
+            AvailabilityFilter filter = new(configuration);
+            bool nextCalled = false;
+
+            // Act
+            await filter.OnActionExecutionAsync(
+                context,
+                () =>
+                {
+                    nextCalled = true;
+                    return Task.FromResult<ActionExecutedContext>(null!);
+                });
+
+            // Assert
+            Assert.IsType<StatusCodeResult>(context.Result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, ((StatusCodeResult)context.Result).StatusCode);
+            Assert.False(nextCalled); // The action delegate should not be executed when the controller is disabled.
+        }
+
+        /// <summary>
+        /// Verifies that when the specific action is explicitly disabled in configuration,
+        /// the filter returns a 503 Service Unavailable response and does not proceed to execute the action,
+        /// even if the controller is not disabled.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+        [Fact]
+        public async Task OnActionExecutionReturns503WhenActionIsDisabled()
+        {
+            // Arrange
+            IConfiguration configuration = GetConfiguration(isAddLabTestKitFiltered: true);
+            ActionExecutingContext context = CreateContext("Laboratory", "AddLabTestKit");
+
+            AvailabilityFilter filter = new(configuration);
+            bool nextCalled = false;
+
+            // Act
+            await filter.OnActionExecutionAsync(
+                context,
+                () =>
+                {
+                    nextCalled = true;
+                    return Task.FromResult<ActionExecutedContext>(null!);
+                });
+
+            // Assert
+            Assert.IsType<StatusCodeResult>(context.Result);
+            Assert.Equal(StatusCodes.Status503ServiceUnavailable, ((StatusCodeResult)context.Result).StatusCode);
+            Assert.False(nextCalled); // The action delegate should not be executed when the action is disabled.
+        }
+
+        /// <summary>
+        /// Verifies that when neither the controller nor the action is disabled in configuration,
+        /// the filter allows execution of the action and does not modify the result.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
+        [Fact]
+        public async Task ShouldOnActionExecution()
+        {
+            // Arrange
+            IConfiguration configuration = GetConfiguration();
+            ActionExecutingContext context = CreateContext("Laboratory", "AddLabTestKit");
+
+            AvailabilityFilter filter = new(configuration);
+            bool nextCalled = false;
+
+            // Act
+            await filter.OnActionExecutionAsync(
+                context,
+                () =>
+                {
+                    nextCalled = true;
+                    return Task.FromResult<ActionExecutedContext>(null!);
+                });
+
+            // Assert
+            Assert.Null(context.Result);
+            Assert.True(nextCalled); // The filter should call the next delegate
+        }
+
+        private static ActionExecutingContext CreateContext(string controller, string action)
+        {
+            ActionExecutingContext context = new(
+                new ActionContext
+                {
+                    HttpContext = new DefaultHttpContext(),
+                    RouteData = new RouteData(),
+                    ActionDescriptor = new ControllerActionDescriptor(),
+                },
+                [],
+                new Dictionary<string, object?>(),
+                null!);
+
+            context.HttpContext.Request.RouteValues["controller"] = controller;
+            context.HttpContext.Request.RouteValues["action"] = action;
+            return context;
+        }
+
+        private static IConfigurationRoot GetConfiguration(bool? isLaboratoryFiltered = null, bool? isAddLabTestKitFiltered = null)
+        {
+            Dictionary<string, string?> myConfiguration = [];
+
+            if (isLaboratoryFiltered != null)
+            {
+                myConfiguration.Add("AvailabilityFilter:Laboratory", isLaboratoryFiltered.ToString());
+            }
+
+            if (isAddLabTestKitFiltered != null)
+            {
+                myConfiguration.Add("AvailabilityFilter:Laboratory:AddLabTestKit", isAddLabTestKitFiltered.ToString());
+            }
+
+            return new ConfigurationBuilder()
+                .AddInMemoryCollection(myConfiguration)
+                .Build();
+        }
+    }
+}

--- a/Apps/Laboratory/src/Controllers/LaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/LaboratoryController.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.Laboratory.Controllers
     using Asp.Versioning;
     using HealthGateway.Common.AccessManagement.Authorization.Policy;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Filters;
     using HealthGateway.Laboratory.Models;
     using HealthGateway.Laboratory.Models.PHSA;
     using HealthGateway.Laboratory.Services;
@@ -35,6 +36,7 @@ namespace HealthGateway.Laboratory.Controllers
     [ApiVersion("1.0")]
     [Route("[controller]")]
     [ApiController]
+    [TypeFilter(typeof(AvailabilityFilter))]
     [ExcludeFromCodeCoverage]
     [SuppressMessage("SonarLint", "S6960:This controller has multiple responsibilities and could be split into 2 smaller controllers", Justification = "Team decision")]
     public class LaboratoryController : ControllerBase

--- a/Apps/Laboratory/src/Controllers/PublicLaboratoryController.cs
+++ b/Apps/Laboratory/src/Controllers/PublicLaboratoryController.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.Laboratory.Controllers
     using System.Threading.Tasks;
     using Asp.Versioning;
     using HealthGateway.Common.Data.Models;
+    using HealthGateway.Common.Filters;
     using HealthGateway.Laboratory.Models.PHSA;
     using HealthGateway.Laboratory.Services;
     using Microsoft.AspNetCore.Authorization;
@@ -33,6 +34,7 @@ namespace HealthGateway.Laboratory.Controllers
     [ApiVersion("1.0")]
     [Route("[controller]")]
     [ApiController]
+    [TypeFilter(typeof(AvailabilityFilter))]
     [ExcludeFromCodeCoverage]
     public class PublicLaboratoryController : ControllerBase
     {

--- a/Apps/Laboratory/src/appsettings.json
+++ b/Apps/Laboratory/src/appsettings.json
@@ -101,5 +101,14 @@
     "TimeZone": {
         "UnixTimeZoneId": "America/Vancouver",
         "WindowsTimeZoneId": "Pacific Standard Time"
+    },
+    "AvailabilityFilter": {
+        "_comment": "true = disabled (503 Service Unavailable)",
+        "_comment_PublicLaboratory": "Disables the entire PublicLaboratory controller",
+        "PublicLaboratory": true,
+        "Laboratory": {
+            "_comment": "Disables AddLabTestKit endpoint",
+            "AddLabTestKit": true
+        }
     }
 }

--- a/Apps/WebClient/src/featuretoggleconfig.json
+++ b/Apps/WebClient/src/featuretoggleconfig.json
@@ -56,7 +56,7 @@
         }
     ],
     "covid19": {
-        "pcrTestEnabled": true,
+        "pcrTestEnabled": false,
         "publicCovid19": {
             "showFederalProofOfVaccination": true
         },

--- a/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
+++ b/Testing/functional/tests/cypress/integration/e2e/covid19/pcrTestKit.js
@@ -47,7 +47,8 @@ describe("Authenticated PCR Test Kit Registration", () => {
         Cypress.session.clearAllSavedSessions();
     });
 
-    it("Success with Test Kit CID", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Success with Test Kit CID", () => {
         cy.visit(`/pcrtest/${successfulTestKitCid}`);
 
         // populate the form with values from the fixture
@@ -68,7 +69,8 @@ describe("Authenticated PCR Test Kit Registration", () => {
         cy.url().should("include", "/logout");
     });
 
-    it("Already Processed with Test Kit CID", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Already Processed with Test Kit CID", () => {
         cy.visit(`/pcrtest/${processedTestKitCid}`);
 
         // populate the form with values from the fixture
@@ -86,7 +88,8 @@ describe("Authenticated PCR Test Kit Registration", () => {
         cy.get(processedBanner).should("be.visible");
     });
 
-    it("Error with Test Kit CID", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Error with Test Kit CID", () => {
         cy.visit(`/pcrtest/${errorTestKitCid}`);
 
         // populate the form with values from the fixture
@@ -106,7 +109,8 @@ describe("Authenticated PCR Test Kit Registration", () => {
         cy.get(errorBanner).should("be.visible");
     });
 
-    it("Error with Test Kit Code", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Error with Test Kit Code", () => {
         cy.visit("/pcrtest");
 
         // populate the form with values from the fixture
@@ -142,7 +146,8 @@ describe("Unauthenticated PCR Test Kit Registration", () => {
         cy.logout();
     });
 
-    it("Success with Test Kit CID and PHN", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Success with Test Kit CID and PHN", () => {
         cy.visit(`/pcrtest/${successfulTestKitCid}`);
         clickManualRegistrationButton();
 
@@ -175,7 +180,8 @@ describe("Unauthenticated PCR Test Kit Registration", () => {
         cy.location("pathname").should("eq", landingPagePath);
     });
 
-    it("Success with Test Kit CID and No PHN", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Success with Test Kit CID and No PHN", () => {
         cy.visit(`/pcrtest/${successfulTestKitCid}`);
         clickManualRegistrationButton();
 
@@ -216,7 +222,8 @@ describe("Unauthenticated PCR Test Kit Registration", () => {
         cy.location("pathname").should("eq", landingPagePath);
     });
 
-    it("Already Processed with Test Kit CID", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Already Processed with Test Kit CID", () => {
         cy.visit(`/pcrtest/${processedTestKitCid}`);
         clickManualRegistrationButton();
 
@@ -244,7 +251,8 @@ describe("Unauthenticated PCR Test Kit Registration", () => {
         cy.get(processedBanner).should("be.visible");
     });
 
-    it("Error with Test Kit CID", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Error with Test Kit CID", () => {
         cy.visit(`/pcrtest/${errorTestKitCid}`);
         clickManualRegistrationButton();
 
@@ -272,7 +280,8 @@ describe("Unauthenticated PCR Test Kit Registration", () => {
         cy.get(errorBanner).should("be.visible");
     });
 
-    it("Error with Test Kit Code", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Error with Test Kit Code", () => {
         cy.visit("/pcrtest");
         clickManualRegistrationButton();
 

--- a/Testing/functional/tests/cypress/integration/e2e/services/pcrTestKit.js
+++ b/Testing/functional/tests/cypress/integration/e2e/services/pcrTestKit.js
@@ -1,0 +1,88 @@
+const HDID = "P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A";
+
+describe("PCR Lab Test Kit Service", () => {
+    beforeEach(() => {
+        cy.readConfig().as("config");
+        cy.getTokens(
+            Cypress.env("keycloak.username"),
+            Cypress.env("keycloak.password")
+        ).as("tokens");
+    });
+
+    it("Verify Laboratory Swagger", () => {
+        cy.get("@config").then((config) => {
+            cy.log(
+                `Verifying Swagger exists for Laboratory at Endpoint: ${config.serviceEndpoints.Laboratory}swagger`
+            );
+            cy.visit(`${config.serviceEndpoints.Laboratory}swagger`).contains(
+                "Health Gateway Laboratory Services documentation"
+            );
+        });
+    });
+
+    it("Verify Laboratory PCR lab test kit service unavailable", () => {
+        cy.get("@tokens").then((tokens) => {
+            cy.log("Tokens", tokens);
+            cy.get("@config").then((config) => {
+                cy.log(
+                    `Laboratory Service Endpoint: ${config.serviceEndpoints.Laboratory}`
+                );
+                cy.request({
+                    method: "POST",
+                    url: `${config.serviceEndpoints.Laboratory}Laboratory/${HDID}/LabTestKit`,
+                    followRedirect: false,
+                    failOnStatusCode: false,
+                    auth: {
+                        bearer: tokens.access_token,
+                    },
+                    headers: {
+                        accept: "application/json",
+                    },
+                    body: {
+                        testTakenMinutesAgo: 5,
+                        testKitCid: "222BAAB1-8C6E-4FA1-86ED-C4E3517A16A2",
+                        shortCodeFirst: "",
+                        shortCodeSecond: "",
+                    },
+                }).should((response) => {
+                    expect(response.status).to.eq(503);
+                });
+            });
+        });
+    });
+
+    it("Verify Public Laboratory PCR lab test kit service unavailable", () => {
+        cy.get("@config").then((config) => {
+            cy.log(
+                `Public Laboratory Service Endpoint: ${config.serviceEndpoints.Laboratory}`
+            );
+
+            cy.request({
+                method: "POST",
+                url: `${config.serviceEndpoints.Laboratory}PublicLaboratory/LabTestKit`,
+                followRedirect: false,
+                failOnStatusCode: false,
+                headers: {
+                    "Content-Type": "application/json",
+                    "api-version": "1.0",
+                },
+                body: {
+                    phn: "9879454009",
+                    dob: "1928-07-15T00:00:00",
+                    firstName: "ZELDA",
+                    lastName: "BCYPCST",
+                    testTakenMinutesAgo: 360,
+                    testKitCid: "",
+                    shortCodeFirst: "45YFKE7",
+                    shortCodeSecond: "LEKT3",
+                    contactPhoneNumber: "7782223693",
+                    streetAddress: "",
+                    city: "",
+                    postalOrZip: "",
+                },
+            }).should((response) => {
+                expect(response.status).to.eq(503);
+            });
+        });
+    });
+});

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTest.js
@@ -46,7 +46,8 @@ describe("Authenticated Pcr Test Registration", () => {
         Cypress.session.clearAllSavedSessions();
     });
 
-    it("Successful Test Kit", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Successful Test Kit", () => {
         // Authenticated PcrTest Registration Form
         cy.log("Validate Authenticated PcrTest Registration Form");
         cy.get(testKitCodeField).should("be.visible");
@@ -89,7 +90,8 @@ describe("Authenticated Pcr Test Registration", () => {
         cy.url().should("include", "/logout");
     });
 
-    it("Log Out Using Header", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Log Out Using Header", () => {
         cy.get(headerLogOutBtn).should("be.visible").click();
         cy.url().should("include", "/logout");
     });
@@ -118,7 +120,8 @@ describe("Authenticated Pcr Test Registration with Error", () => {
         });
     });
 
-    it("Error Registration Test Kit", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Error Registration Test Kit", () => {
         // get the data in the fixture.
         cy.fixture("LaboratoryService/authenticatedPcrTestError.json").then(
             (data) => {
@@ -163,7 +166,8 @@ describe("Authenticated Pcr Test Registration Previously Processed", () => {
         });
     });
 
-    it("Duplicate Test Kit Registration", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Duplicate Test Kit Registration", () => {
         // get the data in the fixture.
         cy.fixture("LaboratoryService/authenticatedPcrTestDuplicate.json").then(
             (data) => {

--- a/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/authenticatedPcrTestWithTestKit.js
@@ -44,7 +44,8 @@ describe("Authenticated Pcr Test Registration", () => {
         Cypress.session.clearAllSavedSessions();
     });
 
-    it("Successful Test Kit", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Successful Test Kit", () => {
         // Authenticated PcrTest Registration Form
         cy.log("Validate Authenticated PcrTest Registration Form");
         cy.get(testTakenMinutesAgo).should("be.visible");
@@ -100,7 +101,8 @@ describe("Authenticated Pcr Test Registration with Test Kit ID (Error)", () => {
         Cypress.session.clearAllSavedSessions();
     });
 
-    it("Error Test Kit", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Error Test Kit", () => {
         // get the data in the fixture.
         cy.fixture(
             "LaboratoryService/authenticatedPcrTestErrorWithTestKit.json"
@@ -142,7 +144,8 @@ describe("Previously Registered Test Kit", () => {
         Cypress.session.clearAllSavedSessions();
     });
 
-    it("Already Processed Test Kit", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Already Processed Test Kit", () => {
         // get the data in the fixture.
         cy.fixture(
             "LaboratoryService/authenticatedPcrTestDuplicateWithTestKit.json"

--- a/Testing/functional/tests/cypress/integration/ui/covid19/publicPcrTest.js
+++ b/Testing/functional/tests/cypress/integration/ui/covid19/publicPcrTest.js
@@ -82,7 +82,8 @@ describe("Public PcrTest Registration Form", () => {
         cy.visit(pcrTestUrl);
     });
 
-    it("Validate button options and form inputs", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Validate button options and form inputs", () => {
         // Register option buttons are available
         cy.log("Check all button visibility.");
         cy.get("[data-testid=btn-login]").should("be.visible");
@@ -163,7 +164,8 @@ describe("Public PcrTest Registration Submission with Valid PHN", () => {
         });
     });
 
-    it("Successful Test Kit with Valid PHN", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Successful Test Kit with Valid PHN", () => {
         clickManualRegistrationButton();
         // get the data in the fixture.
         cy.fixture("LaboratoryService/publicPcrTestValidPhn.json").then(
@@ -210,7 +212,8 @@ describe("Public PcrTest Registration Submission with no valid PHN", () => {
         });
     });
 
-    it("Successful Test Kit with no Valid PHN", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Successful Test Kit with no Valid PHN", () => {
         clickManualRegistrationButton();
         // get the data in the fixture.
         cy.fixture("LaboratoryService/publicPcrTestNoValidPhn.json").then(
@@ -259,7 +262,8 @@ describe("Public PcrTest Registration with Feature Disabled", () => {
         cy.visit(pcrTestUrl);
     });
 
-    it("HTTP 401", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("HTTP 401", () => {
         cy.visit("/unauthorized");
         cy.contains("h1", "401");
     });
@@ -276,7 +280,8 @@ describe("Public PcrTest Registration with Test Kit Id", () => {
         cy.visit(`${pcrTestUrl}/222BAAB1-8C6E-4FA1-86ED-C4E3517A16A2`);
     });
 
-    it("Register options buttons are available", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("Register options buttons are available", () => {
         cy.get("[data-testid=btn-login]").should("be.visible");
         cy.get("[data-testid=btn-manual]").should("be.visible");
     });
@@ -289,7 +294,8 @@ describe("Public PcrTest Registration with Test Kit Id with Feature Disabled", (
         cy.visit(`${pcrTestUrl}/222BAAB1-8C6E-4FA1-86ED-C4E3517A16A2`);
     });
 
-    it("HTTP 401", () => {
+    // Disable PCR test kit test - AB#16912
+    it.skip("HTTP 401", () => {
         cy.visit("/unauthorized");
         cy.contains("h1", "401");
     });


### PR DESCRIPTION
# Implements [AB#16912](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16912)

## Description

Disable PCR Test Kit functionality.  PCR Test Kit code will be disabled on server side via filter while front end will be disabled via featuretoggleconfig.

- Set featuretoggleconfig => covid19 => pcrTestEnabled: false
- Add back in Availability Filter that was removed from[ PR: AB#16844](https://github.com/bcgov/healthgateway/pull/6337)
- Add availability filter to Laboratory and PublicLaboratory controllers.
- Update appsettings.json to disable AddLabTestKit.
- Add functional tests to validate that Public Laboratory and Laboratory AddLabTestKit has been disabled
- Add unit tests to validate Availability Filter
- Skip functional tests for e2e/covid19/PcrTestKit.js, ui/covid19/authenticatedPcrTest.js, ui/covid19/authenticatedPcrTestWithTestKit.js and ui/covid19/publicPcrTest.js


**PCR Test:**

<img width="1281" alt="Screenshot 2025-05-06 at 4 50 10 PM" src="https://github.com/user-attachments/assets/b933a9cf-a1d6-44a3-a3aa-ef317511eff6" />


## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
