### PR TITLE
Refine cutoff validation in ClearSmsNumber and add to SMS backfill job AB#17058

### DIFF
--- a/Apps/JobScheduler/src/Jobs/ClearSmsNumberJob.cs
+++ b/Apps/JobScheduler/src/Jobs/ClearSmsNumberJob.cs
@@ -47,8 +47,7 @@ namespace HealthGateway.JobScheduler.Jobs
         private const string ClearSmsNumberOptionsName = "ClearSmsNumber";
         private const string NotificationSmsBackfillOptionsName = "NotificationSmsBackfill";
 
-        private ClearSmsNumberOptions clearSmsNumberOptions = null!;
-        private NotificationBackfillOptions notificationBackfillOptions = null!;
+        private ClearSmsNumberOptions options = null!;
 
         /// <summary>
         /// Executes the SMS cleanup workflow by clearing SmsNumber for eligible user profiles.
@@ -58,7 +57,15 @@ namespace HealthGateway.JobScheduler.Jobs
         [DisableConcurrentExecution(ConcurrencyTimeout)]
         public async Task ProcessAsync(CancellationToken ct = default)
         {
-            this.clearSmsNumberOptions = clearSmsNumberOptionsMonitor.Get(ClearSmsNumberOptionsName);
+            this.options = clearSmsNumberOptionsMonitor.Get(ClearSmsNumberOptionsName);
+
+            // Skip execution if the job is disabled via configuration
+            if (!this.options.Enabled)
+            {
+                logger.LogInformation("Job {JobName} is disabled", this.options.JobName);
+                return;
+            }
+
             this.ValidateCutoffMatchesNotificationBackfill();
             await this.ClearSmsNumbersAsync(ct);
         }
@@ -123,39 +130,45 @@ namespace HealthGateway.JobScheduler.Jobs
         /// </exception>
         private void ValidateCutoffMatchesNotificationBackfill()
         {
-            this.notificationBackfillOptions = notificationBackfillOptionsMonitor.Get(NotificationSmsBackfillOptionsName);
-            DateTime? clearSmsNumberCutoff = this.clearSmsNumberOptions.LastLoginAfterDate?.ToUniversalTime();
-            DateTime? notificationBackfillCutoff = this.notificationBackfillOptions.LastLoginAfterDate?.ToUniversalTime();
+            NotificationBackfillOptions notificationBackfillOptions = notificationBackfillOptionsMonitor.Get(NotificationSmsBackfillOptionsName);
+
+            if (!this.options.LastLoginAfterDate.HasValue)
+            {
+                throw new InvalidOperationException(
+                    $"{this.options.JobName}: LastLoginAfterDate must be configured.");
+            }
+
+            if (!notificationBackfillOptions.LastLoginAfterDate.HasValue)
+            {
+                throw new InvalidOperationException(
+                    $"{notificationBackfillOptions.JobName}: LastLoginAfterDate must be configured.");
+            }
+
+            DateTime clearSmsNumberCutoff = this.options.LastLoginAfterDate.Value.ToUniversalTime();
+            DateTime notificationBackfillCutoff = notificationBackfillOptions.LastLoginAfterDate.Value.ToUniversalTime();
 
             if (clearSmsNumberCutoff != notificationBackfillCutoff)
             {
                 throw new InvalidOperationException(
-                    $"Cutoff mismatch: {ClearSmsNumberOptionsName} ({clearSmsNumberCutoff:o}) " +
-                    $"!= {NotificationSmsBackfillOptionsName} ({notificationBackfillCutoff:o}).");
+                    $"Cutoff mismatch: {this.options.JobName} ({clearSmsNumberCutoff:o}) " +
+                    $"!= {notificationBackfillOptions.JobName} ({notificationBackfillCutoff:o}).");
             }
         }
 
         private async Task ClearSmsNumbersAsync(CancellationToken ct)
         {
-            // Skip execution if the job is disabled via configuration
-            if (!this.clearSmsNumberOptions.Enabled)
-            {
-                logger.LogInformation("Job {JobName} is disabled", this.clearSmsNumberOptions.JobName);
-                return;
-            }
-
-            DateTime cutoffDate = this.clearSmsNumberOptions.LastLoginAfterDate?.ToUniversalTime()
-                                  ?? throw new InvalidOperationException("LastLoginAfterDate must be configured for ClearSmsNumberJob");
-
-            logger.LogInformation("Job {JobName} started", this.clearSmsNumberOptions.JobName);
+            logger.LogInformation("Job {JobName} started", this.options.JobName);
             Stopwatch stopwatch = Stopwatch.StartNew();
 
             try
             {
+                // LastLoginAfterDate is validated by ValidateCutoffMatchesNotificationBackfill().
+                DateTime cutoffDate = this.options.LastLoginAfterDate!.Value.ToUniversalTime();
+
                 List<UserProfile> userProfiles = await this.GetNextUserProfilesBeforeCutoffAsync(
                     cutoffDate,
-                    this.clearSmsNumberOptions.JobName,
-                    this.clearSmsNumberOptions.BatchSize,
+                    this.options.JobName,
+                    this.options.BatchSize,
                     ct);
 
                 if (userProfiles.Count > 0)
@@ -171,7 +184,7 @@ namespace HealthGateway.JobScheduler.Jobs
                     foreach (UserProfile userProfile in userProfiles)
                     {
                         userProfile.SmsNumber = null;
-                        jobStatesToInsert.Add(CreateUserJobState(userProfile.HdId, this.clearSmsNumberOptions.JobName, processedDateTime));
+                        jobStatesToInsert.Add(CreateUserJobState(userProfile.HdId, this.options.JobName, processedDateTime));
                         preferencesToInsert.Add(CreateUserPreference(userProfile.HdId, "showSmsRemoved", "true"));
                     }
 
@@ -186,7 +199,7 @@ namespace HealthGateway.JobScheduler.Jobs
 
                 logger.LogInformation(
                     "Job {JobName} cleared SMS numbers for {Count} profiles in {ElapsedMs} ms",
-                    this.clearSmsNumberOptions.JobName,
+                    this.options.JobName,
                     userProfiles.Count,
                     stopwatch.ElapsedMilliseconds);
             }
@@ -194,7 +207,7 @@ namespace HealthGateway.JobScheduler.Jobs
             {
                 stopwatch.Stop();
                 throw new InvalidOperationException(
-                    $"Job {this.clearSmsNumberOptions.JobName} run failed after {stopwatch.ElapsedMilliseconds} ms.",
+                    $"Job {this.options.JobName} run failed after {stopwatch.ElapsedMilliseconds} ms.",
                     ex);
             }
         }

