### PR TITLE
Add event tracking when expanding timeline cards J#3480

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/TimelineEntryComponent.vue
@@ -7,7 +7,7 @@ import { EntryType, entryTypeMap } from "@/constants/entryType";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import TimelineEntry from "@/models/timeline/timelineEntry";
-import { Action, Type } from "@/plugins/extensions";
+import { Action, Origin } from "@/plugins/extensions";
 import { ITrackingService } from "@/services/interfaces";
 import { EventName, useEventStore } from "@/stores/event";
 import { useLayoutStore } from "@/stores/layout";
@@ -60,18 +60,35 @@ const dateString = computed(() => props.entry.date.format());
 const commentCount = computed(() => props.entry.comments?.length ?? 0);
 
 function handleCardClick(): void {
-    if (props.entry.type === EntryType.BcCancerScreening) {
-        trackingService.trackEvent({
-            action: Action.TimelineCardClick,
-            text: props.title,
-            type: Type.BcCancerScreening,
-        });
-    }
     if (layoutStore.isMobile && !props.isMobileDetails) {
         eventStore.emit(EventName.OpenFullscreenTimelineEntry, props.entry);
+        trackCardExpanded();
     } else if (!layoutStore.isMobile && props.canShowDetails) {
         detailsVisible.value = !detailsVisible.value;
+        if (detailsVisible.value) {
+            trackCardExpanded();
+        }
     }
+}
+
+function trackCardExpanded(): void {
+    const entryTypeDetails = entryTypeMap.get(props.entry.type);
+    if (!entryTypeDetails) {
+        return;
+    }
+
+    let text: string = entryTypeDetails?.dataset;
+    if (props.entry.type === EntryType.BcCancerScreening) {
+        text = props.title;
+    }
+
+    trackingService.trackEvent({
+        action: Action.CardClick,
+        text: text,
+        origin: Origin.Timeline,
+        dataset: entryTypeDetails.dataset,
+        type: entryTypeDetails.dataset,
+    });
 }
 
 watch(

--- a/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
+++ b/Apps/WebClient/src/ClientApp/src/constants/entryType.ts
@@ -1,4 +1,5 @@
 import { CommentEntryType } from "@/constants/commentEntryType";
+import { Dataset } from "@/plugins/extensions";
 
 export enum EntryType {
     ClinicalDocument = "ClinicalDocument",
@@ -19,13 +20,13 @@ export class EntryTypeDetails {
     name!: string;
     title!: string;
     description!: string;
-    reportEventName!: string;
     logoUri?: string;
     icon!: string;
     component!: string;
     commentType!: CommentEntryType;
     eventName!: string;
     moduleName!: string;
+    dataset!: Dataset;
 }
 
 const entryTypeMap = new Map<EntryType | undefined, EntryTypeDetails>();
@@ -47,7 +48,7 @@ entryTypeMap.set(EntryType.Immunization, {
     component: "ImmunizationTimelineComponent",
     eventName: "immunizations",
     moduleName: "Immunization",
-    reportEventName: "Immunization",
+    dataset: Dataset.Immunizations,
 });
 
 entryTypeMap.set(EntryType.Medication, {
@@ -60,7 +61,7 @@ entryTypeMap.set(EntryType.Medication, {
     component: "MedicationTimelineComponent",
     eventName: "medications",
     moduleName: "Medication",
-    reportEventName: "Medication",
+    dataset: Dataset.Medications,
 });
 
 entryTypeMap.set(EntryType.LabResult, {
@@ -73,7 +74,7 @@ entryTypeMap.set(EntryType.LabResult, {
     component: "LabResultTimelineComponent",
     eventName: "lab_results",
     moduleName: "AllLaboratory",
-    reportEventName: "Laboratory Tests",
+    dataset: Dataset.LabResults,
 });
 
 entryTypeMap.set(EntryType.Covid19TestResult, {
@@ -87,7 +88,7 @@ entryTypeMap.set(EntryType.Covid19TestResult, {
     component: "Covid19TestResultTimelineComponent",
     eventName: "covid_test",
     moduleName: "Laboratory",
-    reportEventName: "COVID-19 Test",
+    dataset: Dataset.Covid19Tests,
 });
 
 entryTypeMap.set(EntryType.HealthVisit, {
@@ -101,7 +102,7 @@ entryTypeMap.set(EntryType.HealthVisit, {
     component: "HealthVisitTimelineComponent",
     eventName: "health_visits",
     moduleName: "Encounter",
-    reportEventName: "Health Visits",
+    dataset: Dataset.HealthVisits,
 });
 
 entryTypeMap.set(EntryType.Note, {
@@ -114,7 +115,7 @@ entryTypeMap.set(EntryType.Note, {
     component: "NoteTimelineComponent",
     eventName: "my_notes",
     moduleName: "Note",
-    reportEventName: "Notes",
+    dataset: Dataset.Notes,
 });
 
 entryTypeMap.set(EntryType.SpecialAuthorityRequest, {
@@ -128,7 +129,7 @@ entryTypeMap.set(EntryType.SpecialAuthorityRequest, {
     component: "SpecialAuthorityRequestTimelineComponent",
     eventName: "special_authority",
     moduleName: "MedicationRequest",
-    reportEventName: "Special Authority Requests",
+    dataset: Dataset.SpecialAuthorityRequests,
 });
 
 entryTypeMap.set(EntryType.ClinicalDocument, {
@@ -142,7 +143,7 @@ entryTypeMap.set(EntryType.ClinicalDocument, {
     component: "ClinicalDocumentTimelineComponent",
     eventName: "document",
     moduleName: "ClinicalDocument",
-    reportEventName: "Clinical Documents",
+    dataset: Dataset.ClinicalDocuments,
 });
 
 entryTypeMap.set(EntryType.HospitalVisit, {
@@ -156,7 +157,7 @@ entryTypeMap.set(EntryType.HospitalVisit, {
     component: "HospitalVisitTimelineComponent",
     eventName: "hospital_visits",
     moduleName: "HospitalVisit",
-    reportEventName: "Hospital Visits",
+    dataset: Dataset.HospitalVisits,
 });
 
 entryTypeMap.set(EntryType.DiagnosticImaging, {
@@ -169,7 +170,7 @@ entryTypeMap.set(EntryType.DiagnosticImaging, {
     component: "DiagnosticImagingTimelineComponent",
     eventName: "diagnostic_imaging",
     moduleName: "DiagnosticImaging",
-    reportEventName: "Diagnostic Imaging Exams",
+    dataset: Dataset.ImagingReports,
 });
 
 entryTypeMap.set(EntryType.BcCancerScreening, {
@@ -183,7 +184,7 @@ entryTypeMap.set(EntryType.BcCancerScreening, {
     component: "BcCancerScreeningTimelineComponent",
     eventName: "bc_cancer_screening",
     moduleName: "BcCancerScreening",
-    reportEventName: "BC Cancer Screening",
+    dataset: Dataset.BcCancerScreening,
 });
 
 export { entryTypeMap };

--- a/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
@@ -19,7 +19,7 @@ export interface EventData {
     format?: Format;
     origin?: Origin;
     rating?: Rating;
-    type?: Type;
+    type?: Type | Dataset;
     url?: string | InternalUrl | ExternalUrl;
 }
 
@@ -34,7 +34,6 @@ export const enum Action {
     InternalLink = "internal_link",
     ExternalLink = "external_link",
     Submit = "submit",
-    TimelineCardClick = "timeline_card_click",
 }
 
 export const enum Actor {
@@ -43,7 +42,6 @@ export const enum Actor {
 }
 
 export const enum Dataset {
-    BcCancer = "BC Cancer",
     BcCancerScreening = "BC Cancer Screening",
     ClinicalDocuments = "Clinical Documents",
     Covid19Tests = "COVID-19 Tests",

--- a/Apps/WebClient/src/ClientApp/src/stores/patientData.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/patientData.ts
@@ -42,7 +42,7 @@ const defaultPatientDataFileState: PatientDataFileState = {
     error: undefined,
 };
 
-function reportDataLoaded(
+function trackDataLoaded(
     patientDataTypes: PatientDataType[],
     data: PatientDataResponse
 ) {
@@ -234,7 +234,7 @@ export const usePatientDataStore = defineStore("patientData", () => {
             .getPatientData(hdid, patientDataTypes)
             .then((data) => {
                 setPatientData(hdid, patientDataTypes, data.items);
-                reportDataLoaded(patientDataTypes, data);
+                trackDataLoaded(patientDataTypes, data);
                 return data.items;
             })
             .catch((error: ResultError) => {


### PR DESCRIPTION
# Implements [J#3480](https://www.jira.healthcarebc.ca/browse/DHSOHG-3480)

## Description

- expands event tracking when opening timeline cards beyond BC Cancer records to all datasets
  - revises data sent in the events
  - updates the event to only fire when the card is expanded, not when it is collapsed
- tidies up some unused data and a potentially confusing function name

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## Notes

<img width="1418" height="496" alt="image" src="https://github.com/user-attachments/assets/8772ffee-d5a4-4cba-8339-01661ed05e14" />

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
