### PR TITLE
Refine blocked access transaction and change feed logic AB#17083

### DIFF
--- a/Apps/AccountDataAccess/src/ConfigurationExtensions.cs
+++ b/Apps/AccountDataAccess/src/ConfigurationExtensions.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.AccountDataAccess
     using HealthGateway.AccountDataAccess.Patient.Strategy;
     using HealthGateway.Common.Utils.Phsa;
     using HealthGateway.Database.Delegates;
+    using HealthGateway.Database.Providers;
     using Microsoft.Extensions.DependencyInjection;
     using Refit;
 
@@ -57,6 +58,9 @@ namespace HealthGateway.AccountDataAccess
                 .AddScoped<PatientQueryStrategy, HdidPhsaStrategy>(s => s.GetService<HdidPhsaStrategy>()!);
             services.AddScoped<PhnEmpiStrategy>()
                 .AddScoped<PatientQueryStrategy, PhnEmpiStrategy>(s => s.GetService<PhnEmpiStrategy>()!);
+
+            // Abstraction for DbContext transaction and persistence operations
+            services.AddScoped<IGatewayDbContextTransactionProvider, GatewayDbContextTransactionProvider>();
 
             services.AddRefitClient<IPatientIdentityApi>()
                 .ConfigureHttpClient(c => c.BaseAddress = configuration.PhsaApiBaseUrl)

--- a/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/IPatientRepository.cs
@@ -21,7 +21,6 @@ namespace HealthGateway.AccountDataAccess.Patient
     using FluentValidation;
     using HealthGateway.Common.Data.Constants;
     using HealthGateway.Common.ErrorHandling.Exceptions;
-    using HealthGateway.Database.Models;
 
     /// <summary>
     /// Represents the patient detail source to determine what to query.
@@ -67,14 +66,6 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The blocked access or null if not found.</returns>
         Task<bool> CanAccessDataSourceAsync(string hdid, DataSource dataSource, CancellationToken ct = default);
-
-        /// <summary>
-        /// Gets the blocked access record.
-        /// </summary>
-        /// <param name="hdid">The hdid to query on.</param>
-        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
-        /// <returns>The blocked access or null if not found.</returns>
-        Task<BlockedAccess?> GetBlockedAccessRecordsAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Gets the blocked access's data sources for the hdid.

--- a/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
+++ b/Apps/AccountDataAccess/src/Patient/PatientRepository.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.AccountDataAccess.Patient
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Hangfire;
     using HealthGateway.AccountDataAccess.Patient.Strategy;
     using HealthGateway.Common.AccessManagement.Authentication;
     using HealthGateway.Common.CacheProviders;
@@ -33,6 +34,8 @@ namespace HealthGateway.AccountDataAccess.Patient
     using HealthGateway.Common.Models.Events;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
+    using HealthGateway.Database.Providers;
+    using Microsoft.EntityFrameworkCore.Storage;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
 
@@ -54,7 +57,9 @@ namespace HealthGateway.AccountDataAccess.Patient
         private readonly IBlockedAccessDelegate blockedAccessDelegate;
         private readonly ICacheProvider cacheProvider;
         private readonly PatientQueryFactory patientQueryFactory;
-        private readonly IMessageSender messageSender;
+        private readonly IOutboxStore outboxStore;
+        private readonly IBackgroundJobClient backgroundJobClient;
+        private readonly IGatewayDbContextTransactionProvider transactionProvider;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PatientRepository"/> class.
@@ -65,7 +70,12 @@ namespace HealthGateway.AccountDataAccess.Patient
         /// <param name="cacheProvider">The injected cache provider.</param>
         /// <param name="configuration">The Configuration to use.</param>
         /// <param name="patientQueryFactory">The injected patient query factory.</param>
