### PR TITLE
Remove nullable option on Email.To and Email.From AB#17103

### DIFF
--- a/Apps/Database/src/Models/Email.cs
+++ b/Apps/Database/src/Models/Email.cs
@@ -40,14 +40,14 @@ namespace HealthGateway.Database.Models
         /// </summary>
         [Required]
         [MaxLength(254)]
-        public string? From { get; set; }
+        public string From { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the To address for sending the email.
         /// </summary>
         [Required]
         [MaxLength(254)]
-        public string? To { get; set; }
+        public string To { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or sets the Subject line of the email.


### PR DESCRIPTION
# Fixes or Implements [AB#17103](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17103)

## Description

- Changed Email.From and Email.To from nullable to non-nullable strings.
- Initialized both properties with string.Empty to preserve existing runtime behavior.
- Aligned the C# model with the existing [Required] configuration and NOT NULL database columns.

No database migration is required.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
