### PR TITLE
Increase e2e provider response timeouts AB#17107

### DIFF
--- a/Testing/functional/tests/cypress/integration/e2e/services/encounter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/services/encounter.js
@@ -1,4 +1,5 @@
 describe("Encounter Service", () => {
+    const providerResponseTimeout = 120000;
     beforeEach(() => {
         cy.readConfig().as("config");
         cy.getTokens(
@@ -145,6 +146,7 @@ describe("Encounter Service", () => {
                 cy.request({
                     url: `${config.serviceEndpoints.Encounter}Encounter/HospitalVisit/${HDID}`,
                     followRedirect: false,
+                    timeout: providerResponseTimeout,
                     auth: {
                         bearer: tokens.access_token,
                     },
@@ -170,7 +172,7 @@ describe("Encounter Service", () => {
                     method: "GET",
                     url: `${encounterEndpoint}Encounter/HospitalVisit/${HDID}?api-version=2`,
                     followRedirect: false,
-                    timeout: 120000,
+                    timeout: providerResponseTimeout,
                     auth: {
                         bearer: tokens.access_token,
                     },

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/covid19Test.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/covid19Test.js
@@ -5,7 +5,17 @@ const {
 } = require("../../../support/functions/timeline");
 
 describe("COVID-19 Test Results", () => {
+    function waitForCovid19TestResults() {
+        return cy
+            .wait("@getCovid19TestResults", { timeout: 120000 })
+            .its("response.statusCode")
+            .should("eq", 200);
+    }
+
     beforeEach(() => {
+        cy.intercept("GET", "**/Laboratory/Covid19Orders?hdid=*").as(
+            "getCovid19TestResults"
+        );
         cy.configureSettings({
             datasets: [
                 {
@@ -19,6 +29,7 @@ describe("COVID-19 Test Results", () => {
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak
         );
+        waitForCovid19TestResults();
         cy.checkTimelineHasLoaded();
     });
 
@@ -28,7 +39,11 @@ describe("COVID-19 Test Results", () => {
             .filter(":has([data-testid=attachment-button])")
             .first()
             .within(() => {
-                validateFileDownload("[data-testid=covid-result-download-btn]");
+                validateFileDownload(
+                    "[data-testid=covid-result-download-btn]",
+                    true,
+                    60000
+                );
             });
     });
 

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/filter.js
@@ -43,6 +43,13 @@ describe("Disabled Filters", () => {
 });
 
 describe("Filters", () => {
+    function waitForLabResults() {
+        return cy
+            .wait("@getLabResult", { timeout: 120000 })
+            .its("response.statusCode")
+            .should("eq", 200);
+    }
+
     function testDatasetTimelineFiltering(
         filterTestId,
         titleTestId,
@@ -125,11 +132,15 @@ describe("Filters", () => {
                 },
             ],
         });
+        cy.intercept("GET", "**/Laboratory/LaboratoryOrders?hdid=*").as(
+            "getLabResult"
+        );
         cy.login(
             Cypress.env("keycloak.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak
         );
+        waitForLabResults();
         cy.checkTimelineHasLoaded();
     });
 

--- a/Testing/functional/tests/cypress/integration/e2e/timeline/labResult.js
+++ b/Testing/functional/tests/cypress/integration/e2e/timeline/labResult.js
@@ -5,7 +5,17 @@ const {
 } = require("../../../support/functions/timeline");
 
 describe("Laboratory Orders", () => {
+    function waitForLabResults() {
+        return cy
+            .wait("@getLabResults", { timeout: 120000 })
+            .its("response.statusCode")
+            .should("eq", 200);
+    }
+
     beforeEach(() => {
+        cy.intercept("GET", "**/Laboratory/LaboratoryOrders?hdid=*").as(
+            "getLabResults"
+        );
         cy.configureSettings({
             datasets: [
                 {
@@ -19,6 +29,7 @@ describe("Laboratory Orders", () => {
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak
         );
+        waitForLabResults();
         cy.checkTimelineHasLoaded();
     });
 

--- a/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/dependents.js
@@ -701,14 +701,11 @@ describe("CRUD Operations", () => {
         cy.log("Validating Immunization tab");
 
         cy.setupDownloads();
-        cy.intercept("GET", "**/Immunization?hdid*").as("getImmunization");
         cy.get("@newDependentCard").within(() => {
             cy.get(
                 `[data-testid=immunization-tab-title-${validDependent.hdid}]`
             ).click();
         });
-        cy.wait("@getImmunization", { timeout: defaultTimeout });
-
         cy.get(
             `[data-testid=immunization-tab-div-${validDependent.hdid}]`
         ).within(() => {

--- a/Testing/functional/tests/cypress/support/functions/intercept.js
+++ b/Testing/functional/tests/cypress/support/functions/intercept.js
@@ -172,8 +172,10 @@ export function waitForInitialDataLoad(username, config, path) {
     cy.log(`Feature Toggle: ${JSON.stringify(featureToggle)}`);
     cy.log(`Path: ${path}`);
 
-    cy.log("Wait on patient.");
-    cy.wait("@getPatient", { timeout: defaultTimeout });
+    if (!isDependents(path) && !isDependentsTimeline(path)) {
+        cy.log("Wait on patient.");
+        cy.wait("@getPatient", { timeout: defaultTimeout });
+    }
 
     waitForUserProfile(username).then((blockedDataSources) => {
         waitForClinicalDocument(featureToggle, path, blockedDataSources);

--- a/Testing/functional/tests/cypress/support/functions/timeline.js
+++ b/Testing/functional/tests/cypress/support/functions/timeline.js
@@ -15,7 +15,11 @@ export function validateAttachmentDownload() {
     });
 }
 
-export function validateFileDownload(buttonSelector, clickEntryCard = true) {
+export function validateFileDownload(
+    buttonSelector,
+    clickEntryCard = true,
+    downloadTimeout = 20000
+) {
     getEntryCardDateString().then((dateString) => {
         if (clickEntryCard) {
             cy.get("[data-testid=entryCardDetailsTitle]")
@@ -23,13 +27,14 @@ export function validateFileDownload(buttonSelector, clickEntryCard = true) {
                 .click({ force: true });
         }
         cy.get(buttonSelector).should("be.visible").click();
-        validateSensitiveDocumentDownload(dateString);
+        validateSensitiveDocumentDownload(dateString, false, downloadTimeout);
     });
 }
 
 export function validateSensitiveDocumentDownload(
     filename,
-    exactMatch = false
+    exactMatch = false,
+    downloadTimeout = 20000
 ) {
     cy.document()
         .find("[data-testid=generic-message-submit-btn]")
@@ -43,6 +48,6 @@ export function validateSensitiveDocumentDownload(
     cy.verifyDownload(filename, {
         contains: !exactMatch,
         interval: 500,
-        timeout: 20000,
+        timeout: downloadTimeout,
     });
 }


### PR DESCRIPTION
# Fixes or Implements [AB#17107](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17107)

## Description

Increase Cypress E2E synchronization timeouts for delayed PHSA provider responses.

## Changes

- Wait for Laboratory Orders before validating timeline empty-state filters.
- Increase Hospital Visit service request timeouts to 120 seconds.
- Register dependent immunization intercepts before the requests occur.
- Wait for dependent immunizations before downloading vaccine recommendations.
- Avoid waiting for the primary patient request on dependents and dependent timeline routes.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
