### PR TITLE
Remove redundant UserProfile UpdateAsync call when commit=false AB#17073

### DIFF
--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -29,15 +29,12 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.Common.Data.Models;
     using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.ErrorHandling.Exceptions;
-    using HealthGateway.Common.Factories;
     using HealthGateway.Common.Messaging;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Providers;
-    using HealthGateway.Database.Wrapper;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Validations;
     using Microsoft.EntityFrameworkCore.Storage;
@@ -179,11 +176,6 @@ namespace HealthGateway.GatewayApi.Services
             await this.messageVerificationDelegate.UpdateAsync(matchingVerification, false, ct);
 
             userProfile.Email = matchingVerification.Email!.To; // Gets the user email from the email sent.
-            DbResult<UserProfile> dbResult = await this.profileDelegate.UpdateAsync(userProfile, false, ct);
-            if (dbResult.Status == DbStatusCode.NotFound)
-            {
-                return RequestResultFactory.ServiceError<bool>(ErrorType.CommunicationInternal, ServiceType.Database, ErrorMessages.UserProfileNotFound);
-            }
 
             if (this.changeFeedConfiguration.Notifications.Enabled)
             {

--- a/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
@@ -143,7 +143,7 @@ namespace HealthGateway.GatewayApi.Services
                 store.DispatchOutboxItemsAsync(ct));
 
             // Update notification settings after commit
-            await this.QueueNotificationSettingsRequest(userProfile, ct);
+            await this.jobService.QueueNotificationSettingsRequestAsync(userProfile, userProfile.Email, userProfile.SmsNumber, ct: ct);
 
             return true;
         }
@@ -195,7 +195,7 @@ namespace HealthGateway.GatewayApi.Services
                 await this.jobService.SendEmailAsync(messagingVerification.Email, true, ct);
             }
 
-            await this.QueueNotificationSettingsRequest(userProfile, ct);
+            await this.jobService.QueueNotificationSettingsRequestAsync(userProfile, userProfile.Email, userProfile.SmsNumber, ct: ct);
         }
 
         private async Task IncrementEmailVerificationAttempts(string hdid, CancellationToken ct)
@@ -214,7 +214,6 @@ namespace HealthGateway.GatewayApi.Services
             await this.messageVerificationDelegate.UpdateAsync(matchingVerification, false, ct);
 
             userProfile.Email = matchingVerification.Email!.To;
-            await this.profileDelegate.UpdateAsync(userProfile, false, ct);
         }
 
         private async Task NotifyVerificationSuccessful(string hdid, string emailAddress, bool shouldCommit, CancellationToken ct)
@@ -223,11 +222,6 @@ namespace HealthGateway.GatewayApi.Services
             {
                 await this.jobService.NotifyEmailVerificationAsync(hdid, emailAddress, shouldCommit, ct);
             }
-        }
-
-        private async Task QueueNotificationSettingsRequest(UserProfile userProfile, CancellationToken ct)
-        {
-            await this.jobService.QueueNotificationSettingsRequestAsync(userProfile, userProfile.Email, userProfile.SmsNumber, ct: ct);
         }
     }
 }

--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -25,17 +25,13 @@ namespace HealthGateway.GatewayApi.Services
     using HealthGateway.Common.Constants;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.Data.Models;
-    using HealthGateway.Common.ErrorHandling;
     using HealthGateway.Common.ErrorHandling.Exceptions;
-    using HealthGateway.Common.Factories;
     using HealthGateway.Common.Messaging;
     using HealthGateway.Common.Models;
     using HealthGateway.Common.Services;
-    using HealthGateway.Database.Constants;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
     using HealthGateway.Database.Providers;
-    using HealthGateway.Database.Wrapper;
     using HealthGateway.GatewayApi.Models;
     using HealthGateway.GatewayApi.Validations;
     using Microsoft.EntityFrameworkCore.Storage;
@@ -119,11 +115,6 @@ namespace HealthGateway.GatewayApi.Services
                 await this.messageVerificationDelegate.UpdateAsync(smsVerification, false, ct);
 
                 userProfile.SmsNumber = smsVerification.SmsNumber; // Gets the user sms number from the message sent.
