### PR TITLE
Remove unused hdid parameter from endpoint AB#17038

### DIFF
--- a/Apps/Medication/src/Controllers/MedicationStatementController.cs
+++ b/Apps/Medication/src/Controllers/MedicationStatementController.cs
@@ -75,7 +75,6 @@ namespace HealthGateway.Medication.Controllers
         /// <summary>
         /// Gets medication summary by DIN.
         /// </summary>
-        /// <param name="hdid">The patient's HDID.</param>
         /// <param name="din">The Drug Identification Number (DIN) to look up.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The medication summary for the specified DIN.</returns>
@@ -85,7 +84,7 @@ namespace HealthGateway.Medication.Controllers
         [ProducesResponseType<MedicationSummary>(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(ProblemDetails))]
         [AllowAnonymous]
-        public async Task<MedicationSummary> GetMedicationSummary(string hdid, string din, CancellationToken ct)
+        public async Task<MedicationSummary> GetMedicationSummary(string din, CancellationToken ct)
         {
             return await this.medicationStatementService.GetMedicationSummaryAsync(din, ct);
         }


### PR DESCRIPTION
# Fixes or Implements [AB#17038](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17038)

## Description

Removed unused 'hdid' parameter from summary/{din} endpoint.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
