### PR TITLE
Sonar - AV0011: Remove unnecessary default API version AB#17105

### DIFF
--- a/Apps/Common/src/Swagger/ServicesExtensions.cs
+++ b/Apps/Common/src/Swagger/ServicesExtensions.cs
@@ -42,7 +42,6 @@ namespace HealthGateway.Common.Swagger
                     {
                         options.AssumeDefaultVersionWhenUnspecified = true;
                         options.ReportApiVersions = true;
-                        options.DefaultApiVersion = new ApiVersion(1, 0);
                     })
                 .AddApiExplorer(
                     options =>


### PR DESCRIPTION
# Fixes or Implements [AB#17105](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17105)

## Description

Sonar - AV0011: Remove unnecessary default API version.

The Asp.Versioning library already defaults DefaultApiVersion to 1.0, so explicitly assigning the same value has no effect.

## Testing

- [ ] Unit Tests Updated
- [ ] Functional Tests Updated
- [x] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
