### PR TITLE
Update last login only on login callback AB#17099

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/authentication/LoginCallbackView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/authentication/LoginCallbackView.vue
@@ -49,7 +49,7 @@ signIn(defaultPath.value)
             return;
         }
 
-        return userStore.retrieveEssentialData().then(() => {
+        return userStore.retrieveEssentialDataForLogin().then(() => {
             retrieveNotifications();
             redirect();
         });

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -402,7 +402,7 @@ export const useUserStore = defineStore("user", () => {
     }
 
     function retrieveEssentialDataInternal(
-        retrieveProfile: () => Promise<UserProfile>
+        getUserProfile: () => Promise<UserProfile>
     ): Promise<void> {
         if (retrieveEssentialDataPromise !== undefined) {
             return retrieveEssentialDataPromise;
@@ -421,7 +421,7 @@ export const useUserStore = defineStore("user", () => {
 
                 setPatient(result);
 
-                return retrieveProfile()
+                return getUserProfile()
                     .then((userProfile) => {
                         logger.debug(
                             `User Profile: ${JSON.stringify(userProfile)}`

--- a/Apps/WebClient/src/ClientApp/src/stores/user.ts
+++ b/Apps/WebClient/src/ClientApp/src/stores/user.ts
@@ -390,6 +390,20 @@ export const useUserStore = defineStore("user", () => {
     }
 
     function retrieveEssentialData(): Promise<void> {
+        return retrieveEssentialDataInternal(() =>
+            userProfileService.getProfile(user.value.hdid)
+        );
+    }
+
+    function retrieveEssentialDataForLogin(): Promise<void> {
+        return retrieveEssentialDataInternal(() =>
+            userProfileService.getProfileForLogin(user.value.hdid)
+        );
+    }
+
+    function retrieveEssentialDataInternal(
+        retrieveProfile: () => Promise<UserProfile>
+    ): Promise<void> {
         if (retrieveEssentialDataPromise !== undefined) {
             return retrieveEssentialDataPromise;
         }
@@ -407,8 +421,7 @@ export const useUserStore = defineStore("user", () => {
 
                 setPatient(result);
 
-                return userProfileService
-                    .getProfileForLogin(user.value.hdid)
+                return retrieveProfile()
                     .then((userProfile) => {
                         logger.debug(
                             `User Profile: ${JSON.stringify(userProfile)}`
@@ -493,6 +506,7 @@ export const useUserStore = defineStore("user", () => {
         closeUserAccount,
         recoverUserAccount,
         retrieveEssentialData,
+        retrieveEssentialDataForLogin,
         updateAcceptedTerms,
         clearUserData,
         setOidcUserInfo,


### PR DESCRIPTION
# Fixes or Implements [AB#17099](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17099)

## Description

Use read-only profile retrieval during regular app startup. Only the login callback uses the login-specific endpoint that updates `LastLoginDateTime`.

### Changes

- Added separate essential-data retrieval methods for standard startup and login.
- Reused the existing patient retrieval, status, error handling, and promise logic.
- Updated `LoginCallbackView` to use login-specific profile retrieval.
- Kept `main.ts` on the read-only profile path.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
