### PR TITLE
Use separate DbContext for audit writes AB#17090

### DIFF
--- a/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Db.cs
@@ -43,36 +43,47 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
             logger.LogDebug("Sensitive Data Logging is enabled: {IsSensitiveDataLoggingEnabled}", isSensitiveDataLoggingEnabled);
 
             services.AddEntityFrameworkNpgsql();
-            services.AddSingleton(
-                _ =>
-                {
-                    NpgsqlDataSourceBuilder dataSourceBuilder = new(configuration.GetConnectionString("GatewayConnection"));
-                    dataSourceBuilder.EnableDynamicJson();
-                    return dataSourceBuilder.Build();
-                });
+            services.AddSingleton(_ =>
+            {
+                NpgsqlDataSourceBuilder dataSourceBuilder = new(configuration.GetConnectionString("GatewayConnection"));
+                dataSourceBuilder.EnableDynamicJson();
+                return dataSourceBuilder.Build();
+            });
 
-            services.AddDbContextPool<GatewayDbContext>(
-                (sp, options) =>
+            services.AddDbContextPool<GatewayDbContext>((sp, options) =>
+            {
+                NpgsqlDataSource ds = sp.GetRequiredService<NpgsqlDataSource>();
+                options.UseInternalServiceProvider(sp);
+                options.UseNpgsql(
+                    ds,
+                    builder => builder.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
+                if (isSensitiveDataLoggingEnabled)
                 {
-                    NpgsqlDataSource ds = sp.GetRequiredService<NpgsqlDataSource>();
-                    options.UseInternalServiceProvider(sp);
-                    options.UseNpgsql(
-                        ds,
-                        builder => builder.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
-                    if (isSensitiveDataLoggingEnabled)
-                    {
-                        options.EnableSensitiveDataLogging();
-                    }
-                });
+                    options.EnableSensitiveDataLogging();
+                }
+            });
+
+            services.AddPooledDbContextFactory<GatewayDbContext>((sp, options) =>
+            {
+                NpgsqlDataSource ds = sp.GetRequiredService<NpgsqlDataSource>();
+                options.UseInternalServiceProvider(sp);
+                options.UseNpgsql(
+                    ds,
+                    builder => builder.MigrationsHistoryTable("__EFMigrationsHistory", "gateway"));
+
+                if (isSensitiveDataLoggingEnabled)
+                {
+                    options.EnableSensitiveDataLogging();
+                }
+            });
 
             if (isSensitiveDataLoggingEnabled)
             {
-                services.AddLogging(
-                    loggingBuilder =>
-                    {
-                        loggingBuilder.AddConsole()
-                            .AddFilter(DbLoggerCategory.Database.Command.Name, LogLevel.Information);
-                    });
+                services.AddLogging(loggingBuilder =>
+                {
+                    loggingBuilder.AddConsole()
+                        .AddFilter(DbLoggerCategory.Database.Command.Name, LogLevel.Information);
+                });
             }
         }
     }

--- a/Apps/Database/src/Delegates/DbWriteAuditEventDelegate.cs
+++ b/Apps/Database/src/Delegates/DbWriteAuditEventDelegate.cs
@@ -20,18 +20,20 @@ namespace HealthGateway.Database.Delegates
     using System.Threading.Tasks;
     using HealthGateway.Database.Context;
     using HealthGateway.Database.Models;
+    using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Logging;
 
     /// <inheritdoc/>
     /// <param name="logger">The injected logger.</param>
-    /// <param name="dbContext">The context to be used when accessing the database context.</param>
+    /// <param name="dbContextFactory">The factory used to create an isolated database context for writing audit events.</param>
     [ExcludeFromCodeCoverage]
-    public class DbWriteAuditEventDelegate(ILogger<DbWriteAuditEventDelegate> logger, GatewayDbContext dbContext) : IWriteAuditEventDelegate
+    public class DbWriteAuditEventDelegate(ILogger<DbWriteAuditEventDelegate> logger, IDbContextFactory<GatewayDbContext> dbContextFactory) : IWriteAuditEventDelegate
     {
         /// <inheritdoc/>
         public async Task WriteAuditEventAsync(AuditEvent auditEvent, CancellationToken ct = default)
         {
             logger.LogDebug("Adding audit event to DB");
+            await using GatewayDbContext dbContext = await dbContextFactory.CreateDbContextAsync(ct);
             dbContext.Add(auditEvent);
             await dbContext.SaveChangesAsync(ct);
         }


### PR DESCRIPTION
# Fixes or Implements [AB#17090](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17090)

## Description

Updated audit event writes to use a separate `GatewayDbContext` created from `IDbContextFactory`.

This prevents audit logging from reusing the request-scoped context, which may contain other tracked entities with pending or failed changes. Audit writes are now isolated from unrelated request database operations.

### Changes

- Added pooled `GatewayDbContext` factory registration.
- Updated `DbWriteAuditEventDelegate` to create a dedicated context for audit writes.
- Audit event saves now only persist the audit event being written.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
