### PR TITLE
Backfill job channel-aware and use named options (DHSOHG-3025) AB#17044

### DIFF
--- a/Apps/JobScheduler/src/Jobs/NotificationBackfillJob.cs
+++ b/Apps/JobScheduler/src/Jobs/NotificationBackfillJob.cs
@@ -40,38 +40,43 @@ namespace Healthgateway.JobScheduler.Jobs
     /// <param name="outboxStore">The outbox store to use.</param>
     /// <param name="backgroundJobClient">Hangfire background job client.</param>
     /// <param name="logger">The logger to use.</param>
-    /// <param name="options">The notification backfill options to use.</param>
+    /// <param name="optionsMonitor">The monitor used to access the current notification backfill options.</param>
     public class NotificationBackfillJob(
         GatewayDbContext dbContext,
         IOutboxStore outboxStore,
         IBackgroundJobClient backgroundJobClient,
         ILogger<NotificationBackfillJob> logger,
-        IOptions<NotificationBackfillOptions> options)
+        IOptionsMonitor<NotificationBackfillOptions> optionsMonitor)
     {
         private const int ConcurrencyTimeout = 5 * 60; // 5 Minutes
+        private NotificationBackfillOptions options = null!;
 
         /// <summary>
         /// Processes user profiles in batches to pre-populate notification settings for a specific notification type.
-        /// Maintains job-level and run-level state, supports resume via last processed user profile ID,
-        /// and ensures transactional inserts per batch.
+        /// Uses UserJobState tracking to ensure users are processed only once per job.
+        /// Each batch is processed transactionally, and corresponding notification events
+        /// are generated and dispatched via the outbox after a successful commit.
         /// </summary>
+        /// <param name="optionsName">The name of the configuration section used to bind the job options.</param>
         /// <param name="ct">Cancellation token used to stop processing gracefully.</param>
         /// <returns>A <see cref="Task"/> that represents the asynchronous operation.</returns>
         [DisableConcurrentExecution(ConcurrencyTimeout)]
-        public async Task ProcessAsync(CancellationToken ct = default)
+        public async Task ProcessAsync(string optionsName, CancellationToken ct = default)
         {
+            this.options = optionsMonitor.Get(optionsName);
+
             // Skip execution if the job is disabled via configuration
-            if (!options.Value.Enabled)
+            if (!this.options.Enabled)
             {
-                logger.LogInformation("Job {JobName} is disabled", options.Value.JobName);
+                logger.LogInformation("Job {JobName} is disabled", this.options.JobName);
                 return;
             }
 
-            logger.LogInformation("Job {JobName} started", options.Value.JobName);
+            logger.LogInformation("Job {JobName} started", this.options.JobName);
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             ProfileNotificationType notificationType =
-                Enum.Parse<ProfileNotificationType>(options.Value.NotificationType);
+                Enum.Parse<ProfileNotificationType>(this.options.NotificationType);
 
             try
             {
@@ -84,7 +89,7 @@ namespace Healthgateway.JobScheduler.Jobs
 
                 logger.LogInformation(
                     "Job {JobName} finished in {ElapsedMs} ms for {Count} profiles",
-                    options.Value.JobName,
+                    this.options.JobName,
                     stopwatch.ElapsedMilliseconds,
                     userProfilesToBackfill.Count);
             }
@@ -95,7 +100,7 @@ namespace Healthgateway.JobScheduler.Jobs
                 logger.LogError(
                     ex,
                     "Job {JobName} run failed after {ElapsedMs} ms",
-                    options.Value.JobName,
+                    this.options.JobName,
                     stopwatch.ElapsedMilliseconds);
                 throw;
             }
@@ -150,19 +155,19 @@ namespace Healthgateway.JobScheduler.Jobs
         {
             // Build email targets only when EmailEnabled is configured
             IReadOnlyCollection<NotificationTargets> emailNotificationTargets =
-                options.Value.EmailEnabled.HasValue
+                this.options.EmailEnabled.HasValue
                     ? GetTargets(
                         notificationType,
-                        options.Value.EmailEnabled.Value,
+                        this.options.EmailEnabled.Value,
                         !string.IsNullOrEmpty(userProfile.Email))
                     : [];
 
             // Build SMS targets only when SmsEnabled is configured
             IReadOnlyCollection<NotificationTargets> smsNotificationTargets =
-                options.Value.SmsEnabled.HasValue
+                this.options.SmsEnabled.HasValue
                     ? GetTargets(
                         notificationType,
-                        options.Value.SmsEnabled.Value,
+                        this.options.SmsEnabled.Value,
                         !string.IsNullOrEmpty(userProfile.SmsNumber))
                     : [];
 
@@ -192,8 +197,8 @@ namespace Healthgateway.JobScheduler.Jobs
             {
                 Hdid = hdid,
                 NotificationType = notificationType,
-                EmailEnabled = options.Value.EmailEnabled,
-                SmsEnabled = options.Value.SmsEnabled,
+                EmailEnabled = this.options.EmailEnabled,
+                SmsEnabled = this.options.SmsEnabled,
             };
         }
 
@@ -213,7 +218,7 @@ namespace Healthgateway.JobScheduler.Jobs
         {
             return new UserJobState
             {
-                JobName = options.Value.JobName,
+                JobName = this.options.JobName,
                 Hdid = hdid,
                 ProcessedDateTime = processedDateTime,
             };
@@ -246,9 +251,13 @@ namespace Healthgateway.JobScheduler.Jobs
         /// <summary>
         /// Retrieves the next batch of user profiles eligible for notification backfill.
         /// Selection criteria:
-        /// - User has a valid contact channel (Email or SMS based on configuration)
-        /// - No existing notification setting for the specified type, or only null values
-        /// - Has not already been processed for this job
+        /// - Channel is determined by <c>UseSmsChannel</c>:
+        ///   - When false: selects users with a non-empty Email
+        ///   - When true: selects users with a non-empty SmsNumber
+        /// - No existing notification setting for the specified type, or only null values for the selected channel:
+        ///   - When false: EmailEnabled is null
+        ///   - When true: SmsEnabled is null
+        /// - User has not already been processed for this job (no matching UserJobState for Hdid and JobName)
         /// Results are ordered by most recent login (descending) with HDID as a tie-breaker
         /// to ensure deterministic batching.
         /// </summary>
@@ -260,7 +269,7 @@ namespace Healthgateway.JobScheduler.Jobs
             IQueryable<UserProfile> query = dbContext.UserProfile
                 .AsNoTracking()
                 .Where(x =>
-                    options.Value.UseSmsChannel
+                    this.options.UseSmsChannel
                         ? !string.IsNullOrWhiteSpace(x.SmsNumber)
                         : !string.IsNullOrWhiteSpace(x.Email))
                 .Where(x =>
@@ -268,16 +277,19 @@ namespace Healthgateway.JobScheduler.Jobs
                         .Where(ns =>
                             ns.Hdid == x.HdId &&
                             ns.NotificationType == notificationType)
-                        .All(ns => ns.EmailEnabled == null))
+                        .All(ns =>
+                            this.options.UseSmsChannel
+                                ? ns.SmsEnabled == null
+                                : ns.EmailEnabled == null))
                 .Where(x =>
                     !dbContext.UserJobState.Any(js =>
                         js.Hdid == x.HdId &&
-                        js.JobName == options.Value.JobName))
+                        js.JobName == this.options.JobName))
                 .OrderByDescending(x => x.LastLoginDateTime)
                 .ThenBy(x => x.HdId);
 
             return await query
