### PR TITLE
Update front-end for V2 Hospital Visits AB#17091

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/models/datasetState.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/datasetState.ts
@@ -26,9 +26,7 @@ export type Covid19TestResultState = DatasetState<Covid19LaboratoryOrder[]>;
 export type HealthVisitState = DatasetState<Encounter[]>;
 export type PatientDataState = DatasetState<PatientDataMap>;
 export type PatientDataFileState = DatasetState<PatientDataFile | undefined>;
-export interface HospitalVisitState extends DatasetState<HospitalVisit[]> {
-    queued: boolean;
-}
+export type HospitalVisitState = DatasetState<HospitalVisit[]>;
 export interface ImmunizationDatasetState extends DatasetState<
     ImmunizationEvent[]
 > {

--- a/Apps/WebClient/src/ClientApp/src/models/hospitalVisitResult.ts
+++ b/Apps/WebClient/src/ClientApp/src/models/hospitalVisitResult.ts
@@ -1,8 +1,0 @@
-import { HospitalVisit } from "@/models/encounter";
-
-export default interface HospitalVisitResult {
-    loaded: boolean;
-    queued: boolean;
-    retryin: number;
-    hospitalVisits: HospitalVisit[];
-}

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -7,8 +7,7 @@ import CovidVaccineRecord from "@/models/covidVaccineRecord";
 import { StringISODate } from "@/models/dateWrapper";
 import type { Dependent } from "@/models/dependent";
 import EncodedMedia from "@/models/encodedMedia";
-import { Encounter } from "@/models/encounter";
-import HospitalVisitResult from "@/models/hospitalVisitResult";
+import { Encounter, HospitalVisit } from "@/models/encounter";
 import type ImmunizationResult from "@/models/immunizationResult";
 import {
     Covid19LaboratoryOrderResult,
@@ -97,9 +96,7 @@ export interface IEncounterService {
 }
 
 export interface IHospitalVisitService {
-    getHospitalVisits(
-        hdid: string
-    ): Promise<RequestResult<HospitalVisitResult>>;
+    getHospitalVisits(hdid: string): Promise<HospitalVisit[]>;
 }
 
 export interface ILaboratoryService {

--- a/Apps/WebClient/src/ClientApp/src/services/restHospitalVisitService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restHospitalVisitService.ts
@@ -1,10 +1,8 @@
 import { EntryType } from "@/constants/entryType";
-import { ResultType } from "@/constants/resulttype";
 import { ServiceCode } from "@/constants/serviceCodes";
 import { ExternalConfiguration } from "@/models/configData";
+import { HospitalVisit } from "@/models/encounter";
 import { HttpError } from "@/models/errors";
-import HospitalVisitResult from "@/models/hospitalVisitResult";
-import RequestResult from "@/models/requestResult";
 import {
     IHospitalVisitService,
     IHttpDelegate,
@@ -14,6 +12,7 @@ import ConfigUtil from "@/utility/configUtil";
 import ErrorTranslator from "@/utility/errorTranslator";
 
 export class RestHospitalVisitService implements IHospitalVisitService {
+    private readonly API_VERSION: string = "2.0";
     private readonly HOSPITAL_VISIT_BASE_URI: string = "Encounter";
     private readonly logger;
     private readonly http;
@@ -31,28 +30,15 @@ export class RestHospitalVisitService implements IHospitalVisitService {
         this.isEnabled = ConfigUtil.isDatasetEnabled(EntryType.HospitalVisit);
     }
 
-    public getHospitalVisits(
-        hdid: string
-    ): Promise<RequestResult<HospitalVisitResult>> {
+    public getHospitalVisits(hdid: string): Promise<HospitalVisit[]> {
         if (!this.isEnabled) {
-            return Promise.resolve({
-                pageIndex: 0,
-                pageSize: 0,
-                resourcePayload: {
-                    loaded: true,
-                    queued: false,
-                    retryin: 0,
-                    hospitalVisits: [],
-                },
-                resultStatus: ResultType.Success,
-                totalResultCount: 0,
-            });
+            return Promise.resolve([]);
         }
 
         return this.http
             .getWithCors<
-                RequestResult<HospitalVisitResult>
-            >(`${this.baseUri}${this.HOSPITAL_VISIT_BASE_URI}/HospitalVisit/${hdid}`)
+                HospitalVisit[]
+            >(`${this.baseUri}${this.HOSPITAL_VISIT_BASE_URI}/HospitalVisit/${hdid}?api-version=${this.API_VERSION}`)
             .catch((err: HttpError) => {
                 this.logger.error(
                     `Error in RestHospitalVisitService.getHospitalVisits()`

--- a/Apps/WebClient/src/ClientApp/src/stores/hospitalVisit.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/hospitalVisit.ts
@@ -1,16 +1,12 @@
 ﻿import { defineStore } from "pinia";
 import { ref } from "vue";
 
-import { ActionType } from "@/constants/actionType";
 import { ErrorSourceType, ErrorType } from "@/constants/errorType";
-import { ResultType } from "@/constants/resulttype";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
 import { HospitalVisitState } from "@/models/datasetState";
 import { HospitalVisit } from "@/models/encounter";
 import { ResultError } from "@/models/errors";
-import HospitalVisitResult from "@/models/hospitalVisitResult";
-import RequestResult from "@/models/requestResult";
 import { LoadStatus } from "@/models/storeOperations";
 import { Action, Dataset, Text } from "@/plugins/extensions";
 import {
@@ -26,7 +22,6 @@ const defaultHospitalVisitState: HospitalVisitState = {
     status: LoadStatus.NONE,
     statusMessage: "",
     error: undefined,
-    queued: false,
 };
 
 export const useHospitalVisitStore = defineStore("hospitalVisit", () => {
@@ -55,39 +50,20 @@ export const useHospitalVisitStore = defineStore("hospitalVisit", () => {
         return getHospitalVisitsState(hdid).status === LoadStatus.REQUESTED;
     }
 
-    function hospitalVisitsAreQueued(hdid: string): boolean {
-        return getHospitalVisitsState(hdid).queued;
-    }
-
     function hospitalVisitsCount(hdid: string): number {
         return getHospitalVisitsState(hdid).data.length;
     }
 
-    function setHospitalVisitRefreshInProgress(
-        hdid: string,
-        hospitalVisitResult: HospitalVisitResult
-    ) {
-        const hospitalVisitState = getHospitalVisitsState(hdid);
-        hospitalVisitsMap.value.set(hdid, {
-            ...hospitalVisitState,
-            data: hospitalVisitResult.hospitalVisits,
-            error: undefined,
-            statusMessage: "",
-            status: LoadStatus.REQUESTED,
-            queued: hospitalVisitResult.queued,
-        });
-    }
-
     function setHospitalVisits(
         hdid: string,
-        hospitalVisitResult: HospitalVisitResult
+        hospitalVisits: HospitalVisit[]
     ): void {
         datasetMapUtil.setStateData(
             hospitalVisitsMap.value,
             hdid,
-            hospitalVisitResult.hospitalVisits,
+            hospitalVisits,
             {
-                queued: hospitalVisitResult.queued,
+                queued: false,
             }
         );
     }
@@ -115,28 +91,13 @@ export const useHospitalVisitStore = defineStore("hospitalVisit", () => {
         }
     }
 
-    function retrieveHospitalVisits(
-        hdid: string
-    ): Promise<RequestResult<HospitalVisitResult>> {
+    function retrieveHospitalVisits(hdid: string): Promise<HospitalVisit[]> {
         const trackingService = container.get<ITrackingService>(
             SERVICE_IDENTIFIER.TrackingService
         );
         if (getHospitalVisitsState(hdid).status === LoadStatus.LOADED) {
             logger.debug(`Hospital Visits found stored, not querying!`);
-            const visits: HospitalVisit[] = hospitalVisits(hdid);
-            const hospitalVisitsQueued: boolean = hospitalVisitsAreQueued(hdid);
-            return Promise.resolve({
-                pageIndex: 0,
-                pageSize: 0,
-                resourcePayload: {
-                    loaded: true,
-                    queued: hospitalVisitsQueued,
-                    retryin: 0,
-                    hospitalVisits: visits,
-                },
-                resultStatus: ResultType.Success,
-                totalResultCount: visits.length,
-            });
+            return Promise.resolve(hospitalVisits(hdid));
         }
 
         logger.debug(`Retrieving Hospital Visits`);
@@ -144,43 +105,15 @@ export const useHospitalVisitStore = defineStore("hospitalVisit", () => {
         return hospitalVisitService
             .getHospitalVisits(hdid)
             .then((result) => {
-                const payload = result.resourcePayload;
-                if (
-                    result.resultStatus === ResultType.Success &&
-                    payload.loaded
-                ) {
-                    if (result.totalResultCount > 0) {
-                        trackingService.trackEvent({
-                            action: Action.Load,
-                            text: Text.Data,
-                            dataset: Dataset.HospitalVisits,
-                        });
-                    }
-                    logger.info(`Hospital Visits loaded.`);
-                    setHospitalVisits(hdid, payload);
-                } else if (
-                    result.resultError?.actionCode === ActionType.Refresh &&
-                    !payload.loaded &&
-                    payload.retryin > 0
-                ) {
-                    logger.info(
-                        `Refresh in progress.... partially load hospital visits`
-                    );
-                    setHospitalVisitRefreshInProgress(hdid, payload);
-                    setTimeout(() => {
-                        logger.info("Re-querying for hospital visits");
-                        retrieveHospitalVisits(hdid);
-                    }, payload.retryin);
-                } else {
-                    if (result.resultError) {
-                        throw ResultError.fromModel(result.resultError);
-                    }
-                    logger.warn(
-                        `Hospital visits retrieval failed! ${JSON.stringify(
-                            result
-                        )}`
-                    );
+                if (result.length > 0) {
+                    trackingService.trackEvent({
+                        action: Action.Load,
+                        text: Text.Data,
+                        dataset: Dataset.HospitalVisits,
+                    });
                 }
+                logger.info(`Hospital Visits loaded.`);
+                setHospitalVisits(hdid, result);
 
                 return result;
             })
@@ -198,7 +131,6 @@ export const useHospitalVisitStore = defineStore("hospitalVisit", () => {
     return {
         hospitalVisits,
         hospitalVisitsAreLoading,
-        hospitalVisitsAreQueued,
         hospitalVisitsCount,
         retrieveHospitalVisits,
     };

--- a/Apps/WebClient/src/ClientApp/src/stores/hospitalVisit.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/hospitalVisit.ts
@@ -61,10 +61,7 @@ export const useHospitalVisitStore = defineStore("hospitalVisit", () => {
         datasetMapUtil.setStateData(
             hospitalVisitsMap.value,
             hdid,
-            hospitalVisits,
-            {
-                queued: false,
-            }
+            hospitalVisits
         );
     }
 

--- a/Testing/functional/tests/cypress/fixtures/Report/hospitalVisitUnSorted.json
+++ b/Testing/functional/tests/cypress/fixtures/Report/hospitalVisitUnSorted.json
@@ -1,44 +1,32 @@
-{
-    "resourcePayload": {
-        "loaded": true,
-        "queued": false,
-        "retryin": 0,
-        "hospitalVisits": [
-            {
-                "encounterId": "4edcc644-2877-4d4a-a3da-b189f1b5de26",
-                "facility": "Vancouver General Hospital",
-                "healthService": "Gynecology",
-                "visitType": "Series",
-                "healthAuthority": "VCHA",
-                "admitDateTime": "2019-02-01T15:00:00Z",
-                "endDateTime": "2020-01-31T15:00:00Z",
-                "provider": null
-            },
-            {
-                "encounterId": "38406137-1bd3-4f6c-8bce-cb8316177c78",
-                "facility": "BC Cancer",
-                "healthService": "Hematology",
-                "visitType": "Preadmit",
-                "healthAuthority": "VCHA",
-                "admitDateTime": "2018-12-20T01:18:00Z",
-                "endDateTime": "2018-12-20T01:18:00Z",
-                "provider": null
-            },
-            {
-                "encounterId": "2220582e-9922-42be-a158-1fe6b69f7863",
-                "facility": "BC Cancer",
-                "healthService": "Hematology",
-                "visitType": "Preadmit",
-                "healthAuthority": "VCHA",
-                "admitDateTime": "2020-12-19T01:18:00Z",
-                "endDateTime": "2020-12-19T01:18:00Z",
-                "provider": null
-            }
-        ]
+[
+    {
+        "encounterId": "4edcc644-2877-4d4a-a3da-b189f1b5de26",
+        "facility": "Vancouver General Hospital",
+        "healthService": "Gynecology",
+        "visitType": "Series",
+        "healthAuthority": "VCHA",
+        "admitDateTime": "2019-02-01T15:00:00Z",
+        "endDateTime": "2020-01-31T15:00:00Z",
+        "provider": null
     },
-    "totalResultCount": 3,
-    "pageIndex": null,
-    "pageSize": null,
-    "resultStatus": 1,
-    "resultError": null
-}
+    {
+        "encounterId": "38406137-1bd3-4f6c-8bce-cb8316177c78",
+        "facility": "BC Cancer",
+        "healthService": "Hematology",
+        "visitType": "Preadmit",
+        "healthAuthority": "VCHA",
+        "admitDateTime": "2018-12-20T01:18:00Z",
+        "endDateTime": "2018-12-20T01:18:00Z",
+        "provider": null
+    },
+    {
+        "encounterId": "2220582e-9922-42be-a158-1fe6b69f7863",
+        "facility": "BC Cancer",
+        "healthService": "Hematology",
+        "visitType": "Preadmit",
+        "healthAuthority": "VCHA",
+        "admitDateTime": "2020-12-19T01:18:00Z",
+        "endDateTime": "2020-12-19T01:18:00Z",
+        "provider": null
+    }
+]

--- a/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
+++ b/Testing/functional/tests/cypress/integration/ui/report/reportSorting.js
@@ -284,9 +284,13 @@ describe("Reports - Hospital Visits", () => {
     });
 
     it("Validate Hospital Visit Report with Unsorted Data", () => {
-        cy.intercept("GET", `**/Encounter/HospitalVisit/${HDID}`, {
-            fixture: "Report/hospitalVisitUnSorted.json",
-        });
+        cy.intercept(
+            "GET",
+            `**/Encounter/HospitalVisit/${HDID}?api-version=2.0`,
+            {
+                fixture: "Report/hospitalVisitUnSorted.json",
+            }
+        );
         cy.vSelect("[data-testid=report-type]", "Hospital Visits");
 
         cy.get("[data-testid=report-sample]").should("be.visible");


### PR DESCRIPTION
# Implements [AB#17091](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17091)

## Description

Updates the hospital visit service in the front-end to call the new V2 endpoint. Removes logic associated with retries, as the new models do not include the properties to support that behaviour. Updates a functional test that previously used a fixture for V1 hospital visits to now use a fixture for V2 hospital visits.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
