### PR TITLE
Sync PHSA notification settings when contact channels change AB#17081

### DIFF
--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -277,6 +277,21 @@ namespace HealthGateway.GatewayApi.Services
                 await this.emailQueueService.QueueNewEmailAsync(emailVerification.Email, false, ct);
             }
 
+            // Because the email address was deleted or requires re-verification,
+            // update PHSA notification settings to disable email notifications.
+            UserProfileNotificationSettingModel[] notificationSettingModels =
+            [
+                new()
+                {
+                    Type = ProfileNotificationType.BcCancerScreening,
+                    EmailEnabled = false,
+                    SmsEnabled = null,
+                },
+            ];
+
+            // Store an event indicating user profile notification settings have been defaulted.
+            await this.profileNotificationSettingService.UpdateAsync(hdid, notificationSettingModels, false, ct);
+
             // Persist changes within transaction
             await this.transactionProvider.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);

--- a/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
@@ -204,6 +204,21 @@ namespace HealthGateway.GatewayApi.Services
             userProfile.Email = null;
             userProfile.BetaFeatureCodes = [];
 
+            // Because the email address was deleted or requires re-verification,
+            // update PHSA notification settings to disable email notifications.
+            UserProfileNotificationSettingModel[] notificationSettingModels =
+            [
+                new()
+                {
+                    Type = ProfileNotificationType.BcCancerScreening,
+                    EmailEnabled = false,
+                    SmsEnabled = null,
+                },
+            ];
+
+            // Store an event indicating user profile notification settings have been defaulted.
+            await this.profileNotificationSettingService.UpdateAsync(hdid, notificationSettingModels, false, ct);
+
             if (messagingVerification != null)
             {
                 this.logger.LogDebug("Sending new email verification");

--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -201,6 +201,21 @@ namespace HealthGateway.GatewayApi.Services
                 notificationRequest.SmsVerificationCode = messagingVerification.SmsValidationCode;
             }
 
+            // Because the sms number was deleted or requires re-verification,
+            // update PHSA notification settings to disable sms notifications.
+            UserProfileNotificationSettingModel[] notificationSettingModels =
+            [
+                new()
+                {
+                    Type = ProfileNotificationType.BcCancerScreening,
+                    EmailEnabled = null,
+                    SmsEnabled = false,
+                },
+            ];
+
+            // Store an event indicating user profile notification settings have been defaulted.
+            await this.profileNotificationSettingService.UpdateAsync(hdid, notificationSettingModels, false, ct);
+
             // Persist changes within transaction
             await this.transactionProvider.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);

--- a/Apps/GatewayApi/src/Services/UserSmsServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsServiceV2.cs
@@ -191,6 +191,21 @@ namespace HealthGateway.GatewayApi.Services
                 messagingVerification = await this.messagingVerificationService.AddSmsVerificationAsync(hdid, sanitizedSms, false, ct);
             }
 
+            // Because the sms number was deleted or requires re-verification,
+            // update PHSA notification settings to disable sms notifications.
+            UserProfileNotificationSettingModel[] notificationSettingModels =
+            [
+                new()
+                {
+                    Type = ProfileNotificationType.BcCancerScreening,
+                    EmailEnabled = null,
+                    SmsEnabled = false,
+                },
+            ];
+
+            // Store an event indicating user profile notification settings have been defaulted.
+            await this.profileNotificationSettingService.UpdateAsync(hdid, notificationSettingModels, false, ct);
+
             // Persist changes within transaction
             await this.transactionProvider.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -258,6 +258,124 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             }
         }
 
