### PR TITLE
Add intercept/wait when calling BlockAccess AB#17042

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details-write.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details-write.cy.js
@@ -93,9 +93,13 @@ function validateDatasetAccess() {
             .should("be.visible")
             .type(auditBlockReason);
 
+        cy.intercept("PUT", "**/Support/*/BlockAccess*").as("blockAccess");
+
         cy.get("[data-testid=audit-confirm-button]")
             .should("be.visible")
             .click({ force: true });
+
+        cy.wait("@blockAccess", { timeout: defaultTimeout });
 
         cy.get(`[data-testid=block-access-switch-${switchName}]`).should(
             "be.checked"
@@ -139,9 +143,13 @@ function validateDatasetAccess() {
             .should("be.visible")
             .type(auditUnblockReason);
 
+        cy.intercept("PUT", "**/Support/*/BlockAccess*").as("blockAccess");
+
         cy.get("[data-testid=audit-confirm-button]")
             .should("be.visible")
             .click({ force: true });
+
+        cy.wait("@blockAccess", { timeout: defaultTimeout });
 
         cy.get(`[data-testid=block-access-switch-${switchName}]`).should(
             "not.be.checked"


### PR DESCRIPTION
# Fixes or Implements [AB#17042](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17042)

## Description

Add intercept/wait when calling BlockAccess to fix flakiness.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
