### PR TITLE
Update AccessMyHealth confirmation dialog content AB#17032

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/OtherRecordSourcesView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/OtherRecordSourcesView.vue
@@ -182,21 +182,21 @@ function trackRecordSourceClick(tile: InfoTile, text: string, url: string) {
     <PageTitleComponent title="Other record sources" />
     <ExternalLinkConfirmationDialog
         v-model="isExternalLinkDialogOpen"
-        title="Open AccessMyHealth"
+        title="Do you want to open AccessMyHealth?"
         :body="[
-            'This will sign you into AccessMyHealth directly. You must have at least one record in AccessMyHealth for this to work.',
             {
-                prefix: 'To find out more, visit ',
-                text: ExternalUrl.AccessMyHealth,
+                text: Text.AccessMyHealth,
                 trackingText: Text.AccessMyHealthDialogUrl,
                 href: ExternalUrl.AccessMyHealth,
-                suffix: '.',
+                suffix: ' may contain more health records and information.',
             },
+            'You are currently signed into Health Gateway. If you wish to continue, you will be signed in to AccessMyHealth in a new window. You must have at least one record in AccessMyHealth for this to work.',
         ]"
-        confirm-label="Sign in"
-        cancel-label="Cancel"
+        confirm-label="SIGN IN"
+        cancel-label="CANCEL"
         :origin="Origin.OtherRecordSources"
         :tracking-text="Text.AccessMyHealthDialogUrl"
+        :width="960"
         @confirm="confirmExternalNavigation"
         @cancel="cancelExternalNavigation"
     />

--- a/Apps/WebClient/src/ClientApp/src/components/private/home/OtherRecordSourcesView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/OtherRecordSourcesView.vue
@@ -190,10 +190,10 @@ function trackRecordSourceClick(tile: InfoTile, text: string, url: string) {
                 href: ExternalUrl.AccessMyHealth,
                 suffix: ' may contain more health records and information.',
             },
-            'You are currently signed into Health Gateway. If you wish to continue, you will be signed in to AccessMyHealth in a new window. You must have at least one record in AccessMyHealth for this to work.',
+            'You are currently signed in to Health Gateway. If you wish to continue, you will be signed in to AccessMyHealth in a new window. You must have at least one record in AccessMyHealth for this to work.',
         ]"
-        confirm-label="SIGN IN"
-        cancel-label="CANCEL"
+        confirm-label="Sign in"
+        cancel-label="Cancel"
         :origin="Origin.OtherRecordSources"
         :width="960"
         @confirm="confirmExternalNavigation"

--- a/Apps/WebClient/src/ClientApp/src/components/private/home/OtherRecordSourcesView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/OtherRecordSourcesView.vue
@@ -195,7 +195,6 @@ function trackRecordSourceClick(tile: InfoTile, text: string, url: string) {
         confirm-label="SIGN IN"
         cancel-label="CANCEL"
         :origin="Origin.OtherRecordSources"
-        :tracking-text="Text.AccessMyHealthDialogUrl"
         :width="960"
         @confirm="confirmExternalNavigation"
         @cancel="cancelExternalNavigation"

--- a/Apps/WebClient/src/ClientApp/src/components/site/ExternalLinkConfirmationDialog.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/ExternalLinkConfirmationDialog.vue
@@ -36,6 +36,7 @@ const props = withDefaults(
         confirmLabel?: string;
         cancelLabel?: string;
         width?: number | string;
+        uppercase?: boolean;
     }>(),
     {
         title: "",
@@ -43,6 +44,7 @@ const props = withDefaults(
         confirmLabel: "Proceed",
         cancelLabel: "Cancel",
         width: 700,
+        uppercase: undefined,
     }
 );
 
@@ -114,11 +116,10 @@ function trackExternalLinkDialogAction(text: string, url?: ExternalUrl): void {
                 </v-card-title>
                 <v-card-text class="pa-4">
                     <div v-if="props.body?.length">
-                        <div
+                        <p
                             v-for="(line, i) in props.body"
                             :key="i"
                             class="text-body-1"
-                            :class="{ 'mb-4': i < props.body.length - 1 }"
                             :data-testid="`external-link-confirmation-dialog-body-${i}`"
                         >
                             <template v-if="typeof line === 'string'">
@@ -148,20 +149,20 @@ function trackExternalLinkDialogAction(text: string, url?: ExternalUrl): void {
                                     line.suffix
                                 }}</span>
                             </template>
-                        </div>
+                        </p>
                     </div>
                 </v-card-text>
                 <v-card-actions class="justify-end border-t-sm px-4 py-3">
                     <HgButtonComponent
                         variant="secondary"
-                        :uppercase="false"
+                        :uppercase="props.uppercase"
                         :text="props.cancelLabel"
                         data-testid="external-link-confirmation-dialog-cancel-button"
                         @click="cancel()"
                     />
                     <HgButtonComponent
                         variant="primary"
-                        :uppercase="false"
+                        :uppercase="props.uppercase"
                         :text="props.confirmLabel"
                         data-testid="external-link-confirmation-dialog-proceed-button"
                         @click="confirm()"

--- a/Apps/WebClient/src/ClientApp/src/components/site/ExternalLinkConfirmationDialog.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/site/ExternalLinkConfirmationDialog.vue
@@ -35,12 +35,14 @@ const props = withDefaults(
         body?: DialogBodyLine[];
         confirmLabel?: string;
         cancelLabel?: string;
+        width?: number | string;
     }>(),
     {
         title: "",
         body: () => [],
         confirmLabel: "Proceed",
         cancelLabel: "Cancel",
+        width: 700,
     }
 );
 
