### PR TITLE
Fix patient details test flakiness (blur, force click, refresh) AB#17056

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details-write.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/patient-details-write.cy.js
@@ -37,7 +37,10 @@ function checkAgentAuditHistory() {
 
     cy.get("[data-testid=agent-audit-history-table]").should("be.visible");
 
-    return cy.get("[data-testid=agent-audit-history-count]").invoke("text");
+    return cy
+        .get("[data-testid=agent-audit-history-count]")
+        .invoke("text")
+        .then((text) => Number(text.trim()));
 }
 
 function validateDatasetAccess() {
@@ -89,17 +92,20 @@ function validateDatasetAccess() {
             .should("exist", "be.visible")
             .click();
 
-        cy.get("[data-testid=audit-reason-input")
+        cy.get("[data-testid=audit-reason-input]")
             .should("be.visible")
-            .type(auditBlockReason);
+            .type(auditBlockReason)
+            .blur();
 
         cy.intercept("PUT", "**/Support/*/BlockAccess*").as("blockAccess");
 
         cy.get("[data-testid=audit-confirm-button]")
             .should("be.visible")
-            .click({ force: true });
+            .should("not.be.disabled")
+            .click();
 
         cy.wait("@blockAccess", { timeout: defaultTimeout });
+        cy.wait("@getPatientSupportDetails", { timeout: defaultTimeout });
 
         cy.get(`[data-testid=block-access-switch-${switchName}]`).should(
             "be.checked"
@@ -139,17 +145,20 @@ function validateDatasetAccess() {
             .should("exist", "be.visible")
             .click();
 
-        cy.get("[data-testid=audit-reason-input")
+        cy.get("[data-testid=audit-reason-input]")
             .should("be.visible")
-            .type(auditUnblockReason);
+            .type(auditUnblockReason)
+            .blur();
 
         cy.intercept("PUT", "**/Support/*/BlockAccess*").as("blockAccess");
 
         cy.get("[data-testid=audit-confirm-button]")
             .should("be.visible")
-            .click({ force: true });
+            .should("not.be.disabled")
+            .click();
 
         cy.wait("@blockAccess", { timeout: defaultTimeout });
+        cy.wait("@getPatientSupportDetails", { timeout: defaultTimeout });
 
         cy.get(`[data-testid=block-access-switch-${switchName}]`).should(
             "not.be.checked"


### PR DESCRIPTION
# Fixes or Implements [AB#17056](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17056)

## Description

Updated the patient details functional test to reduce flakiness in dataset access audit flows.

Changes made:

* converted agent audit history count text to a trimmed numeric value before comparison
* fixed the audit reason input selector
* added .blur() after entering the audit reason so Blazor updates the confirm button state correctly
* replaced forced confirm button clicks with a normal click after asserting the button is enabled
* added a wait for refreshed patient support details after the block/unblock save request completes

These changes improve reliability of the block/unblock dataset access test without changing application behavior.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
