### PR TITLE
Disable dependent hospital visits v2 cypress tests due to data AB#17092

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/dependent/report.js
+++ b/Testing/functional/tests/cypress/integration/e2e/dependent/report.js
@@ -328,7 +328,9 @@ describe("Reports", () => {
         );
     });
 
-    it("Validate Hospital Visits Report", () => {
+    // AB#17092 - Test skipped until PHSA fixes dependent test data for hospital visists V2.
+    // Re-enable test when PHSA fixes test data.
+    it.skip("Validate Hospital Visits Report", () => {
         const hdid = dependent1.hdid;
 
         const cardSelector = getCardSelector(hdid);

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/dependent/dataset.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/dependent/dataset.js
@@ -177,7 +177,9 @@ describe("Dependent Timeline Datasets", () => {
     });
 
     describe("Validate hospital visits on dependent timeline", () => {
-        it("Enabled HospitalVisit dataset should be present", () => {
+        // AB#17092 - Test skipped until PHSA fixes dependent test data for hospital visists V2.
+        // Re-enable test when PHSA fixes test data.
+        it.skip("Enabled HospitalVisit dataset should be present", () => {
             enabledDatasetShouldBePresent(Dataset.HospitalVisit);
         });
         it("Disabled HospitalVisit dataset should not be present", () => {


### PR DESCRIPTION
# Fixes or Implements [AB#17092](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17092)

## Description

Dependent functional tests using Hospital Visits V2 are failing because no test data is available. The tests have been temporarily disabled until the required test data is set up.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
