### PR TITLE
Add promise guard to prevent concurrent profile retrieval AB#17085

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/accept-terms-of-service/AcceptTermsOfServiceView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/accept-terms-of-service/AcceptTermsOfServiceView.vue
@@ -28,7 +28,7 @@ const termsOfService = ref("");
 const accepted = ref(false);
 
 function onSubmit(): void {
-    if (accepted.value !== true) {
+    if (accepted.value !== true || isLoading.value) {
         return;
     }
 
@@ -116,7 +116,7 @@ userProfileService
             <HgButtonComponent
                 data-testid="continue-btn"
                 variant="primary"
-                :disabled="!accepted"
+                :disabled="!accepted || isLoading"
                 text="Continue"
                 @click="onSubmit"
             />

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/InactiveUserProfileComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/InactiveUserProfileComponent.vue
@@ -29,6 +29,7 @@ const userStore = useUserStore();
 
 const timeForDeletion = ref(-1);
 const intervalHandler = ref<ReturnType<typeof setInterval>>();
+const isRecovering = ref(false);
 
 const timeForDeletionString = computed(() => {
     if (userStore.userIsActive) {
@@ -48,6 +49,12 @@ const timeForDeletionString = computed(() => {
 });
 
 function recoverAccount(): void {
+    if (isRecovering.value) {
+        return;
+    }
+
+    isRecovering.value = true;
+
     trackingService.trackEvent({
         action: Action.ButtonClick,
         text: Text.RecoverAccount,
@@ -56,18 +63,23 @@ function recoverAccount(): void {
     loadingStore.applyLoader(
         Loader.UserProfile,
         "recoverAccount",
-        userStore.recoverUserAccount().catch((err: ResultError) => {
-            logger.error(err.message);
-            if (err.statusCode === 429) {
-                errorStore.setTooManyRequestsError("page");
-            } else {
-                errorStore.addCustomError(
-                    `Unable to recover ${ErrorSourceType.Profile}`,
-                    ErrorSourceType.Profile,
-                    undefined
-                );
-            }
-        })
+        userStore
+            .recoverUserAccount()
+            .catch((err: ResultError) => {
+                logger.error(err.message);
+                if (err.statusCode === 429) {
+                    errorStore.setTooManyRequestsError("page");
+                } else {
+                    errorStore.addCustomError(
+                        `Unable to recover ${ErrorSourceType.Profile}`,
+                        ErrorSourceType.Profile,
+                        undefined
+                    );
+                }
+            })
+            .finally(() => {
+                isRecovering.value = false;
+            })
     );
 }
 
@@ -109,6 +121,7 @@ intervalHandler.value = globalThis.setInterval(
         id="recoverAccountCancelBtn"
         data-testid="recoverAccountCancelBtn"
         variant="primary"
+        :disabled="isRecovering"
         text="Recover Account"
         @click="recoverAccount"
     />

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileEmailComponent.vue
@@ -31,6 +31,7 @@ const userStore = useUserStore();
 
 const isEmailEditable = ref(false);
 const inputValue = ref(userStore.user.email);
+const isUpdatingEmail = ref(false);
 
 const email = computed(() => userStore.user.email);
 const emailVerified = computed(() => userStore.user.verifiedEmail);
@@ -80,6 +81,12 @@ function saveEmailEdit(): void {
 }
 
 function sendUserEmailUpdate(): void {
+    if (isUpdatingEmail.value) {
+        return;
+    }
+
+    isUpdatingEmail.value = true;
+
     trackingService.trackEvent({
         action: Action.ButtonClick,
         text: Text.VerifyEmailAddress,
@@ -103,6 +110,9 @@ function sendUserEmailUpdate(): void {
                 if (resultError?.statusCode === 429) {
                     errorStore.setTooManyRequestsError("page");
                 }
+            })
+            .finally(() => {
+                isUpdatingEmail.value = false;
             })
     );
 }
@@ -163,6 +173,7 @@ watch(email, (value) => (inputValue.value = value));
             variant="primary"
             text="Save"
             :disabled="
+                isUpdatingEmail ||
                 inputValue === email ||
                 !ValidationUtil.isValid(v$.inputValue, undefined, false)
             "
@@ -203,7 +214,7 @@ watch(email, (value) => (inputValue.value = value));
             class="mb-4"
             variant="secondary"
             text="Resend Verification"
-            :disabled="emailVerificationSent"
+            :disabled="emailVerificationSent || isUpdatingEmail"
             @click="sendUserEmailUpdate"
         />
     </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileManageAccountComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileManageAccountComponent.vue
@@ -24,8 +24,15 @@ const loadingStore = useLoadingStore();
 const userStore = useUserStore();
 
 const showCloseWarning = ref(false);
+const isClosingAccount = ref(false);
 
 function closeAccount(): void {
+    if (isClosingAccount.value) {
+        return;
+    }
+
+    isClosingAccount.value = true;
+
     trackingService.trackEvent({
         action: Action.ButtonClick,
         text: Text.DeleteAccount,
@@ -48,6 +55,9 @@ function closeAccount(): void {
                         undefined
                     );
                 }
+            })
+            .finally(() => {
+                isClosingAccount.value = false;
             })
     );
 }
@@ -91,6 +101,7 @@ function closeAccount(): void {
                     data-testid="closeAccountBtn"
                     color="error"
                     text="Delete Account"
+                    :disabled="isClosingAccount"
                     @click="closeAccount"
                 />
             </template>

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileSmsComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/UserProfileSmsComponent.vue
@@ -56,6 +56,7 @@ const maskedStorePhoneNumber = computed(() =>
 
 const inputPhoneNumber = ref(storePhoneNumber.value);
 const maskedInputPhoneNumber = ref(maskedStorePhoneNumber.value);
+const isUpdatingSms = ref(false);
 
 const verifySmsDialog = ref<InstanceType<typeof VerifySmsDialogComponent>>();
 
@@ -115,6 +116,12 @@ function saveSmsEdit(): void {
 }
 
 function updateSms(): void {
+    if (isUpdatingSms.value) {
+        return;
+    }
+
+    isUpdatingSms.value = true;
+
     // Reset timer when user submits their SMS number
     userStore.updateSmsResendDateTime(DateWrapper.now());
 
@@ -143,6 +150,9 @@ function updateSms(): void {
                         undefined
                     );
                 }
+            })
+            .finally(() => {
+                isUpdatingSms.value = false;
             })
     );
 }
@@ -248,6 +258,7 @@ watch(maskedInputPhoneNumber, (value) => {
             variant="primary"
             text="Save"
             :disabled="
+                isUpdatingSms ||
                 inputPhoneNumber === storePhoneNumber ||
                 !ValidationUtil.isValid(v$.inputPhoneNumber)
             "

--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
@@ -87,6 +87,10 @@ function setResendTimeout(): void {
 }
 
 async function verifySms(): Promise<void> {
+    if (isLoading.value) {
+        return;
+    }
+
     smsVerificationCode.value = smsVerificationCode.value.replaceAll(/\D/g, "");
     isLoading.value = true;
 
@@ -116,12 +120,18 @@ async function verifySms(): Promise<void> {
 }
 
 function sendUserSmsUpdate(): void {
+    if (smsVerificationSent.value) {
+        return;
+    }
+
     smsVerificationSent.value = true;
     userStore.updateSmsResendDateTime(DateWrapper.now());
     userProfileService
         .updateSmsNumber(user.value.hdid, props.smsNumber)
         .then(() => setTimeout(() => (smsVerificationSent.value = false), 5000))
         .catch((error) => {
+            smsVerificationSent.value = false;
+
             if (isTooManyRequestsError(error)) {
                 errorStore.setTooManyRequestsWarning("page");
             } else {

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -121,6 +121,8 @@ export const useUserStore = defineStore("user", () => {
             : `${oidcUserInfo.value.given_name} ${oidcUserInfo.value.family_name}`
     );
 
+    let retrieveEssentialDataPromise: Promise<void> | undefined = undefined;
+
     function setOidcUserInfo(userInfo: OidcUserInfo) {
         user.value.hdid = userInfo.hdid;
         oidcUserInfo.value = userInfo;
@@ -388,8 +390,13 @@ export const useUserStore = defineStore("user", () => {
     }
 
     function retrieveEssentialData(): Promise<void> {
+        if (retrieveEssentialDataPromise !== undefined) {
+            return retrieveEssentialDataPromise;
+        }
+
         status.value = LoadStatus.REQUESTED;
-        return patientService
+
+        retrieveEssentialDataPromise = patientService
             .getPatient(user.value.hdid)
             .then((result: Patient) => {
                 if (!result) {
@@ -397,7 +404,9 @@ export const useUserStore = defineStore("user", () => {
                     logger.debug("Patient retrieval failed");
                     return;
                 }
+
                 setPatient(result);
+
                 return userProfileService
                     .getProfile(user.value.hdid)
                     .then((userProfile) => {
@@ -433,7 +442,12 @@ export const useUserStore = defineStore("user", () => {
                 } else {
                     logger.debug("Patient retrieval failed");
                 }
+            })
+            .finally(() => {
+                retrieveEssentialDataPromise = undefined;
             });
+
+        return retrieveEssentialDataPromise;
     }
 
     function updateNotificationSettings(

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -121,7 +121,8 @@ export const useUserStore = defineStore("user", () => {
             : `${oidcUserInfo.value.given_name} ${oidcUserInfo.value.family_name}`
     );
 
-    let retrieveEssentialDataPromise: Promise<void> | undefined = undefined;
+let retrieveEssentialDataPromise: Promise<void> | undefined;
+let retrieveEssentialDataHdid: string | undefined;
 
     function setOidcUserInfo(userInfo: OidcUserInfo) {
         user.value.hdid = userInfo.hdid;


### PR DESCRIPTION
# Fixes or Implements [AB#17085](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17085)

## Description

* Added client-side guards to prevent duplicate submissions caused by rapid repeated clicks on profile and registration actions.
* Added a guard around retrieveEssentialData() to prevent concurrent execution during application initialization and authentication flows.
* Updated affected UI actions to disable controls while requests are in progress.

**Motivation**

These changes reduce the likelihood of duplicate requests being sent to the backend and help prevent concurrent operations that can contribute to UserProfile update conflicts and other race conditions.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
