### PR TITLE
Move Timezone from PatientDataAccess to EncounterMappingService AB#17106

### DIFF
--- a/Apps/Encounter/src/MapProfiles/HospitalVisitModelProfile.cs
+++ b/Apps/Encounter/src/MapProfiles/HospitalVisitModelProfile.cs
@@ -35,8 +35,10 @@ namespace HealthGateway.Encounter.MapProfiles
                 .ForMember(dest => dest.Provider, opt => opt.MapFrom(src => src.Clinicians.Select(c => c.DisplayName).FirstOrDefault()))
                 .ReverseMap();
 
-            // Provider has already been converted in HealthData
-            this.CreateMap<PatientDataHospitalVisit, HospitalVisitModel>();
+            this.CreateMap<PatientDataHospitalVisit, HospitalVisitModel>()
+                .ForMember(dest => dest.Provider, opt => opt.MapFrom(src => src.Clinicians == null
+                    ? null
+                    : src.Clinicians.Select(c => c.DisplayName).FirstOrDefault()));
         }
     }
 }

--- a/Apps/Encounter/src/Services/EncounterMappingService.cs
+++ b/Apps/Encounter/src/Services/EncounterMappingService.cs
@@ -47,7 +47,10 @@ namespace HealthGateway.Encounter.Services
         /// <inheritdoc/>
         public HospitalVisitModel MapToHospitalVisitModel(PatientDataAccess.HospitalVisit source)
         {
-            return mapper.Map<PatientDataAccess.HospitalVisit, HospitalVisitModel>(source);
+            HospitalVisitModel dest = mapper.Map<PatientDataAccess.HospitalVisit, HospitalVisitModel>(source);
+            dest.AdmitDateTime = dest.AdmitDateTime == null ? null : DateFormatter.SpecifyTimeZone(dest.AdmitDateTime.Value, this.LocalTimeZone);
+            dest.EndDateTime = dest.EndDateTime == null ? null : DateFormatter.SpecifyTimeZone(dest.EndDateTime.Value, this.LocalTimeZone);
+            return dest;
         }
     }
 }

--- a/Apps/Encounter/src/Services/EncounterMappingService.cs
+++ b/Apps/Encounter/src/Services/EncounterMappingService.cs
@@ -37,9 +37,17 @@ namespace HealthGateway.Encounter.Services
         public HospitalVisitModel MapToHospitalVisitModel(HospitalVisit source)
         {
             HospitalVisitModel? dest = mapper.Map<HospitalVisit, HospitalVisitModel>(source);
+            TimeZoneInfo localTimeZone = this.LocalTimeZone;
 
-            dest.AdmitDateTime = dest.AdmitDateTime == null ? null : DateFormatter.SpecifyTimeZone(dest.AdmitDateTime.Value, this.LocalTimeZone);
-            dest.EndDateTime = dest.EndDateTime == null ? null : DateFormatter.SpecifyTimeZone(dest.EndDateTime.Value, this.LocalTimeZone);
+            if (dest.AdmitDateTime != null)
+            {
+                dest.AdmitDateTime = DateFormatter.SpecifyTimeZone(dest.AdmitDateTime.Value, localTimeZone);
+            }
+
+            if (dest.EndDateTime != null)
+            {
+                dest.EndDateTime = DateFormatter.SpecifyTimeZone(dest.EndDateTime.Value, localTimeZone);
+            }
 
             return dest;
         }
@@ -48,8 +56,18 @@ namespace HealthGateway.Encounter.Services
         public HospitalVisitModel MapToHospitalVisitModel(PatientDataAccess.HospitalVisit source)
         {
             HospitalVisitModel dest = mapper.Map<PatientDataAccess.HospitalVisit, HospitalVisitModel>(source);
-            dest.AdmitDateTime = dest.AdmitDateTime == null ? null : DateFormatter.SpecifyTimeZone(dest.AdmitDateTime.Value, this.LocalTimeZone);
-            dest.EndDateTime = dest.EndDateTime == null ? null : DateFormatter.SpecifyTimeZone(dest.EndDateTime.Value, this.LocalTimeZone);
+            TimeZoneInfo localTimeZone = this.LocalTimeZone;
+
+            if (dest.AdmitDateTime != null)
+            {
+                dest.AdmitDateTime = DateFormatter.SpecifyTimeZone(dest.AdmitDateTime.Value, localTimeZone);
+            }
+
+            if (dest.EndDateTime != null)
+            {
+                dest.EndDateTime = DateFormatter.SpecifyTimeZone(dest.EndDateTime.Value, localTimeZone);
+            }
+
             return dest;
         }
     }

