### PR TITLE
Finalize removal of vaccine card tile from home page AB#16982

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/AddQuickLinkComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/AddQuickLinkComponent.vue
@@ -74,11 +74,6 @@ const enabledQuickLinkFilter = computed(() =>
 const isAddButtonEnabled = computed(
     () => selectedQuickLinks.value.length > 0 && !isLoading.value
 );
-const showVaccineCard = computed(
-    () =>
-        user.value.preferences[UserPreferenceType.HideVaccineCardQuickLink]
-            ?.value === "true"
-);
 const showRecommendationsDialog = computed(
     () =>
         ConfigUtil.isDatasetEnabled(EntryType.Immunization) &&
@@ -178,10 +173,6 @@ async function handleSubmit(): Promise<void> {
             updateSelectedUserPreference(
                 "health-connect-registry",
                 UserPreferenceType.HideHealthConnectRegistryQuickLink
-            ),
-            updateSelectedUserPreference(
-                "bc-vaccine-card",
-                UserPreferenceType.HideVaccineCardQuickLink
             ),
             updateSelectedUserPreference(
                 "immunization-record",
@@ -320,16 +311,6 @@ function hideModal(): void {
                             :variant="
                                 isSelectedVariant('health-connect-registry')
                             "
-                        />
-                        <v-chip
-                            v-if="showVaccineCard"
-                            id="bc-vaccine-card-filter"
-                            data-testid="bc-vaccine-card-filter"
-                            name="bc-vaccine-card-filter"
-                            value="bc-vaccine-card"
-                            text="BC Vaccine Card"
-                            color="primary"
-                            :variant="isSelectedVariant('bc-vaccine-card')"
                         />
                         <v-chip
                             v-if="showImmunizationRecord"

--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -99,11 +99,6 @@ const showFederalCardButton = computed(
         configStore.webConfig.featureToggleConfiguration.homepage
             .showFederalProofOfVaccination
 );
-const preferenceVaccineCardHidden = computed(
-    () =>
-        user.value.preferences[UserPreferenceType.HideVaccineCardQuickLink]
-            ?.value === "true"
-);
 const preferenceOrganDonorHidden = computed(
     () =>
         user.value.preferences[UserPreferenceType.HideOrganDonorQuickLink]
@@ -132,9 +127,6 @@ const showRecommendationsCardButton = computed(
             .showRecommendationsLink &&
         ConfigUtil.isDatasetEnabled(EntryType.Immunization) &&
         !preferenceRecommendationsLinkHidden.value
-);
-const showVaccineCardButton = computed(
-    () => !preferenceVaccineCardHidden.value
 );
 const showOrganDonorCardButton = computed(
     () =>
@@ -202,7 +194,6 @@ const isAddQuickLinkButtonDisabled = computed(
                 )
         ).length === 0 &&
         !preferenceImmunizationRecordHidden.value &&
-        !preferenceVaccineCardHidden.value &&
         !preferenceOrganDonorHidden.value &&
         !preferenceHealthConnectHidden.value &&
         !preferenceRecommendationsLinkHidden.value
@@ -270,17 +261,6 @@ function handleClickImmunizationRecord(): void {
     });
 }
 
-function handleClickVaccineCard(): void {
-    trackingService.trackEvent({
-        action: Action.InternalLink,
-        text: Text.BcVaccineCard,
-        origin: Origin.Home,
-        destination: Destination.BcVaccineCard,
-        type: Type.HomeTile,
-    });
-    router.push({ path: "/covid19" });
-}
-
 function handleClickOrganDonorCard(): void {
     trackingService.trackEvent({
         action: Action.InternalLink,
@@ -332,11 +312,6 @@ function handleClickRemoveQuickLink(index: number): void {
     logger.debug("Removing quick link");
     const quickLink = enabledQuickLinks.value[index];
     removeQuickLink(quickLink);
-}
-
-function handleClickRemoveVaccineCardQuickLink(): void {
-    logger.debug("Removing vaccine card quick link");
-    setPreferenceValue(UserPreferenceType.HideVaccineCardQuickLink, "true");
 }
 
 function handleClickRemoveOrganDonorQuickLink(): void {
@@ -676,37 +651,6 @@ watch(vaccineRecordState, () => {
                 <p class="text-body-1">
                     Download and print your Federal Proof of Vaccination
                     Certificate (PVC) for domestic and international travel.
-                </p>
-            </HgCardComponent>
-        </v-col>
-        <v-col
-            v-if="showVaccineCardButton && false"
-            :cols="columns"
-            class="d-flex"
-        >
-            <HgCardComponent
-                title="BC Vaccine Card"
-                variant="outlined"
-                elevation="1"
-                border="thin grey-lighten-2"
-                data-testid="bc-vaccine-card-card"
-                class="flex-grow-1"
-                @click="handleClickVaccineCard()"
-            >
-                <template #icon>
-                    <v-icon icon="check-circle" color="success" />
-                </template>
-                <template #menu-items>
-                    <v-list-item
-                        data-testid="remove-quick-link-button"
-                        title="Remove"
-                        @click.stop="handleClickRemoveVaccineCardQuickLink()"
-                    />
-                </template>
-                <p class="text-body-1">
-                    View, download and print your BC Vaccine Card. Present this
-                    card as proof of vaccination at some BC businesses, services
-                    and events.
                 </p>
             </HgCardComponent>
         </v-col>

--- a/Apps/WebClient/src/ClientApp/src/constants/userPreferenceType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/userPreferenceType.ts
@@ -1,9 +1,6 @@
 export default abstract class UserPreferenceType {
     public static readonly QuickLinks = "quickLinks";
 
-    public static readonly HideVaccineCardQuickLink =
-        "hideVaccineCardQuickLink";
-
     public static readonly HideImmunizationRecordQuickLink =
         "hideImmunizationRecordQuickLink";
 

--- a/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
@@ -58,7 +58,6 @@ export const enum Dataset {
 }
 
 export const enum Destination {
-    BcVaccineCard = "BC Vaccine Card",
     BookVaccine = "Book a Vaccine",
     HealthGatewayBeta = "Health Gateway Beta",
     HealthRecords = "Health Records",
@@ -146,7 +145,6 @@ export const enum Text {
     AddDependent = "Add a Dependent",
     AddNote = "Add a Note",
     AppRating = "App Rating",
-    BcVaccineCard = "BC Vaccine Card",
     BcVaccineSchedule = "BC Vaccine Schedule",
     Cancel = "Cancel",
     Covid19VaccineInformation = "COVID-19 Vaccine Information",

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -131,11 +131,6 @@ export const useUserStore = defineStore("user", () => {
         if (userProfile) {
             PreferenceUtil.setDefaultValue(
                 userProfile.preferences,
-                UserPreferenceType.HideVaccineCardQuickLink,
-                "false"
-            );
-            PreferenceUtil.setDefaultValue(
-                userProfile.preferences,
                 UserPreferenceType.HideOrganDonorQuickLink,
                 "false"
             );

--- a/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/quickLinks.js
@@ -420,64 +420,6 @@ describe("Disabling organ donor services", () => {
     });
 });
 
-// Vaccine Card Quick Link tests
-const vaccineCardQuickLinkCardSelector = "[data-testid=bc-vaccine-card-card]";
-const vaccineCardAddQuickLinkChipSelector =
-    "[data-testid=bc-vaccine-card-filter]";
-
-describe("Vaccine Card Quick Link", () => {
-    // AB#16941 - Skip test as Vaccine Card has been removed from Home
-    it.skip("Remove and Add Vaccine Card Quick Link", () => {
-        cy.configureSettings({});
-
-        cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            homePath
-        );
-
-        cy.log("Verifying vaccine quick link card is present");
-        cy.get(vaccineCardQuickLinkCardSelector).should(
-            "be.visible",
-            "be.enabled"
-        );
-
-        cy.log("Removing vaccine card quick link");
-        cy.get(vaccineCardQuickLinkCardSelector).within(() => {
-            cy.get(quickLinkMenuButtonSelector)
-                .should("be.visible", "be.enabled")
-                .click();
-        });
-        clickRemoveQuickLinkSelector(true);
-
-        cy.log("Verifying vaccine card quick link no longer exists");
-        cy.get(vaccineCardQuickLinkCardSelector).should("not.exist");
-
-        cy.log("Adding vaccine card quick link");
-        cy.get(addQuickLinkButtonSelector)
-            .should("be.visible")
-            .should("be.enabled")
-            .click();
-        cy.get(vaccineCardAddQuickLinkChipSelector).should("exist").click();
-        cy.get(addQuickLinkSubmitButtonSelector)
-            .should("be.visible")
-            .should("be.enabled")
-            .click();
-
-        cy.log("Verifying add quick link button is disabled");
-        cy.get(addQuickLinkButtonSelector)
-            .should("be.visible")
-            .should("not.be.enabled");
-
-        cy.log("Verifying vaccine quick link card is present");
-        cy.get(vaccineCardQuickLinkCardSelector).should(
-            "be.visible",
-            "be.enabled"
-        );
-    });
-});
-
 // Health Connect Registry Quick Link tests
 const healthConnectQuickLinkCardSelector =
     "[data-testid=health-connect-registry-card]";

--- a/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
+++ b/Testing/functional/tests/cypress/integration/ui/errors/errorAlerts.js
@@ -328,41 +328,6 @@ function testRemoveQuickLinkError(statusCode = serverErrorStatusCode) {
     }
 }
 
-function testHideVaccineCardQuickLinkError(statusCode = serverErrorStatusCode) {
-    cy.configureSettings({});
-
-    setupStandardFixtures();
-
-    cy.intercept("PUT", "**/UserProfile/*/preference?api-version=2.0", {
-        statusCode,
-    });
-    cy.intercept("POST", "**/UserProfile/*/preference?api-version=2.0", {
-        statusCode,
-    });
-    cy.login(
-        Cypress.env("keycloak.username"),
-        Cypress.env("keycloak.password"),
-        AuthMethod.KeyCloak,
-        "/home"
-    );
-
-    cy.get("[data-testid=bc-vaccine-card-card]").within(() => {
-        cy.get("[data-testid=card-menu-button]")
-            .should("be.visible", "be.enabled")
-            .click();
-        cy.document()
-            .find("[data-testid=remove-quick-link-button]")
-            .should("be.visible")
-            .click();
-    });
-
-    if (statusCode === tooManyRequestsStatusCode) {
-        cy.get("[data-testid=too-many-requests-error]").should("be.visible");
-    } else {
-        cy.get("[data-testid=errorBanner]").should("be.visible");
-    }
-}
-
 function testEditSmsError(statusCode = serverErrorStatusCode) {
     cy.configureSettings({});
 
@@ -493,11 +458,6 @@ describe("Error Alerts", () => {
         testRemoveQuickLinkError();
     });
 
-    // AB#16941 - Skip test as Vaccine Card removed from home page.
-    it.skip("Error Hiding Vaccine Card Quick Link", () => {
-        testHideVaccineCardQuickLinkError();
-    });
-
     it("Error Editing SMS Number", () => {
         testEditSmsError();
     });
@@ -537,11 +497,6 @@ describe("429 Alerts", () => {
 
     it("429 Error Removing Quick Link", () => {
         testRemoveQuickLinkError(429);
-    });
-
-    // AB#16941 - Skip test as Vaccine Card removed from home page.
-    it.skip("429 Error Hiding Vaccine Card Quick Link", () => {
-        testHideVaccineCardQuickLinkError(429);
     });
 
     it("429 Error Editing SMS Number", () => {

--- a/Testing/functional/tests/cypress/integration/ui/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/home.js
@@ -2,7 +2,6 @@ import { AuthMethod } from "../../../support/constants";
 import { setupStandardFixtures } from "../../../support/functions/intercept";
 
 const homeUrl = "/home";
-const covid19Url = "/covid19";
 const timelineUrl = "/timeline";
 const otherRecordSourcesUrl = "/otherRecordSources";
 
@@ -19,8 +18,6 @@ describe("Authenticated User - Home Page", () => {
             homeUrl
         );
 
-        // AB#16941 - Vaccine Card has been removed from Home
-        // cy.get("[data-testid=bc-vaccine-card-card]").should("be.visible");
         cy.get("[data-testid=health-records-card]").should("be.visible");
     });
 
@@ -93,26 +90,6 @@ describe("Authenticated User - Home Page", () => {
             .click();
 
         cy.url().should("include", otherRecordSourcesUrl);
-    });
-
-    // AB#16941 - Skip test as Vaccine Card has been removed from Home
-    it.skip("Home - Link to COVID-19 page", () => {
-        cy.configureSettings({});
-
-        setupStandardFixtures();
-
-        cy.login(
-            Cypress.env("keycloak.username"),
-            Cypress.env("keycloak.password"),
-            AuthMethod.KeyCloak,
-            homeUrl
-        );
-
-        cy.get("[data-testid=bc-vaccine-card-card]")
-            .should("be.visible")
-            .click();
-
-        cy.url().should("include", covid19Url);
     });
 
     it("Home - Link to timeline page", () => {


### PR DESCRIPTION
# Implements [AB#16982](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/16982)

## Description

- removes disabled code associated with displaying the Vaccine Card tile on the home page or adding it via the quick link dialog
- removes SnowPlow event associated with clicking the tile
- removes hideVaccineCardQuickLink user preference
- removes disabled functional tests related to adding, removing, or clicking the Vaccine Card tile on the home page

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
