### PR TITLE
Dispatch outbox events after commit (DHSOHG-3496) AB#17081

### DIFF
--- a/Apps/GatewayApi/src/Services/UserEmailService.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailService.cs
@@ -296,11 +296,16 @@ namespace HealthGateway.GatewayApi.Services
             await this.transactionProvider.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);
 
+            // Dispatch events after commit
             if (emailVerification != null)
             {
                 // Queue a background job to send the email.
                 this.backgroundJobClient.Enqueue<IEmailJob>(j => j.SendEmailAsync(emailVerification.Email!.Id, ct));
             }
+
+            this.logger.LogDebug("Dispatching events after commit");
+            this.backgroundJobClient.Enqueue<DbOutboxStore>(store =>
+                store.DispatchOutboxItemsAsync(ct));
 
             // Queue background job to push notification settings through the job scheduler for user and dependents.
             NotificationSettingsRequest notificationSettingsRequest = new(userProfile, userProfile.Email, userProfile.SmsNumber);

--- a/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserEmailServiceV2.cs
@@ -236,6 +236,9 @@ namespace HealthGateway.GatewayApi.Services
                 this.backgroundJobClient.Enqueue<IEmailJob>(j => j.SendEmailAsync(messagingVerification.Email.Id, ct));
             }
 
+            this.backgroundJobClient.Enqueue<DbOutboxStore>(store =>
+                store.DispatchOutboxItemsAsync(ct));
+
             // Queue background job to push notification settings through the job scheduler for user and dependents.
             NotificationSettingsRequest notificationSettingsRequest = new(userProfile, userProfile.Email, userProfile.SmsNumber);
             await this.notificationSettingsService.QueueNotificationSettingsAsync(notificationSettingsRequest, ct);

--- a/Apps/GatewayApi/src/Services/UserSmsServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsServiceV2.cs
@@ -210,6 +210,11 @@ namespace HealthGateway.GatewayApi.Services
             await this.transactionProvider.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);
 
+            // Dispatch outbox events after commit
+            this.logger.LogDebug("Dispatching events after commit");
+            this.backgroundJobClient.Enqueue<DbOutboxStore>(store =>
+                store.DispatchOutboxItemsAsync(ct));
+
             // Queue background job to push notification settings through the job scheduler for user and dependents.
             NotificationSettingsRequest notificationRequest = new(userProfile, userProfile.Email, sanitizedSms)
             {

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -374,6 +374,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     false,
                     It.IsAny<CancellationToken>()),
                 expectedEmailVerificationCreated ? Times.Once : Times.Never);
+
+            backgroundJobClientMock.Verify(
+                v => v.Create(
+                    It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
+                    It.IsAny<EnqueuedState>()),
+                Times.Once);
         }
 
         private static Mock<IGatewayDbContextTransactionProvider> GetTransactionProviderMock()

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
@@ -198,6 +198,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             VerifyAddEmailVerification(mock.MessagingVerificationServiceMock, expectedVerificationInsertTimes);
             VerifyUserProfileNotificationSettingsEmailDisabled(mock.ProfileNotificationSettingServiceMock);
+            VerifyDispatchOutboxItems(mock.BackgroundJobClientMock);
             VerifyQueueNotificationSettings(mock.NotificationSettingServiceMock);
             VerifyQueueNewEmail(mock.EmailQueueServiceMock, expectedQueueNewEmailByEntityTimes);
         }
@@ -301,11 +302,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     It.IsAny<CancellationToken>()),
                 times ?? Times.Once());
 
-            backgroundJobClient.Verify(
-                v => v.Create(
-                    It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
-                    It.IsAny<EnqueuedState>()),
-                times ?? Times.Once());
+            VerifyDispatchOutboxItems(backgroundJobClient, times);
         }
 
         private static void VerifyUserProfileNotificationSettingsEmailDisabled(
@@ -321,6 +318,17 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         models.Single().SmsEnabled == null),
                     false,
                     It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyDispatchOutboxItems(
+            Mock<IBackgroundJobClient> backgroundJobClient,
+            Times? times = null)
+        {
+            backgroundJobClient.Verify(
+                v => v.Create(
+                    It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
+                    It.IsAny<EnqueuedState>()),
                 times ?? Times.Once());
         }
 
@@ -681,6 +689,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
             Mock<IEmailQueueService> emailQueueServiceMock = new();
             Mock<IUserProfileNotificationSettingService> profileNotificationSettingServiceMock = new();
