### PR TITLE
Add config for Api Registration field in admin patient details - AB#16925

### DIFF
--- a/Apps/Admin/Client/Api/ISupportApi.cs
+++ b/Apps/Admin/Client/Api/ISupportApi.cs
@@ -47,9 +47,10 @@ public interface ISupportApi
     /// Whether the call should force cached vaccine validation details data to be
     /// refreshed.
     /// </param>
+    /// <param name="includeApiRegistration">Indicates whether the response should include Api Registration status.</param>
     /// <returns>The patient support details object.</returns>
-    [Get("/PatientSupportDetails?queryType={queryType}&queryString={queryString}")]
-    Task<PatientSupportDetails> GetPatientSupportDetailsAsync(ClientRegistryType queryType, string queryString, bool refreshVaccineDetails);
+    [Get("/PatientSupportDetails?queryType={queryType}&queryString={queryString}&includeApiRegistration={includeApiRegistration}")]
+    Task<PatientSupportDetails> GetPatientSupportDetailsAsync(ClientRegistryType queryType, string queryString, bool refreshVaccineDetails, bool includeApiRegistration);
 
     /// <summary>
     /// Creates, updates, or deletes block access configuration for the passed HDID.

--- a/Apps/Admin/Client/Api/ISupportApi.cs
+++ b/Apps/Admin/Client/Api/ISupportApi.cs
@@ -49,7 +49,7 @@ public interface ISupportApi
     /// </param>
     /// <param name="includeApiRegistration">Indicates whether the response should include Api Registration status.</param>
     /// <returns>The patient support details object.</returns>
-    [Get("/PatientSupportDetails?queryType={queryType}&queryString={queryString}&includeApiRegistration={includeApiRegistration}")]
+    [Get("/PatientSupportDetails?queryType={queryType}&queryString={queryString}&refreshVaccineDetails={refreshVaccineDetails}&includeApiRegistration={includeApiRegistration}")]
     Task<PatientSupportDetails> GetPatientSupportDetailsAsync(ClientRegistryType queryType, string queryString, bool refreshVaccineDetails, bool includeApiRegistration);
 
     /// <summary>

--- a/Apps/Admin/Client/Components/Details/AccountTab.razor
+++ b/Apps/Admin/Client/Components/Details/AccountTab.razor
@@ -26,7 +26,7 @@
                 <HgField Label="Last Login" Value="@ProfileLastLoginDateTime.ToString()"
                          data-testid="profile-last-login-datetime"/>
             </MudItem>
-            @if (PatientSupportDetailsLoading)
+            @if (ShowApiRegistration && PatientSupportDetailsLoading)
             {
                 <MudItem xs="12">
                     <MudProgressLinear Class="rounding-t overflow-hidden"
@@ -35,10 +35,13 @@
                 </MudItem>
             }
 
-            <MudItem xs="12">
-                <HgField Label="Api Registration" Value="@IsAccountRegistered?.ToString()"
-                         data-testid="api-registration"/>
-            </MudItem>
+            @if (ShowApiRegistration)
+            {
+                <MudItem xs="12">
+                    <HgField Label="Api Registration" Value="@IsAccountRegistered?.ToString()"
+                             data-testid="api-registration"/>
+                </MudItem>
+            }
         }
         else
         {

--- a/Apps/Admin/Client/Components/Details/AccountTab.razor.cs
+++ b/Apps/Admin/Client/Components/Details/AccountTab.razor.cs
@@ -21,6 +21,7 @@ namespace HealthGateway.Admin.Client.Components.Details
     using Fluxor;
     using Fluxor.Blazor.Web.Components;
     using HealthGateway.Admin.Client.Services;
+    using HealthGateway.Admin.Client.Store.Configuration;
     using HealthGateway.Admin.Client.Store.PatientDetails;
     using HealthGateway.Admin.Client.Store.PatientSupport;
     using HealthGateway.Admin.Common.Constants;
@@ -48,6 +49,9 @@ namespace HealthGateway.Admin.Client.Components.Details
         [Inject]
         private IDateConversionService DateConversionService { get; set; } = default!;
 
+        [Inject]
+        private IState<ConfigurationState> ConfigurationState { get; set; } = null!;
+
         private PatientSupportResult? Patient =>
             this.PatientSupportState.Value.Result?.SingleOrDefault(x => x.PersonalHealthNumber == this.Phn);
 
@@ -64,5 +68,16 @@ namespace HealthGateway.Admin.Client.Components.Details
         private bool IsDefaultPatientStatus => this.Patient?.Status == PatientStatus.Default;
 
         private bool? IsAccountRegistered => this.PatientDetailsState.Value.IsAccountRegistered;
+
+        private bool ShowApiRegistration
+        {
+            get
+            {
+                Dictionary<string, bool>? features = this.ConfigurationState.Value.Result?.Features;
+                return features != null &&
+                       features.TryGetValue("ShowApiRegistration", out bool enabled) &&
+                       enabled;
+            }
+        }
     }
 }