-        /// <param name="messageSender">The change feed message sender.</param>
+        /// <param name="outboxStore">The outbox store to use.</param>
+        /// <param name="backgroundJobClient">Hangfire background job client.</param>
+        /// <param name="transactionProvider">
+        /// Provides database transaction and persistence operations for the current request
+        /// scope.
+        /// </param>
         public PatientRepository(
             ILogger<PatientRepository> logger,
             IBlockedAccessDelegate blockedAccessDelegate,
@@ -73,14 +83,18 @@ namespace HealthGateway.AccountDataAccess.Patient
             ICacheProvider cacheProvider,
             IConfiguration configuration,
             PatientQueryFactory patientQueryFactory,
-            IMessageSender messageSender)
+            IOutboxStore outboxStore,
+            IBackgroundJobClient backgroundJobClient,
+            IGatewayDbContextTransactionProvider transactionProvider)
         {
             this.logger = logger;
             this.blockedAccessDelegate = blockedAccessDelegate;
             this.authenticationDelegate = authenticationDelegate;
             this.cacheProvider = cacheProvider;
             this.patientQueryFactory = patientQueryFactory;
-            this.messageSender = messageSender;
+            this.outboxStore = outboxStore;
+            this.backgroundJobClient = backgroundJobClient;
+            this.transactionProvider = transactionProvider;
             this.blockedAccessCacheTtl = configuration.GetValue($"{BlockedAccessKey}:{CacheTtlKey}", 30);
             ChangeFeedOptions? changeFeedConfiguration = configuration.GetSection(ChangeFeedOptions.ChangeFeed).Get<ChangeFeedOptions>();
             this.blockedDataSourcesChangeFeedEnabled = changeFeedConfiguration?.BlockedDataSources.Enabled ?? false;
@@ -112,6 +126,10 @@ namespace HealthGateway.AccountDataAccess.Patient
         {
             string authenticatedUserId = this.authenticationDelegate.FetchAuthenticatedUserId() ?? UserId.DefaultUser;
 
+            // Begin transaction for all database updates
+            await using IDbContextTransaction transaction =
+                await this.transactionProvider.BeginTransactionAsync(ct);
+
             AgentAudit agentAudit = new()
             {
                 Hdid = command.Hdid,
@@ -124,7 +142,7 @@ namespace HealthGateway.AccountDataAccess.Patient
                 UpdatedBy = authenticatedUserId,
             };
 
-            BlockedAccess blockedAccess = await this.blockedAccessDelegate.GetBlockedAccessAsync(command.Hdid, ct) ?? new()
+            BlockedAccess blockedAccess = await this.blockedAccessDelegate.GetAsync(command.Hdid, ct) ?? new()
             {
                 Hdid = command.Hdid,
                 CreatedBy = authenticatedUserId,
@@ -142,32 +160,49 @@ namespace HealthGateway.AccountDataAccess.Patient
                 .ToList();
 #pragma warning restore IDE0305
 
-            // commit to the database if change feed is disabled; if change feed enabled, commit will happen when message sender is called
-            // this is temporary and will be changed when we introduce a proper unit of work to manage transactions.
+            // Keep the entity in sync with the requested state.
+            // This ensures the change-feed payload is empty when access is unblocked.
+            blockedAccess.DataSources = sources;
+
             if (sources.Count != 0)
             {
-                blockedAccess.DataSources = sources;
-                blockedAccess.CreatedDateTime = DateTime.UtcNow;
-                blockedAccess.UpdatedDateTime = DateTime.UtcNow;
-                await this.blockedAccessDelegate.UpdateBlockedAccessAsync(blockedAccess, agentAudit, !this.blockedDataSourcesChangeFeedEnabled, ct);
+                await this.blockedAccessDelegate.UpsertAsync(blockedAccess, agentAudit, false, ct);
             }
             else
             {
-                await this.blockedAccessDelegate.DeleteBlockedAccessAsync(blockedAccess, agentAudit, !this.blockedDataSourcesChangeFeedEnabled, ct);
+                await this.blockedAccessDelegate.DeleteAsync(blockedAccess, agentAudit, false, ct);
             }
 
             if (this.blockedDataSourcesChangeFeedEnabled)
             {
                 this.logger.LogDebug("Sending change feed notification for blocked data sources");
-                IEnumerable<string> dataSourceValues = blockedAccess.DataSources.Select(ds => EnumUtility.ToEnumString(ds));
-                await this.messageSender.SendAsync([new MessageEnvelope(new DataSourcesBlockedEvent(command.Hdid, dataSourceValues), command.Hdid)], ct);
-            }
-        }
+                string[] dataSourceValues = blockedAccess.DataSources
+                    .Select(ds => EnumUtility.ToEnumString(ds))
+                    .ToArray();
 
-        /// <inheritdoc/>
-        public async Task<BlockedAccess?> GetBlockedAccessRecordsAsync(string hdid, CancellationToken ct = default)
-        {
-            return await this.blockedAccessDelegate.GetBlockedAccessAsync(hdid, ct);
+                MessageEnvelope[] events =
+                [
+                    new(
+                        new DataSourcesBlockedEvent(
+                            command.Hdid,
+                            dataSourceValues),
+                        command.Hdid),
+                ];
+
+                await this.outboxStore.StoreAsync(events, false, ct);
+            }
+
+            // Persist changes within transaction
+            await this.transactionProvider.SaveChangesAsync(ct);
+            await transaction.CommitAsync(ct);
+
+            if (this.blockedDataSourcesChangeFeedEnabled)
+            {
+                // Dispatch outbox events after commit
+                this.logger.LogDebug("Dispatching events after commit");
+                this.backgroundJobClient.Enqueue<DbOutboxStore>(store =>
+                    store.DispatchOutboxItemsAsync(ct));
+            }
         }
 
         /// <inheritdoc/>

--- a/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
+++ b/Apps/AccountDataAccess/test/unit/PatientRepositoryTests.cs
@@ -20,6 +20,9 @@ namespace AccountDataAccessTest
     using AccountDataAccessTest.Utils;
     using AutoMapper;
     using DeepEqual.Syntax;
+    using Hangfire;
+    using Hangfire.Common;
+    using Hangfire.States;
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.AccountDataAccess.Patient.Api;
     using HealthGateway.AccountDataAccess.Patient.Strategy;
@@ -32,6 +35,8 @@ namespace AccountDataAccessTest
     using HealthGateway.Common.Models.Events;
     using HealthGateway.Database.Delegates;
     using HealthGateway.Database.Models;
+    using HealthGateway.Database.Providers;
+    using Microsoft.EntityFrameworkCore.Storage;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
@@ -149,17 +154,25 @@ namespace AccountDataAccessTest
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, true)]
+        [InlineData(false, false)]
         public async Task ShouldBlockAccess(bool changeFeedEnabled, bool datasourceExist)
         {
             // Arrange
             const string reason = "Unit Test Block Access";
-            bool commit = !changeFeedEnabled;
-            IList<DataSource> dataSources = datasourceExist ? [DataSource.Immunization, DataSource.Medication] : [];
+            IList<DataSource> commandDataSources = datasourceExist
+                ? [DataSource.Immunization, DataSource.Medication]
+                : [];
 
-            BlockedAccess blockedAccess = new()
+            BlockedAccess existingBlockedAccess = new()
             {
                 Hdid = Hdid,
-                DataSources = dataSources,
+                DataSources = [DataSource.Immunization],
+            };
+
+            BlockedAccess expectedBlockedAccess = new()
+            {
+                Hdid = Hdid,
+                DataSources = commandDataSources,
             };
 
             AgentAudit audit = new()
@@ -170,35 +183,47 @@ namespace AccountDataAccessTest
                 GroupCode = AuditGroup.BlockedAccess,
             };
 