-                DbResult<UserProfile> dbResult = await this.profileDelegate.UpdateAsync(userProfile, false, ct);
-                if (dbResult.Status == DbStatusCode.NotFound)
-                {
-                    return RequestResultFactory.ServiceError<bool>(ErrorType.CommunicationInternal, ServiceType.Database, ErrorMessages.UserProfileNotFound);
-                }
 
                 if (this.changeFeedConfiguration.Notifications.Enabled)
                 {

--- a/Apps/GatewayApi/src/Services/UserSmsServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsServiceV2.cs
@@ -120,11 +120,6 @@ namespace HealthGateway.GatewayApi.Services
             await this.messageVerificationDelegate.UpdateAsync(smsVerification, false, ct);
 
             userProfile.SmsNumber = smsVerification.SmsNumber; // Gets the user sms number from the message sent.
-            DbResult<UserProfile> dbResult = await this.profileDelegate.UpdateAsync(userProfile, false, ct);
-            if (dbResult.Status == DbStatusCode.NotFound)
-            {
-                throw new NotFoundException(ErrorMessages.UserProfileNotFound);
-            }
 
             if (this.notificationsChangeFeedEnabled)
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -82,7 +82,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = email,
             };
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock = new();
-            Mock<IUserProfileDelegate> userProfileDelegateMock = new();
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
             Mock<IJobService> jobServiceMock = new();
             Mock<IUserProfileNotificationSettingService> userProfileNotificationSettingServiceMock = new();
@@ -92,7 +91,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 userProfileMock,
                 verificationByInviteKey,
                 messagingVerificationDelegateMock,
-                userProfileDelegateMock: userProfileDelegateMock,
                 notificationSettingsServiceMock: notificationSettingsServiceMock,
                 jobServiceMock: jobServiceMock,
                 userProfileNotificationSettingServiceMock: userProfileNotificationSettingServiceMock,
