### PR TITLE
Remove info popover assertion in laboratory order test for AB#16930.

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/mobile/laboratoryOrder.js
@@ -71,19 +71,6 @@ describe("Laboratory Orders", () => {
                 cy.get("[data-testid=reporting-lab-information-text]").should(
                     "be.visible"
                 );
-                cy.get("[data-testid=other-resources-info-button]")
-                    .should("be.visible")
-                    .click();
-                cy.get("[data-testid=other-resources-info-popover]").should(
-                    "be.visible"
-                );
-                cy.get("[data-testid=result-info-button]")
-                    .should("be.visible")
-                    .click();
-
-                cy.document()
-                    .find("[data-testid=result-info-popover]")
-                    .should("exist");
             });
 
         cy.get("[data-testid=backBtn]").click({ force: true });


### PR DESCRIPTION
# Fixes or Implements [AB#16930](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16930)

## Description

Lab Results no longer has an info popover.  Therefore, removing assertions for  this functionality.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