-            BlockAccessCommand command = new(Hdid, dataSources, reason);
-            (IPatientRepository repository, Mock<IBlockedAccessDelegate> blockedAccessDelegateMock, Mock<IMessageSender> messageSenderMock) = SetupBlockAccessMock(blockedAccess, changeFeedEnabled);
+            BlockAccessCommand command = new(Hdid, commandDataSources, reason);
+
+            (
+                IPatientRepository repository,
+                Mock<IBlockedAccessDelegate> blockedAccessDelegateMock,
+                Mock<IOutboxStore> outboxStoreMock,
+                Mock<IBackgroundJobClient> backgroundJobClientMock) = SetupBlockAccessMock(existingBlockedAccess, changeFeedEnabled);
 
             // Act
             await repository.BlockAccessAsync(command);
 
             // Verify
             blockedAccessDelegateMock.Verify(
-                d => d.UpdateBlockedAccessAsync(
-                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(blockedAccess, ba)),
+                d => d.UpsertAsync(
+                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(expectedBlockedAccess, ba)),
                     It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa)),
-                    commit,
+                    false,
                     It.IsAny<CancellationToken>()),
                 datasourceExist ? Times.Once : Times.Never);
 
             blockedAccessDelegateMock.Verify(
-                d => d.DeleteBlockedAccessAsync(
-                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(blockedAccess, ba)),
+                d => d.DeleteAsync(
+                    It.Is<BlockedAccess>(ba => AssertBlockedAccess(expectedBlockedAccess, ba)),
                     It.Is<AgentAudit>(aa => AssertAgentAudit(audit, aa)),
-                    commit,
+                    false,
                     It.IsAny<CancellationToken>()),
                 !datasourceExist ? Times.Once : Times.Never);
 
