### PR TITLE
Reduce vertical margins under labels J#3480

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/common/LabelComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/common/LabelComponent.vue
@@ -4,7 +4,7 @@ interface Props {
     margin?: string;
 }
 withDefaults(defineProps<Props>(), {
-    margin: "mb-4",
+    margin: "mb-2",
 });
 </script>
 

--- a/Apps/WebClient/src/ClientApp/src/components/private/timeline/FilterComponent.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/timeline/FilterComponent.vue
@@ -197,8 +197,8 @@ function getFormattedFilterCount(entryType: EntryType): string {
                         placeholder="i.e. Medication Name"
                         prepend-inner-icon="search"
                     />
-                    <LabelComponent title="Type" margin="mb-3" />
-                    <div class="mb-3">
+                    <LabelComponent title="Type" margin="mb-0" />
+                    <div class="mb-2">
                         <v-chip-group
                             v-model="selectedEntryTypes"
                             column


### PR DESCRIPTION
# Implements J#3480

## Description

Further enhancement to 3480. Reduces margins between labels and fields from 16px to 8px. Affects the profile page primarily, along with the filter dialog on the timeline.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

Affects spacing under 'Full Name', 'Personal Health Number', 'Email Address', 'Cell Number (SMS notifications)', 'Mailing Address', and 'Physical Address'.

Before:

<img width="1920" height="1594" alt="current" src="https://github.com/user-attachments/assets/5b24c3ee-e8d3-4514-a418-f2551632d723" />

<img width="1920" height="959" alt="current-timeline-filter" src="https://github.com/user-attachments/assets/1548645e-40f2-4eb4-a363-c204eb6dccab" />

After:

<img width="1920" height="1546" alt="proposed" src="https://github.com/user-attachments/assets/ad07eea7-e24a-4137-b076-8e9c80dc6a6d" />

<img width="1920" height="959" alt="proposed-timeline-filter" src="https://github.com/user-attachments/assets/d28f94d1-25b9-42dd-8153-4ff288463d64" />

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
