### PR TITLE
Fix SMS resend countdown to start only after successful send AB#17086

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/profile/VerifySmsDialogComponent.vue
@@ -125,10 +125,12 @@ function sendUserSmsUpdate(): void {
     }
 
     smsVerificationSent.value = true;
-    userStore.updateSmsResendDateTime(DateWrapper.now());
     userProfileService
         .updateSmsNumber(user.value.hdid, props.smsNumber)
-        .then(() => setTimeout(() => (smsVerificationSent.value = false), 5000))
+        .then(() => {
+            userStore.updateSmsResendDateTime(DateWrapper.now());
+            setTimeout(() => (smsVerificationSent.value = false), 5000);
+        })
         .catch((error) => {
             smsVerificationSent.value = false;
 


### PR DESCRIPTION
# Fixes or Implements [AB#17086](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17086)

## Description

Fix SMS verification resend cooldown behavior so the countdown only starts after a verification SMS has been successfully sent.

**Issue**

The resend cooldown timestamp (smsResendDateTime) was being updated before the updateSmsNumber API call completed successfully.

As a result, if the SMS update request failed, the UI could still enter the resend cooldown state and display the countdown indicating that a verification code had been sent, even though no SMS was successfully sent.

**Fix**

Move the smsResendDateTime update into the successful completion path of the updateSmsNumber request.

This ensures that:

* The resend countdown only starts after a verification SMS has been successfully sent.
* Failed SMS update requests do not trigger the resend cooldown.
* The UI state remains consistent with the actual outcome of the SMS update operation.

No functional changes were made to successful SMS verification flows.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