+        [Theory]
+        [InlineData("updated@healthgateway.gov.bc.ca", true)]
+        [InlineData("", false)]
+        public async Task UpdateUserEmailShouldDisableEmailNotificationSettings(
+            string emailAddress,
+            bool expectedEmailVerificationCreated)
+        {
+            // Arrange
+            UserProfile userProfile = new()
+            {
+                HdId = HdIdMock,
+                Email = "old@healthgateway.gov.bc.ca",
+            };
+
+            MessagingVerification lastVerificationForUser = new()
+            {
+                UserProfileId = HdIdMock,
+                InviteKey = Guid.NewGuid(),
+                Email = new Email
+                {
+                    To = "old@healthgateway.gov.bc.ca",
+                },
+            };
+
+            Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock = new();
+            messagingVerificationDelegateMock
+                .Setup(s => s.InsertAsync(
+                    It.IsAny<MessagingVerification>(),
+                    false,
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(Guid.NewGuid());
+
+            Mock<IEmailQueueService> emailQueueServiceMock = new();
+            emailQueueServiceMock
+                .Setup(s => s.GetEmailTemplateAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new EmailTemplate());
+
+            emailQueueServiceMock
+                .Setup(s => s.ProcessTemplate(
+                    It.IsAny<string>(),
+                    It.IsAny<EmailTemplate>(),
+                    It.IsAny<Dictionary<string, string>>()))
+                .Returns((string to, EmailTemplate _, Dictionary<string, string> _) => new Email
+                {
+                    Id = Guid.NewGuid(),
+                    To = to,
+                });
+
+            emailQueueServiceMock
+                .Setup(s => s.QueueNewEmailAsync(
+                    It.IsAny<Email>(),
+                    false,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            Mock<IUserProfileNotificationSettingService> userProfileNotificationSettingServiceMock = new();
+            userProfileNotificationSettingServiceMock
+                .Setup(s => s.UpdateAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<IReadOnlyCollection<UserProfileNotificationSettingModel>>(),
+                    false,
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
+            notificationSettingsServiceMock
+                .Setup(s => s.QueueNotificationSettingsAsync(
+                    It.IsAny<NotificationSettingsRequest>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            Mock<IBackgroundJobClient> backgroundJobClientMock = new();
+
+            IUserEmailService service = GetUserEmailService(
+                userProfile,
+                null,
+                messagingVerificationDelegateMock,
+                lastVerificationForUser,
+                notificationSettingsServiceMock: notificationSettingsServiceMock,
+                userProfileNotificationSettingServiceMock: userProfileNotificationSettingServiceMock,
+                backgroundJobClientMock: backgroundJobClientMock,
+                emailQueueServiceMock: emailQueueServiceMock);
+
+            // Act
+            bool actual = await service.UpdateUserEmailAsync(HdIdMock, emailAddress);
+
+            // Assert
+            Assert.True(actual);
+            Assert.Null(userProfile.Email);
+
+            userProfileNotificationSettingServiceMock.Verify(
+                v => v.UpdateAsync(
+                    HdIdMock,
+                    It.Is<IReadOnlyCollection<UserProfileNotificationSettingModel>>(models =>
+                        models.Single().Type == ProfileNotificationType.BcCancerScreening &&
+                        models.Single().EmailEnabled == false &&
+                        models.Single().SmsEnabled == null),
+                    false,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            messagingVerificationDelegateMock.Verify(
+                v => v.InsertAsync(
+                    It.IsAny<MessagingVerification>(),
+                    false,
+                    It.IsAny<CancellationToken>()),
+                expectedEmailVerificationCreated ? Times.Once : Times.Never);
+
+            emailQueueServiceMock.Verify(
+                v => v.QueueNewEmailAsync(
+                    It.IsAny<Email>(),
+                    false,
+                    It.IsAny<CancellationToken>()),
+                expectedEmailVerificationCreated ? Times.Once : Times.Never);
+        }
+
         private static Mock<IGatewayDbContextTransactionProvider> GetTransactionProviderMock()
         {
             Mock<IGatewayDbContextTransactionProvider> transactionProviderMock = new();

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
@@ -197,6 +197,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             await mock.Service.UpdateEmailAddressAsync(Hdid, emailAddress);
 
             VerifyAddEmailVerification(mock.MessagingVerificationServiceMock, expectedVerificationInsertTimes);
+            VerifyUserProfileNotificationSettingsEmailDisabled(mock.ProfileNotificationSettingServiceMock);
             VerifyQueueNotificationSettings(mock.NotificationSettingServiceMock);
             VerifyQueueNewEmail(mock.EmailQueueServiceMock, expectedQueueNewEmailByEntityTimes);
         }
@@ -304,6 +305,22 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 v => v.Create(
                     It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
                     It.IsAny<EnqueuedState>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyUserProfileNotificationSettingsEmailDisabled(
+            Mock<IUserProfileNotificationSettingService> notificationSettingServiceMock,
+            Times? times = null)
+        {
+            notificationSettingServiceMock.Verify(
+                v => v.UpdateAsync(
+                    Hdid,
+                    It.Is<IReadOnlyCollection<UserProfileNotificationSettingModel>>(models =>
+                        models.Single().Type == ProfileNotificationType.BcCancerScreening &&
+                        models.Single().EmailEnabled == false &&
+                        models.Single().SmsEnabled == null),
+                    false,
+                    It.IsAny<CancellationToken>()),
                 times ?? Times.Once());
         }
 
@@ -663,19 +680,22 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
             Mock<IEmailQueueService> emailQueueServiceMock = new();
+            Mock<IUserProfileNotificationSettingService> profileNotificationSettingServiceMock = new();
 
             IUserEmailServiceV2 service = GetUserEmailService(
                 emailQueueServiceMock: emailQueueServiceMock,
                 messagingVerificationDelegateMock: messagingVerificationDelegateMock,
                 messagingVerificationServiceMock: messagingVerificationServiceMock,
                 userProfileDelegateMock: userProfileDelegateMock,
-                notificationSettingsServiceMock: notificationSettingsServiceMock);
+                notificationSettingsServiceMock: notificationSettingsServiceMock,
+                profileNotificationSettingServiceMock: profileNotificationSettingServiceMock);
 
             return new(
                 service,
                 emailQueueServiceMock,
                 notificationSettingsServiceMock,
-                messagingVerificationServiceMock ?? new Mock<IMessagingVerificationService>());
+                messagingVerificationServiceMock ?? new Mock<IMessagingVerificationService>(),
+                profileNotificationSettingServiceMock);
         }
 
         private static IUserEmailServiceV2 SetupUpdateEmailAddressThrowsExceptionMock(
@@ -704,7 +724,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IUserEmailServiceV2 Service,
             Mock<IEmailQueueService> EmailQueueServiceMock,
             Mock<INotificationSettingsService> NotificationSettingServiceMock,
-            Mock<IMessagingVerificationService> MessagingVerificationServiceMock);
+            Mock<IMessagingVerificationService> MessagingVerificationServiceMock,
+            Mock<IUserProfileNotificationSettingService> ProfileNotificationSettingServiceMock);
 
         private sealed record VerifyEmailAddressMock(
             IUserEmailServiceV2 Service,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -147,15 +147,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 successPathTimes);
         }
 
-        /// <summary>
-        /// UpdateUserSmsAsync.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldUpdateUserSms()
+        [Theory]
+        [InlineData("2508801234", true)]
+        [InlineData("", false)]
+        public async Task ShouldUpdateUserSms(string sms, bool expectedVerificationInsert)
         {
             // Arrange
-            const string sms = "2508801234";
             UserProfile userProfile = new();
 
             MessagingVerification expectedResult = new()
@@ -168,12 +165,14 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock = new();
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
+            Mock<IUserProfileNotificationSettingService> profileNotificationSettingServiceMock = new();
 
             IUserSmsService service = GetUserSmsService(
                 messagingVerificationDelegateMock,
                 expectedResult,
                 userProfile: userProfile,
-                notificationSettingsServiceMock: notificationSettingsServiceMock);
+                notificationSettingsServiceMock: notificationSettingsServiceMock,
+                profileNotificationSettingServiceMock: profileNotificationSettingServiceMock);
 
             // Act and Assert
             Assert.True(await service.UpdateUserSmsAsync(HdIdMock, sms));
@@ -187,11 +186,24 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                             x.SmsNumber == sms),
                         false,
                         It.IsAny<CancellationToken>()),
-                    Times.Once);
+                    expectedVerificationInsert ? Times.Once : Times.Never);
+
+            profileNotificationSettingServiceMock.Verify(
+                v => v.UpdateAsync(
+                    HdIdMock,
+                    It.Is<IReadOnlyCollection<UserProfileNotificationSettingModel>>(models =>
+                        models.Single().Type == ProfileNotificationType.BcCancerScreening &&
+                        models.Single().EmailEnabled == null &&
+                        models.Single().SmsEnabled == false),
+                    false,
+                    It.IsAny<CancellationToken>()),
+                Times.Once);
 
             notificationSettingsServiceMock
                 .Verify(
-                    s => s.QueueNotificationSettingsAsync(It.IsAny<NotificationSettingsRequest>(), It.IsAny<CancellationToken>()),
+                    s => s.QueueNotificationSettingsAsync(
+                        It.IsAny<NotificationSettingsRequest>(),
+                        It.IsAny<CancellationToken>()),
                     Times.Once);
         }
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceV2Tests.cs
@@ -73,11 +73,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         [InlineData(SmsNumberWithDashes, false)]
         [InlineData(SmsNumberAllAlpha, true)]
         [InlineData(SmsNumberAllAlpha, false)]