-                .Take(options.Value.BatchSize)
+                .Take(this.options.BatchSize)
                 .ToListAsync(ct);
         }
 
@@ -377,15 +389,15 @@ namespace Healthgateway.JobScheduler.Jobs
         {
             bool updated = false;
 
-            if (existing.EmailEnabled == null && options.Value.EmailEnabled.HasValue)
+            if (existing.EmailEnabled == null && this.options.EmailEnabled.HasValue)
             {
-                existing.EmailEnabled = options.Value.EmailEnabled.Value;
+                existing.EmailEnabled = this.options.EmailEnabled.Value;
                 updated = true;
             }
 
-            if (existing.SmsEnabled == null && options.Value.SmsEnabled.HasValue)
+            if (existing.SmsEnabled == null && this.options.SmsEnabled.HasValue)
             {
-                existing.SmsEnabled = options.Value.SmsEnabled.Value;
+                existing.SmsEnabled = this.options.SmsEnabled.Value;
                 updated = true;
             }
 
@@ -410,7 +422,7 @@ namespace Healthgateway.JobScheduler.Jobs
         {
             if (userProfilesToBackfill.Count == 0)
             {
-                logger.LogInformation("Job {JobName} no records to process", options.Value.JobName);
+                logger.LogInformation("Job {JobName} no records to process", this.options.JobName);
                 return;
             }
 
@@ -451,7 +463,7 @@ namespace Healthgateway.JobScheduler.Jobs
             // Log batch summary
             logger.LogInformation(
                 "Job {JobName} processed {TotalProfiles} profiles. Inserted {InsertCount}. Updated {UpdateCount}",
-                options.Value.JobName,
+                this.options.JobName,
                 userProfilesToBackfill.Count,
                 result.RowsToInsert.Count,
                 result.UpdatedCount);

--- a/Apps/JobScheduler/src/Models/NotificationBackfillOptions.cs
+++ b/Apps/JobScheduler/src/Models/NotificationBackfillOptions.cs
@@ -21,16 +21,6 @@ namespace HealthGateway.JobScheduler.Models
     public class NotificationBackfillOptions
     {
         /// <summary>
-        /// The section key to use when binding this object by JobScheduler (top-level section).
-        /// </summary>
-        public const string JobConfigurationSectionKey = "NotificationBackfill";
-
-        /// <summary>
-        /// The section key to use when binding the Options object (nested section).
-        /// </summary>
-        public const string OptionsConfigurationSectionKey = "NotificationBackfill:Options";
-
-        /// <summary>
         /// Gets or sets a value indicating whether the job is enabled.
         /// </summary>
         public bool Enabled { get; set; } = true;

--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -99,7 +99,8 @@ namespace HealthGateway.JobScheduler
 
             // Bind configuration
             services.Configure<NotificationBackfillOptions>(
-                this.startupConfig.Configuration.GetSection(NotificationBackfillOptions.OptionsConfigurationSectionKey));
+                "NotificationEmailBackfill",
+                this.startupConfig.Configuration.GetSection("NotificationEmailBackfill:Options"));
 
             // Add Delegates and services for jobs
             services.AddTransient<IFileDownloadService, FileDownloadService>();
@@ -145,7 +146,7 @@ namespace HealthGateway.JobScheduler
                     c.UseNpgsqlConnection(this.configuration.GetConnectionString("GatewayConnection"))));
 
             // Add processing server as IHostedService
