### PR TITLE
Add home page alert for BC Cancer notifications J#3474

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -21,6 +21,7 @@ import { ServiceName } from "@/constants/serviceName";
 import UserPreferenceType from "@/constants/userPreferenceType";
 import { container } from "@/ioc/container";
 import { SERVICE_IDENTIFIER } from "@/ioc/identifier";
+import { DateWrapper } from "@/models/dateWrapper";
 import { QuickLink } from "@/models/quickLink";
 import { LoadStatus } from "@/models/storeOperations";
 import { TimelineFilterBuilder } from "@/models/timeline/timelineFilter";
@@ -127,6 +128,14 @@ const preferenceShowSmsRemoved = computed(
     () =>
         user.value.preferences[UserPreferenceType.ShowSmsRemoved]?.value ===
         "true"
+);
+const showBcCancerNotificationsAlert = computed(
+    () =>
+        user.value.lastLoginDateTimes.length > 1 &&
+        user.value.lastLoginDateTimes[1] &&
+        DateWrapper.fromIso(user.value.lastLoginDateTimes[1]).isBefore(
+            DateWrapper.fromIso("2026-05-19T09:00")
+        )
 );
 const showRecommendationsCardButton = computed(
     () =>
@@ -442,6 +451,26 @@ if (preferenceShowSmsRemoved.value) {
         :is-loading="isVaccineRecordDownloading"
         :text="vaccineRecordStatusMessage"
     />
+    <HgAlertComponent
+        v-if="showBcCancerNotificationsAlert"
+        data-testid="bc-cancer-notifications-banner"
+        type="info"
+        variant="outlined"
+    >
+        <template #default>
+            <p class="text-body-1">
+                Email and text notifications are now being sent for BC Cancer
+                Screening program letters. Review your preferences in your
+                <router-link
+                    id="profileNotificationsLink"
+                    data-testid="profile-notifications-link"
+                    class="text-link"
+                    to="/profile"
+                    >profile</router-link
+                >.
+            </p>
+        </template>
+    </HgAlertComponent>
     <HgAlertComponent
         v-if="unverifiedEmail || unverifiedSms || showSmsRemoved"
         data-testid="incomplete-profile-banner"

--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -131,9 +131,8 @@ const preferenceShowSmsRemoved = computed(
 );
 const showBcCancerNotificationsAlert = computed(
     () =>
-        user.value.lastLoginDateTimes.length > 1 &&
-        user.value.lastLoginDateTimes[1] &&
-        DateWrapper.fromIso(user.value.lastLoginDateTimes[1]).isBefore(
+        userStore.lastLoginDateTime != undefined &&
+        DateWrapper.fromIso(userStore.lastLoginDateTime).isBefore(
             DateWrapper.fromIso("2026-05-19T09:00")
         )
 );


### PR DESCRIPTION
# Implements [J#3474](https://www.jira.healthcarebc.ca/browse/DHSOHG-3474)

## Description

Displays alert on home page if the user's most recent log in time (before this session) was before May 19, 9:00 AM.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

No functional tests yet.

## UI Changes

<img width="2560" height="1229" alt="ScreenShot Tool -20260804171923" src="https://github.com/user-attachments/assets/1b89d29a-9426-4920-9d52-de29c2c652ab" />

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
