### PR TITLE
Fix sonar test coverage AB#17020

### DIFF
--- a/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
+++ b/Apps/AccountDataAccess/test/unit/AccountDataAccessTests.csproj
@@ -21,7 +21,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="DeepEqual" Version="5.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
@@ -36,5 +36,14 @@
     <ItemGroup>
       <ProjectReference Include="..\..\src\AccountDataAccess.csproj" />
     </ItemGroup>
-
+    <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+        <ItemGroup>
+            <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+        </ItemGroup>
+        <Copy
+            SourceFiles="@(KeyDerivationDll)"
+            DestinationFolder="$(OutDir)"
+            SkipUnchangedFiles="true"
+            Condition="'@(KeyDerivationDll)' != ''" />
+    </Target>
 </Project>

--- a/Apps/Admin/Tests/Admin.Tests.csproj
+++ b/Apps/Admin/Tests/Admin.Tests.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -36,4 +36,14 @@
     <ProjectReference Include="..\Common\Admin.Common.csproj" />
     <ProjectReference Include="..\Server\Admin.Server.csproj" />
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+      <ItemGroup>
+          <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+      </ItemGroup>
+      <Copy
+          SourceFiles="@(KeyDerivationDll)"
+          DestinationFolder="$(OutDir)"
+          SkipUnchangedFiles="true"
+          Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>
 </Project>

--- a/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
+++ b/Apps/ClinicalDocument/test/unit/ClinicalDocumentTests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -32,4 +32,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\ClinicalDocument.csproj" />
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>  
 </Project>

--- a/Apps/Common/src/Common.csproj
+++ b/Apps/Common/src/Common.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.20.1" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.6.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.3" />
     <!-- Newtonsoft is used by Hangfire -->
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />

--- a/Apps/Common/test/unit/CommonTests.csproj
+++ b/Apps/Common/test/unit/CommonTests.csproj
@@ -19,7 +19,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="DeepEqual" Version="5.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Testcontainers" Version="4.10.0" />
@@ -41,4 +41,14 @@
         <None Remove="MockAsset.txt" />
         <EmbeddedResource Include="MockAsset.txt" />
     </ItemGroup>
+    <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+        <ItemGroup>
+            <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+        </ItemGroup>
+        <Copy
+            SourceFiles="@(KeyDerivationDll)"
+            DestinationFolder="$(OutDir)"
+            SkipUnchangedFiles="true"
+            Condition="'@(KeyDerivationDll)' != ''" />
+    </Target>
 </Project>

--- a/Apps/Encounter/test/unit/EncounterTests.csproj
+++ b/Apps/Encounter/test/unit/EncounterTests.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -40,4 +40,14 @@
   <ItemGroup>
     <Folder Include="Services\" />
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>
 </Project>

--- a/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
+++ b/Apps/GatewayApi/test/unit/GatewayApiTests.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
     <PackageReference Include="FluentAssertions" Version="8.8.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
@@ -35,4 +35,14 @@
     <ProjectReference Include="..\..\..\AccountDataAccess\src\AccountDataAccess.csproj" />
     <ProjectReference Include="..\..\src\GatewayApi.csproj" />
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>  
 </Project>

--- a/Apps/Immunization/test/unit/ImmunizationTests.csproj
+++ b/Apps/Immunization/test/unit/ImmunizationTests.csproj
@@ -24,7 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -40,4 +40,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Immunization.csproj" />
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>    
 </Project>

--- a/Apps/Laboratory/test/unit/LaboratoryTests.csproj
+++ b/Apps/Laboratory/test/unit/LaboratoryTests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -32,4 +32,14 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Laboratory.csproj" />
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>   
 </Project>

--- a/Apps/Medication/test/unit/MedicationTests.csproj
+++ b/Apps/Medication/test/unit/MedicationTests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
@@ -39,4 +39,14 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target>    
 </Project>

--- a/Apps/Patient/test/unit/PatientTests.csproj
+++ b/Apps/Patient/test/unit/PatientTests.csproj
@@ -19,7 +19,7 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="DeepEqual" Version="5.1.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Moq" Version="4.18.4" />
@@ -34,4 +34,14 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\Patient.csproj" />
     </ItemGroup>
