### PR TITLE
Remove regex usage for Base64 padding detection to address Sonar hotspot (DoS) AB#17050

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/reports/ReportsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/reports/ReportsComponent.vue
@@ -266,7 +266,8 @@ function base64ToBlob(base64: string, mimeType: string): Blob {
  * in the browser.
  */
 function estimateBase64SizeInBytes(base64: string): number {
-    const padding = base64.match(/=*$/)?.[0].length ?? 0;
+    const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+
     return Math.floor((base64.length * 3) / 4) - padding;
 }
 


### PR DESCRIPTION
# Implements [AB#17050](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17050)

## Description

**Summary**

Replaced regex-based Base64 padding detection with a simpler string-based approach to address SonarCloud security hotspot.

**Changes**

- Removed regex usage (/=*$/) for detecting Base64 padding
- Implemented endsWith logic to determine padding (=, ==)
- No change to functional behavior

**Reason**

- SonarCloud flagged regex as a potential DoS (ReDoS) risk
- Although low risk, replacing with a simpler approach:
- Improves readability
- Eliminates unnecessary regex usage
- Removes Sonar warning without suppression

**Testing**

- No functional changes
- Existing behavior verified unchanged

Impact

- No impact to runtime behavior
- Code quality improvement only

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
