### PR TITLE
Implement V2 for hospital visits AB#17088

### DIFF
--- a/Apps/Patient/src/Constants/PatientDataType.cs
+++ b/Apps/Patient/src/Constants/PatientDataType.cs
@@ -37,5 +37,10 @@ namespace HealthGateway.Patient.Constants
         /// BC Cancer screening.
         /// </summary>
         BcCancerScreening,
+
+        /// <summary>
+        /// Hospital Visits.
+        /// </summary>
+        HospitalVisits,
     }
 }

--- a/Apps/Patient/src/Mappings/PatientDataAccessMappings.cs
+++ b/Apps/Patient/src/Mappings/PatientDataAccessMappings.cs
@@ -36,31 +36,31 @@ namespace HealthGateway.Patient.Mappings
         public PatientDataAccessMappings()
         {
             this.CreateMap<PatientDataType, HealthCategory>()
-                .ConvertUsing(
-                    (source, _, _) =>
+                .ConvertUsing((source, _, _) =>
+                {
+                    return source switch
                     {
-                        return source switch
-                        {
-                            PatientDataType.OrganDonorRegistrationStatus => HealthCategory.OrganDonorRegistrationStatus,
-                            PatientDataType.DiagnosticImaging => HealthCategory.DiagnosticImaging,
-                            PatientDataType.BcCancerScreening => HealthCategory.BcCancerScreening,
-                            _ => throw new NotImplementedException($"Mapping for {source} is not implemented"),
-                        };
-                    });
+                        PatientDataType.OrganDonorRegistrationStatus => HealthCategory.OrganDonorRegistrationStatus,
+                        PatientDataType.DiagnosticImaging => HealthCategory.DiagnosticImaging,
+                        PatientDataType.BcCancerScreening => HealthCategory.BcCancerScreening,
+                        PatientDataType.HospitalVisits => HealthCategory.HospitalVisits,
+                        _ => throw new NotImplementedException($"Mapping for {source} is not implemented"),
+                    };
+                });
             this.CreateMap<HealthData, PatientData>()
                 .ConvertUsing<PatientDataConverter>();
             this.CreateMap<PatientDataType, DataSource>()
-                .ConvertUsing(
-                    (source, _, _) =>
+                .ConvertUsing((source, _, _) =>
+                {
+                    return source switch
                     {
-                        return source switch
-                        {
-                            PatientDataType.OrganDonorRegistrationStatus => DataSource.OrganDonorRegistration,
-                            PatientDataType.DiagnosticImaging => DataSource.DiagnosticImaging,
-                            PatientDataType.BcCancerScreening => DataSource.BcCancerScreening,
-                            _ => throw new NotImplementedException($"Mapping for {source} is not implemented"),
-                        };
-                    });
+                        PatientDataType.OrganDonorRegistrationStatus => DataSource.OrganDonorRegistration,
+                        PatientDataType.DiagnosticImaging => DataSource.DiagnosticImaging,
+                        PatientDataType.BcCancerScreening => DataSource.BcCancerScreening,
+                        PatientDataType.HospitalVisits => DataSource.HospitalVisit,
+                        _ => throw new NotImplementedException($"Mapping for {source} is not implemented"),
+                    };
+                });
         }
 
 #pragma warning disable SA1600

--- a/Apps/PatientDataAccess/src/Api/HealthDataEntry.cs
+++ b/Apps/PatientDataAccess/src/Api/HealthDataEntry.cs
@@ -139,6 +139,34 @@ namespace HealthGateway.PatientDataAccess.Api
 
         public DateTimeOffset ResultTimestamp { get; set; }
     }
+
+    [ExcludeFromCodeCoverage]
+    internal record HospitalVisit : HealthDataEntry
+    {
+        public string? EncounterId { get; init; }
+
+        public string? Facility { get; init; }
+
+        public string? HealthService { get; init; }
+
+        public string? VisitType { get; init; }
+
+        public string? HealthAuthority { get; init; }
+
+        public DateTime? AdmitDateTime { get; init; }
+
+        public DateTime? EndDateTime { get; init; }
+
+        public IEnumerable<Clinician>? Clinicians { get; init; }
+    }
+
+    [ExcludeFromCodeCoverage]
+    internal record Clinician
+    {
+        public string? DisplayName { get; set; }
+
+        public string? RoleDescription { get; set; }
+    }
 }
 #pragma warning restore SA1600
 #pragma warning restore SA1602