+    <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+        <ItemGroup>
+            <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+        </ItemGroup>
+        <Copy
+            SourceFiles="@(KeyDerivationDll)"
+            DestinationFolder="$(OutDir)"
+            SkipUnchangedFiles="true"
+            Condition="'@(KeyDerivationDll)' != ''" />
+    </Target>    
 </Project>

--- a/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
+++ b/Apps/PatientDataAccess/test/unit/PatientDataAccessTests.csproj
@@ -19,7 +19,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+        <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
         <PackageReference Include="Moq" Version="4.18.4" />
         <PackageReference Include="Shouldly" Version="4.3.0" />
@@ -34,5 +34,14 @@
     <ItemGroup>
         <ProjectReference Include="..\..\src\PatientDataAccess.csproj" />
     </ItemGroup>
-
+    <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+        <ItemGroup>
+            <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+        </ItemGroup>
+        <Copy
+            SourceFiles="@(KeyDerivationDll)"
+            DestinationFolder="$(OutDir)"
+            SkipUnchangedFiles="true"
+            Condition="'@(KeyDerivationDll)' != ''" />
+    </Target> 
 </Project>

--- a/Apps/WebClient/src/Server/Models/FeatureToggleConfiguration.cs
+++ b/Apps/WebClient/src/Server/Models/FeatureToggleConfiguration.cs
@@ -27,6 +27,7 @@ namespace HealthGateway.WebClient.Server.Models
     /// <param name="Covid19">Settings for covid19 features.</param>
     /// <param name="Dependents">Settings for dependents features.</param>
     /// <param name="Services">Settings for services features.</param>
+    /// <param name="Profile">Settings for profile features.</param>
     public record FeatureToggleConfiguration(
         HomepageSettings Homepage,
         NotificationCentreSettings NotificationCentre,

--- a/Apps/WebClient/test/unit/WebClientTests.csproj
+++ b/Apps/WebClient/test/unit/WebClientTests.csproj
@@ -26,7 +26,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="DeepEqual" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="10.0.3" GeneratePathProperty="true" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.9.3" />
@@ -49,4 +49,14 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <Target Name="CopyKeyDerivationAssembly" BeforeTargets="VSTest">
+    <ItemGroup>
+      <KeyDerivationDll Include="$(PkgMicrosoft_AspNetCore_Cryptography_KeyDerivation)/lib/**/Microsoft.AspNetCore.Cryptography.KeyDerivation.dll" />
+    </ItemGroup>
+    <Copy
+      SourceFiles="@(KeyDerivationDll)"
+      DestinationFolder="$(OutDir)"
+      SkipUnchangedFiles="true"
+      Condition="'@(KeyDerivationDll)' != ''" />
+  </Target> 
 </Project>


### PR DESCRIPTION
# Fixes or Implements [AB#17020](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17020)

## Description

**Summary**

Resolved an issue where code coverage was missing for classes in the Common project (e.g., CDogsDelegate) across multiple test projects.

**Problem**

Although all unit tests were executing successfully, Coverlet was unable to instrument Common.dll during coverage collection. This was due to a dependency (Microsoft.AspNetCore.Cryptography.KeyDerivation) not being resolvable at instrumentation time.

As a result:

- Coverage data for Common was incomplete or missing
- Classes such as CDogsDelegate did not appear in SonarCloud
- The issue affected all test projects that depend on Common, including:

-- AccountDataAccessTests
-- AdminTests
-- ClinicalDocumentTests
-- EncounterTests
-- GatewayApiTests
-- ImmunizationTests
-- LaboratoryTests
-- MedicationTests
-- PatientTests
-- PatientDataAccessTests
-- WebClientTests

**Solution**

- Added a direct package reference to Microsoft.AspNetCore.Cryptography.KeyDerivation in Common.csproj to ensure the dependency is explicitly declared and consistently resolved.
- Ensured the dependency DLL is available in test output directories so that Coverlet can successfully instrument Common.dll during coverage collection.

**Result**

- Coverlet is now able to instrument Common.dll
- Coverage data for Common classes is correctly generated
- CDogsDelegate and other affected classes now appear in SonarCloud with accurate coverage

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
