### PR TITLE
Do not include sms number when submitting registration for AB#16923.

### DIFF
--- a/Testing/functional/tests/README.md
+++ b/Testing/functional/tests/README.md
@@ -28,7 +28,7 @@ Create a cypress.env.json and update with passwords or any other environment var
     "keycloak.password": "THE PASSWORD",
     "idir.password": "THE PASSWORD",
     "keycloak.unregistered.password": "THE PASSWORD",
-    "phoneNumber": "2505084843"
+    "phoneNumber": "<VALID PHONE NUMBER>"
 }
 ```
 

--- a/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
@@ -81,6 +81,14 @@ describe("Registration Page", () => {
             cy.get("div").contains("Invalid phone number").should("not.exist");
         });
 
+        cy.get("[data-testid=smsNumberInput] input")
+            .should("be.visible")
+            .clear();
+        cy.get('[data-testid="sms-checkbox"] input')
+            .should("be.enabled")
+            .uncheck({ force: true });
+        cy.get("[data-testid=smsNumberInput] input").should("have.value", "");
+
         cy.get("[data-testid=acceptCheckbox] input")
             .should("be.enabled")
             .check();


### PR DESCRIPTION
# Fixes or Implements [AB#16923](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16923)

## Description

- Do not include sms number when submitting registration in functional test.  
- Updated README.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