--- a/Apps/JobScheduler/src/Jobs/NotificationBackfillJob.cs
+++ b/Apps/JobScheduler/src/Jobs/NotificationBackfillJob.cs
@@ -40,15 +40,18 @@ namespace HealthGateway.JobScheduler.Jobs
     /// <param name="outboxStore">The outbox store to use.</param>
     /// <param name="backgroundJobClient">Hangfire background job client.</param>
     /// <param name="logger">The logger to use.</param>
-    /// <param name="optionsMonitor">The monitor used to access the current notification backfill options.</param>
+    /// <param name="clearSmsNumberOptionsMonitor">Provides access to the configured clear SMS number job options.</param>
+    /// <param name="notificationBackfillOptionsMonitor">The monitor used to access the current notification backfill options.</param>
     public class NotificationBackfillJob(
         GatewayDbContext dbContext,
         IOutboxStore outboxStore,
         IBackgroundJobClient backgroundJobClient,
         ILogger<NotificationBackfillJob> logger,
-        IOptionsMonitor<NotificationBackfillOptions> optionsMonitor)
+        IOptionsMonitor<ClearSmsNumberOptions> clearSmsNumberOptionsMonitor,
+        IOptionsMonitor<NotificationBackfillOptions> notificationBackfillOptionsMonitor)
     {
         private const int ConcurrencyTimeout = 5 * 60; // 5 Minutes
+        private const string ClearSmsNumberOptionsName = "ClearSmsNumber";
         private const string NotificationEmailBackfillOptionsName = "NotificationEmailBackfill";
         private const string NotificationSmsBackfillOptionsName = "NotificationSmsBackfill";
         private NotificationBackfillOptions options = null!;
@@ -126,7 +129,7 @@ namespace HealthGateway.JobScheduler.Jobs
         /// </returns>
         private async Task<int> ProcessChannelAsync(string optionsName, CancellationToken ct = default)
         {
-            this.options = optionsMonitor.Get(optionsName);
+            this.options = notificationBackfillOptionsMonitor.Get(optionsName);
 
             // Skip execution if the job is disabled via configuration
             if (!this.options.Enabled)
@@ -134,6 +137,8 @@ namespace HealthGateway.JobScheduler.Jobs
                 logger.LogInformation("Job {JobName} is disabled", this.options.JobName);
                 return 0;
             }
+
+            this.ValidateCutoffMatchesNotificationBackfill();
 
             logger.LogInformation("Job {JobName} started", this.options.JobName);
             Stopwatch stopwatch = Stopwatch.StartNew();
@@ -257,6 +262,56 @@ namespace HealthGateway.JobScheduler.Jobs
         }
 
         /// <summary>
