### PR TITLE
Delete UserProfileNotificationSetting no longer required AB#17044

### DIFF
--- a/Testing/functional/tests/cypress/db/seed-test.sql
+++ b/Testing/functional/tests/cypress/db/seed-test.sql
@@ -18,7 +18,6 @@ TRUNCATE gateway."AgentAudit" CASCADE;
 TRUNCATE gateway."BlockedAccess" CASCADE;
 TRUNCATE gateway."BetaFeatureAccess" CASCADE;
 TRUNCATE gateway."Outbox" CASCADE;
-TRUNCATE gateway."UserProfileNotificationSetting" CASCADE;
 
 
 /* Registered HealthGateway User - Keycloak User (healthgateway) */


### PR DESCRIPTION
# Implements [AB#17044](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17044)

## Description

Relationship with cascade enabled between UserProfile and UserProfileNotificationSetting had been previously added.  Therefore, delete on UserProfileNotificationSetting is no longer required - see #6652.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