--- a/Apps/Admin/Common/Models/PatientSupportDetails.cs
+++ b/Apps/Admin/Common/Models/PatientSupportDetails.cs
@@ -53,6 +53,6 @@ namespace HealthGateway.Admin.Common.Models
         /// <summary>
         /// Gets a value indicating whether the patient's account is registered in the system.
         /// </summary>
-        public bool IsAccountRegistered { get; init; }
+        public bool? IsAccountRegistered { get; init; }
     }
 }

--- a/Apps/Admin/Server/Controllers/SupportController.cs
+++ b/Apps/Admin/Server/Controllers/SupportController.cs
@@ -82,6 +82,7 @@ namespace HealthGateway.Admin.Server.Controllers
         /// Whether the call should force cached vaccine validation details data to be
         /// refreshed.
         /// </param>
+        /// <param name="includeApiRegistration">Indicates whether the response should include the Api Registration status.</param>
         /// <param name="ct">A cancellation token.</param>
         /// <returns>Patient support details matching the query.</returns>
         /// <response code="200">Returns the patient support details matching the query.</response>
@@ -103,6 +104,7 @@ namespace HealthGateway.Admin.Server.Controllers
             [FromQuery] ClientRegistryType queryType,
             [FromQuery] string queryString,
             [FromQuery] bool refreshVaccineDetails,
+            [FromQuery] bool includeApiRegistration,
             CancellationToken ct)
         {
             ClaimsPrincipal user = this.HttpContext.User;
@@ -120,6 +122,7 @@ namespace HealthGateway.Admin.Server.Controllers
                     IncludeAgentActions = userIsAdmin,
                     IncludeDependents = userIsAdmin || userIsReviewer,
                     IncludeCovidDetails = userIsAdmin || userIsSupport,
+                    IncludeApiRegistration = includeApiRegistration,
                     RefreshVaccineDetails = refreshVaccineDetails,
                 },
                 ct);

--- a/Apps/Admin/Server/Models/PatientSupportDetailsQuery.cs
+++ b/Apps/Admin/Server/Models/PatientSupportDetailsQuery.cs
@@ -58,6 +58,11 @@ namespace HealthGateway.Admin.Server.Models
         public bool IncludeCovidDetails { get; init; }
 
         /// <summary>
+        /// Gets a value indicating whether Api Registration status should be included in the result.
+        /// </summary>
+        public bool IncludeApiRegistration { get; init; }
+
+        /// <summary>
         /// Gets a value indicating whether the query should force cached vaccine validation details data to be refreshed.
         /// </summary>
         public bool RefreshVaccineDetails { get; init; }

--- a/Apps/Admin/Server/Services/SupportService.cs
+++ b/Apps/Admin/Server/Services/SupportService.cs
@@ -97,8 +97,13 @@ namespace HealthGateway.Admin.Server.Services
             IEnumerable<PatientSupportDependentInfo>? dependents =
                 query.IncludeDependents ? await this.GetAllDependentInfoAsync(patient.Hdid, ct) : null;
 
-            PersonalAccountStatusRequest request = new() { Phn = patient.Phn };
-            PersonalAccountsResponse response = await hgAdminApi.PersonalAccountsStatusAsync(request, ct);
+            PersonalAccountsResponse? response = null;
+
+            if (query.IncludeApiRegistration)
+            {
+                PersonalAccountStatusRequest request = new() { Phn = patient.Phn };
+                response = await hgAdminApi.PersonalAccountsStatusAsync(request, ct);
+            }
 
             return new()
             {
@@ -107,7 +112,7 @@ namespace HealthGateway.Admin.Server.Services
                 AgentActions = agentActions,
                 Dependents = dependents,
                 VaccineDetails = getVaccineDetails == null ? null : await getVaccineDetails,
-                IsAccountRegistered = response.Registered,
+                IsAccountRegistered = response?.Registered,
             };
         }
 

--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -33,7 +33,8 @@
         "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "Features": {
-        "Showcase": true
+        "Showcase": true,
+        "ShowApiRegistration": true
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"

--- a/Apps/Admin/Server/appsettings.hgdev.json
+++ b/Apps/Admin/Server/appsettings.hgdev.json
@@ -33,7 +33,8 @@
         "BaseUrl": "https://dev.loginproxy.gov.bc.ca/auth/admin/realms/health-gateway-gold"
     },
     "Features": {
-        "Showcase": true
+        "Showcase": true,
+        "ShowApiRegistration": true
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -103,7 +103,8 @@
     },
     "Features": {
         "Showcase": false,
-        "UserInfo": true
+        "UserInfo": true,
+        "ShowApiRegistration": false
     },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-prod.azurewebsites.net",

