### PR TITLE
Enable Save button when clearing SMS (DHSOHG-3249) for AB#17035

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -146,7 +146,7 @@ watch(email, (value) => (inputValue.value = value));
             v-if="!inputValue && email"
             data-testid="emailOptOutMessage"
             class="pt-0"
-            type="error"
+            type="warning"
             variant="text"
             text="Removing your email address will disable future email
                 communications from the Health Gateway."

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileSmsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileSmsComponent.vue
@@ -30,7 +30,8 @@ const maskString = "(###) ###-####";
 const mask = new Mask({ mask: maskString });
 const maskOptions = {
     mask: maskString,
-    onMaska: (detail: MaskaDetail) => (rawValue.value = detail.unmasked),
+    onMaska: (detail: MaskaDetail) =>
+        (inputPhoneNumber.value = detail.unmasked),
 };
 
 const userProfileService = container.get<IUserProfileService>(
@@ -46,24 +47,26 @@ const userStore = useUserStore();
 const isSmsEditable = ref(false);
 
 const verified = computed(() => userStore.user.verifiedSms);
-const rawStoreValue = computed(() => userStore.user.sms);
-const maskedStoreValue = computed(() => mask.masked(rawStoreValue.value));
+const storePhoneNumber = computed(() => userStore.user.sms);
+const maskedStorePhoneNumber = computed(() =>
+    mask.masked(storePhoneNumber.value)
+);
 
-const rawValue = ref(rawStoreValue.value);
-const maskedValue = ref(maskedStoreValue.value);
+const inputPhoneNumber = ref(storePhoneNumber.value);
+const maskedInputPhoneNumber = ref(maskedStorePhoneNumber.value);
 
 const verifySmsDialog = ref<InstanceType<typeof VerifySmsDialogComponent>>();
 
 const inputErrorMessages = computed(() =>
     !isSmsEditable.value
         ? []
-        : ValidationUtil.getErrorMessages(v$.value.rawValue)
+        : ValidationUtil.getErrorMessages(v$.value.inputPhoneNumber)
 );
 const validations = computed(() => ({
-    rawValue: {
+    inputPhoneNumber: {
         newSMSNumber: helpers.withMessage(
             "New SMS number must be different from the previous one",
-            not(sameAs(rawStoreValue))
+            not(sameAs(storePhoneNumber))
         ),
         sms: helpers.withMessage(
             "Valid SMS number is required",
@@ -72,12 +75,12 @@ const validations = computed(() => ({
     },
 }));
 
-const v$ = useVuelidate(validations, { rawValue });
+const v$ = useVuelidate(validations, { inputPhoneNumber });
 
 async function validPhoneNumberFormat(
     value: string
 ): Promise<boolean | undefined> {
-    if (value === rawStoreValue.value || !value) {
+    if (value === storePhoneNumber.value || !value) {
         return true;
     }
 
@@ -94,17 +97,17 @@ async function validPhoneNumberFormat(
 
 function makeSmsEditable(): void {
     isSmsEditable.value = true;
-    v$.value.rawValue.$touch();
+    v$.value.inputPhoneNumber.$touch();
 }
 
 function cancelSmsEdit(): void {
     isSmsEditable.value = false;
-    maskedValue.value = maskedStoreValue.value;
+    maskedInputPhoneNumber.value = maskedStorePhoneNumber.value;
 }
 
 function saveSmsEdit(): void {
     v$.value.$touch();
-    if (v$.value.rawValue.$invalid !== true) {
+    if (v$.value.inputPhoneNumber.$invalid !== true) {
         updateSms();
     }
 }
@@ -118,13 +121,13 @@ function updateSms(): void {
         Loader.UserProfile,
         "updateSms",
         userProfileService
-            .updateSmsNumber(userStore.hdid, rawValue.value)
+            .updateSmsNumber(userStore.hdid, inputPhoneNumber.value)
             .then(refreshProfile)
             .then(() => {
                 isSmsEditable.value = false;
                 v$.value.$reset();
 
-                if (rawStoreValue.value) {
+                if (storePhoneNumber.value) {
                     verifySms();
                 }
             })
@@ -169,7 +172,13 @@ function refreshProfile(): Promise<void> {
     });
 }
 
-watch(maskedStoreValue, (value) => (maskedValue.value = value));
+watch(
+    maskedStorePhoneNumber,
+    (value) => (maskedInputPhoneNumber.value = value)
+);
+watch(maskedInputPhoneNumber, (value) => {
+    inputPhoneNumber.value = value ? PhoneUtil.stripPhoneMask(value) : "";
+});
 </script>
 
 <template>
@@ -187,7 +196,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
     </SectionHeaderComponent>
     <v-sheet :max-width="400">
         <v-text-field
-            v-model="maskedValue"
+            v-model="maskedInputPhoneNumber"
             v-maska="maskOptions"
             data-testid="smsNumberInput"
             :class="{ 'mb-4': inputErrorMessages.length > 0 }"
@@ -202,7 +211,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
         >
             <template #append-inner>
                 <v-progress-circular
-                    v-if="v$.rawValue.$pending"
+                    v-if="v$.inputPhoneNumber.$pending"
                     color="info"
                     indeterminate
                     size="24"
@@ -212,7 +221,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
     </v-sheet>
     <div v-if="isSmsEditable" class="mb-4">
         <HgAlertComponent
-            v-if="!rawValue && rawStoreValue"
+            v-if="!inputPhoneNumber && storePhoneNumber"
             data-testid="smsOptOutMessage"
             class="pt-0"
             type="error"
@@ -233,8 +242,8 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
             variant="primary"
             text="Save"
             :disabled="
-                rawValue === rawStoreValue ||
-                !ValidationUtil.isValid(v$.rawValue)
+                inputPhoneNumber === storePhoneNumber ||
+                !ValidationUtil.isValid(v$.inputPhoneNumber)
             "
             @click="saveSmsEdit"
         />
@@ -250,7 +259,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
                 horizontal
             />
             <DisplayFieldComponent
-                v-else-if="!rawStoreValue"
+                v-else-if="!storePhoneNumber"
                 name="Status"
                 value="Opted Out"
                 value-class="text-medium-emphasis"
@@ -267,7 +276,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
             />
         </div>
         <HgButtonComponent
-            v-if="!verified && rawStoreValue"
+            v-if="!verified && storePhoneNumber"
             data-testid="verifySMSBtn"
             class="mb-4"
             variant="secondary"
@@ -277,7 +286,7 @@ watch(maskedStoreValue, (value) => (maskedValue.value = value));
     </template>
     <VerifySmsDialogComponent
         ref="verifySmsDialog"
-        :sms-number="rawStoreValue"
+        :sms-number="storePhoneNumber"
         @verified="handleSmsVerified"
     />
 </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileSmsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileSmsComponent.vue
@@ -224,7 +224,7 @@ watch(maskedInputPhoneNumber, (value) => {
             v-if="!inputPhoneNumber && storePhoneNumber"
             data-testid="smsOptOutMessage"
             class="pt-0"
-            type="error"
+            type="warning"
             variant="text"
             text="Removing your phone number will disable future SMS communications
                 from the Health Gateway."


### PR DESCRIPTION
# Fixes or Implements [AB#17035](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17035)

## Description

For more details see [DHSOHG-3249](https://www.jira.healthcarebc.ca/browse/DHSOHG-3249)

**Summary**

- Renamed variables for improved clarity and consistency.
- Added watchers to ensure the Save button state updates correctly when fields are cleared using the “X”.
- Use Alert type 'warning' instead of 'error'

**Details**

- Refactored variable names to better reflect their purpose and align with existing naming conventions.
- Implemented watchers to detect when input fields are cleared (via the clear “X” control).
- Fixed an issue where the Save button remained disabled after clearing a value, even though the form state had changed.
- Save button now correctly enables when a field is modified or cleared.
- When email or sms are not entered, warning icon is displayed for message instead of error icon

**Impact**

- Improves form usability and correctness.
- Ensures consistent behavior between manual edits and clearing via UI controls.
- More appropriate alert type icon is displayed

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

SMS:

<img width="1116" height="225" alt="Screenshot 2026-03-17 at 11 27 55 AM" src="https://github.com/user-attachments/assets/b84d2fde-1049-4a7d-9f56-8576adba3bc8" />

Email:

<img width="919" height="229" alt="Screenshot 2026-03-17 at 11 27 45 AM" src="https://github.com/user-attachments/assets/482a7a63-4f6f-4665-84b4-56ab6bb3c34a" />


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
