### PR TITLE
Add no-tracking notification setting query AB#17080

### DIFF
--- a/Apps/Database/src/Delegates/DbUserProfileNotificationSettingDelegate.cs
+++ b/Apps/Database/src/Delegates/DbUserProfileNotificationSettingDelegate.cs
@@ -38,6 +38,15 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
+        public async Task<IReadOnlyList<UserProfileNotificationSetting>> GetNoTrackingAsync(string hdid, CancellationToken ct = default)
+        {
+            return await dbContext.UserProfileNotificationSetting
+                .AsNoTracking()
+                .Where(d => d.Hdid == hdid)
+                .ToListAsync(ct);
+        }
+
+        /// <inheritdoc/>
         public async Task UpdateAsync(
             UserProfileNotificationSetting notificationSetting,
             bool commit = true,

--- a/Apps/Database/src/Delegates/IUserProfileNotificationSettingDelegate.cs
+++ b/Apps/Database/src/Delegates/IUserProfileNotificationSettingDelegate.cs
@@ -37,6 +37,17 @@ namespace HealthGateway.Database.Delegates
         Task<IReadOnlyList<UserProfileNotificationSetting>> GetAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
+        /// Fetches the user profile notification settings by hdid from the database without tracking.
+        /// </summary>
+        /// <param name="hdid">The hdid to search by.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>
+        /// A read-only list of user profile notification settings for the specified hdid.
+        /// Returns an empty collection if none are found.
+        /// </returns>
+        Task<IReadOnlyList<UserProfileNotificationSetting>> GetNoTrackingAsync(string hdid, CancellationToken ct = default);
+
+        /// <summary>
         /// Adds or updates the user profile notification object to the DB.
         /// </summary>
         /// <param name="notificationSetting">The user profile notification setting object to add or update.</param>

--- a/Apps/GatewayApi/src/Services/UserProfileNotificationSettingService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileNotificationSettingService.cs
@@ -46,7 +46,7 @@ namespace HealthGateway.GatewayApi.Services
             CancellationToken ct = default)
         {
             IReadOnlyList<UserProfileNotificationSetting> notificationSettings =
-                await notificationSettingDelegate.GetAsync(hdid, ct);
+                await notificationSettingDelegate.GetNoTrackingAsync(hdid, ct);
             return mappingService.MapToUserProfileNotificationSettingModels(notificationSettings);
         }
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileNotificationSettingServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileNotificationSettingServiceTests.cs
@@ -78,7 +78,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             Mock<IUserProfileNotificationSettingDelegate> notificationSettingDelegateMock = new();
             notificationSettingDelegateMock
-                .Setup(s => s.GetAsync(Hdid, It.IsAny<CancellationToken>()))
+                .Setup(s => s.GetNoTrackingAsync(Hdid, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(notificationSettings);
 
             Mock<IUserProfileDelegate> profileDelegateMock = new();
@@ -482,7 +482,6 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             capturedEvent!.EmailNotificationTargets.Count.ShouldBe(expectedEmailTargetCount);
             capturedEvent.SmsNotificationTargets.Count.ShouldBe(expectedSmsTargetCount);
         }
-
 
         /// <summary>
         /// UpdateAsync throws NotFoundException.


### PR DESCRIPTION
# Fixes or Implements [AB#17080](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17080)

## Description

- Added GetNoTrackingAsync to IUserProfileNotificationSettingDelegate
- Implemented no-tracking query in DbUserProfileNotificationSettingDelegate
- Updated UserProfileNotificationSettingService.GetAsync to use no-tracking reads
- Updated unit tests to mock GetNoTrackingAsync

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
