### PR TITLE
Fix missing Snowplow URL for Immunization Report (DHSOHG-3240) AB#17039

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/ImmunizationReportComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/ImmunizationReportComponent.vue
@@ -12,7 +12,14 @@ import ReportFilter from "@/models/reportFilter";
 import ReportHeader from "@/models/reportHeader";
 import { ReportFormatType, TemplateType } from "@/models/reportRequest";
 import RequestResult from "@/models/requestResult";
-import { Action, Destination, Origin, Text, Type } from "@/plugins/extensions";
+import {
+    Action,
+    Destination,
+    ExternalUrl,
+    Origin,
+    Text,
+    Type,
+} from "@/plugins/extensions";
 import {
     ILogger,
     IReportService,
@@ -191,15 +198,16 @@ function onIsEmptyChanged(): void {
     emit("on-is-empty-changed", isEmpty.value && isRecommendationEmpty.value);
 }
 
-function trackLink(href: string, text: Text, destination: Destination) {
+function trackLink(url: ExternalUrl, text: Text, destination: Destination) {
     trackingService.trackEvent({
         action: Action.ExternalLink,
         text: text,
         destination: destination,
         origin: Origin.Download,
         type: Type.Immunizations,
+        url: url,
     });
-    window.open(href, "_blank", "noopener");
+    window.open(url, "_blank", "noopener");
 }
 
 watch(isLoading, () => {
@@ -241,11 +249,11 @@ immunizationStore
                 <p>
                     You can add or update immunizations by visiting
                     <a
-                        href="https://www.immunizationrecord.gov.bc.ca/"
+                        :href="ExternalUrl.ImmunizationRecordBC"
                         class="text-link"
                         @click.prevent="
                             trackLink(
-                                'https://www.immunizationrecord.gov.bc.ca/',
+                                ExternalUrl.ImmunizationRecordBC,
                                 Text.ImmunizationRecordDownload,
                                 Destination.ImmunizationRecordBC
                             )
@@ -300,11 +308,11 @@ immunizationStore
                     <p>
                         Recommended immunizations are based on the
                         <a
-                            href="https://www.healthlinkbc.ca/health-library/immunizations/schedules"
+                            :href="ExternalUrl.ImmunizationSchedule"
                             class="text-link"
                             @click.prevent="
                                 trackLink(
-                                    'https://www.healthlinkbc.ca/health-library/immunizations/schedules',
+                                    ExternalUrl.ImmunizationSchedule,
                                     Text.BcVaccineSchedule,
                                     Destination.ImmunizationSchedule
                                 )
@@ -312,11 +320,11 @@ immunizationStore
                             >BC Vaccine Schedule</a
                         >. For more information, please visit
                         <a
-                            href="https://www.healthlinkbc.ca/health-library/immunizations"
+                            :href="ExternalUrl.Immunizations"
                             class="text-link"
                             @click.prevent="
                                 trackLink(
-                                    'https://www.healthlinkbc.ca/health-library/immunizations',
+                                    ExternalUrl.Immunizations,
                                     Text.ImmunizationsHealthLinkBC,
                                     Destination.ImmunizationsHealthLinkBC
                                 )

--- a/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
@@ -340,6 +340,8 @@ export const enum ExternalUrl {
     AccessMyHealth = "https://www.accessmyhealth.ca",
     AddressChangeBC = "https://www.addresschange.gov.bc.ca",
     ImmunizationRecordBC = "https://www.immunizationrecord.gov.bc.ca",
+    ImmunizationSchedule = "https://www.healthlinkbc.ca/health-library/immunizations/schedules",
+    Immunizations = "https://www.healthlinkbc.ca/health-library/immunizations",
     HealthConnectRegistry = "https://www.healthlinkbc.ca/find-care/health-connect-registry",
     HealthGateway = "https://www.healthgateway.gov.bc.ca",
     OrganDonorRegistration = "https://www.transplant.bc.ca/organ-donation/register-as-an-organ-donor/register-your-decision",


### PR DESCRIPTION
# Fixes or Implements [AB#17039](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17039)

## Description

**Summary**

Fixed missing Snowplow URL tracking for external links on the Immunization Download Report page.

**Details**

- Updated Snowplow tracking calls to include the url field
- Addressed 3 external links that were not passing URLs:
-- Immunization Record BC
-- BC Vaccine Schedule
-- Immunizations – HealthLink BC
- Ensured all external_link events now include the correct destination URL

**Impact**

- Snowplow events for these links now contain complete data
- Improves tracking accuracy and reporting for Immunization-related external links

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

**Immunization Record BC**

<img width="2538" height="1062" alt="Screenshot 2026-03-18 at 9 25 47 AM" src="https://github.com/user-attachments/assets/fd211c16-43c2-4f1f-afb2-94b1cdcd6e62" />

 **BC Vaccine Schedule**

<img width="2557" height="1067" alt="Screenshot 2026-03-18 at 9 26 48 AM" src="https://github.com/user-attachments/assets/eebf7a55-d296-415d-98cc-e6e159e745cc" />

**Immunizations – HealthLink BC**

<img width="2535" height="1072" alt="Screenshot 2026-03-18 at 9 27 22 AM" src="https://github.com/user-attachments/assets/54ab6e05-c875-48c1-81bd-5425abb01621" />

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
