### PR TITLE
Improve CDOGS error handling and logging in report generation for AB#17033

### DIFF
--- a/Apps/Common/src/Delegates/CDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/CDogsDelegate.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.Common.Delegates
 {
     using System;
     using System.Diagnostics;
+    using System.IO;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -62,44 +63,69 @@ namespace HealthGateway.Common.Delegates
 
             try
             {
-                this.logger.LogDebug("Generating report using CDOGS");
                 HttpResponseMessage response = await this.cdogsApi.GenerateDocumentAsync(request, ct);
-                byte[] payload = await response.Content.ReadAsByteArrayAsync(ct);
+
                 activity?.AddBaggage("ResponseStatusCode", response.StatusCode.ToString());
 
-                if (response.IsSuccessStatusCode)
+                if (!response.IsSuccessStatusCode)
                 {
-                    retVal.ResultStatus = ResultType.Success;
-                    retVal.ResourcePayload = new ReportModel
-                    {
-                        Data = Convert.ToBase64String(payload),
-                        FileName = $"{request.Options.ReportName}.{request.Options.ConvertTo}",
-                    };
-                    retVal.TotalResultCount = 1;
-                }
-                else
-                {
-                    this.logger.LogWarning("Error generating report using CDOGS: {Payload}", payload);
+                    string errorBody = await response.Content.ReadAsStringAsync(ct);
+
+                    this.logger.LogWarning(
+                        "CDOGS report generation failed. StatusCode: {StatusCode}. Body: {Body}",
+                        response.StatusCode,
+                        errorBody);
+
                     retVal.ResultError = new RequestResultError
                     {
-                        ResultMessage = $"Unable to connect to CDogs API, HTTP Error {response.StatusCode}",
+                        ResultMessage = $"CDOGS returned HTTP {(int)response.StatusCode}: {errorBody}",
                         ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.CDogs),
                     };
+
+                    return retVal;
                 }
+
+                await using Stream stream = await response.Content.ReadAsStreamAsync(ct);
+                using MemoryStream ms = new();
+
+                await stream.CopyToAsync(ms, ct);
+
+                retVal.ResultStatus = ResultType.Success;
+                retVal.ResourcePayload = new ReportModel
+                {
+                    Data = Convert.ToBase64String(ms.ToArray()),
+                    FileName = $"{request.Options.ReportName}.{request.Options.ConvertTo}",
+                };
+                retVal.TotalResultCount = 1;
+
+                return retVal;
             }
-#pragma warning disable CA1031 // Do not catch general exception types
-            catch (Exception e)
-#pragma warning restore CA1031 // Do not catch general exception types
+#pragma warning disable CA1031
+            catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
             {
-                this.logger.LogError(e, "Error generating report using CDOGS");
+                this.logger.LogError(ex, "CDOGS request timed out.");
+
                 retVal.ResultError = new RequestResultError
                 {
-                    ResultMessage = $"Exception generating report: {e}",
+                    ResultMessage = "CDOGS request timed out.",
                     ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.CDogs),
                 };
-            }
 
-            return retVal;
+                return retVal;
+            }
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                this.logger.LogError(ex, "Exception generating report using CDOGS");
+
+                retVal.ResultError = new RequestResultError
+                {
+                    ResultMessage = $"Exception generating report using CDOGS: {ex.Message}",
+                    ErrorCode = ErrorTranslator.ServiceError(ErrorType.CommunicationInternal, ServiceType.CDogs),
+                };
+
+                return retVal;
+            }
         }
     }
 }

--- a/Apps/Common/src/Delegates/CDogsDelegate.cs
+++ b/Apps/Common/src/Delegates/CDogsDelegate.cs
@@ -63,6 +63,7 @@ namespace HealthGateway.Common.Delegates
 
             try
             {
+                this.logger.LogDebug("Generating report using CDOGS");
                 HttpResponseMessage response = await this.cdogsApi.GenerateDocumentAsync(request, ct);
 
                 activity?.AddBaggage("ResponseStatusCode", response.StatusCode.ToString());
@@ -100,10 +101,9 @@ namespace HealthGateway.Common.Delegates
 
                 return retVal;
             }
