### PR TITLE
Fix Communications - Actively track current tab

### DIFF
--- a/Apps/Admin/Client/Pages/CommunicationsPage.razor
+++ b/Apps/Admin/Client/Pages/CommunicationsPage.razor
@@ -27,7 +27,8 @@
 
 @if (BroadcastsLoaded || BroadcastsLoading || CommunicationsLoaded || CommunicationsLoading)
 {
-    <HgTabs @ref="@Tabs" data-testid="banner-tabs">
+    <HgTabs data-testid="banner-tabs"
+            ActivePanelIndexChanged="@OnTabChanged">
         <Header>
             <HgButton EndIcon="fas fa-plus"
                       TopMargin="@Breakpoint.Always"

--- a/Apps/Admin/Client/Pages/CommunicationsPage.razor.cs
+++ b/Apps/Admin/Client/Pages/CommunicationsPage.razor.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.Admin.Client.Pages;
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Fluxor;
@@ -56,8 +55,7 @@ public partial class CommunicationsPage : FluxorComponent
     [Inject]
     private ISnackbar Snackbar { get; set; } = default!;
 
-    [SuppressMessage("Minor Code Smell", "S3459:Unassigned members should be removed", Justification = "Assigned in .razor file")]
-    private HgTabs? Tabs { get; set; }
+    private int ActivePanelIndex { get; set; }
 
     private bool BroadcastsLoading => this.BroadcastsState.Value.IsLoading;
 
@@ -101,7 +99,7 @@ public partial class CommunicationsPage : FluxorComponent
         this.AllCommunications.Where(c => c.CommunicationTypeCode == CommunicationType.Mobile);
 
     private CommunicationType? SelectedCommunicationType =>
-        this.Tabs?.MudComponent.ActivePanelIndex switch
+        this.ActivePanelIndex switch
         {
             1 => CommunicationType.Banner,
             2 => CommunicationType.InApp,
@@ -130,6 +128,11 @@ public partial class CommunicationsPage : FluxorComponent
     {
         this.Dispatcher.Dispatch(new BroadcastsActions.ResetStateAction());
         this.Dispatcher.Dispatch(new CommunicationsActions.ResetStateAction());
+    }
+
+    private void OnTabChanged(int index)
+    {
+        this.ActivePanelIndex = index;
     }
 
     private async Task CreateBroadcastAsync()


### PR DESCRIPTION
# Fixes or Implements DHSOHG-3347

## Description

Fixes the Communications admin page “Create” behavior by correctly tracking the currently selected tab so the correct create action (broadcast vs communication type) is chosen.

Changes:

Removed the HgTabs component reference-based approach for determining the active tab.
Added local ActivePanelIndex state and updated it via HgTabs.ActivePanelIndexChanged.
Updated SelectedCommunicationType to use the tracked ActivePanelIndex.


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [X] Not Required

## UI Changes
None


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
