### PR TITLE
Remove Cypress force click from profile toggle switches AB#17054

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/profile.js
@@ -55,8 +55,8 @@ describe("User Profile Notification Settings", () => {
         cy.get(selector)
             .scrollIntoView()
             .should("be.visible")
-            .find(".v-switch__track")
-            .click({ force: true });
+            .find("input[type='checkbox']")
+            .click();
     }
 
     beforeEach(() => {

--- a/Testing/functional/tests/cypress/integration/ui/user/profileNotificationSettings.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/profileNotificationSettings.js
@@ -98,8 +98,8 @@ describe("User Profile Notification Settings", () => {
         cy.get(selector)
             .scrollIntoView()
             .should("be.visible")
-            .find(".v-switch__track")
-            .click({ force: true });
+            .find("input[type='checkbox']")
+            .click();
     }
 
     describe("Payload mapping", () => {


### PR DESCRIPTION
# Fixes or Implements [AB#17054](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17054)

## Description

Removed use of .click({ force: true }) in Cypress tests for notification toggle switches.

Replaced with a standard click on the underlying input[type="checkbox"] element to ensure interactions follow normal browser behavior. This avoids bypassing visibility and interactability checks and improves test reliability.

No changes to application logic.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
