### PR TITLE
Fix seed data due to NotificationBackfillJob run (DHSOHG-3025) AB#17044

### DIFF
--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -1758,3 +1758,75 @@ VALUES (
 		'System', 
 		current_timestamp - INTERVAL '2 day'
 );
+
+/* User hthgtwy20 */
+INSERT INTO gateway."UserProfileNotificationSetting" (
+    "Id",
+    "UserProfileId",
+    "NotificationType",
+    "EmailEnabled",
+    "SmsEnabled",
+    "CreatedBy",
+    "CreatedDateTime",
+    "UpdatedBy",
+    "UpdatedDateTime"
+)
+VALUES (
+    gen_random_uuid(),
+    'DEV4FPEGCXG2NB5K2USBL52S66SC3GOUHWRP3GTXR2BTY5HEC4YA',
+    'BcCancerScreening',
+    false,
+    false,
+    'System',
+    CURRENT_TIMESTAMP,
+    'System',
+    CURRENT_TIMESTAMP
+);
+
+/* hthgtwy03 */
+INSERT INTO gateway."UserProfileNotificationSetting" (
+    "Id",
+    "UserProfileId",
+    "NotificationType",
+    "EmailEnabled",
+    "SmsEnabled",
+    "CreatedBy",
+    "CreatedDateTime",
+    "UpdatedBy",
+    "UpdatedDateTime"
+)
+VALUES (
+    gen_random_uuid(),
+    'R43YCT4ZY37EIJLW2O5LV2I77BZA3K3M25EUJGWAVGVJ7JKBDKCQ',
+    'BcCancerScreening',
+    false,
+    false,
+    'System',
+    CURRENT_TIMESTAMP,
+    'System',
+    CURRENT_TIMESTAMP
+);
+
+/* protected */
+INSERT INTO gateway."UserProfileNotificationSetting" (
+    "Id",
+    "UserProfileId",
+    "NotificationType",
+    "EmailEnabled",
+    "SmsEnabled",
+    "CreatedBy",
+    "CreatedDateTime",
+    "UpdatedBy",
+    "UpdatedDateTime"
+)
+VALUES (
+    gen_random_uuid(),
+    'RD33Y2LJEUZCY2TCMOIECUTKS3E62MEQ62CSUL6Q553IHHBI3AWQ',
+    'BcCancerScreening',
+    false,
+    false,
+    'System',
+    CURRENT_TIMESTAMP,
+    'System',
+    CURRENT_TIMESTAMP
+);


### PR DESCRIPTION
# Fixes or Implements [AB#17044](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17044)

## Description

Seed data for profile notification setting functional tests must be updated because the NotificationBackfillJob (introduced in PR #6657) modifies existing data, causing previously expected records to no longer exist.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
