### PR TITLE
Disable dependent health visit/medication tests until ODR fix AB#16921

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/dependent/report.js
+++ b/Testing/functional/tests/cypress/integration/e2e/dependent/report.js
@@ -186,7 +186,8 @@ describe("Reports", () => {
             });
     });
 
-    it("Validate Medication Report", () => {
+    // AB#16921 - test should be skipped until ODR fixes test data for this dependent
+    it.skip("Validate Medication Report", () => {
         const hdid = dependent2.hdid;
 
         const cardSelector = getCardSelector(hdid);
@@ -225,7 +226,8 @@ describe("Reports", () => {
         cy.get("[data-testid=generic-message-modal]").should("not.exist");
     });
 
-    it("Validate MSP Visits Report", () => {
+    // AB#16921 - test should be skipped until ODR fixes test data for this dependent
+    it.skip("Validate MSP Visits Report", () => {
         const hdid = dependent2.hdid;
 
         const cardSelector = getCardSelector(hdid);

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/dependent/dataset.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/dependent/dataset.js
@@ -191,7 +191,8 @@ describe("Dependent Timeline Datasets", () => {
     describe("Validate health visits on dependent timeline", () => {
         // Michael Testertwo
         const hdid = "BNV554213556";
-        it("Enabled HealthVisit dataset should be present", () => {
+        // AB#16921 - test should be skipped until ODR fixes test data for this dependent
+        it.skip("Enabled HealthVisit dataset should be present", () => {
             enabledDatasetShouldBePresent(Dataset.HealthVisit, hdid);
         });
         it("Disabled HealthVisit dataset should not be present", () => {
@@ -208,7 +209,9 @@ describe("Dependent Timeline Datasets", () => {
     describe("Validate medications on dependent timeline", () => {
         // Michael Testertwo
         const hdid = "BNV554213556";
-        it("Enabled Medication dataset should be present", () => {
+
+        // AB#16921 - test should be skipped until ODR fixes test data for this dependent
+        it.skip("Enabled Medication dataset should be present", () => {
             enabledDatasetShouldBePresent(Dataset.Medication, hdid);
         });
         it("Disabled Medication dataset should not be present", () => {


### PR DESCRIPTION
# Fixes or Implements [AB#16921](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16921)

## Description

Disable dependent health visit and medication tests until test data has been restored by ODR.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