-            messageSenderMock.Verify(
-                s => s.SendAsync(
+            outboxStoreMock.Verify(
+                s => s.StoreAsync(
                     It.Is<IEnumerable<MessageEnvelope>>(me => AssertDataSourcesBlockedEvent(
-                        blockedAccess,
-                        me.Select(envelope => envelope.Content as DataSourcesBlockedEvent).First())),
+                        expectedBlockedAccess,
+                        me.Select(envelope => envelope.Content as DataSourcesBlockedEvent).First()!)),
+                    false,
                     It.IsAny<CancellationToken>()),
+                changeFeedEnabled ? Times.Once : Times.Never);
+
+            backgroundJobClientMock.Verify(
+                x => x.Create(
+                    It.IsAny<Job>(),
+                    It.IsAny<EnqueuedState>()),
                 changeFeedEnabled ? Times.Once : Times.Never);
         }
 
@@ -223,29 +248,6 @@ namespace AccountDataAccessTest
 
             // Assert
             Assert.Equal(expected, actual);
-        }
-
-        /// <summary>
-        /// Get blocked access by hdid.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ShouldGetBlockedAccess()
-        {
-            // Arrange
-            BlockedAccess expected = new()
-            {
-                Hdid = Hdid,
-                DataSources = [DataSource.Immunization, DataSource.Medication],
-            };
-
-            IPatientRepository patientRepository = SetupPatientRepositoryForGetBlockedAccess(expected);
-
-            // Act
-            BlockedAccess? actual = await patientRepository.GetBlockedAccessRecordsAsync(Hdid);
-
-            // Verify
-            actual.ShouldDeepEqual(expected);
         }
 
         /// <summary>
@@ -311,30 +313,37 @@ namespace AccountDataAccessTest
             return dataSources.Select(ds => EnumUtility.ToEnumString(ds));
         }
 