--- a/Apps/Encounter/test/unit/Services/EncounterServiceV2Tests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceV2Tests.cs
@@ -17,11 +17,13 @@ namespace HealthGateway.EncounterTests.Services
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using HealthGateway.AccountDataAccess.Patient;
     using HealthGateway.Common.Data.Constants;
+    using HealthGateway.Common.Data.Utils;
     using HealthGateway.Common.Models.PHSA;
     using HealthGateway.Common.Services;
     using HealthGateway.Encounter.Models;
@@ -60,18 +62,21 @@ namespace HealthGateway.EncounterTests.Services
                 },
             };
 
+            DateTime rawAdmitDateTime = DateTime.Parse("2020-01-15T10:00:00", CultureInfo.InvariantCulture);
+            DateTime rawEndDateTime = DateTime.Parse("2020-01-16T08:00:00", CultureInfo.InvariantCulture);
+
             HospitalVisit hospitalVisit = new()
             {
                 Id = "123",
                 EncounterId = "encounter-id",
                 Facility = "Vancouver General Hospital",
+                AdmitDateTime = rawAdmitDateTime,
+                EndDateTime = rawEndDateTime,
             };
 
-            HospitalVisitModel mappedHospitalVisit = new()
-            {
-                EncounterId = "encounter-id",
-                Facility = "Vancouver General Hospital",
-            };
+            TimeZoneInfo localTimeZone = DateFormatter.GetLocalTimeZone(Configuration);
+            DateTime expectedAdmitDateTime = DateFormatter.SpecifyTimeZone(rawAdmitDateTime, localTimeZone);
+            DateTime expectedEndDateTime = DateFormatter.SpecifyTimeZone(rawEndDateTime, localTimeZone);
 
             patientRepository
                 .Setup(s => s.CanAccessDataSourceAsync(hdid, DataSource.HospitalVisit, ct))
@@ -99,8 +104,10 @@ namespace HealthGateway.EncounterTests.Services
 
             // Assert
             HospitalVisitModel actual = Assert.Single(result);
-            Assert.Equal(mappedHospitalVisit.EncounterId, actual.EncounterId);
-            Assert.Equal(mappedHospitalVisit.Facility, actual.Facility);
+            Assert.Equal(hospitalVisit.EncounterId, actual.EncounterId);
+            Assert.Equal(hospitalVisit.Facility, actual.Facility);
+            Assert.Equal(expectedAdmitDateTime, actual.AdmitDateTime);
+            Assert.Equal(expectedEndDateTime, actual.EndDateTime);
         }
 
         [Fact]

--- a/Apps/Encounter/test/unit/Services/EncounterServiceV2Tests.cs
+++ b/Apps/Encounter/test/unit/Services/EncounterServiceV2Tests.cs
@@ -72,6 +72,7 @@ namespace HealthGateway.EncounterTests.Services
                 Facility = "Vancouver General Hospital",
                 AdmitDateTime = rawAdmitDateTime,
                 EndDateTime = rawEndDateTime,
+                Clinicians = [new() { DisplayName = "Dr. Smith" }],
             };
 
             TimeZoneInfo localTimeZone = DateFormatter.GetLocalTimeZone(Configuration);
@@ -108,6 +109,7 @@ namespace HealthGateway.EncounterTests.Services
             Assert.Equal(hospitalVisit.Facility, actual.Facility);
             Assert.Equal(expectedAdmitDateTime, actual.AdmitDateTime);
             Assert.Equal(expectedEndDateTime, actual.EndDateTime);
+            Assert.Equal("Dr. Smith", actual.Provider);
         }
 
         [Fact]

