### PR TITLE
Prevent GetUserProfile from updating the user profile on every request by restricting profile updates to the login flow only for AB#17093

### DIFF
--- a/Apps/GatewayApi/src/Controllers/UserProfileController.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileController.cs
@@ -121,6 +121,12 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The user profile model wrapped in a request result.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <param name="isLogin">
+        /// Indicates whether the request is part of the user's login flow. When <c>true</c>,
+        /// the user's last login metadata (last login time, client type, and year of birth)
+        /// is updated before returning the profile. When <c>false</c>, the profile is returned
+        /// without modifying the user record.
+        /// </param>
         /// <response code="200">Returns the user profile json.</response>
         /// <response code="401">the client must authenticate itself to get the requested response.</response>
         /// <response code="403">
@@ -130,12 +136,12 @@ namespace HealthGateway.GatewayApi.Controllers
         [HttpGet]
         [Route("{hdid}")]
         [Authorize(Policy = UserProfilePolicy.Read)]
-        public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, CancellationToken ct)
+        public async Task<RequestResult<UserProfileModel>> GetUserProfile(string hdid, CancellationToken ct, [FromQuery] bool isLogin = false)
         {
             ClaimsPrincipal? user = this.httpContextAccessor.HttpContext?.User;
             DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(user);
 
-            return await this.userProfileService.GetUserProfileAsync(hdid, jwtAuthTime, ct);
+            return await this.userProfileService.GetUserProfileAsync(hdid, jwtAuthTime, isLogin, ct);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
+++ b/Apps/GatewayApi/src/Controllers/UserProfileControllerV2.cs
@@ -136,6 +136,12 @@ namespace HealthGateway.GatewayApi.Controllers
         /// <returns>The requested user profile, or an empty profile if the requested profile doesn't exist.</returns>
         /// <param name="hdid">The user hdid.</param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
+        /// <param name="isLogin">
+        /// Indicates whether the request is part of the user's login flow. When <c>true</c>,
+        /// the user's last login metadata (last login time, client type, and year of birth)
+        /// is updated before returning the profile. When <c>false</c>, the profile is returned
+        /// without modifying the user record.
+        /// </param>
         /// <response code="200">Returns the requested user profile, or an empty profile if the requested profile doesn't exist.</response>
         /// <response code="400">Validation error.</response>
         /// <response code="401">The client must authenticate itself to get the requested response.</response>
@@ -155,10 +161,10 @@ namespace HealthGateway.GatewayApi.Controllers
         [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status500InternalServerError, Type = typeof(ProblemDetails))]
         [ProducesResponseType(StatusCodes.Status502BadGateway, Type = typeof(ProblemDetails))]
-        public async Task<UserProfileModel> GetUserProfile(string hdid, CancellationToken ct)
+        public async Task<UserProfileModel> GetUserProfile(string hdid, CancellationToken ct, [FromQuery] bool isLogin = false)
         {
             DateTime jwtAuthTime = ClaimsPrincipalReader.GetAuthDateTime(this.httpContextAccessor.HttpContext!.User);
-            return await this.userProfileService.GetUserProfileAsync(hdid, jwtAuthTime, ct);
+            return await this.userProfileService.GetUserProfileAsync(hdid, jwtAuthTime, isLogin, ct);
         }
 
         /// <summary>

--- a/Apps/GatewayApi/src/Services/IUserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileService.cs
@@ -31,9 +31,15 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="hdid">The requested user hdid.</param>
         /// <param name="jwtAuthTime">The date of last jwt authorization time.</param>
+        /// <param name="isLogin">
+        /// Indicates whether the request is part of the user's login flow. When <c>true</c>,
+        /// the user's last login metadata (last login time, client type, and year of birth)
+        /// is updated before returning the profile. When <c>false</c>, the profile is returned
+        /// without modifying the user record.
+        /// </param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The wrapped user profile.</returns>
-        Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default);
+        Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin = false, CancellationToken ct = default);
 
         /// <summary>
         /// Saves the user profile to the database.