+        private static Mock<IGatewayDbContextTransactionProvider> GetTransactionProviderMock()
+        {
+            Mock<IGatewayDbContextTransactionProvider> transactionProviderMock = new();
+            Mock<IDbContextTransaction> transactionMock = new();
+
+            transactionProviderMock
+                .Setup(x => x.BeginTransactionAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(transactionMock.Object);
+
+            transactionProviderMock
+                .Setup(x => x.SaveChangesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(1);
+
+            transactionMock
+                .Setup(x => x.CommitAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            return transactionProviderMock;
+        }
+
         private static BlockAccessMock SetupBlockAccessMock(BlockedAccess blockedAccess, bool changeFeedEnabled)
         {
             Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
-            blockedAccessDelegate.Setup(s => s.GetBlockedAccessAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()))
+
+            blockedAccessDelegate
+                .Setup(s => s.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(blockedAccess);
-            blockedAccessDelegate.Setup(s => s.GetDataSourcesAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(blockedAccess.DataSources);
 
-            Mock<IMessageSender> messageSender = new();
-
-            if (changeFeedEnabled)
-            {
-                IEnumerable<MessageEnvelope> events =
-                [
-                    new(
-                        new DataSourcesBlockedEvent(blockedAccess.Hdid, GetDataSourceValues(blockedAccess.DataSources)),
-                        blockedAccess.Hdid),
-                ];
-                messageSender.Setup(ms => ms.SendAsync(events, It.IsAny<CancellationToken>()));
-            }
+            Mock<IOutboxStore> outboxStoreMock = new();
+            Mock<IBackgroundJobClient> backgroundJobClientMock = new();
+            Mock<IGatewayDbContextTransactionProvider> transactionProviderMock = GetTransactionProviderMock();
 
             PatientRepository patientRepository = new(
                 new Mock<ILogger<PatientRepository>>().Object,
@@ -343,9 +352,15 @@ namespace AccountDataAccessTest
                 new Mock<ICacheProvider>().Object,
                 GetIConfigurationRoot(changeFeedEnabled),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
-                messageSender.Object);
+                outboxStoreMock.Object,
+                backgroundJobClientMock.Object,
+                transactionProviderMock.Object);
 
-            return new(patientRepository, blockedAccessDelegate, messageSender);
+            return new(
+                patientRepository,
+                blockedAccessDelegate,
+                outboxStoreMock,
+                backgroundJobClientMock);
         }
 
         private static IPatientRepository SetupPatientRepositoryForCanAccessDataSource(HashSet<DataSource> dataSources, bool useCache)
@@ -388,25 +403,9 @@ namespace AccountDataAccessTest
                 cacheProviderMock.Object,
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
-                new Mock<IMessageSender>().Object);
-        }
-
-        private static IPatientRepository SetupPatientRepositoryForGetBlockedAccess(BlockedAccess blockedAccess)
-        {
-            Mock<IBlockedAccessDelegate> blockedAccessDelegate = new();
-            blockedAccessDelegate.Setup(s => s.GetBlockedAccessAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(blockedAccess);
-
-            return new PatientRepository(
-                new Mock<ILogger<PatientRepository>>().Object,
-                blockedAccessDelegate.Object,
-                new Mock<IAuthenticationDelegate>().Object,
-                new Mock<ICacheProvider>().Object,
-                GetIConfigurationRoot(),
-                new PatientQueryFactory(new Mock<IServiceProvider>().Object),
-                new Mock<IMessageSender>().Object);
+                new Mock<IOutboxStore>().Object,
+                new Mock<IBackgroundJobClient>().Object,
+                GetTransactionProviderMock().Object);
         }
 
         private static IPatientRepository SetupPatientRepositoryForGetDataSources(HashSet<DataSource> dataSources, bool useCache)
@@ -450,7 +449,9 @@ namespace AccountDataAccessTest
                 cacheProviderMock.Object,
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
-                new Mock<IMessageSender>().Object);
+                new Mock<IOutboxStore>().Object,
+                new Mock<IBackgroundJobClient>().Object,
+                GetTransactionProviderMock().Object);
         }
 
         private static IPatientRepository SetupPatientRepositoryForQuery(PatientModel patient, PatientIdentity patientIdentity)