--- a/Apps/Patient/src/Mappings/HospitalVisitProfile.cs
+++ b/Apps/Patient/src/Mappings/HospitalVisitProfile.cs
@@ -16,6 +16,7 @@
 namespace HealthGateway.Patient.Mappings
 {
     using System;
+    using System.Linq;
     using AutoMapper;
     using HealthGateway.Common.Data.Utils;
     using HealthGateway.PatientDataAccess;
@@ -36,7 +37,12 @@ namespace HealthGateway.Patient.Mappings
                     opts => opts.MapFrom(s => s.AdmitDateTime.HasValue ? DateFormatter.SpecifyUtc(s.AdmitDateTime.Value) : (DateTime?)null))
                 .ForMember(
                     d => d.EndDateTime,
-                    opts => opts.MapFrom(s => s.EndDateTime.HasValue ? DateFormatter.SpecifyUtc(s.EndDateTime.Value) : (DateTime?)null));
+                    opts => opts.MapFrom(s => s.EndDateTime.HasValue ? DateFormatter.SpecifyUtc(s.EndDateTime.Value) : (DateTime?)null))
+                .ForMember(
+                    d => d.Provider,
+                    opts => opts.MapFrom(s => s.Clinicians == null
+                        ? null
+                        : s.Clinicians.Select(c => c.DisplayName).FirstOrDefault()));
         }
     }
 }

--- a/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
+++ b/Apps/Patient/test/unit/Services/PatientDataServiceTests.cs
@@ -351,7 +351,7 @@ namespace HealthGateway.PatientTests.Services
                 HealthAuthority = "Provincial Health Services Authority",
                 AdmitDateTime = new DateTime(2022, 5, 2, 13, 42, 59, DateTimeKind.Unspecified),
                 EndDateTime = new DateTime(2022, 5, 2, 14, 27, 0, DateTimeKind.Unspecified),
-                Provider = "Plisvci, B",
+                Clinicians = [new() { DisplayName = "Plisvci, B" }],
             };
 
             Mock<IPatientDataRepository> patientDataRepository = new();
@@ -377,7 +377,7 @@ namespace HealthGateway.PatientTests.Services
                 actual.HealthAuthority.ShouldBe(expected.HealthAuthority);
                 actual.AdmitDateTime.ShouldBe(expected.AdmitDateTime);
                 actual.EndDateTime.ShouldBe(expected.EndDateTime);
-                actual.Provider.ShouldBe(expected.Provider);
+                actual.Provider.ShouldBe(expected.Clinicians!.First().DisplayName);
             }
             else
             {

--- a/Apps/PatientDataAccess/src/HealthData.cs
+++ b/Apps/PatientDataAccess/src/HealthData.cs
@@ -17,6 +17,7 @@ namespace HealthGateway.PatientDataAccess
 {
 #pragma warning disable SA1201 // Elements should appear in the correct order
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
@@ -152,9 +153,26 @@ namespace HealthGateway.PatientDataAccess
         public DateTime? EndDateTime { get; init; }
 
         /// <summary>
-        /// Gets the provider.
+        /// Gets the clinicians associated with the hospital visit.
         /// </summary>
-        public string? Provider { get; init; }
+        public IEnumerable<Clinician>? Clinicians { get; init; }
+    }
+
+    /// <summary>
+    /// Represents a clinician associated with a hospital visit.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    public record Clinician
+    {
+        /// <summary>
+        /// Gets the clinician's display name.
+        /// </summary>
+        public string? DisplayName { get; init; }
+
+        /// <summary>
+        /// Gets the clinician's role description.
+        /// </summary>
+        public string? RoleDescription { get; init; }
     }
 
     /// <summary>

--- a/Apps/PatientDataAccess/src/Mappings.cs
+++ b/Apps/PatientDataAccess/src/Mappings.cs
@@ -16,7 +16,6 @@
 namespace HealthGateway.PatientDataAccess
 {
 #pragma warning disable SA1600 // Disables documentation for internal class.
-    using System.Linq;
     using AutoMapper;
     using HealthGateway.PatientDataAccess.Api;
 
@@ -42,12 +41,9 @@ namespace HealthGateway.PatientDataAccess
                 .ForMember(d => d.EventDateTime, opts => opts.MapFrom(cse => cse.EventTimestampUtc))
                 .ForMember(d => d.ResultDateTime, opts => opts.MapFrom(cse => cse.ResultTimestamp.UtcDateTime));
 
-            this.CreateMap<Api.HospitalVisit, HospitalVisit>()
-                .ForMember(
-                    dest => dest.Provider,
-                    opt => opt.MapFrom(src => src.Clinicians == null
-                        ? null
-                        : src.Clinicians.Select(c => c.DisplayName).FirstOrDefault()));
+            this.CreateMap<Api.HospitalVisit, HospitalVisit>();
+
+            this.CreateMap<Api.Clinician, Clinician>();
         }
     }
 }

