### PR TITLE
Prevent LastLoginDateTime from being updated with older auth times AB#17084

### DIFF
--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -162,7 +162,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             DateTime previousLastLogin = userProfile.LastLoginDateTime;
-            if (DateTime.Compare(previousLastLogin, jwtAuthTime) != 0)
+            if (jwtAuthTime > previousLastLogin)
             {
                 userProfile.LastLoginDateTime = jwtAuthTime;
                 userProfile.LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType();

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -63,7 +63,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             DateTime previousLastLogin = userProfile.LastLoginDateTime;
-            if (DateTime.Compare(previousLastLogin, jwtAuthTime) != 0)
+            if (jwtAuthTime > previousLastLogin)
             {
                 PatientDetails patient = await patientDetailsService.GetPatientAsync(hdid, ct: ct);
 


### PR DESCRIPTION
# Fixes or Implements [AB#17084](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17084)

## Description

Updated user profile login tracking to only update LastLoginDateTime when the incoming JWT authentication time is newer than the existing value.

**Changes**

* Replaced the login timestamp comparison logic from:
    * Update when timestamps are different
* To:
    * Update only when jwtAuthTime is greater than the current LastLoginDateTime

**Reason for Change**

The previous implementation allowed older authentication timestamps to overwrite newer login timestamps. This could occur when users had multiple active sessions (for example, mobile and desktop) using tokens with different authentication times.

These unnecessary updates increased the likelihood of EF Core optimistic concurrency conflicts, resulting in DbUpdateConcurrencyException entries being logged to Application Insights.

Look in [AB#17084](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17084) for more details.

**Expected Outcome**

* Prevents login timestamps from moving backwards.
* Reduces unnecessary database updates.
* Reduces non-actionable concurrency exception logging in Application Insights.
* Preserves existing login tracking behavior by continuing to record newer authentication events.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
