### PR TITLE
Display one-time message for removed SMS AB#17064

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -66,6 +66,8 @@ const errorStore = useErrorStore();
 const timelineStore = useTimelineStore();
 const { columns } = useGrid();
 
+const showSmsRemoved = ref<boolean>();
+
 const sensitiveDocumentDownloadModal =
     ref<InstanceType<typeof MessageModalComponent>>();
 const vaccineRecordResultModal =
@@ -120,6 +122,11 @@ const preferenceHealthConnectHidden = computed(
         user.value.preferences[
             UserPreferenceType.HideHealthConnectRegistryQuickLink
         ]?.value === "true"
+);
+const preferenceShowSmsRemoved = computed(
+    () =>
+        user.value.preferences[UserPreferenceType.ShowSmsRemoved]?.value ===
+        "true"
 );
 const showRecommendationsCardButton = computed(
     () =>
@@ -423,6 +430,11 @@ watch(vaccineRecordState, () => {
         stopAuthenticatedVaccineRecordDownload(user.value.hdid);
     }
 });
+
+if (preferenceShowSmsRemoved.value) {
+    showSmsRemoved.value = true;
+    setPreferenceValue(UserPreferenceType.ShowSmsRemoved, "false");
+}
 </script>
 
 <template>
@@ -431,7 +443,7 @@ watch(vaccineRecordState, () => {
         :text="vaccineRecordStatusMessage"
     />
     <HgAlertComponent
-        v-if="unverifiedEmail || unverifiedSms"
+        v-if="unverifiedEmail || unverifiedSms || showSmsRemoved"
         data-testid="incomplete-profile-banner"
         closable
         type="info"
@@ -439,7 +451,36 @@ watch(vaccineRecordState, () => {
         variant="outlined"
     >
         <template #default>
-            <span class="text-body-1">
+            <p
+                v-if="showSmsRemoved"
+                class="text-body-1"
+                data-testid="sms-removed-message"
+            >
+                We see you haven't logged in for a while &mdash; please review
+                your
+                <router-link
+                    id="profilePageLink"
+                    data-testid="profile-page-link"
+                    class="text-link"
+                    to="/profile"
+                    @click="
+                        trackingService.trackEvent({
+                            action: Action.InternalLink,
+                            text: Text.VerifyContactInformation,
+                            origin: Origin.Home,
+                            destination: Destination.Profile,
+                            type: Type.InfoBanner,
+                            url: InternalUrl.Profile,
+                        })
+                    "
+                    >notification preferences</router-link
+                >.
+            </p>
+            <p
+                v-else
+                class="text-body-1"
+                data-testid="unverified-email-sms-message"
+            >
                 Your email or cell phone number has not been verified. You can
                 use the Health Gateway without verified contact information,
                 however, you will not receive notifications. Visit the
@@ -461,7 +502,7 @@ watch(vaccineRecordState, () => {
                     >Profile Page</router-link
                 >
                 to complete your verification.
-            </span>
+            </p>
         </template>
     </HgAlertComponent>
     <PageTitleComponent title="Home">

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
@@ -58,7 +58,9 @@ const errorMessages = computed(() =>
 );
 
 function showDialog(): void {
-    getTimeout();
+    if (smsResendDateTime.value === undefined) {
+        sendUserSmsUpdate();
+    }
     isVisible.value = true;
 }
 
@@ -130,15 +132,11 @@ function sendUserSmsUpdate(): void {
 }
 
 function getTimeout(): number {
-    let resendTime: IDateWrapper;
-    if (smsResendDateTime.value) {
-        resendTime = smsResendDateTime.value;
-    } else {
-        const now = DateWrapper.now();
-        userStore.updateSmsResendDateTime(now);
-        resendTime = now;
+    if (smsResendDateTime.value === undefined) {
+        return 0;
     }
-    resendTime = resendTime.add(
+
+    const resendTime = smsResendDateTime.value.add(
         configStore.webConfig.timeouts.resendSMS * 60 * 1000
     );
     return resendTime.diff(DateWrapper.now()).milliseconds;

--- a/Apps/WebClient/src/ClientApp/src/constants/userPreferenceType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/userPreferenceType.ts
@@ -11,4 +11,6 @@ export default abstract class UserPreferenceType {
 
     public static readonly HideRecommendationsQuickLink =
         "hideRecommendationsQuickLink";
+
+    public static readonly ShowSmsRemoved = "showSmsRemoved";
 }

--- a/Testing/functional/tests/cypress/db/seed.sql
+++ b/Testing/functional/tests/cypress/db/seed.sql
@@ -1398,6 +1398,41 @@ VALUES (
 	'fakeemail@healthgateway.gov.bc.ca'
 );
 
+/* Keycloak User (hthgtwy06) used for User Preferences: showSmsRemoved */
+INSERT INTO gateway."MessagingVerification"(
+	"MessagingVerificationId", 
+	"CreatedBy", 
+	"CreatedDateTime", 
+	"UpdatedBy", 
+	"UpdatedDateTime", 
+	"HdId", 
+	"Validated", 
+	"EmailId", 
+	"InviteKey", 
+	"ExpireDate", 
+	"SMSNumber", 
+	"SMSValidationCode", 
+	"VerificationType", 
+	"Deleted", 
+	"VerificationAttempts")
+VALUES (
+	uuid_generate_v4(),
+	'System',
+	TIMESTAMP WITH TIME ZONE '2022-12-31T00:05:00Z',
+	'System',
+	TIMESTAMP WITH TIME ZONE '2022-12-31T08:00:00Z',
+	'GO4DOSMRJ7MFKPPADDZ3FK2MOJ45SFKONJWR67XNLMZQFNEHDKDA',
+	true,
+	null,
+	'00000000-0000-0000-0000-000000000000',
+	TIMESTAMP WITH TIME ZONE '2023-01-01T00:05:00Z',
+	'2506715000',
+	'654321',
+	'SMS',
+	false,
+	0
+);
+
 /* Keycloak User (hthgtwy20) */
 INSERT INTO gateway."MessagingVerification"(
 	"MessagingVerificationId", 


### PR DESCRIPTION
# Implements [AB#17064](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17064)

## Description

- Updates seed script to add messaging verification for HTHGTWY06
- Displays one-time message to review notification preferences
- Fixes sending new verification after setting SMS in previous visit
  - This bug would have been rare previously, but it would have hit everyone affected by the SMS removal.
  - _If a user's SMS number was updated in a previous visit to the site, and is now unverified (because the verification was never completed or now, because the number was removed due to inactivity), opening the Verify dialog would not create a new verification even after stating it did. One could be created by waiting for the countdown to expire and clicking the Resend button._

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

<img width="1920" height="919" alt="image" src="https://github.com/user-attachments/assets/d033a6ae-a25b-4851-8dac-14470b68b6b7" />

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