--- a/Apps/PatientDataAccess/src/Api/HealthDataJsonConverter.cs
+++ b/Apps/PatientDataAccess/src/Api/HealthDataJsonConverter.cs
@@ -33,6 +33,7 @@ namespace HealthGateway.PatientDataAccess.Api
                 "ClinicalDocument" => typeof(ClinicalDocument),
                 "DiagnosticImaging" => typeof(DiagnosticImagingExam),
                 "BcCancerScreening" => typeof(BcCancerScreening),
+                "HospitalVisits" => typeof(HospitalVisit),
                 _ => null,
             };
         }

--- a/Apps/PatientDataAccess/src/Api/IPatientApi.cs
+++ b/Apps/PatientDataAccess/src/Api/IPatientApi.cs
@@ -39,6 +39,7 @@ namespace HealthGateway.PatientDataAccess.Api
         ClinicalDocument,
         DiagnosticImaging,
         BcCancerScreening,
+        HospitalVisits,
     }
 
     internal enum DiagnosticImagingStatus

--- a/Apps/PatientDataAccess/src/HealthData.cs
+++ b/Apps/PatientDataAccess/src/HealthData.cs
@@ -111,6 +111,53 @@ namespace HealthGateway.PatientDataAccess
     }
 
     /// <summary>
+    /// The details of a hospital visit.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public record HospitalVisit : HealthData
+    {
+        /// <summary>
+        /// Gets the encounter id.
+        /// </summary>
+        public string? EncounterId { get; init; }
+
+        /// <summary>
+        /// Gets the facility.
+        /// </summary>
+        public string? Facility { get; init; }
+
+        /// <summary>
+        /// Gets the health service.
+        /// </summary>
+        public string? HealthService { get; init; }
+
+        /// <summary>
+        /// Gets the visit type.
+        /// </summary>
+        public string? VisitType { get; init; }
+
+        /// <summary>
+        /// Gets the health authority.
+        /// </summary>
+        public string? HealthAuthority { get; init; }
+
+        /// <summary>
+        /// Gets the admit date time.
+        /// </summary>
+        public DateTime? AdmitDateTime { get; init; }
+
+        /// <summary>
+        /// Gets the end date time.
+        /// </summary>
+        public DateTime? EndDateTime { get; init; }
+
+        /// <summary>
+        /// Gets the provider.
+        /// </summary>
+        public string? Provider { get; init; }
+    }
+
+    /// <summary>
     /// Diagnostic image exam statuses.
     /// </summary>
     public enum DiagnosticImagingStatus

--- a/Apps/PatientDataAccess/src/IPatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/IPatientDataRepository.cs
@@ -67,6 +67,11 @@ namespace HealthGateway.PatientDataAccess
         /// BC Cancer Screening.
         /// </summary>
         BcCancerScreening,
+
+        /// <summary>
+        /// Hospital Visits.
+        /// </summary>
+        HospitalVisits,
     }
 
     /// <summary>

--- a/Apps/PatientDataAccess/src/Mappings.cs
+++ b/Apps/PatientDataAccess/src/Mappings.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.PatientDataAccess
 {
 #pragma warning disable SA1600 // Disables documentation for internal class.
+    using System.Linq;
     using AutoMapper;
     using HealthGateway.PatientDataAccess.Api;
 
@@ -40,6 +41,13 @@ namespace HealthGateway.PatientDataAccess
             this.CreateMap<Api.BcCancerScreening, BcCancerScreening>()
                 .ForMember(d => d.EventDateTime, opts => opts.MapFrom(cse => cse.EventTimestampUtc))
                 .ForMember(d => d.ResultDateTime, opts => opts.MapFrom(cse => cse.ResultTimestamp.UtcDateTime));
+
+            this.CreateMap<Api.HospitalVisit, HospitalVisit>()
+                .ForMember(
+                    dest => dest.Provider,
+                    opt => opt.MapFrom(src => src.Clinicians == null
+                        ? null
+                        : src.Clinicians.Select(c => c.DisplayName).FirstOrDefault()));
         }
     }
 }

--- a/Apps/PatientDataAccess/src/PatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/PatientDataRepository.cs
@@ -67,6 +67,7 @@ namespace HealthGateway.PatientDataAccess
             {
                 HealthCategory.DiagnosticImaging => "DiagnosticImaging",
                 HealthCategory.BcCancerScreening => "BcCancerScreening",
+                HealthCategory.HospitalVisits => "HospitalVisits",
                 _ => null,
             };
         }

