### PR TITLE
Add verified email & SMS success alert checks (DHSOHG-3438) AB#17070

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/user/emailValidation.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/emailValidation.js
@@ -27,15 +27,26 @@ describe("User Email Verification", () => {
 
     it("Check verified email invite", () => {
         setupStandardFixtures();
-
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
             "/validateEmail/valid"
         );
+
         cy.get("[data-testid=verifyingInvite]").should("not.exist");
-        cy.get("[data-testid=verifiedInvite]").should("be.visible");
+        cy.get("[data-testid=verifiedInvite]")
+            .should("be.visible")
+            .within(() => {
+                cy.contains("Your email address has been verified.");
+                cy.contains("Health Gateway may now send you notifications.");
+                cy.contains("You can change your preferences");
+
+                cy.get("[data-testid=verified-profile-page-link]")
+                    .should("exist")
+                    .and("have.attr", "href")
+                    .and("include", "/profile");
+            });
         cy.get("[data-testid=continueButton]").click();
         cy.url().should("include", "/home");
     });

--- a/Testing/functional/tests/cypress/integration/ui/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/profile.js
@@ -136,6 +136,12 @@ describe("User Profile", () => {
         cy.get("[data-testid=smsStatusNotVerified]").should("not.exist");
         cy.get("[data-testid=verifySMSBtn]").should("not.exist");
         cy.get("[data-testid=smsStatusVerified]").should("be.visible");
+        cy.get("[data-testid=verified-sms-message]")
+            .should("be.visible")
+            .and(
+                "contain",
+                "Health Gateway may now send you notifications. You can change your preferences at any time."
+            );
 
         cy.log("Edit SMS number");
         cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0`, {
@@ -155,6 +161,7 @@ describe("User Profile", () => {
         cy.get("[data-testid=verifySMSBtn]")
             .should("be.visible")
             .should("be.enabled");
+        cy.get("[data-testid=verified-sms-message]").should("not.exist");
 
         cy.log("Clear/OptOut SMS number");
         cy.get("[data-testid=editSMSBtn]").click();
@@ -175,6 +182,7 @@ describe("User Profile", () => {
         });
         cy.get("[data-testid=saveSMSEditBtn]").click();
         cy.get("[data-testid=smsStatusOptedOut]").should("be.visible");
+        cy.get("[data-testid=verified-sms-message]").should("not.exist");
     });
 });
 


### PR DESCRIPTION
# Fixes or Implements [AB#17070](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17070)

## Description

**Summary**

Enhance Cypress tests to validate success messaging and behavior for email and SMS verification.

**Changes**

* emailValidation.js
    * Added assertions to verify success text content
    * Added validation for Profile link presence and correct destination
* profile.js
    * Added assertions for verified-sms-message
    * Validate alert only displays when SMS is verified
    * Ensure alert does not display when:
        * SMS is not verified
        * SMS is cleared (opt-out)

**Impact**

* Improves test coverage for user-facing verification flows
* Ensures correct conditional display of success messaging
* Prevents regressions in messaging and navigation behavior

<img width="1213" height="712" alt="Screenshot 2026-05-05 at 10 48 03 AM" src="https://github.com/user-attachments/assets/c781726c-e9af-4fca-9918-78ebf4f62457" />

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes



## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