--- a/Apps/GatewayApi/src/Services/IUserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/IUserProfileServiceV2.cs
@@ -30,9 +30,15 @@ namespace HealthGateway.GatewayApi.Services
         /// </summary>
         /// <param name="hdid">The requested user HDID.</param>
         /// <param name="jwtAuthTime">The authenticated login time from the JWT.</param>
+        /// <param name="isLogin">
+        /// Indicates whether the request is part of the user's login flow. When <c>true</c>,
+        /// the user's last login metadata (last login time, client type, and year of birth)
+        /// is updated before returning the profile. When <c>false</c>, the profile is returned
+        /// without modifying the user record.
+        /// </param>
         /// <param name="ct"><see cref="CancellationToken"/> to manage the async request.</param>
         /// <returns>The user profile.</returns>
-        Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default);
+        Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin = false, CancellationToken ct = default);
 
         /// <summary>
         /// Closes a user profile.

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -149,7 +149,7 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin, CancellationToken ct = default)
+public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin = false, CancellationToken ct = default)
         {
             UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
             if (userProfile == null)

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -149,7 +149,7 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin = false, CancellationToken ct = default)
+        public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin = false, CancellationToken ct = default)
         {
             UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
             if (userProfile == null)

--- a/Apps/GatewayApi/src/Services/UserProfileService.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileService.cs
@@ -149,7 +149,7 @@ namespace HealthGateway.GatewayApi.Services
         }
 
         /// <inheritdoc/>
-        public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default)
+        public async Task<RequestResult<UserProfileModel>> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin, CancellationToken ct = default)
         {
             UserProfile? userProfile = await this.userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
             if (userProfile == null)
@@ -162,7 +162,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             DateTime previousLastLogin = userProfile.LastLoginDateTime;
-            if (jwtAuthTime > previousLastLogin)
+            if (isLogin && jwtAuthTime > previousLastLogin)
             {
                 userProfile.LastLoginDateTime = jwtAuthTime;
                 userProfile.LastLoginClientCode = this.authenticationDelegate.FetchAuthenticatedUserClientType();

--- a/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
+++ b/Apps/GatewayApi/src/Services/UserProfileServiceV2.cs
@@ -54,7 +54,7 @@ namespace HealthGateway.GatewayApi.Services
         private readonly EmailTemplateConfig emailTemplateConfig = configuration.GetSection(EmailTemplateConfig.ConfigurationSectionKey).Get<EmailTemplateConfig>() ?? new();
 
         /// <inheritdoc/>
-        public async Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, CancellationToken ct = default)
+        public async Task<UserProfileModel> GetUserProfileAsync(string hdid, DateTime jwtAuthTime, bool isLogin = false, CancellationToken ct = default)
         {
             UserProfile? userProfile = await userProfileDelegate.GetUserProfileAsync(hdid, true, ct);
             if (userProfile == null)
@@ -63,7 +63,7 @@ namespace HealthGateway.GatewayApi.Services
             }
 
             DateTime previousLastLogin = userProfile.LastLoginDateTime;
-            if (jwtAuthTime > previousLastLogin)
+            if (isLogin && jwtAuthTime > previousLastLogin)
             {
                 PatientDetails patient = await patientDetailsService.GetPatientAsync(hdid, ct: ct);
 

--- a/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
+++ b/Apps/GatewayApi/test/unit/Controllers.Test/UserProfileControllerTests.cs
@@ -606,7 +606,7 @@ namespace HealthGateway.GatewayApiTests.Controllers.Test
             Mock<IHttpContextAccessor> httpContextAccessorMock = CreateValidHttpContext(this.token, this.userId, this.hdid);
 
             Mock<IUserProfileService> userProfileServiceMock = new();
-            userProfileServiceMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<DateTime>(), It.IsAny<CancellationToken>())).ReturnsAsync(expected);
+            userProfileServiceMock.Setup(s => s.GetUserProfileAsync(this.hdid, It.IsAny<DateTime>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(expected);
 
             Mock<ILegalAgreementService> legalAgreementServiceMock = new();
             legalAgreementServiceMock.Setup(s => s.GetActiveTermsOfServiceAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new RequestResult<TermsOfServiceModel>());

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -71,19 +71,22 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// <param name="emailIsVerified">The value indicating whether email is verified or not.</param>
         /// <param name="smsIsVerified">The value indicating whether sms is verified or not.</param>
         /// <param name="tourChangeDateIsLatest">The value indicating whether tour change date is latest or not.</param>
+        /// <param name="isLogin">The value indicating whether the request is part of login flow.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(true, true, true, true, true)]
-        [InlineData(true, false, false, true, true)]
-        [InlineData(true, false, false, false, true)]
-        [InlineData(true, false, false, false, false)]
-        [InlineData(false, false, false, false, false)] // Cannot get profile because user profile does not exist
+        [InlineData(true, true, true, true, true, true)] // Login flow, update expected
+        [InlineData(true, true, true, true, true, false)] // Not login flow, no update expected
+        [InlineData(true, false, false, true, true, true)]
+        [InlineData(true, false, false, false, true, true)]
+        [InlineData(true, false, false, false, false, true)]
+        [InlineData(false, false, false, false, false, true)] // Cannot get profile because user profile does not exist
         public async Task ShouldGetUserProfile(
             bool userProfileExists,
             bool jwtAuthTimeIsDifferent,
             bool emailIsVerified,
             bool smsIsVerified,
-            bool tourChangeDateIsLatest)
+            bool tourChangeDateIsLatest,
+            bool isLogin)
         {
             // Arrange
             const int patientAge = 15;
@@ -104,7 +107,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
             DateTime[] lastLoginDateTimes =
             [
-                jwtAuthTimeIsDifferent ? jwtAuthTime : currentUtcDate,
+                isLogin && jwtAuthTimeIsDifferent ? jwtAuthTime : currentUtcDate,
                 userProfileHistoryList[0].LastLoginDateTime,
                 userProfileHistoryList[1].LastLoginDateTime,
             ];
@@ -123,7 +126,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 ResultStatus = ResultType.Success,
             };
 
-            Times expectedTimesUpdateUserProfile = jwtAuthTimeIsDifferent
+            Times expectedTimesUpdateUserProfile = userProfileExists && isLogin && jwtAuthTimeIsDifferent
                 ? Times.Once()
                 : Times.Never();
 
@@ -137,7 +140,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 userProfileHistoryList: userProfileHistoryList);
 
             // Act
