### PR TITLE
Fix improper nullable declarations on Email and EmailTemplate AB#17103

### DIFF
--- a/Apps/Admin/Tests/Services/SupportServiceTests.cs
+++ b/Apps/Admin/Tests/Services/SupportServiceTests.cs
@@ -685,7 +685,7 @@ namespace HealthGateway.Admin.Tests.Services
             return
             [
                 new() { Id = Guid.NewGuid(), Validated = true, SmsNumber = sms },
-                new() { Id = Guid.NewGuid(), Validated = false, Email = new() { To = email } },
+                new() { Id = Guid.NewGuid(), Validated = false, Email = new() { From = string.Empty, To = email } },
             ];
         }
 

--- a/Apps/Common/src/Services/EmailQueueService.cs
+++ b/Apps/Common/src/Services/EmailQueueService.cs
@@ -123,12 +123,10 @@ namespace HealthGateway.Common.Services
         public Email ProcessTemplate(string toEmail, EmailTemplate emailTemplate, Dictionary<string, string> keyValues)
         {
             this.logger.LogDebug("Processing email template {EmailTemplateName}", emailTemplate.Name);
-            Email email = this.ParseTemplate(emailTemplate, keyValues);
-            email.To = toEmail;
-            return email;
+            return this.ParseTemplate(toEmail, emailTemplate, keyValues);
         }
 
-        private Email ParseTemplate(EmailTemplate emailTemplate, Dictionary<string, string> keyValues)
+        private Email ParseTemplate(string toEmail, EmailTemplate emailTemplate, Dictionary<string, string> keyValues)
         {
             if (!keyValues.ContainsKey(EmailTemplateVariable.Environment))
             {
@@ -138,9 +136,10 @@ namespace HealthGateway.Common.Services
             return new Email
             {
                 From = emailTemplate.From,
+                To = toEmail,
                 Priority = emailTemplate.Priority,
-                Subject = StringManipulator.Replace(emailTemplate.Subject!, keyValues),
-                Body = StringManipulator.Replace(emailTemplate.Body!, keyValues),
+                Subject = StringManipulator.Replace(emailTemplate.Subject, keyValues),
+                Body = StringManipulator.Replace(emailTemplate.Body, keyValues),
                 FormatCode = emailTemplate.FormatCode,
                 Personalization = keyValues,
                 Template = emailTemplate.Name,

--- a/Apps/Common/test/unit/Services/EmailQueueServiceTests.cs
+++ b/Apps/Common/test/unit/Services/EmailQueueServiceTests.cs
@@ -111,6 +111,8 @@ namespace HealthGateway.CommonTests.Services
             };
             EmailTemplate template = new()
             {
+                Name = string.Empty,
+                From = string.Empty,
                 Subject = "Subject=${SUBJECT}",
                 Body = "PARM1=${PARM1}, PARM2=${PARM2}, PARM3=${PARM3}",
                 FormatCode = EmailFormat.Text,
@@ -118,6 +120,7 @@ namespace HealthGateway.CommonTests.Services
             };
             Email expected = new()
             {
+                From = string.Empty,
                 To = emailTo,
                 Subject = "Subject=Test Subject",
                 Body = "PARM1=PARM1, PARM2=PARM2, PARM3=PARM3",
@@ -148,6 +151,8 @@ namespace HealthGateway.CommonTests.Services
             string expectedBody = $"{bodyPrefix} {environment}";
             EmailTemplate template = new()
             {
+                Name = string.Empty,
+                From = string.Empty,
                 Subject = "Mock Subject",
                 Body = $"{bodyPrefix} ${{Environment}}",
                 FormatCode = EmailFormat.Text,
@@ -179,6 +184,8 @@ namespace HealthGateway.CommonTests.Services
             string expectedBody = $"{bodyPrefix} {environment}";
             EmailTemplate template = new()
             {
+                Name = string.Empty,
+                From = string.Empty,
                 Subject = "Mock Subject",
                 Body = $"{bodyPrefix} ${{Environment}}",
                 FormatCode = EmailFormat.Text,
@@ -213,6 +220,7 @@ namespace HealthGateway.CommonTests.Services
             Email email = new()
             {
                 Id = Guid.NewGuid(),
+                From = string.Empty,
                 To = string.Empty, // This will cause an exception
             };
 
@@ -293,7 +301,7 @@ namespace HealthGateway.CommonTests.Services
                 shouldCommit ? Times.Once() : Times.Never());
         }
 
-        private static EmailTemplate GenerateEmailTemplate(string? body = null)
+        private static EmailTemplate GenerateEmailTemplate(string body = "")
         {
             return new()
             {
@@ -302,6 +310,7 @@ namespace HealthGateway.CommonTests.Services
                 CreatedDateTime = DateTime.UtcNow,
                 UpdatedBy = "Mocked Updated By",
                 UpdatedDateTime = DateTime.UtcNow,
+                Name = string.Empty,
                 Subject = "Mock Subject",
                 Body = body,
                 From = "mock@mock.com",

--- a/Apps/Database/src/Models/Email.cs
+++ b/Apps/Database/src/Models/Email.cs
@@ -40,14 +40,14 @@ namespace HealthGateway.Database.Models
         /// </summary>
         [Required]
         [MaxLength(254)]
-        public string? From { get; set; }
+        public required string From { get; set; }
 
         /// <summary>
         /// Gets or sets the To address for sending the email.
         /// </summary>
         [Required]
         [MaxLength(254)]
-        public string? To { get; set; }
+        public required string To { get; set; }
 
         /// <summary>
         /// Gets or sets the Subject line of the email.

--- a/Apps/Database/src/Models/EmailTemplate.cs
+++ b/Apps/Database/src/Models/EmailTemplate.cs
@@ -37,28 +37,28 @@ namespace HealthGateway.Database.Models
         /// </summary>
         [Required]
         [MaxLength(30)]
-        public string? Name { get; set; }
+        public required string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the From address for sending the email.
         /// </summary>
         [Required]
         [MaxLength(254)]
-        public string? From { get; set; }
+        public required string From { get; set; }
 
         /// <summary>
         /// Gets or sets the subject line.
         /// </summary>
         [Required]
         [MaxLength(100)]
-        public string? Subject { get; set; }
+        public required string Subject { get; set; }
 
         /// <summary>
         /// Gets or sets the Body.
         /// </summary>
         [Required]
         [Column(TypeName = "text")]
-        public string? Body { get; set; }
+        public required string Body { get; set; }
 
         /// <summary>
         /// Gets or sets the priority of the email.

--- a/Apps/GatewayApi/test/unit/Services.Test/DataAccessServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/DataAccessServiceTests.cs
@@ -144,6 +144,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     Email = verificationEmailExists
                         ? new()
                         {
+                            From = string.Empty,
                             To = Email,
                         }
                         : null,

--- a/Apps/GatewayApi/test/unit/Services.Test/MessagingVerificationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/MessagingVerificationServiceTests.cs
@@ -139,6 +139,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new()
             {
                 Id = emailId,
+                From = string.Empty,
                 To = toEmailAddress,
             };
         }
@@ -199,6 +200,9 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 {
                     Id = Guid.NewGuid(),
                     Name = EmailTemplateName.RegistrationTemplate,
+                    From = string.Empty,
+                    Subject = string.Empty,
+                    Body = string.Empty,
                 }
                 : null;
 

--- a/Apps/GatewayApi/test/unit/Services.Test/RegistrationServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/RegistrationServiceTests.cs
@@ -290,6 +290,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new()
             {
                 Id = emailId ?? Guid.NewGuid(),
+                From = string.Empty,
                 To = toEmailAddress,
             };
         }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceTests.cs
@@ -74,6 +74,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Validated = false,
                 Email = new Email
                 {
+                    From = string.Empty,
                     To = email,
                 },
             };
@@ -278,6 +279,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 InviteKey = Guid.NewGuid(),
                 Email = new Email
                 {
+                    From = string.Empty,
                     To = "old@healthgateway.gov.bc.ca",
                 },
             };
@@ -295,7 +297,13 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 .Setup(s => s.GetEmailTemplateAsync(
                     It.IsAny<string>(),
                     It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new EmailTemplate());
+                .ReturnsAsync(new EmailTemplate
+                {
+                    Name = string.Empty,
+                    From = string.Empty,
+                    Subject = string.Empty,
+                    Body = string.Empty,
+                });
 
             emailQueueServiceMock
                 .Setup(s => s.ProcessTemplate(
@@ -305,6 +313,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 .Returns((string to, EmailTemplate _, Dictionary<string, string> _) => new Email
                 {
                     Id = Guid.NewGuid(),
+                    From = string.Empty,
                     To = to,
                 });
 

--- a/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserEmailServiceV2Tests.cs
@@ -337,6 +337,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new()
             {
                 Id = emailId ?? Guid.NewGuid(),
+                From = string.Empty,
                 To = toEmailAddress,
             };
         }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileModelServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileModelServiceTests.cs
@@ -115,6 +115,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
             return new()
             {
                 Id = emailId ?? Guid.NewGuid(),
+                From = string.Empty,
                 To = toEmailAddress,
             };
         }

--- a/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
+++ b/Apps/GatewayApi/test/unit/Services.Test/UserProfileServiceTests.cs
@@ -1102,6 +1102,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                         Email = new Email
                         {
                             Id = Guid.NewGuid(),
+                            From = string.Empty,
                             To = email,
                         },
                     });