+        [InlineData("", true)]
+        [InlineData("", false)]
         public async Task ShouldUpdateSmsNumber(string sms, bool lastSmsVerificationExists)
         {
             // Arrange
             Times expectedVerificationExpireTimes = ConvertToTimes(lastSmsVerificationExists);
-            Times expectedVerificationInsertTimes = ConvertToTimes(sms != SmsNumberAllAlpha);
+            Times expectedVerificationInsertTimes = ConvertToTimes(!string.IsNullOrEmpty(SanitizeSmsForTest(sms)));
 
             UpdateSmsNumberMock mock = SetupUpdateSmsNumberMock(Hdid, SmsValidationCode, sms, lastSmsVerificationExists: lastSmsVerificationExists);
 
@@ -87,6 +89,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             // Assert and Verify
             VerifyVerificationExpire(mock.MessagingVerificationDelegateMock, expectedVerificationExpireTimes);
             VerifyAddSmsVerification(mock.MessagingVerificationServiceMock, expectedVerificationInsertTimes);
+            VerifyUserProfileNotificationSettingsSmsDisabled(mock.ProfileNotificationSettingServiceMock);
             VerifyQueueNotificationSettings(mock.NotificationSettingsServiceMock);
         }
 
@@ -247,9 +250,30 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 times ?? Times.Once());
         }
 