+            Mock<IBackgroundJobClient> backgroundJobClientMock = new();
 
             IUserEmailServiceV2 service = GetUserEmailService(
                 emailQueueServiceMock: emailQueueServiceMock,
@@ -688,14 +697,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 messagingVerificationServiceMock: messagingVerificationServiceMock,
                 userProfileDelegateMock: userProfileDelegateMock,
                 notificationSettingsServiceMock: notificationSettingsServiceMock,
-                profileNotificationSettingServiceMock: profileNotificationSettingServiceMock);
+                profileNotificationSettingServiceMock: profileNotificationSettingServiceMock,
+                backgroundJobClientMock: backgroundJobClientMock);
 
             return new(
                 service,
                 emailQueueServiceMock,
                 notificationSettingsServiceMock,
                 messagingVerificationServiceMock ?? new Mock<IMessagingVerificationService>(),
-                profileNotificationSettingServiceMock);
+                profileNotificationSettingServiceMock,
+                backgroundJobClientMock);
         }
 
         private static IUserEmailServiceV2 SetupUpdateEmailAddressThrowsExceptionMock(
@@ -725,7 +736,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IEmailQueueService> EmailQueueServiceMock,
             Mock<INotificationSettingsService> NotificationSettingServiceMock,
             Mock<IMessagingVerificationService> MessagingVerificationServiceMock,
-            Mock<IUserProfileNotificationSettingService> ProfileNotificationSettingServiceMock);
+            Mock<IUserProfileNotificationSettingService> ProfileNotificationSettingServiceMock,
+            Mock<IBackgroundJobClient> BackgroundJobClientMock);
 
         private sealed record VerifyEmailAddressMock(
             IUserEmailServiceV2 Service,

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceV2Tests.cs
@@ -90,6 +90,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             VerifyVerificationExpire(mock.MessagingVerificationDelegateMock, expectedVerificationExpireTimes);
             VerifyAddSmsVerification(mock.MessagingVerificationServiceMock, expectedVerificationInsertTimes);
             VerifyUserProfileNotificationSettingsSmsDisabled(mock.ProfileNotificationSettingServiceMock);
+            VerifyDispatchOutboxItems(mock.BackgroundJobClientMock);
             VerifyQueueNotificationSettings(mock.NotificationSettingsServiceMock);
         }
 
@@ -219,11 +220,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     It.IsAny<CancellationToken>()),
                 times ?? Times.Once());
 
-            backgroundJobClient.Verify(
-                v => v.Create(
-                    It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
-                    It.IsAny<EnqueuedState>()),
-                times ?? Times.Once());
+            VerifyDispatchOutboxItems(backgroundJobClient, times);
         }
 
         private static void VerifyVerificationExpire(Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock, Times? times = null)
@@ -263,6 +260,17 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         models.Single().SmsEnabled == false),
                     false,
                     It.IsAny<CancellationToken>()),
+                times ?? Times.Once());
+        }
+
+        private static void VerifyDispatchOutboxItems(
+            Mock<IBackgroundJobClient> backgroundJobClient,
+            Times? times = null)
+        {
+            backgroundJobClient.Verify(
+                v => v.Create(
+                    It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
+                    It.IsAny<EnqueuedState>()),
                 times ?? Times.Once());
         }
 
@@ -488,6 +496,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IMessagingVerificationService> messagingVerificationServiceMock = SetupMessagingVerificationServiceMock(smsVerification);
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
             Mock<IUserProfileNotificationSettingService> profileNotificationSettingServiceMock = new();
+            Mock<IBackgroundJobClient> backgroundJobClientMock = new();
 
             if (updateProfileStatus != null)
             {
@@ -505,14 +514,16 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 messagingVerificationServiceMock: messagingVerificationServiceMock,
                 userProfileDelegateMock: userProfileDelegateMock,
                 notificationSettingsServiceMock: notificationSettingsServiceMock,
-                userProfileNotificationSettingServiceMock: profileNotificationSettingServiceMock);
+                userProfileNotificationSettingServiceMock: profileNotificationSettingServiceMock,
+                backgroundJobClientMock: backgroundJobClientMock);
 
             return new(
                 service,
                 notificationSettingsServiceMock,
                 messagingVerificationDelegateMock,
                 messagingVerificationServiceMock,
-                profileNotificationSettingServiceMock);
+                profileNotificationSettingServiceMock,
+                backgroundJobClientMock);
         }
 
         private static VerifySmsNumberMock SetupVerifySmsNumberMock(
@@ -566,7 +577,8 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<INotificationSettingsService> NotificationSettingsServiceMock,
             Mock<IMessagingVerificationDelegate> MessagingVerificationDelegateMock,
             Mock<IMessagingVerificationService> MessagingVerificationServiceMock,
-            Mock<IUserProfileNotificationSettingService> ProfileNotificationSettingServiceMock);
+            Mock<IUserProfileNotificationSettingService> ProfileNotificationSettingServiceMock,
+            Mock<IBackgroundJobClient> BackgroundJobClientMock);
 
         private sealed record VerifySmsNumberMock(
             IUserSmsServiceV2 Service,


### PR DESCRIPTION
# Fixes or Implements [AB#17081](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17081)

## Description

Implemented outbox dispatch after transaction commit for email and SMS notification flows.

**Service Changes**

* Added DbOutboxStore.DispatchOutboxItemsAsync background job enqueue after successful transaction commit in:
    * UserEmailService.UpdateUserEmailAsync
    * UserEmailServiceV2.UpdateEmailAddressAsync
    * UserSmsServiceV2.UpdateSmsNumberAsync
* Ensures outbox events are dispatched only after database changes are committed successfully.

**Unit Test Changes**

* Updated existing email and SMS service unit tests to verify:
    * DbOutboxStore background job is enqueued after commit.
* Reused existing mocks/setup patterns instead of introducing new test structures.
* Added reusable helper verification methods where appropriate to reduce duplication.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