-            RequestResult<UserProfileModel> actual = await service.GetUserProfileAsync(Hdid, jwtAuthTime);
+            RequestResult<UserProfileModel> actual = await service.GetUserProfileAsync(Hdid, jwtAuthTime, isLogin);
 
             // Assert
             actual.ShouldDeepEqual(expected);

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceV2Tests.cs
@@ -139,33 +139,45 @@ namespace HealthGateway.GatewayApiTests.Services.Test
         /// </summary>
         /// <param name="userProfileExists">The value indicating whether user profile exists or not.</param>
         /// <param name="jwtAuthTimeIsDifferent">The value indicating whether jwt auth time is different from last login or not.</param>
+        /// <param name="isLogin">The value indicating whether the request is part of login flow.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData(true, true)] // User profile exists and jwt auth time is different
-        [InlineData(true, false)] // User profile exists and jwt auth time is not different
-        [InlineData(false, false)] // Cannot get profile because user profile does not exist
+        [InlineData(true, true, true)] // Login flow, update expected
+        [InlineData(true, true, false)] // Not login flow, update not expected
+        [InlineData(true, false, true)] // Login flow, auth time not newer, update not expected
+        [InlineData(false, false, true)] // Cannot get profile because user profile does not exist
         public async Task ShouldGetUserProfile(
             bool userProfileExists,
-            bool jwtAuthTimeIsDifferent)
+            bool jwtAuthTimeIsDifferent,
+            bool isLogin)
         {
             // Arrange
-            Times expectedUserProfileUpdate = ConvertToTimes(jwtAuthTimeIsDifferent);
+            Times expectedUserProfileUpdate = ConvertToTimes(
+                userProfileExists && jwtAuthTimeIsDifferent && isLogin);
 
             DateTime currentDateTime = DateTime.UtcNow.Date;
             DateTime jwtAuthTime = jwtAuthTimeIsDifferent
                 ? currentDateTime.AddHours(1)
                 : currentDateTime;
 
+            DateTime expectedLastLoginDateTime = isLogin && jwtAuthTimeIsDifferent
+                ? jwtAuthTime
+                : currentDateTime;
+
             UserProfileModel expected = userProfileExists
-                ? GenerateUserProfileModel(currentDateTime)
+                ? GenerateUserProfileModel(expectedLastLoginDateTime)
                 : new();
 
             UserProfileMock mock = SetupUserProfileMock(
                 currentDateTime,
+                expectedLastLoginDateTime,
                 userProfileExists);
 
             // Act
-            UserProfileModel actual = await mock.Service.GetUserProfileAsync(Hdid, jwtAuthTime);
+            UserProfileModel actual = await mock.Service.GetUserProfileAsync(
+                Hdid,
+                jwtAuthTime,
+                isLogin);
 
             // Assert and Verify
             actual.ShouldDeepEqual(expected);
@@ -616,6 +628,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
 
         private static UserProfileMock SetupUserProfileMock(
             DateTime currentDateTime,
+            DateTime expectedLastLoginDateTime,
             bool userProfileExists = true)
         {
             DateTime birthDate = GenerateBirthDate();
@@ -631,7 +644,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             PatientDetails patientDetails = GeneratePatientDetails(birthDate: DateOnly.FromDateTime(birthDate));
             Mock<IPatientDetailsService> patientDetailsServiceMock = SetupPatientDetailsServiceMock(patientDetails);
 
-            UserProfileModel userProfileModel = userProfileExists ? GenerateUserProfileModel(currentDateTime) : new();
+            UserProfileModel userProfileModel = userProfileExists ? GenerateUserProfileModel(expectedLastLoginDateTime) : new();
             Mock<IUserProfileModelService> userProfileModelServiceMock = SetupUserProfileModelServiceMock(userProfileModel, profileHistoryRecordLimit);
 
             IUserProfileServiceV2 service = GetUserProfileService(

--- a/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/interfaces.ts
@@ -124,7 +124,7 @@ export interface IConfigService {
 
 export interface IUserProfileService {
     createProfile(createRequest: CreateUserRequest): Promise<UserProfile>;
-    getProfile(hdid: string): Promise<UserProfile>;
+    getProfile(hdid: string, isLogin?: boolean): Promise<UserProfile>;
     validateAge(hdid: string): Promise<boolean>;
     getTermsOfService(): Promise<TermsOfService>;
     closeAccount(hdid: string): Promise<void>;

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileService.ts
@@ -36,10 +36,10 @@ export class RestUserProfileService implements IUserProfileService {
         this.baseUri = config.serviceEndpoints["GatewayApi"];
     }
 
-    public getProfile(hdid: string): Promise<UserProfile> {
+    public getProfile(hdid: string, isLogin = false): Promise<UserProfile> {
         return this.http
             .getWithCors<RequestResult<UserProfile>>(
-                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}`
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}?isLogin=${isLogin}`
             )
             .catch((err: HttpError) => {
                 this.logger.error(

--- a/Apps/WebClient/src/ClientApp/src/services/restUserProfileServiceV2.ts
+++ b/Apps/WebClient/src/ClientApp/src/services/restUserProfileServiceV2.ts
@@ -35,10 +35,10 @@ export class RestUserProfileServiceV2 implements IUserProfileService {
         this.baseUri = config.serviceEndpoints["GatewayApi"];
     }
 
-    public getProfile(hdid: string): Promise<UserProfile> {
+    public getProfile(hdid: string, isLogin = false): Promise<UserProfile> {
         return this.http
             .getWithCors<UserProfile>(
-                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}?api-version=${this.API_VERSION}`
+                `${this.baseUri}${this.USER_PROFILE_BASE_URI}/${hdid}?api-version=${this.API_VERSION}&isLogin=${isLogin}`
             )
             .catch((err: HttpError) => {
                 this.logger.error(

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -408,7 +408,7 @@ export const useUserStore = defineStore("user", () => {
                 setPatient(result);
 
                 return userProfileService
-                    .getProfile(user.value.hdid)
+                    .getProfile(user.value.hdid, true)
                     .then((userProfile) => {
                         logger.debug(
                             `User Profile: ${JSON.stringify(userProfile)}`

--- a/Testing/functional/tests/cypress/integration/ui/user/profile.js
+++ b/Testing/functional/tests/cypress/integration/ui/user/profile.js
@@ -69,7 +69,7 @@ describe("User Profile", () => {
             }
         ).then((data) => {
             data.email = Cypress.env("emailAddress");
-            cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0`, {
+            cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0*`, {
                 ...data,
             });
         });
@@ -98,7 +98,7 @@ describe("User Profile", () => {
         cy.get("[data-testid=editEmailBtn]").click();
         cy.get("[data-testid=email-input] input").clear();
         cy.get("[data-testid=emailOptOutMessage]").should("be.visible");
-        cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0`, {
+        cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0*`, {
             fixture: "UserProfileService/userProfile.json",
         });
         cy.get("[data-testid=editEmailSaveBtn]").click();
@@ -118,7 +118,7 @@ describe("User Profile", () => {
 
         cy.log("Verify SMS number");
         cy.get("[data-testid=smsStatusNotVerified]").should("be.visible");
-        cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0`, {
+        cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0*`, {
             fixture: "UserProfileService/userProfileSMSVerified.json",
         });
         cy.get("[data-testid=verifySMSBtn]")
@@ -144,7 +144,7 @@ describe("User Profile", () => {
             );
 
         cy.log("Edit SMS number");
-        cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0`, {
+        cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0*`, {
             fixture: "UserProfileService/userProfile.json",
         });
         cy.get("[data-testid=editSMSBtn]").click();
@@ -176,7 +176,7 @@ describe("User Profile", () => {
             }
         ).then((data) => {
             data.smsNumber = undefined;
-            cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0`, {
+            cy.intercept("GET", `**/UserProfile/${HDID}?api-version=2.0*`, {
                 ...data,
             });
         });

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -104,7 +104,7 @@ export function setupUserProfileFixture(options = {}) {
         statusCode = defaultUserProfileStatusCode,
     } = options;
 
-    const url = `**/UserProfile/${hdid}?api-version=2.0`;
+    const url = `**/UserProfile/${hdid}?api-version=2.0*`;
 
     if (statusCode !== 200) {
         cy.intercept("GET", url, { statusCode });


### PR DESCRIPTION
# Fixes or Implements [AB#17033](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17033)

## Description

Prevent GetUserProfile from updating the user profile on every request by restricting profile updates to the login flow only.

**Changes:**

* Service
    * Added an isLogin parameter to GetUserProfileAsync().
    * Only update LastLoginDateTime, LastLoginClientCode, and YearOfBirth when isLogin is true and the JWT authentication time is newer than the stored login time.
* Controller
    * Added an optional isLogin query parameter (defaults to false).
    * Passed the flag through to the service.
* Vue services
    * Updated the IUserProfileService interface and both REST implementations to support the optional isLogin parameter.
    * Updated the initial login profile retrieval to call getProfile(..., true).
    * All other profile retrievals continue using the default (false).
* Functional tests
    * Updated Get UserProfile endpoint intercepts to allow the additional isLogin query parameter.

**Why:**

Previously, every call to GetUserProfile attempted to update the user’s profile if the JWT authentication time was newer than the stored login time. This caused unnecessary database writes during non-login operations (for example, after accepting the Terms of Service), increasing the likelihood of DbUpdateConcurrencyException errors.

By limiting profile updates to the login flow, only genuine login requests update login metadata, while all other profile reads remain read-only. This reduces unnecessary writes and avoids concurrency conflicts.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

UI not changed but service call updated.

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