+        private static void VerifyUserProfileNotificationSettingsSmsDisabled(
+            Mock<IUserProfileNotificationSettingService> notificationSettingServiceMock,
+            Times? times = null)
+        {
+            notificationSettingServiceMock.Verify(
+                v => v.UpdateAsync(
+                    Hdid,
+                    It.Is<IReadOnlyCollection<UserProfileNotificationSettingModel>>(models =>
+                        models.Single().Type == ProfileNotificationType.BcCancerScreening &&
+                        models.Single().EmailEnabled == null &&
+                        models.Single().SmsEnabled == false),
+                    false,
+                    It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
         private static Times ConvertToTimes(bool expected)
         {
             return expected ? Times.Once() : Times.Never();
+        }
+
+        private static string SanitizeSmsForTest(string smsNumber)
+        {
+            return new string(smsNumber.Where(char.IsDigit).ToArray());
         }
 
         private static MessagingVerification GenerateMessagingVerification(
@@ -463,6 +487,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 userProfile: userProfile);
             Mock<IMessagingVerificationService> messagingVerificationServiceMock = SetupMessagingVerificationServiceMock(smsVerification);
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
+            Mock<IUserProfileNotificationSettingService> profileNotificationSettingServiceMock = new();
 
             if (updateProfileStatus != null)
             {
@@ -479,13 +504,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 messagingVerificationDelegateMock: messagingVerificationDelegateMock,
                 messagingVerificationServiceMock: messagingVerificationServiceMock,
                 userProfileDelegateMock: userProfileDelegateMock,
-                notificationSettingsServiceMock: notificationSettingsServiceMock);
+                notificationSettingsServiceMock: notificationSettingsServiceMock,
+                userProfileNotificationSettingServiceMock: profileNotificationSettingServiceMock);
 
             return new(
                 service,
                 notificationSettingsServiceMock,
                 messagingVerificationDelegateMock,
-                messagingVerificationServiceMock);
+                messagingVerificationServiceMock,
+                profileNotificationSettingServiceMock);
         }
 
         private static VerifySmsNumberMock SetupVerifySmsNumberMock(
@@ -538,7 +565,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             IUserSmsServiceV2 Service,
             Mock<INotificationSettingsService> NotificationSettingsServiceMock,
             Mock<IMessagingVerificationDelegate> MessagingVerificationDelegateMock,
-            Mock<IMessagingVerificationService> MessagingVerificationServiceMock);
+            Mock<IMessagingVerificationService> MessagingVerificationServiceMock,
+            Mock<IUserProfileNotificationSettingService> ProfileNotificationSettingServiceMock);
 
         private sealed record VerifySmsNumberMock(
             IUserSmsServiceV2 Service,


### PR DESCRIPTION
# Fixes or Implements [AB#17081](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17081)

## Description

* Updated UserEmailService and UserEmailServiceV2
    * Disable email notification preferences when email is deleted or updated.
    * Preserve existing SMS notification preference values when sending updates to PHSA.
    
* Updated UserSmsService and UserSmsServiceV2
    * Disable SMS notification preferences when SMS number is deleted or updated.
    * Preserve existing email notification preference values when sending updates to PHSA.

Unit Tests:

* Added unit test coverage for
    * Updating email address
    * Deleting email address
    * Updating SMS number
    * Deleting SMS number

<img width="685" height="335" alt="Screenshot 2026-05-25 at 3 33 44 PM" src="https://github.com/user-attachments/assets/3414b3fb-8ca3-4992-a308-5c4eec871498" />

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
