### PR TITLE
Add functional tests for the removed SMS alert AB#17075

### DIFF
--- a/Testing/functional/tests/cypress.config.js
+++ b/Testing/functional/tests/cypress.config.js
@@ -26,6 +26,7 @@ module.exports = defineConfig({
         "keycloak.deceased.username": "hthgtwy19",
         "keycloak.healthgateway12.username": "healthgateway12",
         "keycloak.hlthgw401.username": "hlthgw401",
+        "keycloak.hthgtwy06.username": "hthgtwy06",
         "keycloak.hthgtwy20.username": "hthgtwy20",
         "keycloak.laboratory.queued.username": "hthgtwy09",
         "keycloak.notfound.username": "hthgtwy03",

--- a/Testing/functional/tests/cypress/db/seed-test.sql
+++ b/Testing/functional/tests/cypress/db/seed-test.sql
@@ -218,7 +218,7 @@ VALUES (
 	'Android'
 );
 
-/* PHN: 9735352535 used for admin covid assessment and blocked dataset tests */
+/* PHN: 9735352535 (hthgtwy06) used for admin covid assessment and blocked dataset tests */
 INSERT INTO gateway."UserProfile"(
 	"UserProfileId", 
 	"CreatedBy", 
@@ -1374,6 +1374,41 @@ VALUES (
 	false,
 	0,
 	'fakeemail@healthgateway.gov.bc.ca'
+);
+
+/* Keycloak User (hthgtwy06) used for User Preferences: showSmsRemoved */
+INSERT INTO gateway."MessagingVerification"(
+	"MessagingVerificationId", 
+	"CreatedBy", 
+	"CreatedDateTime", 
+	"UpdatedBy", 
+	"UpdatedDateTime", 
+	"HdId", 
+	"Validated", 
+	"EmailId", 
+	"InviteKey", 
+	"ExpireDate", 
+	"SMSNumber", 
+	"SMSValidationCode", 
+	"VerificationType", 
+	"Deleted", 
+	"VerificationAttempts")
+VALUES (
+	uuid_generate_v4(),
+	'System',
+	TIMESTAMP WITH TIME ZONE '2022-12-31T00:05:00Z',
+	'System',
+	TIMESTAMP WITH TIME ZONE '2022-12-31T08:00:00Z',
+	'GO4DOSMRJ7MFKPPADDZ3FK2MOJ45SFKONJWR67XNLMZQFNEHDKDA',
+	true,
+	null,
+	'00000000-0000-0000-0000-000000000000',
+	TIMESTAMP WITH TIME ZONE '2023-01-01T00:05:00Z',
+	'2506715000',
+	'654321',
+	'SMS',
+	false,
+	0
 );
 
 /* Keycloak User (hthgtwy20) */

--- a/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/Registration.js
@@ -106,7 +106,13 @@ describe("Registration Page", () => {
         // AB#16942 Disable full App Tour and display only one slide - change back to original once App Tour has been redesigned.
         // cy.get("[data-testid=app-tour-skip]").click();
         cy.get("[data-testid=app-tour-done]").click();
-        cy.get("[data-testid=incomplete-profile-banner]").should("be.visible");
+        cy.get("[data-testid=incomplete-profile-banner]")
+            .should("be.visible")
+            .within(() => {
+                cy.get("[data-testid=unverified-email-sms-message]").should(
+                    "be.visible"
+                );
+            });
     });
 
     it("Validate Closed Profile Registration", () => {

--- a/Testing/functional/tests/cypress/integration/e2e/pages/home.js
+++ b/Testing/functional/tests/cypress/integration/e2e/pages/home.js
@@ -2,6 +2,7 @@ const { AuthMethod } = require("../../../support/constants");
 const homeUrl = "/home";
 const timelineUrl = "/timeline";
 const downloadUrl = "/reports";
+const profileUrl = "/profile";
 const defaultTimeout = 60000;
 
 describe("Home Page", () => {
@@ -101,6 +102,58 @@ describe("Home Page", () => {
         cy.get("[data-testid=content-placeholders]").should("not.exist");
         cy.get("[data-testid=loading-toast]").should("exist");
         cy.get("[data-testid=timeline-record-count]").should("be.visible");
+    });
+});
+
+describe("Home page - notification settings alert", () => {
+    it("SMS removed alert should display if SMS is removed", () => {
+        cy.configureSettings({});
+
+        cy.login(
+            Cypress.env("keycloak.hthgtwy06.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homeUrl
+        );
+
+        cy.log("The alert should be visible when first logging in.");
+        cy.get("[data-testid=incomplete-profile-banner]")
+            .should("be.visible")
+            .within(() => {
+                cy.get("[data-testid=sms-removed-message]").should(
+                    "be.visible"
+                );
+
+                cy.get("[data-testid=unverified-email-sms-message]").should(
+                    "not.exist"
+                );
+            });
+
+        cy.log("The link in the alert should go to the profile page.");
+        cy.get("[data-testid=profile-preferences-link]")
+            .should("be.visible")
+            .click();
+        cy.location("pathname").should("eq", profileUrl);
+
+        cy.log("When returning to the home page, the alert should be gone.");
+        cy.get("[data-testid=menu-btn-home-link]").should("be.visible").click();
+        cy.location("pathname").should("eq", homeUrl);
+        cy.contains("#subject", "Home").should("exist");
+        cy.get("[data-testid=sms-removed-message]").should("not.exist");
+    });
+
+    it("SMS removed alert should not display on subsequent visits", () => {
+        cy.configureSettings({});
+
+        cy.login(
+            Cypress.env("keycloak.hthgtwy06.username"),
+            Cypress.env("keycloak.password"),
+            AuthMethod.KeyCloak,
+            homeUrl
+        );
+
+        cy.contains("#subject", "Home").should("exist");
+        cy.get("[data-testid=sms-removed-message]").should("not.exist");
     });
 });
 

--- a/Tools/KeyCloak/dev_users.json
+++ b/Tools/KeyCloak/dev_users.json
@@ -65,6 +65,22 @@
             ]
         },
         {
+            "username": "hthgtwy06",
+            "enabled": true,
+            "firstName": "Dr",
+            "lastName": "Gateway",
+            "attributes": {
+                "hdid": "GO4DOSMRJ7MFKPPADDZ3FK2MOJ45SFKONJWR67XNLMZQFNEHDKDA"
+            },
+            "credentials": [
+                {
+                    "type": "password",
+                    "value": "{PASSWORD}",
+                    "temporary": false
+                }
+            ]
+        },
+        {
             "username": "hthgtwy09",
             "enabled": true,
             "firstName": "Dr",
@@ -127,7 +143,8 @@
                     "temporary": false
                 }
             ]
-        },        {
+        },
+        {
             "username": "hlthgw401",
             "enabled": true,
             "firstName": "Dr",
@@ -211,10 +228,9 @@
         {
             "username": "hgateway@idir",
             "enabled": true
-        },
-
+        }
     ],
-    "roleMappings": { 
+    "roleMappings": {
         "blazoradmin": ["AdminUser"],
         "blazorreviewer": ["AdminReviewer"],
         "blazoranalyst": ["AdminAnalyst"],


### PR DESCRIPTION
# Implements [AB#17075](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17075)

## Description

- Adds functional tests for the removed SMS alert
- Updates registration functional test to check alert message
- Updates seed-test.sql so the removed SMS alert can be seen in the TEST environment
- Updates dev_users.json with hthgtwy06 to match dev KeyCloak users

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