@@ -517,7 +518,9 @@ namespace AccountDataAccessTest
                 new Mock<ICacheProvider>().Object,
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(serviceProvider),
-                new Mock<IMessageSender>().Object);
+                new Mock<IOutboxStore>().Object,
+                new Mock<IBackgroundJobClient>().Object,
+                GetTransactionProviderMock().Object);
         }
 
         private static IPatientRepository SetupPatientRepositoryForQueryThrowsInvalidOperationException()
@@ -529,12 +532,15 @@ namespace AccountDataAccessTest
                 new Mock<ICacheProvider>().Object,
                 GetIConfigurationRoot(),
                 new PatientQueryFactory(new Mock<IServiceProvider>().Object),
-                new Mock<IMessageSender>().Object);
+                new Mock<IOutboxStore>().Object,
+                new Mock<IBackgroundJobClient>().Object,
+                GetTransactionProviderMock().Object);
         }
 
         private sealed record BlockAccessMock(
             PatientRepository PatientRepository,
             Mock<IBlockedAccessDelegate> BlockedAccessDelegate,
-            Mock<IMessageSender> MessageSender);
+            Mock<IOutboxStore> OutboxStore,
+            Mock<IBackgroundJobClient> BackgroundJobClient);
     }
 }

--- a/Apps/Admin/Server/Services/AdminReportService.cs
+++ b/Apps/Admin/Server/Services/AdminReportService.cs
@@ -41,22 +41,21 @@ namespace HealthGateway.Admin.Server.Services
             (IList<string> hdids, int totalHdids) = await delegationDelegate.GetProtectedDependentHdidsAsync(page, pageSize, sortDirection, ct);
 
             IEnumerable<Task<ProtectedDependentRecord>> tasks = hdids
-                .Select(
-                    async hdid =>
+                .Select(async hdid =>
+                {
+                    PatientQuery query = new PatientDetailsQuery(Hdid: hdid, Source: PatientDetailSource.All);
+                    PatientModel? patient = null;
+                    try
                     {
-                        PatientQuery query = new PatientDetailsQuery(Hdid: hdid, Source: PatientDetailSource.All);
-                        PatientModel? patient = null;
-                        try
-                        {
-                            patient = (await patientRepository.QueryAsync(query, ct)).Item;
-                        }
-                        catch (NotFoundException e)
-                        {
-                            logger.LogWarning(e, "Error retrieving patient details for dependent {DependentHdid}", hdid);
-                        }
+                        patient = (await patientRepository.QueryAsync(query, ct)).Item;
+                    }
+                    catch (NotFoundException e)
+                    {
+                        logger.LogWarning(e, "Error retrieving patient details for dependent {DependentHdid}", hdid);
+                    }
 
-                        return new ProtectedDependentRecord(hdid, patient?.Phn);
-                    });
+                    return new ProtectedDependentRecord(hdid, patient?.Phn);
+                });
 
             return new(await Task.WhenAll(tasks), new(totalHdids, page, pageSize));
         }
@@ -64,7 +63,7 @@ namespace HealthGateway.Admin.Server.Services
         /// <inheritdoc/>
         public async Task<IEnumerable<BlockedAccessRecord>> GetBlockedAccessReportAsync(CancellationToken ct = default)
         {
-            IList<BlockedAccess> records = await blockedAccessDelegate.GetAllAsync(ct);
+            IList<BlockedAccess> records = await blockedAccessDelegate.GetAllNoTrackingAsync(ct);
             return records
                 .Where(r => r.DataSources.Count > 0)
                 .Select(r => new BlockedAccessRecord(r.Hdid, [.. r.DataSources]));

--- a/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/AdminReportServiceTests.cs
@@ -231,7 +231,7 @@ namespace HealthGateway.Admin.Tests.Services
             ];
 
             Mock<IBlockedAccessDelegate> blockedAccessDelegateMock = new();
-            blockedAccessDelegateMock.Setup(s => s.GetAllAsync(It.IsAny<CancellationToken>())).ReturnsAsync(records);
+            blockedAccessDelegateMock.Setup(s => s.GetAllNoTrackingAsync(It.IsAny<CancellationToken>())).ReturnsAsync(records);
 
             IAdminReportService service = GetAdminReportService(blockedAccessDelegateMock: blockedAccessDelegateMock);
             return service;

