### PR TITLE
Add missing HospitalVisit polymorphic type registration AB#17097

### DIFF
--- a/Apps/Patient/src/Services/IPatientDataService.cs
+++ b/Apps/Patient/src/Services/IPatientDataService.cs
@@ -70,6 +70,7 @@ namespace HealthGateway.Patient.Services
     [KnownType(typeof(OrganDonorRegistration))]
     [KnownType(typeof(DiagnosticImagingExam))]
     [KnownType(typeof(BcCancerScreening))]
+    [KnownType(typeof(HospitalVisit))]
     [ExcludeFromCodeCoverage]
     public abstract record PatientData
     {
@@ -285,6 +286,8 @@ namespace HealthGateway.Patient.Services
             {
                 nameof(OrganDonorRegistration) => typeof(OrganDonorRegistration),
                 nameof(DiagnosticImagingExam) => typeof(DiagnosticImagingExam),
+                nameof(BcCancerScreening) => typeof(BcCancerScreening),
+                nameof(HospitalVisit) => typeof(HospitalVisit),
                 _ => null,
             };
         }

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -41,6 +41,10 @@ namespace HealthGateway.PatientTests.Services
     using OrganDonorRegistrationStatus = HealthGateway.Patient.Models.OrganDonorRegistrationStatus;
     using PatientDataQuery = HealthGateway.Patient.Services.PatientDataQuery;
     using PatientFileQuery = HealthGateway.PatientDataAccess.PatientFileQuery;
+    using ServiceBcCancerScreening =
+        HealthGateway.Patient.Services.BcCancerScreening;
+    using ServiceBcCancerScreeningType =
+        HealthGateway.Patient.Models.BcCancerScreeningType;
 
     public class PatientDataServiceTests
     {
@@ -119,6 +123,88 @@ namespace HealthGateway.PatientTests.Services
             actualDiagnosticImagingExam.ExamStatus.ShouldBe(diagnosticImagingExam.ExamStatus);
         }
 
+        [Fact]
+        public void CanSerializeBcCancerScreening()
+        {
+            ServiceBcCancerScreening bcCancerScreening = new()
+            {
+                EventType = ServiceBcCancerScreeningType.Recall,
+                ProgramName = "Test Program",
+                EventDateTime = DateTime.UtcNow,
+                ResultDateTime = DateTime.UtcNow,
+            };
+
+            PatientData[] data =
+            [
+                bcCancerScreening,
+            ];
+
+            PatientDataResponse response = new(data);
+
+            string serialized = JsonSerializer.Serialize(response);
+
+            serialized.ShouldNotBeNullOrEmpty();
+
+            PatientDataResponse deserialized =
+                JsonSerializer.Deserialize<PatientDataResponse>(serialized)
+                    .ShouldNotBeNull();
+
+            ServiceBcCancerScreening actualBcCancerScreening =
+                deserialized.Items
+                    .ShouldHaveSingleItem()
+                    .ShouldBeOfType<ServiceBcCancerScreening>();
+
+            actualBcCancerScreening.EventType.ShouldBe(
+                bcCancerScreening.EventType);
+            actualBcCancerScreening.ProgramName.ShouldBe(
+                bcCancerScreening.ProgramName);
+            actualBcCancerScreening.EventDateTime.ShouldBe(
+                bcCancerScreening.EventDateTime);
+            actualBcCancerScreening.ResultDateTime.ShouldBe(
+                bcCancerScreening.ResultDateTime);
+        }
+
+        [Fact]
+        public void CanSerializeHospitalVisit()
+        {
+            HospitalVisit hospitalVisit = new()
+            {
+                EncounterId = "Encounter Id",
+                AdmitDateTime = DateTime.UtcNow,
+                EndDateTime = DateTime.UtcNow,
+                Provider = "Provider Id",
+            };
+
+            PatientData[] data =
+            [
+                hospitalVisit,
+            ];
+
+            PatientDataResponse response = new(data);
+
+            string serialized = JsonSerializer.Serialize(response);
+
+            serialized.ShouldNotBeNullOrEmpty();
+
+            PatientDataResponse deserialized =
+                JsonSerializer.Deserialize<PatientDataResponse>(serialized)
+                    .ShouldNotBeNull();
+
+            HospitalVisit actualHospitalVisit =
+                deserialized.Items
+                    .ShouldHaveSingleItem()
+                    .ShouldBeOfType<HospitalVisit>();
+
+            actualHospitalVisit.EncounterId.ShouldBe(
+                hospitalVisit.EncounterId);
+            actualHospitalVisit.AdmitDateTime.ShouldBe(
+                hospitalVisit.AdmitDateTime);
+            actualHospitalVisit.EndDateTime.ShouldBe(
+                hospitalVisit.EndDateTime);
+            actualHospitalVisit.Provider.ShouldBe(
+                hospitalVisit.Provider);
+        }
+
         [Theory]
         [InlineData(true)]
         [InlineData(false)]
@@ -190,7 +276,7 @@ namespace HealthGateway.PatientTests.Services
 
             if (canAccessDataSource)
             {
-                Patient.Services.BcCancerScreening actual = result.Items.ShouldHaveSingleItem().ShouldBeOfType<Patient.Services.BcCancerScreening>();
+                ServiceBcCancerScreening actual = result.Items.ShouldHaveSingleItem().ShouldBeOfType<ServiceBcCancerScreening>();
                 actual.Id.ShouldBe(expected.Id);
                 actual.FileId.ShouldBe(expected.FileId);
                 actual.ProgramName.ShouldBe(expected.ProgramName);


### PR DESCRIPTION
# Fixes or Implements [AB#17097](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17097)

## Description

Added missing polymorphic type registrations for patient data:

- Added `HospitalVisit` as a known type.
- Added `HospitalVisit` and `BcCancerScreening` to `PatientDataJsonConverter`.
- Added unit test coverage

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
