### PR TITLE
Fix EF tracking for detached entities in UpdateAsync AB#17068

### DIFF
--- a/Apps/Database/src/Delegates/DbUserProfileNotificationSettingDelegate.cs
+++ b/Apps/Database/src/Delegates/DbUserProfileNotificationSettingDelegate.cs
@@ -22,6 +22,7 @@ namespace HealthGateway.Database.Delegates
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.ChangeTracking;
 
     /// <inheritdoc/>
     /// <param name="dbContext">he context to be used when accessing the database.</param>
@@ -37,15 +38,23 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task UpdateAsync(UserProfileNotificationSetting notificationSetting, bool commit = true, CancellationToken ct = default)
+        public async Task UpdateAsync(
+            UserProfileNotificationSetting notificationSetting,
+            bool commit = true,
+            CancellationToken ct = default)
         {
-            if (notificationSetting.Version == 0)
+            EntityEntry<UserProfileNotificationSetting> entry = dbContext.Entry(notificationSetting);
+
+            if (entry.State == EntityState.Detached)
             {
-                dbContext.UserProfileNotificationSetting.Add(notificationSetting);
-            }
-            else
-            {
-                dbContext.UserProfileNotificationSetting.Update(notificationSetting);
+                if (notificationSetting.Version == 0)
+                {
+                    dbContext.UserProfileNotificationSetting.Add(notificationSetting);
+                }
+                else
+                {
+                    dbContext.UserProfileNotificationSetting.Update(notificationSetting);
+                }
             }
 
             if (commit)


### PR DESCRIPTION
# Fixes or Implements [AB#17068](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17068)

## Description

**Summary**

Fix EF Core tracking issue in UserProfileNotificationSettingDelegate.UpdateAsync.

**Details**

* Handle detached entities by checking Entry.State
* Apply Add or Update only when entity is not tracked
* Prevent incorrect updates/inserts when using detached entities

**Impact**

* Ensures consistent persistence behavior
* No change to existing logic for tracked entities

See [Microsoft Documentation](https://learn.microsoft.com/en-us/ef/core/querying/tracking?utm_source=chatgpt.com) and [Entity Tracking](https://learn.microsoft.com/en-us/ef/core/change-tracking/?utm_source=chatgpt.com)

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