--- a/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/DbBlockedAccessDelegate.cs
@@ -23,6 +23,7 @@ namespace HealthGateway.Database.Delegates
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
     using Microsoft.EntityFrameworkCore;
+    using Microsoft.EntityFrameworkCore.ChangeTracking;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
@@ -31,7 +32,7 @@ namespace HealthGateway.Database.Delegates
     public class DbBlockedAccessDelegate(ILogger<DbBlockedAccessDelegate> logger, GatewayDbContext dbContext) : IBlockedAccessDelegate
     {
         /// <inheritdoc/>
-        public async Task DeleteBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default)
+        public async Task DeleteAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default)
         {
             logger.LogDebug("Removing blocked access from DB for {Hdid}", blockedAccess.Hdid);
 
@@ -44,11 +45,14 @@ namespace HealthGateway.Database.Delegates
             logger.LogDebug("Adding audit record to DB");
             dbContext.AgentAudit.Add(agentAudit);
 
-            await dbContext.SaveChangesAsync(ct);
+            if (commit)
+            {
+                await dbContext.SaveChangesAsync(ct);
+            }
         }
 
         /// <inheritdoc/>
-        public async Task<BlockedAccess?> GetBlockedAccessAsync(string hdid, CancellationToken ct = default)
+        public async Task<BlockedAccess?> GetAsync(string hdid, CancellationToken ct = default)
         {
             logger.LogDebug("Retrieving blocked access from DB for {Hdid}", hdid);
             return await dbContext.BlockedAccess
@@ -57,32 +61,51 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
+        public async Task<BlockedAccess?> GetNoTrackingAsync(string hdid, CancellationToken ct = default)
+        {
+            return await dbContext.BlockedAccess
+                .AsNoTracking()
+                .Where(d => d.Hdid == hdid)
+                .SingleOrDefaultAsync(ct);
+        }
+
+        /// <inheritdoc/>
         public async Task<IEnumerable<DataSource>> GetDataSourcesAsync(string hdid, CancellationToken ct = default)
         {
-            BlockedAccess? blockedAccess = await this.GetBlockedAccessAsync(hdid, ct);
+            BlockedAccess? blockedAccess = await this.GetNoTrackingAsync(hdid, ct);
             return blockedAccess?.DataSources ?? [];
         }
 
         /// <inheritdoc/>
-        public async Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default)
+        public async Task UpsertAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default)
         {
             // Ensure the DataSources list remains logically unique.
             // This property was previously a HashSet<DataSource>, which prevented duplicates automatically.
-            // Since EF Core JSON mapping now requires List<T>, duplicates could appear;
-            // apply Distinct() to remove them if present before saving.
-            blockedAccess.DataSources = blockedAccess.DataSources
+            // Since EF Core JSON mapping now requires List<T>, duplicates could appear.
+            // Remove duplicates before saving while avoiding unnecessary updates when the list is already unique.
+            List<DataSource> distinctSources = blockedAccess.DataSources
                 .Distinct()
                 .ToList();
 
-            if (blockedAccess.Version == 0)
+            if (distinctSources.Count != blockedAccess.DataSources.Count)
             {
-                logger.LogDebug("Adding blocked access to DB for {Hdid}", blockedAccess.Hdid);
-                dbContext.BlockedAccess.Add(blockedAccess);
+                blockedAccess.DataSources = distinctSources;
             }
-            else
+
+            EntityEntry<BlockedAccess> entry = dbContext.Entry(blockedAccess);
+
+            if (entry.State == EntityState.Detached)
             {
-                logger.LogDebug("Updating blocked access in DB for {Hdid}", blockedAccess.Hdid);
-                dbContext.BlockedAccess.Update(blockedAccess);
+                if (blockedAccess.Version == 0)
+                {
+                    logger.LogDebug("Adding blocked access to DB for {Hdid}", blockedAccess.Hdid);
+                    dbContext.BlockedAccess.Add(blockedAccess);
+                }
+                else
+                {
+                    logger.LogDebug("Updating blocked access in DB for {Hdid}", blockedAccess.Hdid);
+                    dbContext.BlockedAccess.Update(blockedAccess);
+                }
             }
 
             logger.LogDebug("Adding audit record to DB");
@@ -95,10 +118,11 @@ namespace HealthGateway.Database.Delegates
         }
 
         /// <inheritdoc/>
