### PR TITLE
Remove Clear SMS & Notification Backfill from Job Scheduler AB#17074

### DIFF
--- a/Apps/JobScheduler/src/Startup.cs
+++ b/Apps/JobScheduler/src/Startup.cs
@@ -200,14 +200,6 @@ namespace HealthGateway.JobScheduler
             SchedulerHelper.ScheduleJobAsync<OneTimeJob>(this.configuration, "OneTime", j => j.ProcessAsync(CancellationToken.None));
             SchedulerHelper.ScheduleJobAsync<DeleteEmailJob>(this.configuration, "DeleteEmailJob", j => j.DeleteOldEmailsAsync(CancellationToken.None));
             SchedulerHelper.ScheduleJobAsync<AssignBetaFeatureAccessJob>(this.configuration, AssignBetaFeatureAccessJob.JobKey, j => j.ProcessAsync(CancellationToken.None));
-            SchedulerHelper.ScheduleJobAsync<NotificationBackfillJob>(
-                this.configuration,
-                "NotificationBackfill",
-                j => j.ProcessAsync(CancellationToken.None));
-            SchedulerHelper.ScheduleJobAsync<ClearSmsNumberJob>(
-                this.configuration,
-                "ClearSmsNumber",
-                j => j.ProcessAsync(CancellationToken.None));
         }
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#17074](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17074)

## Description

Removed Clear SMS Number and Notification Backfill jobs from Job Scheduler startup.

- Above jobs have been manually removed from DEV, TEST and PROD environments.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
