### PR TITLE
Dispatch outbox events after commit (DHSOHG-3496) AB#17081

### DIFF
--- a/Apps/GatewayApi/src/Services/UserSmsService.cs
+++ b/Apps/GatewayApi/src/Services/UserSmsService.cs
@@ -220,6 +220,11 @@ namespace HealthGateway.GatewayApi.Services
             await this.transactionProvider.SaveChangesAsync(ct);
             await transaction.CommitAsync(ct);
 
+            // Dispatch outbox events after commit
+            this.logger.LogDebug("Dispatching events after commit");
+            this.backgroundJobClient.Enqueue<DbOutboxStore>(store =>
+                store.DispatchOutboxItemsAsync(ct));
+
             // Queue background job to push notification settings through the job scheduler for user and dependents.
             await this.notificationSettingsService.QueueNotificationSettingsAsync(notificationRequest, ct);
             return true;

--- a/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserSmsServiceTests.cs
@@ -166,13 +166,15 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             Mock<IMessagingVerificationDelegate> messagingVerificationDelegateMock = new();
             Mock<INotificationSettingsService> notificationSettingsServiceMock = new();
             Mock<IUserProfileNotificationSettingService> profileNotificationSettingServiceMock = new();
+            Mock<IBackgroundJobClient> backgroundJobClientMock = new();
 
             IUserSmsService service = GetUserSmsService(
                 messagingVerificationDelegateMock,
                 expectedResult,
                 userProfile: userProfile,
                 notificationSettingsServiceMock: notificationSettingsServiceMock,
-                profileNotificationSettingServiceMock: profileNotificationSettingServiceMock);
+                profileNotificationSettingServiceMock: profileNotificationSettingServiceMock,
+                backgroundJobClientMock: backgroundJobClientMock);
 
             // Act and Assert
             Assert.True(await service.UpdateUserSmsAsync(HdIdMock, sms));
@@ -197,6 +199,12 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         models.Single().SmsEnabled == false),
                     false,
                     It.IsAny<CancellationToken>()),
+                Times.Once);
+
+            backgroundJobClientMock.Verify(
+                v => v.Create(
+                    It.Is<Job>(job => job.Type == typeof(DbOutboxStore)),
+                    It.IsAny<EnqueuedState>()),
                 Times.Once);
 
             notificationSettingsServiceMock


### PR DESCRIPTION
# Fixes or Implements [AB#17081](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17081)

## Description

Implemented outbox dispatch after transaction commit for SMS notification flows.

**Service Changes**

* Added DbOutboxStore.DispatchOutboxItemsAsync background job enqueue after successful transaction commit in:
    * UserSmsService.UpdateUserSmsAsync
* Ensures outbox events are dispatched only after database changes are committed successfully.

**Unit Test Changes**

* Updated existing SMS service unit tests to verify:
    * DbOutboxStore background job is enqueued after commit.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