@@ -90,13 +92,19 @@ function trackExternalLinkDialogAction(text: string, url?: ExternalUrl): void {
         @update:model-value="emit('update:modelValue', $event)"
     >
         <div class="d-flex justify-center">
-            <v-card max-width="700">
+            <!-- Prevent the dialog from exceeding the viewport width -->
+            <v-card :width="props.width" max-width="95vw">
                 <v-card-title class="bg-primary px-0">
                     <v-toolbar
-                        :title="props.title"
                         density="compact"
                         color="primary"
+                        height="auto"
+                        class="ps-4 pe-1"
                     >
+                        <div class="dialog-title text-h6">
+                            {{ props.title }}
+                        </div>
+
                         <HgIconButtonComponent
                             icon="close"
                             aria-label="Close"
@@ -110,7 +118,7 @@ function trackExternalLinkDialogAction(text: string, url?: ExternalUrl): void {
                             v-for="(line, i) in props.body"
                             :key="i"
                             class="text-body-1"
-                            :class="{ 'mb-1': i < props.body.length - 1 }"
+                            :class="{ 'mb-4': i < props.body.length - 1 }"
                             :data-testid="`external-link-confirmation-dialog-body-${i}`"
                         >
                             <template v-if="typeof line === 'string'">
@@ -163,3 +171,11 @@ function trackExternalLinkDialogAction(text: string, url?: ExternalUrl): void {
         </div>
     </v-dialog>
 </template>
+
+<style scoped>
+.dialog-title {
+    flex: 1 1 0;
+    min-width: 0;
+    white-space: normal;
+}
+</style>

--- a/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
+++ b/Apps/WebClient/src/ClientApp/src/plugins/extensions.ts
@@ -135,6 +135,7 @@ export const enum Text {
     Page = "Page",
     Request = "Request",
     AboutUs = "About Us",
+    AccessMyHealth = "AccessMyHealth",
     AccessMyHealthDialogCancel = "AccessMyHealth Dialog Cancel",
     AccessMyHealthDialogUrl = "AccessMyHealth Dialog URL",
     AccessMyHealthDialogSignin = "AccessMyHealth Dialog Sign in",


### PR DESCRIPTION
# Implements [AB#17032](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17032)

## Description

Updates the AccessMyHealth external link confirmation dialog to reflect the revised business messaging.

See: [DHSOHG-3308](https://www.jira.healthcarebc.ca/browse/DHSOHG-3308)

## Changes

- Updated the dialog title and body content.
- Enhanced the dialog component to support configurable widths and improved title/body wrapping for longer content.
- Updated the AccessMyHealth dialog to use the new width option.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

**iPhone 12:**

<img width="693" height="944" alt="Screenshot 2026-07-14 at 1 45 17 PM" src="https://github.com/user-attachments/assets/6edaf7d9-6d7f-4661-83de-bc7b48538a04" />

**iPhone SE:**

<img width="696" height="755" alt="Screenshot 2026-07-14 at 1 44 54 PM" src="https://github.com/user-attachments/assets/39dc2f19-3a1d-4c67-8a72-7e9d55f0d508" />

**Desktop:**

<img width="2562" height="852" alt="Screenshot 2026-07-14 at 1 44 38 PM" src="https://github.com/user-attachments/assets/64b623b3-e7cd-47a0-9f8d-d2e1df37ea2a" />

**Snowplow:**

<img width="2231" height="863" alt="Screenshot 2026-07-14 at 11 38 54 AM" src="https://github.com/user-attachments/assets/94f365b6-f51f-4d3c-9b4c-8916d74e3da2" />


## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
