### PR TITLE
Revert changes due to Featuretoggleconfig being used instead (AB#16943)

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/ReportsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/ReportsComponent.vue
@@ -7,6 +7,7 @@ import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
 import HgDatePickerComponent from "@/components/common/HgDatePickerComponent.vue";
 import LoadingComponent from "@/components/common/LoadingComponent.vue";
 import MessageModalComponent from "@/components/common/MessageModalComponent.vue";
+import Covid19TestResultReportComponent from "@/components/private/reports/Covid19TestResultReportComponent.vue";
 import HealthVisitReportComponent from "@/components/private/reports/HealthVisitReportComponent.vue";
 import HospitalVisitReportComponent from "@/components/private/reports/HospitalVisitReportComponent.vue";
 import ImmunizationReportComponent from "@/components/private/reports/ImmunizationReportComponent.vue";
@@ -46,6 +47,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const reportComponentMap = new Map<EntryType, unknown>([
+    [EntryType.Covid19TestResult, Covid19TestResultReportComponent],
     [EntryType.HealthVisit, HealthVisitReportComponent],
     [EntryType.HospitalVisit, HospitalVisitReportComponent],
     [EntryType.Immunization, ImmunizationReportComponent],

--- a/Testing/functional/tests/cypress/integration/e2e/report/report.js
+++ b/Testing/functional/tests/cypress/integration/e2e/report/report.js
@@ -152,8 +152,7 @@ describe("Reports", () => {
         cy.get("[data-testid=generic-message-modal]").should("not.exist");
     });
 
-    // AB#16941 - Skip test as Covid19 removed from report list.
-    it.skip("Validate COVID-19 Report", () => {
+    it("Validate COVID-19 Report", () => {
         cy.vSelect("[data-testid=report-type]", "COVID‑19 Tests");
         cy.wait("@getCovid19Tests", { timeout: defaultTimeout });
 


### PR DESCRIPTION
# Fixes or Implements [AB#16943](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16943)

## Description

Because Covid19 was disabled via Feature Toggle Configuration - see [AB#16942](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16942) - 631496882d716532f2990fafce0a9ed592f87743, the following changes can be reverted:

- Apps/WebClient/src/ClientApp/src/components/private/reports/ReportsComponent.vue (7abd156a474c443983a6f1f074bc988b047171e9)
- Testing/functional/tests/cypress/integration/e2e/dependent/report.js ( c014f9e12a968014322eada7e26218e4d81d9912)

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

**Covid19 option not shown:**

<img width="2559" height="647" alt="Screenshot 2025-09-03 at 2 44 10 PM" src="https://github.com/user-attachments/assets/f918d2e8-4c4f-4dee-bd9d-3a244070c73a" />


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