@@ -1223,6 +1224,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                 Email = new()
                 {
                     Id = Guid.NewGuid(),
+                    From = string.Empty,
                     To = Email,
                 },
             };
@@ -1356,6 +1358,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     new Email
                     {
                         Id = Guid.NewGuid(),
+                        From = string.Empty,
                         To = Email,
                     });
 
@@ -1426,6 +1429,7 @@ namespace HealthGateway.GatewayApiTests.Services.Test
                     new Email
                     {
                         Id = Guid.NewGuid(),
+                        From = string.Empty,
                         To = Email,
                     });
 


### PR DESCRIPTION
# Fixes or Implements [AB#17103](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17103)

## Description

The [Required] properties Email.From, Email.To, EmailTemplate.Name, EmailTemplate.From, EmailTemplate.Subject, and EmailTemplate.Body were incorrectly declared as string? in C#, creating an inconsistency between the database NOT NULL constraints and the C# type system.

See original [copilot issue](https://github.com/bcgov/healthgateway/pull/6784#discussion_r3678703947).

**Changes:**

- Replaced string? with required string on all affected properties in Email.cs and EmailTemplate.cs
- Removed ! null workarounds in EmailQueueService.cs that were required to compensate for the incorrect nullable declarations
- Fixed all unit tests that were constructing Email or EmailTemplate objects without populating the required fields — previously undetected by the compiler, now enforced at compile time

**No Migration necessary:**

<img width="2517" height="496" alt="Screenshot 2026-08-04 at 11 26 06 AM" src="https://github.com/user-attachments/assets/75940052-40d6-45d1-a827-d3cd56473f6d" />


## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
