### PR TITLE
Improved error handling (429) and logging (DHSOHG-3275) for AB#17022

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -438,7 +438,11 @@ export const useUserStore = defineStore("user", () => {
             .updateNotificationSettings(user.value.hdid, notificationSetting)
             .then(retrieveProfile)
             .catch((resultError: ResultError) => {
-                setUserError(resultError.message);
+                handleError(
+                    resultError,
+                    ErrorType.Update,
+                    ErrorSourceType.Profile
+                );
                 throw resultError;
             });
     }


### PR DESCRIPTION
# Fixes or Implements [AB#17022](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17022)

## Description

Profile Notification Preferences – Toggle Stability & 429 Handling Improvements

**Summary**

Improves stability and error handling for Profile Notification Preferences toggles.

This change ensures correct UI rollback behavior, prevents rapid repeated toggle submissions, and properly surfaces Too Many Requests (429) errors via the existing page-level banner.

⸻

**Changes**

**1. Fixed Toggle Rollback Logic**

- Corrected previous value calculation in handleChannelToggle.
- Rollback now derives from the event payload (normalizedValue) instead of already-mutated state.
- Prevents inconsistent UI state and uncaught promise errors when save fails.

**2. Prevent Rapid Repeated Toggle Submissions**

- ntroduced per-row savingState tracking.
- Disabled switches while a save request is in-flight.
- Prevents duplicate API calls caused by rapid clicking.

**3. Prevent Watcher From Interfering During Save**

- Added guard in contact-verification watcher:
- Prevents overlapping save calls when contact channels become invalid.

**4. Proper 429 Handling**

**On HTTP 429**

- UI state is rolled back.
- errorStore.setTooManyRequestsError("page") is triggered.
- Uses existing TooManyRequestsComponent banner on the parent page.

⸻

**Result**
	•	Stable toggle behavior
	•	Correct rollback on failure
	•	No duplicate submissions
	•	Consistent 429 banner handling
	•	No changes to shared/common store logic


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
