### PR TITLE
Fix profile email input reverting to stale value after update AB#17076

### DIFF
--- a/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
+++ b/Apps/Database/src/Delegates/DbMessagingVerificationDelegate.cs
@@ -92,7 +92,7 @@ namespace HealthGateway.Database.Delegates
                 .MessagingVerification
                 .Include(email => email.Email)
                 .Where(p => p.UserProfileId == hdid && p.VerificationType == messagingVerificationType)
-                .OrderByDescending(p => p.UpdatedDateTime)
+                .OrderByDescending(p => p.CreatedDateTime)
                 .FirstOrDefaultAsync(ct);
 
             return verification?.Deleted == true ? null : verification;

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -82,8 +82,6 @@ function saveEmailEdit(): void {
 }
 
 function sendUserEmailUpdate(): void {
-    const updatedEmail = inputValue.value;
-
     trackingService.trackEvent({
         action: Action.ButtonClick,
         text: Text.VerifyEmailAddress,
@@ -96,9 +94,6 @@ function sendUserEmailUpdate(): void {
         userStore
             .updateUserEmail(inputValue.value)
             .then(() => {
-                userStore.user.email = updatedEmail;
-                userStore.user.verifiedEmail = false;
-
                 isEmailEditable.value = false;
                 v$.value.$reset();
                 emit("email-updated", email.value);


### PR DESCRIPTION
# Fixes or Implements [AB#17076](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17076)

## Description

Fixed email update issue where input value was reverting after save, and removed unused updateUserEmail method from user store.

This problem was encountered in dev and local environments.

See [AB#17076 ](https://dev.azure.com/qslvic/Health%20Gateway/_workitems/edit/17076)for bug details.

**Details**

* Reverted [previous failed fix](https://github.com/bcgov/healthgateway/pull/6694/changes/e882a70c8c37f33e77c44bfb228dfb915a8a3d83)
* Query to bring back email was wrong

**Result**

* Email input now displays correct updated value

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

**Step 1 - email address before change:**

<img width="2545" height="971" alt="Screenshot 2026-05-05 at 2 02 44 PM" src="https://github.com/user-attachments/assets/db6b375e-c993-4ba0-b435-402dcd4eccda" />


**Step 2 - Edit email address:**

<img width="2551" height="912" alt="Screenshot 2026-05-05 at 2 02 57 PM" src="https://github.com/user-attachments/assets/5ef1581a-2931-4fb1-a9fc-034f35cb4b33" />


**Step 3 - email address after save:**

<img width="2551" height="872" alt="Screenshot 2026-05-05 at 2 03 06 PM" src="https://github.com/user-attachments/assets/a415c1a3-120b-4df7-a903-314b906e42b6" />


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
