### PR TITLE
Update wording on home page alerts J#3604

### DIFF
--- a/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
+++ b/Apps/WebClient/src/ClientApp/src/components/private/home/HomeView.vue
@@ -59,7 +59,7 @@ const errorStore = useErrorStore();
 const timelineStore = useTimelineStore();
 const { columns } = useGrid();
 
-const showSmsRemoved = ref<boolean>();
+const showSmsRemoved = ref<boolean>(false);
 
 const recommendationsDialogComponent =
     ref<InstanceType<typeof RecommendationsDialogComponent>>();
@@ -401,8 +401,8 @@ if (preferenceShowSmsRemoved.value) {
                 class="text-body-large"
                 data-testid="sms-removed-message"
             >
-                We see you haven't logged in for a while &mdash; please review
-                your
+                You have not logged in for a while. Please verify your contact
+                information in your
                 <router-link
                     id="profilePreferencesLink"
                     data-testid="profile-preferences-link"
@@ -418,7 +418,7 @@ if (preferenceShowSmsRemoved.value) {
                             url: InternalUrl.Profile,
                         })
                     "
-                    >notification preferences</router-link
+                    >profile</router-link
                 >.
             </p>
             <p
@@ -426,9 +426,8 @@ if (preferenceShowSmsRemoved.value) {
                 class="text-body-large"
                 data-testid="unverified-email-sms-message"
             >
-                Your email or cell phone number has not been verified. You can
-                use the Health Gateway without verified contact information,
-                however, you will not receive notifications. Visit the
+                Your email or cell phone number has not been verified. Visit
+                your
                 <router-link
                     id="profilePageLink"
                     data-testid="profile-page-link"
@@ -444,9 +443,9 @@ if (preferenceShowSmsRemoved.value) {
                             url: InternalUrl.Profile,
                         })
                     "
-                    >Profile Page</router-link
+                    >profile</router-link
                 >
-                to complete your verification.
+                to verify your contact information.
             </p>
         </template>
     </HgAlertComponent>


### PR DESCRIPTION
# Implements [J#3604](https://www.jira.healthcarebc.ca/browse/DHSOHG-3604)

## Description

Changes text on the Verify Contact Information alerts on the home page.

Also addresses a minor inconsistency noticed while testing: the showSmsRemoved `ref<boolean>` property on the page was not initialized with a value, so it was actually a `ref<boolean | undefined>` property that starts as undefined (not false). It was intended to be a simple boolean property, so initializing it to false is good practice, even though the logic on this page was not negatively impacted by the slip-up.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

<img width="1920" height="959" alt="ScreenShot Tool -20260810151741" src="https://github.com/user-attachments/assets/b07af72e-9298-4b54-b03e-42b81db81809" />

<img width="1920" height="959" alt="ScreenShot Tool -20260810151720" src="https://github.com/user-attachments/assets/2909a1bc-93e0-495b-ab8c-bfd2ca4c9133" />

## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
