### PR TITLE
Move profile refresh to store; refresh after update/validation AB#17028

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -7,12 +7,11 @@ import DisplayFieldComponent from "@/components/common/DisplayFieldComponent.vue
 import HgAlertComponent from "@/components/common/HgAlertComponent.vue";
 import HgButtonComponent from "@/components/common/HgButtonComponent.vue";
 import SectionHeaderComponent from "@/components/common/SectionHeaderComponent.vue";
-import { ErrorSourceType, ErrorType } from "@/constants/errorType";
 import { Loader } from "@/constants/loader";
 import ValidationRegEx from "@/constants/validationRegEx";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
-import { isTooManyRequestsError } from "@/models/errors";
+import { ResultError } from "@/models/errors";
 import { Action, Text, Type } from "@/plugins/extensions";
 import { ILogger, ITrackingService } from "@/services/interfaces";
 import { useErrorStore } from "@/stores/error";
@@ -88,46 +87,28 @@ function sendUserEmailUpdate(): void {
         text: Text.VerifyEmailAddress,
         type: Type.Profile,
     });
+
     loadingStore.applyLoader(
         Loader.UserProfile,
         "updateUserEmail",
         userStore
             .updateUserEmail(inputValue.value)
             .then(() => {
-                userStore
-                    .retrieveProfile()
-                    .then(() => {
-                        isEmailEditable.value = false;
-                        v$.value.$reset();
-                        emit("email-updated", email.value);
-                    })
-                    .catch((error) => {
-                        if (isTooManyRequestsError(error)) {
-                            errorStore.setTooManyRequestsWarning("page");
-                        } else {
-                            errorStore.addError(
-                                ErrorType.Retrieve,
-                                ErrorSourceType.Profile,
-                                undefined
-                            );
-                        }
-                    });
+                isEmailEditable.value = false;
+                v$.value.$reset();
+                emit("email-updated", email.value);
             })
             .catch((err) => {
-                logger.error(err);
-                if (err.statusCode === 429) {
+                const resultError = err as ResultError | undefined;
+                logger.error(resultError?.message ?? String(err));
+
+                if (resultError?.statusCode === 429) {
                     errorStore.setTooManyRequestsError("page");
-                } else {
-                    errorStore.addError(
-                        ErrorType.Update,
-                        ErrorSourceType.Profile,
-                        undefined
-                    );
+                    return;
                 }
             })
     );
 }
-
 watch(email, (value) => (inputValue.value = value));
 </script>
 

--- a/Apps/WebClient/src/ClientApp/src/components/private/validate-email/ValidateEmailView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/validate-email/ValidateEmailView.vue
@@ -32,7 +32,7 @@ loadingStore.applyLoader(
     "verifyingEmailAddress",
     userStore
         .validateEmail(props.inviteKey)
-        .then((result) => {
+        .then((result: boolean) => {
             isVerified.value = result;
         })
         .catch((resultError: ResultError) => {

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -275,8 +275,15 @@ export const useUserStore = defineStore("user", () => {
     function updateUserEmail(emailAddress: string): Promise<void> {
         return userProfileService
             .updateEmail(user.value.hdid, emailAddress)
+            .then(retrieveProfile)
             .catch((resultError: ResultError) => {
-                setUserError(resultError.message);
+                if (resultError.statusCode !== 409) {
+                    handleError(
+                        resultError,
+                        ErrorType.Update,
+                        ErrorSourceType.User
+                    );
+                }
                 throw resultError;
             });
     }
@@ -347,9 +354,12 @@ export const useUserStore = defineStore("user", () => {
         return setUserPreference(preference);
     }
 
-    function validateEmail(inviteKey: string) {
+    function validateEmail(inviteKey: string): Promise<boolean> {
         return userProfileService
             .validateEmail(user.value.hdid, inviteKey)
+            .then((result: boolean) => {
+                return retrieveProfile().then(() => result);
+            })
             .catch((resultError: ResultError) => {
                 if (resultError.statusCode !== 409) {
                     handleError(


### PR DESCRIPTION
# Fixes or Implements [AB#17028](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17028)

## Description

**Issue:**

User profile state was not refreshing correctly after email update or email validation. The component previously attempted to refresh the profile, but the store state was not consistently updated.

**Changes:**

Store: updateUserEmail():

- Added .then(retrieveProfile) after updateEmail
- Ensures user profile state refreshes immediately after successful email update
- Fixes issue where email verification status did not update properly in UI


Store: validateEmail():

- Added retrieveProfile() after successful validation
- Preserved Promise<boolean> return by returning result after refresh
- Ensures store reflects updated verification status

Component Cleanup: sendUserEmailUpdate():

- Removed redundant profile refresh and error handling from sendUserEmailUpdate
- Store now owns refresh and error logic

**Result:**

Profile state is consistently refreshed after email update or validation, and component logic is simplified.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