--- a/Apps/PatientDataAccess/src/PatientDataRepository.cs
+++ b/Apps/PatientDataAccess/src/PatientDataRepository.cs
@@ -23,9 +23,7 @@ namespace HealthGateway.PatientDataAccess
     using System.Threading;
     using System.Threading.Tasks;
     using AutoMapper;
-    using HealthGateway.Common.Data.Utils;
     using HealthGateway.PatientDataAccess.Api;
-    using Microsoft.Extensions.Configuration;
     using Refit;
 
     /// <summary>
@@ -33,8 +31,7 @@ namespace HealthGateway.PatientDataAccess
     /// </summary>
     /// <param name="patientApi">The patient API to use.</param>
     /// <param name="mapper">The injected mapper.</param>
-    /// <param name="configuration">The injected configuration provider.</param>
-    internal class PatientDataRepository(IPatientApi patientApi, IMapper mapper, IConfiguration configuration) : IPatientDataRepository
+    internal class PatientDataRepository(IPatientApi patientApi, IMapper mapper) : IPatientDataRepository
     {
         /// <summary>
         /// Performs a query against the data repository.
@@ -154,22 +151,6 @@ namespace HealthGateway.PatientDataAccess
 
         private HealthData Map(HealthDataEntry healthDataEntry)
         {
-            if (healthDataEntry is Api.HospitalVisit hospitalVisit)
-            {
-                TimeZoneInfo localTimeZone = DateFormatter.GetLocalTimeZone(configuration);
-
-                healthDataEntry = hospitalVisit with
-                {
-                    AdmitDateTime = hospitalVisit.AdmitDateTime == null
-                        ? null
-                        : DateFormatter.SpecifyTimeZone(hospitalVisit.AdmitDateTime.Value, localTimeZone),
-
-                    EndDateTime = hospitalVisit.EndDateTime == null
-                        ? null
-                        : DateFormatter.SpecifyTimeZone(hospitalVisit.EndDateTime.Value, localTimeZone),
-                };
-            }
-
             return mapper.Map<HealthData>(healthDataEntry);
         }
     }

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -18,10 +18,8 @@ namespace PatientDataAccessTests
     using System.Globalization;
     using System.Net;
     using AutoMapper;
-    using HealthGateway.Common.Data.Utils;
     using HealthGateway.PatientDataAccess;
     using HealthGateway.PatientDataAccess.Api;
-    using Microsoft.Extensions.Configuration;
     using Moq;
     using Refit;
     using BcCancerScreening = HealthGateway.PatientDataAccess.Api.BcCancerScreening;
@@ -160,8 +158,7 @@ namespace PatientDataAccessTests
 
             IPatientDataRepository sut = CreateSut(patientApi.Object);
 
-            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening]), CancellationToken.None)
-                ;
+            PatientDataQueryResult result = await sut.QueryAsync(new HealthQuery(this.pid, [HealthCategory.DiagnosticImaging, HealthCategory.BcCancerScreening]), CancellationToken.None);
 
             result.ShouldNotBeNull();
             HealthGateway.PatientDataAccess.DiagnosticImagingExam diExam = result.Items.First().ShouldBeOfType<HealthGateway.PatientDataAccess.DiagnosticImagingExam>();
@@ -186,13 +183,6 @@ namespace PatientDataAccessTests
                 Clinicians = [new() { DisplayName = "Display", RoleDescription = "Role" }],
             };
 