-            services.AddHangfireServer(opts => { opts.Queues = new[] { "default", AzureServiceBusSettings.OutboxQueueName }; });
+            services.AddHangfireServer(opts => { opts.Queues = ["default", AzureServiceBusSettings.OutboxQueueName]; });
 
             // Add Background Services
             services.AddHostedService<BannerListener>();
@@ -194,7 +195,10 @@ namespace HealthGateway.JobScheduler
             SchedulerHelper.ScheduleJobAsync<OneTimeJob>(this.configuration, "OneTime", j => j.ProcessAsync(CancellationToken.None));
             SchedulerHelper.ScheduleJobAsync<DeleteEmailJob>(this.configuration, "DeleteEmailJob", j => j.DeleteOldEmailsAsync(CancellationToken.None));
             SchedulerHelper.ScheduleJobAsync<AssignBetaFeatureAccessJob>(this.configuration, AssignBetaFeatureAccessJob.JobKey, j => j.ProcessAsync(CancellationToken.None));
-            SchedulerHelper.ScheduleJobAsync<NotificationBackfillJob>(this.configuration, NotificationBackfillOptions.JobConfigurationSectionKey, j => j.ProcessAsync(CancellationToken.None));
+            SchedulerHelper.ScheduleJobAsync<NotificationBackfillJob>(
+                this.configuration,
+                "NotificationEmailBackfill",
+                j => j.ProcessAsync("NotificationEmailBackfill", CancellationToken.None));
         }
     }
 }

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -196,10 +196,10 @@
         "UserCount": 100000,
         "BetaFeature": "Salesforce"
     },
-    "NotificationBackfill": {
+    "NotificationEmailBackfill": {
         "Id": "NotificationBackfill-BcCancerScreening-Email",
         "Schedule": "* * * * *",
-        "Immediate": "false",
+        "Immediate": false,
         "Delay": 60,
         "Options": {
             "Enabled": true,


### PR DESCRIPTION
# Fixes or Implements [AB#17044](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17044)

## Description

**Summary**

Refactored NotificationBackfillJob to support channel-based processing (Email vs SMS) and introduced named options configuration to allow multiple job instances in the future.

**Changes**

- Updated NotificationBackfillOptions:
   - Added UseSmsChannel to control channel selection
   - Made EmailEnabled and SmsEnabled nullable to support backfill without overriding existing user preferences
- Updated NotificationBackfillJob:
   - Channel selection now driven by UseSmsChannel
   - Query logic updated to evaluate the correct channel (EmailEnabled or SmsEnabled)
   - Ensures only users with relevant contact info and unset notification values are processed
   - Continues to respect existing user choices (does not overwrite non-null values)
- Configuration:
   - Introduced named options binding for NotificationEmailBackfill
   - Job scheduling updated to pass configuration name into ProcessAsync

**Behavior**

- When UseSmsChannel = false:
   - Processes users with Email
   - Sets EmailEnabled where null
- When UseSmsChannel = true:
   - Processes users with SMS
   - Sets SmsEnabled where null

**Notes**

- Current implementation is configured for Email only
- Structure is now in place to support SMS backfill without additional refactoring
- No impact to existing user preferences or previously processed users

**Testing**

- Verified email backfill logic with updated query and options
- Confirmed no regression in existing behavior

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