@@ -109,11 +107,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             messagingVerificationDelegateMock
                 .Verify(
                     s => s.UpdateAsync(It.IsAny<MessagingVerification>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
-                    Times.Once);
-
-            userProfileDelegateMock
-                .Verify(
-                    s => s.UpdateAsync(It.IsAny<UserProfile>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
                     Times.Once);
 
             jobServiceMock.Verify(
@@ -205,41 +198,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             // Assert
             Assert.Equal(ResultType.Error, actual.ResultStatus);
-        }
-
-        /// <summary>
-        /// ValidateEmailAsync returns not found error when updating user profile to the database.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ValidateEmailReturnsErrorWhenUserProfileUpdateNotFound()
-        {
-            // Arrange
-            DbResult<UserProfile> dbResult = new() { Status = DbStatusCode.NotFound }; // Should cause error to be returned.
-
-            Guid inviteKey = Guid.NewGuid();
-            MessagingVerification verificationByInviteKey = new()
-            {
-                UserProfileId = HdIdMock,
-                VerificationAttempts = 0,
-                InviteKey = inviteKey,
-                ExpireDate = DateTime.Now.AddDays(1),
-                Validated = false,
-                Email = new Email
-                {
-                    To = "fakeemail@healthgateway.gov.bc.ca",
-                },
-            };
-
-            UserProfile userProfile = new();
-            IUserEmailService service = GetUserEmailService(userProfile, verificationByInviteKey, updateUserProfileResult: dbResult);
-
-            // Act
-            RequestResult<bool> actual = await service.ValidateEmailAsync(HdIdMock, inviteKey);
-
-            // Assert
-            Assert.Equal(ResultType.Error, actual.ResultStatus);
-            Assert.Equal(ErrorMessages.UserProfileNotFound, actual.ResultError?.ResultMessage);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
@@ -77,8 +77,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Assert and Verify
             Assert.True(actual);
 
+            Assert.Equal(MainEmailAddress, mock.UserProfile.Email);
             VerifyVerificationUpdateValidatedTrue(mock.MessagingVerificationDelegateMock);
-            VerifyUserProfileUpdate(mock.UserProfileDelegateMock);
             VerifyNotifyEmailVerification(mock.JobServiceMock, expectedNotificationChannelVerifiedEventTimes);
             VerifyUserProfileNotificationSettingsUpdate(mock.NotificationSettingServiceMock, mock.BackgroundJobClientMock);
             VerifyQueueNotificationSettingsRequest(mock.JobServiceMock);
@@ -530,10 +530,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         }
 
         private static Mock<IUserProfileDelegate> SetupUserProfileDelegateMock(
+            UserProfile? userProfile = null,
             bool userProfileExists = true,
             DbStatusCode? dbUpdateStatus = null)
         {
-            UserProfile? userProfile = userProfileExists ? new() : null;
+            userProfile ??= userProfileExists ? new() : null;
             Mock<IUserProfileDelegate> userProfileDelegateMock = new();
 
             userProfileDelegateMock.Setup(u => u.GetUserProfileAsync(
@@ -557,10 +558,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
         private static VerifyEmailAddressMock SetupVerifyEmailAddressMock(Guid inviteKey, bool changeFeedEnabled)
         {
+            UserProfile userProfile = new();
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock =
                 SetupMessagingVerificationDelegateMock(matchingVerificationInviteKey: inviteKey);
             Mock<IUserProfileDelegate> userProfileDelegateMock =
-                SetupUserProfileDelegateMock(dbUpdateStatus: DbStatusCode.Updated);
+                SetupUserProfileDelegateMock(userProfile, dbUpdateStatus: DbStatusCode.Updated);
             Mock<IJobService> jobServiceMock = new();
             Mock<IUserProfileNotificationSettingService> notificationSettingServiceMock = new();
             Mock<IBackgroundJobClient> backgroundJobClientMock = new();
@@ -579,7 +581,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 messagingVerificationDelegateMock,
                 userProfileDelegateMock,
                 notificationSettingServiceMock,
-                backgroundJobClientMock);
+                backgroundJobClientMock,
+                userProfile);
         }
 
         private static IUserEmailServiceV2 SetupVerifyEmailAddressTooManyAttemptsMock(Guid inviteKey)
@@ -703,7 +706,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     setupMatchingVerification: false,
                     setupLatestVerification: true);
 
-            Mock<IUserProfileDelegate> userProfileDelegateMock = SetupUserProfileDelegateMock(userProfileExists, updateProfileStatus);
+            Mock<IUserProfileDelegate> userProfileDelegateMock = SetupUserProfileDelegateMock(userProfileExists: userProfileExists, dbUpdateStatus: updateProfileStatus);
             Mock<IJobService> jobServiceMock = new();
             Mock<IMessagingVerificationService> messagingVerificationServiceMock = new();
 
@@ -726,7 +729,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IMessagingVerificationDelegate> MessagingVerificationDelegateMock,
             Mock<IUserProfileDelegate> UserProfileDelegateMock,
             Mock<IUserProfileNotificationSettingService> NotificationSettingServiceMock,
-            Mock<IBackgroundJobClient> BackgroundJobClientMock);
+            Mock<IBackgroundJobClient> BackgroundJobClientMock,
+            UserProfile UserProfile);
 
         private sealed record VerifyEmailAddressInvalidInviteMock(
             IUserEmailServiceV2 Service,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -149,48 +149,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         }
 
         /// <summary>
-        /// ValidateSmsAsync returns not found error when updating user profile to the database.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ValidateSmsReturnsErrorWhenUserProfileUpdateNotFound()
-        {
-            // Arrange
-            DbResult<UserProfile> dbResult = new() { Status = DbStatusCode.NotFound }; // Should cause error to be returned.
-            UserProfile userProfile = new();
-            MessagingVerification messagingVerification = new()
-            {
-                UserProfileId = HdIdMock,
-                VerificationAttempts = 0,
-                SmsValidationCode = SmsValidationCode,
-                ExpireDate = DateTime.Now.AddDays(1),
-            };
-
-            Mock<IJobService> jobServiceMock = new();
-            IUserSmsService service = GetUserSmsService(
-                messagingVerification: messagingVerification,
-                userProfile: userProfile,
-                jobServiceMock: jobServiceMock,
-                updateUserProfileResult: dbResult);
-
-            // Act
-            RequestResult<bool> actual = await service.ValidateSmsAsync(HdIdMock, SmsValidationCode, CancellationToken.None);
-
-            // Assert
-            Assert.False(actual.ResourcePayload);
-            Assert.Equal(ErrorMessages.UserProfileNotFound, actual.ResultError?.ResultMessage);
-
-            // Verify
-            jobServiceMock.Verify(
-                v => v.NotifySmsVerificationAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.Is<bool>(b => b == false),
-                    It.IsAny<CancellationToken>()),
-                Times.Never);
-        }
-
-        /// <summary>
         /// UpdateUserSmsAsync.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -366,10 +324,10 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IUserProfileNotificationSettingService>? profileNotificationSettingServiceMock = null,
             Mock<IBackgroundJobClient>? backgroundJobClientMock = null,
             Mock<IGatewayDbContextTransactionProvider>? transactionProviderMock = null,