--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -112,14 +112,16 @@ namespace HealthGateway.Admin.Tests.Services
         /// <param name="expectedCovidDetails">Value indicating if expected covid details are returned.</param>
         /// <param name="queryType">Value indicating the type of query to execute.</param>
         /// <param name="isPatientRegistered">Value indicating if personal account is registered.</param>
+        /// <param name="includeApiRegistration">Value indicating if api registration should be included.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(true, 2, true, 1, true, 1, true, true, 1, true, false, ClientRegistryType.Hdid, true)]
-        [InlineData(true, 2, true, 1, true, 1, true, true, 1, true, false, ClientRegistryType.Hdid, false)]
-        [InlineData(true, 2, true, 1, true, 1, true, false, 0, true, false, ClientRegistryType.Hdid, true)]
-        [InlineData(false, null, false, null, false, null, false, false, null, false, true, ClientRegistryType.Hdid, true)]
-        [InlineData(false, null, false, null, false, null, false, false, null, true, false, ClientRegistryType.Phn, true)]
-        [InlineData(false, null, false, null, false, null, false, false, null, false, true, ClientRegistryType.Phn, true)]
+        [InlineData(true, 2, true, 1, true, 1, true, true, 1, true, false, ClientRegistryType.Hdid, true, true)]
+        [InlineData(true, 2, true, 1, true, 1, true, true, 1, true, false, ClientRegistryType.Hdid, null, false)]
+        [InlineData(true, 2, true, 1, true, 1, true, true, 1, true, false, ClientRegistryType.Hdid, false, true)]
+        [InlineData(true, 2, true, 1, true, 1, true, false, 0, true, false, ClientRegistryType.Hdid, true, true)]
+        [InlineData(false, null, false, null, false, null, false, false, null, false, true, ClientRegistryType.Hdid, true, true)]
+        [InlineData(false, null, false, null, false, null, false, false, null, true, false, ClientRegistryType.Phn, true, true)]
+        [InlineData(false, null, false, null, false, null, false, false, null, false, true, ClientRegistryType.Phn, true, true)]
         public async Task ShouldGetPatientSupportDetails(
             bool includeMessagingVerifications,
             int? expectedMessagingVerificationCount,
@@ -133,7 +135,8 @@ namespace HealthGateway.Admin.Tests.Services
             bool includeCovidDetails,
             bool expectedCovidDetails,
             ClientRegistryType queryType,
-            bool isPatientRegistered)
+            bool? isPatientRegistered,
+            bool includeApiRegistration)
         {
             // Arrange
             PatientDetailsQuery patientQuery = new()
@@ -176,7 +179,7 @@ namespace HealthGateway.Admin.Tests.Services
                 GetAuthenticationDelegateMock(AccessToken),
                 GetImmunizationAdminDelegateMock(vaccineDetails),
                 GetAuditRepositoryMock((auditQuery, agentAudits)),
-                GetHgAdminApiMock(isPatientRegistered));
+                isPatientRegistered != null ? GetHgAdminApiMock(isPatientRegistered.Value) : null);
 
             // Act
             PatientSupportDetails actualResult =
@@ -191,6 +194,7 @@ namespace HealthGateway.Admin.Tests.Services
                         IncludeDependents = includeDependents,
                         IncludeCovidDetails = includeCovidDetails,
                         RefreshVaccineDetails = false,
+                        IncludeApiRegistration = includeApiRegistration,
                     });
 
             // Assert
@@ -199,7 +203,8 @@ namespace HealthGateway.Admin.Tests.Services
             Assert.Equal(expectedBlockedDataSourceCount, actualResult.BlockedDataSources?.Count());
             Assert.Equal(expectedDependentCount, actualResult.Dependents?.Count());
             Assert.Equal(expectedCovidDetails, actualResult.VaccineDetails == null);
-            Assert.Equal(isPatientRegistered, actualResult.IsAccountRegistered);
+            Assert.Equal(includeApiRegistration ? isPatientRegistered : null, actualResult.IsAccountRegistered);
+            // Assert.Equal(includeApiRegistration ? isPatientRegistered : null, actualResult.IsAccountRegistered);
         }
 
         /// <summary>


### PR DESCRIPTION
# Fixes or Implements [AB#16925](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16925)

## Description

Add configuration to enable or disable API Registration on Patient Details Accounts Tab page.

Enabled for local and dev environments.  Disabled for all other environments.

Note: fixed bug in ISupportApi as it was missing refreshVaccineDetails param in Refit GET

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

**Enabled:**

<img width="1899" alt="Screenshot 2025-06-20 at 10 33 40 AM" src="https://github.com/user-attachments/assets/cfd105e6-5f37-4c75-8d4a-97ff6226206c" />

**Disabled:**

<img width="1906" alt="Screenshot 2025-06-20 at 10 35 15 AM" src="https://github.com/user-attachments/assets/1ea1d8af-4ddb-47dc-955f-843678b51ee5" />



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