-#pragma warning disable CA1031
             catch (OperationCanceledException ex) when (!ct.IsCancellationRequested)
             {
-                this.logger.LogError(ex, "CDOGS request timed out.");
+                this.logger.LogError(ex, "CDOGS request timed out");
 
                 retVal.ResultError = new RequestResultError
                 {
@@ -113,6 +113,7 @@ namespace HealthGateway.Common.Delegates
 
                 return retVal;
             }
+#pragma warning disable CA1031
             catch (Exception ex)
 #pragma warning restore CA1031
             {

--- a/Apps/GatewayApi/src/Services/ReportService.cs
+++ b/Apps/GatewayApi/src/Services/ReportService.cs
@@ -46,7 +46,6 @@ namespace HealthGateway.GatewayApi.Services
             CancellationToken ct = default)
         {
             string reportName = $"HealthGateway{reportRequest.Template}Report";
-            string templateContent = ReadTemplate(reportRequest.Template, reportRequest.Type);
 
             CDogsRequestModel cdogsRequest = new()
             {
@@ -59,7 +58,7 @@ namespace HealthGateway.GatewayApi.Services
                 },
                 Template = new CDogsTemplateModel
                 {
-                    Content = templateContent,
+                    Content = ReadTemplate(reportRequest.Template, reportRequest.Type),
                     FileType = GetTemplateExtension(reportRequest.Type),
                 },
             };

--- a/Apps/GatewayApi/src/Services/ReportService.cs
+++ b/Apps/GatewayApi/src/Services/ReportService.cs
@@ -21,7 +21,6 @@ namespace HealthGateway.GatewayApi.Services
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.Delegates;
     using HealthGateway.Common.Models.CDogs;
@@ -47,6 +46,8 @@ namespace HealthGateway.GatewayApi.Services
             CancellationToken ct = default)
         {
             string reportName = $"HealthGateway{reportRequest.Template}Report";
+            string templateContent = ReadTemplate(reportRequest.Template, reportRequest.Type);
+
             CDogsRequestModel cdogsRequest = new()
             {
                 Data = reportRequest.Data,
@@ -58,27 +59,12 @@ namespace HealthGateway.GatewayApi.Services
                 },
                 Template = new CDogsTemplateModel
                 {
-                    Content = ReadTemplate(reportRequest.Template, reportRequest.Type),
+                    Content = templateContent,
                     FileType = GetTemplateExtension(reportRequest.Type),
                 },
             };
 
-            RequestResult<ReportModel> result =
-                await this.cdogsDelegate.GenerateReportAsync(cdogsRequest, ct);
-
-            if (result.ResourcePayload == null)
-            {
-                return new RequestResult<ReportModel>
-                {
-                    ResultStatus = ResultType.Error,
-                    ResultError = new RequestResultError
-                    {
-                        ResultMessage = "Report generation failed or timed out.",
-                    },
-                };
-            }
-
-            return result;
+            return await this.cdogsDelegate.GenerateReportAsync(cdogsRequest, ct);
         }
 
         private static string GetTemplateExtension(ReportFormatType formatType)

--- a/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/ReportServiceTests.cs
@@ -109,13 +109,18 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         }
 
         [Fact]
-        public async Task ShouldReturnErrorWhenReportPayloadIsNull()
+        public async Task ShouldReturnDelegateResultWhenReportPayloadIsNull()
         {
             // Arrange
             RequestResult<ReportModel> cdogsResult = new()
             {
                 ResourcePayload = null,
-                ResultStatus = ResultType.Success,
+                ResultStatus = ResultType.Error,
+                ResultError = new RequestResultError
+                {
+                    ResultMessage = "CDOGS returned HTTP 500: test error",
+                    ErrorCode = "test-error-code",
+                },
             };
 
             ReportRequestModel reportRequest = new()
@@ -136,10 +141,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             RequestResult<ReportModel> actualResult = await service.GetReportAsync(reportRequest);
 
             // Assert
-            Assert.Equal(ResultType.Error, actualResult.ResultStatus);
-            Assert.NotNull(actualResult.ResultError);
-            Assert.Equal("Report generation failed or timed out.", actualResult.ResultError.ResultMessage);
-            Assert.Null(actualResult.ResourcePayload);
+            actualResult.ShouldDeepEqual(cdogsResult);
         }
     }
 }

--- a/Apps/HealthGateway.code-workspace
+++ b/Apps/HealthGateway.code-workspace
@@ -5,10 +5,6 @@
             "path": "WebClient/src/ClientApp"
         },
         {
-            "name": "Landing",
-            "path": "Landing/src/ClientApp"
-        },
-        {
             "name": "../Testing/functional/tests",
             "path": "../Testing/functional/tests"
         },

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/MedicationTimelineComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/entry/MedicationTimelineComponent.vue
@@ -154,7 +154,7 @@ function formatPhone(phoneNumber: string | undefined): string {
                 class="mt-2"
             >
                 <v-col cols="12">
-                    <div class="font-weight-bold mb-1">Active ingredients</div>
+                    <div class="font-weight-bold mb-1">Active Ingredients</div>
                     <v-sheet max-width="720">
                         <v-table density="compact" class="border rounded">
                             <thead class="bg-grey-lighten-4">


### PR DESCRIPTION
# Fixes or Implements [AB#17033](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17033)

## Description

This change improves error handling and diagnostics when generating reports through CDOGS.

**Changes**

**ReportService:**

- Removed logic that replaced delegate errors with a generic "Report generation failed or timed out" message.
- Now returns the CDogsDelegate result directly so the original error is preserved.
- Minor cleanup by reading the template content once before constructing the request.

**CDogsDelegate:**

- Improved error logging when CDOGS returns a non-success response.
- Logs the HTTP status code and response body returned by CDOGS instead of raw byte payloads.
- Returns the CDOGS response details in ResultError to preserve the actual failure message.
- Added explicit handling for OperationCanceledException to surface request timeouts.
- Switched to stream-based response handling when reading the generated document.

**Context**

During investigation it was determined that the primary issue was not related to the application code but to the CDOGS deployment configuration in the Dev OpenShift environment. The CDOGS container did not have sufficient CPU and memory resources, which caused intermittent rendering failures and long response times. The OpenShift deployment configuration has been updated to increase available resources, which improved stability and performance during report generation.


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

<img width="1092" height="644" alt="Screenshot 2026-03-13 at 12 23 21 PM" src="https://github.com/user-attachments/assets/0a7efbf8-8caf-4c45-b252-41ba621e1837" />


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