-            bool changeFeedEnabled = false,
-            DbResult<UserProfile>? updateUserProfileResult = null)
+            bool changeFeedEnabled = false)
         {
-            updateUserProfileResult ??= new DbResult<UserProfile> { Status = DbStatusCode.Updated };
+            DbResult<UserProfile>? updateUserProfileResult = new()
+                { Status = DbStatusCode.Updated };
             messagingVerificationDelegateMock ??= new();
             messagingVerificationDelegateMock
                 .Setup(s => s.GetLastForUserAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceV2Tests.cs
@@ -180,20 +180,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             VerifyQueueNotificationSettingsRequest(mock.JobServiceMock, Times.Never());
         }
 
-        /// <summary>
-        /// VerifySmsNumberAsync throws database exception.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task VerifySmsNumberShouldThrowDatabaseException()
-        {
-            // Arrange
-            VerifySmsNumberMock mock = SetupVerifySmsNumberMock(Hdid, SmsValidationCode, updateProfileStatus: DbStatusCode.NotFound);
-
-            // Act and Assert
-            await Assert.ThrowsAsync<NotFoundException>(async () => { await mock.Service.VerifySmsNumberAsync(Hdid, SmsValidationCode, CancellationToken.None); });
-        }
-
         private static void VerifyNotifySmsVerification(Mock<IJobService> jobServiceMock, Times? times = null)
         {
             jobServiceMock.Verify(
@@ -218,11 +204,11 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         }
 
         private static void VerifyUserProfileNotificationSettingsUpdate(
-            Mock<IUserProfileNotificationSettingService> notificationSettngServiceMock,
+            Mock<IUserProfileNotificationSettingService> notificationSettingServiceMock,
             Mock<IBackgroundJobClient> backgroundJobClient,
             Times? times = null)
         {
-            notificationSettngServiceMock.Verify(
+            notificationSettingServiceMock.Verify(
                 v => v.UpdateAsync(
                     Hdid,
                     It.Is<IReadOnlyCollection<UserProfileNotificationSettingModel>>(models =>
@@ -517,8 +503,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             bool changeFeedEnabled = false,
             bool verificationValidated = false,
             bool verificationDeleted = false,
-            int verificationAttempts = 0,
-            DbStatusCode updateProfileStatus = DbStatusCode.Updated)
+            int verificationAttempts = 0)
         {
             UserProfile? userProfile = userProfileExists ? GenerateUserProfile() : null;
             MessagingVerification messagingVerification = GenerateMessagingVerification(
@@ -530,7 +515,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 deleted: verificationDeleted,
                 verificationAttempts: verificationAttempts);
             DbResult<UserProfile> updateProfileResult = GenerateUserProfileDbResult(
-                updateProfileStatus,
+                DbStatusCode.Updated,
                 userProfile);
 
             Mock<IJobService> jobServiceMock = new();


### PR DESCRIPTION
# Fixes or Implements [AB#17073](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17073)

## Description

Removed unnecessary UserProfileDelegate.UpdateAsync calls where commit=false.

UserProfile is already tracked by EF Core, and persistence is handled later via SaveChangesAsync within the transaction. The delegate call was a no-op and added misleading behavior.

Updated unit tests to reflect actual behavior (no longer expecting delegate update call).

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
