### PR TITLE
Skip dependents that are deceased from client registry for AB#16954.

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard-read.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/dashboard-read.cy.js
@@ -10,7 +10,7 @@ describe("Dashboard", () => {
     it("Verify dashboard counts from seeded data.", () => {
         cy.log("Dashboard test started.");
         cy.get("[data-testid=total-registered-users]").contains(8);
-        cy.get("[data-testid=total-dependents]").contains(6);
+        cy.get("[data-testid=total-dependents]").contains(7);
         cy.get("[data-testid=total-closed-accounts]").contains(1);
         cy.get("[data-testid=recurring-user-count]").contains(2);
         cy.get("[data-testid=total-mobile-users]").contains(4);
@@ -27,7 +27,7 @@ describe("Dashboard", () => {
                 cy.get(
                     "[data-testid=daily-data-total-logged-in-users]"
                 ).contains("6");
-                cy.get("[data-testid=daily-data-dependents]").contains("6");
+                cy.get("[data-testid=daily-data-dependents]").contains("7");
             });
 
         cy.log("Change value in unique days input field.");

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details-write.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details-write.cy.js
@@ -222,7 +222,7 @@ describe("Patient details page as admin user", () => {
 
         cy.log("Verify dependents.");
         getTableRows("[data-testid=dependent-table]")
-            .should("have.length.gt", 1)
+            .filter(':contains("John Tester")')
             .first()
             .within(() => {
                 cy.get("[data-testid=dependent-name]").contains("John Tester");

--- a/Apps/GatewayApi/test/unit/Services.Test/MessagingVerificationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/MessagingVerificationServiceTests.cs
@@ -72,14 +72,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Assert.Null(actual.SmsNumber);
             Assert.Null(actual.SmsValidationCode);
 
-            mock.MessagingVerificationDelegateMock.Verify(
-                v => v.InsertAsync(
-                    It.Is<MessagingVerification>(
-                        x => string.IsNullOrWhiteSpace(x.SmsNumber)
-                             && x.Email != null
-                             && !string.IsNullOrWhiteSpace(x.EmailAddress)),
-                    It.Is<bool>(x => x == shouldCommit),
-                    It.IsAny<CancellationToken>()));
+            mock.MessagingVerificationDelegateMock.Verify(v => v.InsertAsync(
+                It.Is<MessagingVerification>(x => string.IsNullOrWhiteSpace(x.SmsNumber)
+                                                  && x.Email != null
+                                                  && !string.IsNullOrWhiteSpace(x.EmailAddress)),
+                It.Is<bool>(x => x == shouldCommit),
+                It.IsAny<CancellationToken>()));
         }
 
         /// <summary>
@@ -104,14 +102,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Assert.Equal(SmsNumber, actual.SmsNumber);
             Assert.NotNull(actual.SmsValidationCode);
 
-            mock.MessagingVerificationDelegateMock.Verify(
-                v => v.InsertAsync(
-                    It.Is<MessagingVerification>(
-                        x => !string.IsNullOrWhiteSpace(x.SmsNumber)
-                             && x.Email == null
-                             && string.IsNullOrWhiteSpace(x.EmailAddress)),
-                    It.IsAny<bool>(),
-                    It.IsAny<CancellationToken>()));
+            mock.MessagingVerificationDelegateMock.Verify(v => v.InsertAsync(
+                It.Is<MessagingVerification>(x => !string.IsNullOrWhiteSpace(x.SmsNumber)
+                                                  && x.Email == null
+                                                  && string.IsNullOrWhiteSpace(x.EmailAddress)),
+                It.IsAny<bool>(),
+                It.IsAny<CancellationToken>()));
         }
 
         /// <summary>
@@ -159,7 +155,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     dateTime.Day,
                     dateTime.Hour,
                     dateTime.Minute,
-                    dateTime.Second,
+                    0,
                     dateTime.Kind);
             }
         }
@@ -177,15 +173,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             MessagingVerificationMock mock = SetupEmailMessagingVerificationMock(false);
 
             // Act and Assert
-            await Assert.ThrowsAsync<DatabaseException>(
-                async () =>
-                {
-                    await mock.Service.GenerateMessagingVerificationAsync(
-                        Hdid,
-                        EmailAddress,
-                        inviteKey,
-                        isVerified);
-                });
+            await Assert.ThrowsAsync<DatabaseException>(async () =>
+            {
+                await mock.Service.GenerateMessagingVerificationAsync(
+                    Hdid,
+                    EmailAddress,
+                    inviteKey,
+                    isVerified);
+            });
         }
 
         /// <summary>
@@ -286,19 +281,17 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         private static Mock<IEmailQueueService> SetupEmailQueueServiceMock(EmailTemplate? emailTemplate, Email? email = null)
         {
             Mock<IEmailQueueService> emailQueueServiceMock = new();
-            emailQueueServiceMock.Setup(
-                    s => s.GetEmailTemplateAsync(
-                        It.IsAny<string>(),
-                        It.IsAny<CancellationToken>()))
+            emailQueueServiceMock.Setup(s => s.GetEmailTemplateAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(emailTemplate);
 
             if (email != null)
             {
-                emailQueueServiceMock.Setup(
-                        s => s.ProcessTemplate(
-                            It.IsAny<string>(),
-                            It.IsAny<EmailTemplate>(),
-                            It.IsAny<Dictionary<string, string>>()))
+                emailQueueServiceMock.Setup(s => s.ProcessTemplate(
+                        It.IsAny<string>(),
+                        It.IsAny<EmailTemplate>(),
+                        It.IsAny<Dictionary<string, string>>()))
                     .Returns(email);
             }
 

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -906,6 +906,28 @@ VALUES (
 	'System.DateTime, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e', 
 	'"2021-01-20T00:00:00"'
 );
+/* Dependent PHN:9873224879 (MPOLGP66AV4PPDB6ZMYEWQ63WKRYPM4EPDW5MSXA2LA65EQOEMCQ), Is decesased in client registry - should be ignored when retrieving dependents */
+INSERT INTO gateway."ResourceDelegate"(
+	"ResourceOwnerHdid", 
+	"ProfileHdid", 
+	"ReasonCode", 
+	"CreatedBy", 
+	"CreatedDateTime", 
+	"UpdatedBy", 
+	"UpdatedDateTime", 
+	"ReasonObjectType", 
+	"ReasonObject")
+VALUES (
+	'MPOLGP66AV4PPDB6ZMYEWQ63WKRYPM4EPDW5MSXA2LA65EQOEMCQ', 
+	'P6FFO433A5WPMVTGM7T4ZVWBKCSVNAYGTWTU3J2LWMGUMERKI72A', 
+	'Guardian', 
+	'System', 
+	current_timestamp, 
+	'System', 
+	current_timestamp, 
+	'System.DateTime, System.Private.CoreLib, Version=5.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e', 
+	'"2023-03-27T00:00:00"'
+);
 
 INSERT INTO gateway."Email"(
     "EmailId", 

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -91,6 +91,11 @@ describe("dependents", () => {
         );
     });
 
+    // Ensure this test executes before any dependent-adding tests to maintain accurate count validation.
+    it("Validate only non-deceased dependents (5 of 6) are rendered", () => {
+        cy.get("[data-testid^=dependent-card-]").should("have.length", 5);
+    });
+
     it("Validate Text Fields on Add Dependent Modal", () => {
         //Validate Main Add Button
         cy.get("[data-testid=add-dependent-button]")


### PR DESCRIPTION
# Fixes or Implements [AB#16954](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16954)

## Description

Get Dependents call was returning error when a dependent returned from ResourceDelegate was found to be deceased when validated against client registry.  In these situations, the dependent that is deceased should be ignored and not cause the call to fail:

- Updated get dependents in dependent service
- Updated seed data to include a dependent that is decease
- Updated functional tests to reflect updated seed data
- Updated and added unit tests to reflect updated logic regarding deceased dependent
- Fix flakey unit test

See functional tests:

[16954 Release](https://dev.azure.com/qslvic/Health%20Gateway/_releaseProgress?_a=release-pipeline-progress&releaseId=4380)

## Testing

- [x] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