--- a/Apps/PatientDataAccess/test/unit/HealthDataJsonConverterTests.cs
+++ b/Apps/PatientDataAccess/test/unit/HealthDataJsonConverterTests.cs
@@ -35,6 +35,7 @@ namespace PatientDataAccessTests
         [InlineData("{\"healthDataType\":\"ClinicalDocument\"}", typeof(ClinicalDocument))]
         [InlineData("{\"healthDataType\":\"DiagnosticImaging\"}", typeof(DiagnosticImagingExam))]
         [InlineData("{\"healthDataType\":\"BcCancerScreening\"}", typeof(BcCancerScreening))]
+        [InlineData("{\"healthDataType\":\"HospitalVisits\"}", typeof(HospitalVisit))]
         public void TestValidHealthDataJsonConversions(string json, Type expectedType)
         {
             // Create Utf8JsonReader from json string.

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -26,6 +26,7 @@ namespace PatientDataAccessTests
     using BcCancerScreeningType = HealthGateway.PatientDataAccess.Api.CancerScreeningType;
     using DiagnosticImagingExam = HealthGateway.PatientDataAccess.Api.DiagnosticImagingExam;
     using DiagnosticImagingStatus = HealthGateway.PatientDataAccess.Api.DiagnosticImagingStatus;
+    using HospitalVisit = HealthGateway.PatientDataAccess.Api.HospitalVisit;
     using OrganDonorRegistration = HealthGateway.PatientDataAccess.Api.OrganDonorRegistration;
     using OrganDonorRegistrationStatus = HealthGateway.PatientDataAccess.Api.OrganDonorRegistrationStatus;
 
@@ -166,6 +167,42 @@ namespace PatientDataAccessTests
 
             HealthGateway.PatientDataAccess.BcCancerScreening csExam = result.Items.Last().ShouldBeOfType<HealthGateway.PatientDataAccess.BcCancerScreening>();
             csExam.Id.ShouldBe(bcCancerScreening.HealthDataId);
+        }
+
+        [Fact]
+        public async Task CanGetHospitalVisitData()
+        {
+            Mock<IPatientApi> patientApi = new();
+
+            HospitalVisit hospitalVisit = new()
+            {
+                HealthDataId = "12345678931",
+                HealthDataFileId = "12345678931",
+                EncounterId = "123",
+                AdmitDateTime = DateTime.Parse("2020-01-15", CultureInfo.InvariantCulture),
+                EndDateTime = null,
+                Clinicians = [new() { DisplayName = "Display", RoleDescription = "Role" }],
+            };
+
+            patientApi
+                .Setup(api => api.GetHealthDataAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(
+                    new HealthDataResult(
+                        new HealthDataMetadata(),
+                        [hospitalVisit]));
+
+            IPatientDataRepository sut = CreateSut(patientApi.Object);
+
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.HospitalVisits]), CancellationToken.None);
+
+            result.ShouldNotBeNull();
+            HealthGateway.PatientDataAccess.HospitalVisit visit = result.Items.ShouldHaveSingleItem().ShouldBeOfType<HealthGateway.PatientDataAccess.HospitalVisit>();
+            visit.Id.ShouldBe(hospitalVisit.HealthDataId);
+            visit.FileId.ShouldBe(hospitalVisit.HealthDataFileId);
+            visit.EncounterId.ShouldBe(hospitalVisit.EncounterId);
+            visit.AdmitDateTime.ShouldBe(hospitalVisit.AdmitDateTime);
+            visit.EndDateTime.ShouldBeNull();
+            visit.Provider.ShouldBe("Display");
         }
 
         [Fact]


### PR DESCRIPTION
# Fixes or Implements [AB#17088](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17088)

## Description

Implements V2 support for Hospital Visits in Patient Data Access.

This change adds Hospital Visits as a supported health data category and maps the new V2 API response into the Patient Data Access model.

Updates include:

* Added HospitalVisits to supported patient data types and health categories.
* Added API models for hospital visit records and clinicians.
* Added JSON conversion support for HospitalVisits.
* Added mappings from V2 hospital visit API data to Patient Data Access models.
* Added repository support for querying the HospitalVisits category.
* Added unit test coverage for Hospital Visits JSON conversion and repository mapping.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
