### PR TITLE
Synchronize error alert visibility with store property AB#17049

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/error/ErrorCardComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/error/ErrorCardComponent.vue
@@ -64,7 +64,7 @@ async function copyToClipboard() {
 <template>
     <TooManyRequestsComponent />
     <HgAlertComponent
-        v-show="isShowing"
+        :model-value="isShowing"
         :title="errorTitle"
         type="error"
         data-testid="errorBanner"


### PR DESCRIPTION
# Fixes [AB#17049](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17049)

## Description

Resolves an issue where the generic error alert wouldn't reappear after being dismissed when another error is encountered on the same page.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required