-            // Converting to local time
-            TimeZoneInfo localTimeZone = DateFormatter.GetLocalTimeZone(GetIConfigurationRoot());
-            DateTime expectedAdmitDateTime =
-                DateFormatter.SpecifyTimeZone(
-                    hospitalVisit.AdmitDateTime.Value,
-                    localTimeZone);
-
             patientApi
                 .Setup(api => api.GetHealthDataAsync(this.pid, It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(
@@ -209,7 +199,7 @@ namespace PatientDataAccessTests
             visit.Id.ShouldBe(hospitalVisit.HealthDataId);
             visit.FileId.ShouldBe(hospitalVisit.HealthDataFileId);
             visit.EncounterId.ShouldBe(hospitalVisit.EncounterId);
-            visit.AdmitDateTime.ShouldBe(expectedAdmitDateTime);
+            visit.AdmitDateTime.ShouldBe(hospitalVisit.AdmitDateTime);
             visit.EndDateTime.ShouldBeNull();
             visit.Provider.ShouldBe("Display");
         }
@@ -308,20 +298,7 @@ namespace PatientDataAccessTests
         {
             IMapper? mapper = new MapperConfiguration(cfg => cfg.AddMaps(typeof(Mappings))).CreateMapper();
 
-            return new PatientDataRepository(api, mapper, GetIConfigurationRoot());
-        }
-
-        private static IConfigurationRoot GetIConfigurationRoot()
-        {
-            Dictionary<string, string?> configuration = new()
-            {
-                { "TimeZone:UnixTimeZoneId", "America/Vancouver" },
-                { "TimeZone:WindowsTimeZoneId", "Pacific Standard Time" },
-            };
-
-            return new ConfigurationBuilder()
-                .AddInMemoryCollection(configuration)
-                .Build();
+            return new PatientDataRepository(api, mapper);
         }
 
         private sealed record UnsupportedPatientDataQuery : PatientDataQuery;

--- a/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
+++ b/Apps/PatientDataAccess/test/unit/PatientDataRepositoryTests.cs
@@ -201,7 +201,7 @@ namespace PatientDataAccessTests
             visit.EncounterId.ShouldBe(hospitalVisit.EncounterId);
             visit.AdmitDateTime.ShouldBe(hospitalVisit.AdmitDateTime);
             visit.EndDateTime.ShouldBeNull();
-            visit.Provider.ShouldBe("Display");
+            visit.Clinicians.ShouldNotBeNull().ShouldHaveSingleItem().DisplayName.ShouldBe("Display");
         }
 
         [Fact]


### PR DESCRIPTION
# Fixes or Implements [AB#17106](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17106)

## Description

Timezone adjustment for HospitalVisit dates (AdmitDateTime and EndDateTime) was being applied
inside PatientDataRepository.Map(HealthDataEntry) in the PatientDataAccess project. This is
incorrect because:

- PatientDataAccess is a generic shared data access layer and should not contain
  business/presentation logic
- It created an inconsistency — the V1 path applied timezone adjustment in
  EncounterMappingService, while the V2 path applied it in PatientDataRepository
- Any future consumer of PatientDataAccess.HospitalVisit would receive timezone-adjusted
  dates unexpectedly

Changes Made

- PatientDataAccess/src/PatientDataRepository.cs — Removed timezone adjustment logic from
  Map(HealthDataEntry). Removed unused IConfiguration constructor parameter and related imports.
- Encounter/src/Services/EncounterMappingService.cs — Added timezone adjustment to the V2
  overload of MapToHospitalVisitModel(PatientDataAccess.HospitalVisit), consistent with how
  the V1 overload already handles it. Also fixed redundant LocalTimeZone property lookups in
  both V1 and V2 overloads by caching in a local variable.
- PatientDataAccess/test/unit/PatientDataRepositoryTests.cs — Updated CanGetHospitalVisitData
  to assert raw date passthrough. Removed unused imports and helper methods.
- Encounter/test/unit/Services/EncounterServiceV2Tests.cs — Updated
  GetHospitalVisitsAsyncReturnsMappedHospitalVisits to assert timezone-adjusted dates are
  correctly applied at the mapping layer.

Additionally, HospitalVisit.Provider derivation from Clinicians was moved from PatientDataAccess
to the Encounter and Patient mapping layers, keeping PatientDataAccess as a raw data layer:

- PatientDataAccess/src/HealthData.cs — Replaced Provider with Clinicians on HospitalVisit.
  Added public Clinician record.
- PatientDataAccess/src/Mappings.cs — Simplified Api.HospitalVisit -> HospitalVisit to a
  convention map. Added Api.Clinician -> Clinician mapping. Removed unused System.Linq import.
- Encounter/src/MapProfiles/HospitalVisitModelProfile.cs — Added ForMember to derive Provider
  from Clinicians on the PatientDataAccess.HospitalVisit -> HospitalVisitModel path.
- Patient/src/Mappings/HospitalVisitProfile.cs — Added ForMember to derive Provider from
  Clinicians.
- PatientDataAccess/test/unit/PatientDataRepositoryTests.cs — Updated CanGetHospitalVisitData
  to assert Clinicians instead of Provider.
- Encounter/test/unit/Services/EncounterServiceV2Tests.cs — Added Clinicians to test data
  and added Provider assertion.
- Patient/test/unit/Services/PatientDataServiceTests.cs — Replaced Provider with Clinicians
  in test data and updated assertion.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