+        /// Validates that the cutoff date configured for the ClearSmsNumber job
+        /// matches the cutoff date configured for the NotificationSmsBackfill job.
+        /// </summary>
+        /// <remarks>
+        /// These two jobs are designed to operate on mutually exclusive sets of users
+        /// based on LastLoginDateTime:
+        /// - ClearSmsNumber processes users with LastLoginDateTime less than the cutoff
+        /// - NotificationSmsBackfill processes users with LastLoginDateTime on or after the cutoff
+        /// If the cutoff dates differ, the partitioning becomes invalid and can result in:
+        /// - Overlap: the same user being processed by both jobs
+        /// - Gaps: some users not being processed by either job
+        /// This validation ensures configuration consistency and fails fast if the cutoff
+        /// dates are misaligned.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when the cutoff dates for the two jobs do not match.
+        /// </exception>
+        private void ValidateCutoffMatchesNotificationBackfill()
+        {
+            if (!this.options.UseSmsChannel)
+            {
+                return;
+            }
+
+            ClearSmsNumberOptions clearSmsNumberOptions = clearSmsNumberOptionsMonitor.Get(ClearSmsNumberOptionsName);
+
+            if (!this.options.LastLoginAfterDate.HasValue)
+            {
+                throw new InvalidOperationException(
+                    $"{this.options.JobName}: LastLoginAfterDate must be configured.");
+            }
+
+            if (!clearSmsNumberOptions.LastLoginAfterDate.HasValue)
+            {
+                throw new InvalidOperationException(
+                    $"{clearSmsNumberOptions.JobName}: LastLoginAfterDate must be configured.");
+            }
+
+            DateTime notificationBackfillCutoff = this.options.LastLoginAfterDate.Value.ToUniversalTime();
+            DateTime clearSmsNumberCutoff = clearSmsNumberOptions.LastLoginAfterDate.Value.ToUniversalTime();
+
+            if (notificationBackfillCutoff != clearSmsNumberCutoff)
+            {
+                throw new InvalidOperationException(
+                    $"Cutoff mismatch: {this.options.JobName} ({notificationBackfillCutoff:o}) " +
+                    $"!= {clearSmsNumberOptions.JobName} ({clearSmsNumberCutoff:o}).");
+            }
+        }
+
+        /// <summary>
         /// Retrieves existing notification settings for the specified HDIDs and notification type,
         /// and returns them as a dictionary keyed by HDID for efficient lookup.
         /// </summary>
@@ -322,9 +377,8 @@ namespace HealthGateway.JobScheduler.Jobs
 
             if (this.options.UseSmsChannel)
             {
-                DateTime cutoffDate = this.options.LastLoginAfterDate?.ToUniversalTime()
-                                      ?? throw new InvalidOperationException(
-                                          $"LastLoginAfterDate must be configured for job {this.options.JobName}.");
+                // LastLoginAfterDate is validated by ValidateCutoffMatchesNotificationBackfill().
+                DateTime cutoffDate = this.options.LastLoginAfterDate!.Value.ToUniversalTime();
                 query = query
                     .Where(x => x.LastLoginDateTime >= cutoffDate);
             }


### PR DESCRIPTION
# Fixes or Implements [AB#17058](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17058)

## Description

Refined and enforced cutoff date validation between ClearSmsNumber and SMS Notification Backfill jobs to ensure correct data partitioning.

**Details**

* Added cutoff validation to NotificationBackfillJob (SMS path only)
* Refactored and cleaned up cutoff validation logic in ClearSmsNumberJob
* Ensured both jobs require LastLoginAfterDate to be configured
* Enforced strict equality of cutoff dates (UTC) between:
    * ClearSmsNumber
    * NotificationSmsBackfill
* Validation runs only when SMS channel is enabled (email path unaffected)
* Simplified downstream logic by safely using non-null cutoff values after validation

**Reason**

Prevents:

* Overlap (same users processed by both jobs)
* Gaps (users missed by both jobs)

Ensures both jobs operate on mutually exclusive user sets based on a consistent cutoff boundary.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