-        public async Task<IList<BlockedAccess>> GetAllAsync(CancellationToken ct = default)
+        public async Task<IList<BlockedAccess>> GetAllNoTrackingAsync(CancellationToken ct = default)
         {
             logger.LogDebug("Retrieving blocked access from DB");
             return await dbContext.BlockedAccess
+                .AsNoTracking()
                 .ToListAsync(ct);
         }
     }

--- a/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
+++ b/Apps/Database/src/Delegates/IBlockedAccessDelegate.cs
@@ -34,7 +34,7 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">Should commit, default to true.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task DeleteBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default);
+        Task DeleteAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
         /// Fetches the blocked access by hdid from the database.
@@ -42,7 +42,15 @@ namespace HealthGateway.Database.Delegates
         /// <param name="hdid">The hdid to search by.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The blocked access or null if not found.</returns>
-        Task<BlockedAccess?> GetBlockedAccessAsync(string hdid, CancellationToken ct = default);
+        Task<BlockedAccess?> GetAsync(string hdid, CancellationToken ct = default);
+
+        /// <summary>
+        /// Fetches the blocked access by hdid from the database without tracking.
+        /// </summary>
+        /// <param name="hdid">The hdid to search by.</param>
+        /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <returns>The blocked access or null if not found.</returns>
+        Task<BlockedAccess?> GetNoTrackingAsync(string hdid, CancellationToken ct = default);
 
         /// <summary>
         /// Fetches the blocked access's data sources from the database.
@@ -60,13 +68,13 @@ namespace HealthGateway.Database.Delegates
         /// <param name="commit">Should commit, default to true.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
-        Task UpdateBlockedAccessAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default);
+        Task UpsertAsync(BlockedAccess blockedAccess, AgentAudit agentAudit, bool commit = true, CancellationToken ct = default);
 
         /// <summary>
-        /// Retrieves all blocked access records.
+        /// Retrieves all blocked access records from the database with no tracking.
         /// </summary>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>A collection of records of user HDIDs with the data sources currently blocked.</returns>
-        Task<IList<BlockedAccess>> GetAllAsync(CancellationToken ct = default);
+        Task<IList<BlockedAccess>> GetAllNoTrackingAsync(CancellationToken ct = default);
     }
 }


### PR DESCRIPTION
# Fixes or Implements [AB#17083](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17083)

## Description

This PR implements the DbBlockedAccessDelegate no-tracking work item and refactors blocked access persistence to support transactional processing and outbox-based event publishing.

**Changes**

* Added no-tracking retrieval methods to DbBlockedAccessDelegate and IBlockedAccessDelegate.
* Deleted un-used GetBlockedAccessRecordsAsync from PatientRepository.
* Renamed blocked access retrieval methods to distinguish tracked and no-tracking operations.
* Updated consumers to use no-tracking queries where entity tracking is not required.
* Added transaction handling to blocked access operations in PatientRepository.
* Persisted blocked access changes and outbox events within the same transaction.
* Dispatches outbox events only after a successful transaction commit using a Hangfire background job.
* Updated blocked access delete operations to participate in the transaction workflow.
* Removed manual updates to CreatedDateTime and UpdatedDateTime since these are managed through the audit entity.
* Simplified blocked access update/delete persistence logic and entity state handling.
* Updated unit tests to reflect the new transactional and persistence behaviour.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
