### PR TITLE
Remove click.prevent from modal link (DHSOHG-3349) AB#17037

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/common/InformationModalComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/InformationModalComponent.vue
@@ -151,7 +151,7 @@ function handleClick(
                                 target="_blank"
                                 rel="noopener noreferrer"
                                 :data-testid="`information-modal-link-${paragraphIndex}-${segmentIndex}`"
-                                @click.prevent="
+                                @click="
                                     handleClick(
                                         segment.analyticsText,
                                         segment.analyticsOrigin,


### PR DESCRIPTION
# Fixes or Implements [AB#17037](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17037)

## Description

Fixed modal link not opening by removing .prevent from click handler so default navigation works.

For reference see [DHSOHG-3349](https://www.jira.healthcarebc.ca/browse/DHSOHG-3349?focusedCommentId=4692602)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
