### PR TITLE
Fix EF JSON comparer and align ProcessedDateTime init usage for AB#17026

### DIFF
--- a/Apps/Database/src/Context/GatewayDbContext.cs
+++ b/Apps/Database/src/Context/GatewayDbContext.cs
@@ -30,6 +30,7 @@ namespace HealthGateway.Database.Context
     using HealthGateway.Database.Constants;
     using HealthGateway.Database.Models;
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.ChangeTracking;
     using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
     using BetaFeature = HealthGateway.Database.Constants.BetaFeature;
 
@@ -518,10 +519,23 @@ namespace HealthGateway.Database.Context
                 v => JsonSerializer.Deserialize<List<DataSource>>(v, dataSourceJsonOptions)
                      ?? new List<DataSource>());
 
+            ValueComparer<IList<DataSource>> dataSourcesComparer = new(
+                (left, right) =>
+                    JsonSerializer.Serialize(left, dataSourceJsonOptions) ==
+                    JsonSerializer.Serialize(right, dataSourceJsonOptions),
+                value =>
+                    JsonSerializer.Serialize(value, dataSourceJsonOptions).GetHashCode(),
+                value =>
+                    JsonSerializer.Deserialize<List<DataSource>>(
+                        JsonSerializer.Serialize(value, dataSourceJsonOptions),
+                        dataSourceJsonOptions)
+                    ?? new List<DataSource>());
+
             modelBuilder.Entity<BlockedAccess>()
                 .Property(e => e.DataSources)
                 .HasColumnType("jsonb")
-                .HasConversion(dataSourcesConverter);
+                .HasConversion(dataSourcesConverter)
+                .Metadata.SetValueComparer(dataSourcesComparer);
 
             ValueConverter<ProfileNotificationType, string> profileNotificationTypeCodeConverter = new(
                 v => EnumUtility.ToEnumString(v, false),

--- a/Apps/Database/src/Models/UserJobState.cs
+++ b/Apps/Database/src/Models/UserJobState.cs
@@ -52,7 +52,7 @@ namespace HealthGateway.Database.Models
         /// <summary>
         /// Gets or sets the processed date time for this run.
         /// </summary>
-        public DateTime ProcessedDateTime { get; set; }
+        public DateTime ProcessedDateTime { get; init; }
 
         /// <summary>
         /// Gets the user profile.


### PR DESCRIPTION
# Fixes or Implements [AB#17026](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17026)

## Description

Updated EF Core configuration and entity consistency.

- Added ValueComparer for BlockedAccess.DataSources in GatewayDbContext to address EF Core warning (see screenshot) for collection properties with value converters (jsonb mapping).
- Ensures proper change tracking for IList<DataSource>.
- Updated UserJobState.ProcessedDateTime to use init accessor for consistency with other init-only properties in the model.

See [See Microsoft Documentation regarding EF Core warning](https://learn.microsoft.com/en-us/ef/core/modeling/value-comparers?utm_source=chatgpt.com&tabs=ef5)

**In screenshot see yellow highlight for warning:**

<img width="1450" height="314" alt="Screenshot 2026-04-09 at 3 05 24 PM" src="https://github.com/user-attachments/assets/f91ad77b-4ab6-4655-917d-cec20a4b0d7b" />


## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
