### PR TITLE
Fix Notification Section Indentation Across Displays (DHSOHG-3275) AB#17022

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileNotificationsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileNotificationsComponent.vue
@@ -172,7 +172,7 @@ async function handleChannelToggle(
     channel: NotificationChannel,
     newValue: boolean | null
 ): Promise<void> {
-    const normalizedValue: boolean = newValue ?? false;
+    const newChannelEnabled: boolean = newValue ?? false;
 
     // Prevent rapid repeated toggles while a save is in-flight for this row.
     if (savingState[item.id]) {
@@ -188,15 +188,15 @@ async function handleChannelToggle(
 
     // Compute previous values safely using the event payload
     const previousEmailEnabled =
-        channel === "email" ? !normalizedValue : state.emailEnabled;
+        channel === "email" ? !newChannelEnabled : state.emailEnabled;
     const previousSmsEnabled =
-        channel === "sms" ? !normalizedValue : state.smsEnabled;
+        channel === "sms" ? !newChannelEnabled : state.smsEnabled;
 
     // Ensure state reflects the intended new value
     if (channel === "email") {
-        state.emailEnabled = normalizedValue;
+        state.emailEnabled = newChannelEnabled;
     } else {
-        state.smsEnabled = normalizedValue;
+        state.smsEnabled = newChannelEnabled;
     }
 
     const preferences: ProfileNotificationPreference[] =
@@ -355,7 +355,7 @@ watchEffect(() => {
             {{ saveError }}
         </HgAlertComponent>
         <v-divider class="my-4" />
-        <v-container class="pa-0">
+        <v-container fluid class="pa-0">
             <!-- Key change: constrain width so Email/SMS don't drift on 4K/5K -->
             <v-sheet max-width="720" class="pa-0">
                 <template v-if="hasEnabledNotificationPreferences">


### PR DESCRIPTION
# Fixes or Implements [AB#17022](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17022)

## Description

PR: Fix Notification Section Indentation Across Displays

**Summary:**

Resolved inconsistent indentation of the Notifications section that occurred on certain display configurations (MacBook Retina and Safari on 4K).

**Changes:**

- Made the v-container fluid to prevent breakpoint-based centering.
- Retained v-sheet max-width="720" to control readable content width.
- Ensured consistent alignment with the rest of the Profile page across browsers and monitor resolutions.

**Result**

Notifications section now aligns consistently in:

- Chrome (MacBook + external 4K)
- Safari (MacBook + external 4K)

No functional changes. Layout stabilization only.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

**MacBook Safari:**

<img width="1724" height="1114" alt="Screenshot 2026-03-02 at 11 25 22 AM" src="https://github.com/user-attachments/assets/723b834f-b7bc-4f74-af5c-32e1a9f73f4f" />

**MacBook Chrome:**

<img width="1721" height="1106" alt="Screenshot 2026-03-02 at 11 24 40 AM" src="https://github.com/user-attachments/assets/0ff07231-1bb0-4b61-944c-40fee39d7c4c" />


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
