### PR TITLE
Fix Immunization Sonar warnings and tests AB#17110

### DIFF
--- a/Apps/Immunization/src/Services/IImmunizationMappingService.cs
+++ b/Apps/Immunization/src/Services/IImmunizationMappingService.cs
@@ -32,6 +32,11 @@ namespace HealthGateway.Immunization.Services
         /// <returns>The destination object.</returns>
         ImmunizationEvent MapToImmunizationEvent(ImmunizationViewResponse source);
 
+        /// <summary>Maps a PatientDataAccess ImmunizationRecord to an ImmunizationEvent.</summary>
+        /// <param name="source">The source object to transform.</param>
+        /// <returns>The destination object.</returns>
+        ImmunizationEvent MapToImmunizationEvent(PatientDataImmunizationRecord source);
+
         /// <summary>Maps model.</summary>
         /// <param name="source">The source object to transform.</param>
         /// <returns>The destination object.</returns>
@@ -41,10 +46,5 @@ namespace HealthGateway.Immunization.Services
         /// <param name="source">The source object to transform.</param>
         /// <returns>The destination object.</returns>
         LoadStateModel MapToLoadStateModel(PhsaLoadState source);
-
-        /// <summary>Maps a PatientDataAccess ImmunizationRecord to an ImmunizationEvent.</summary>
-        /// <param name="source">The source object to transform.</param>
-        /// <returns>The destination object.</returns>
-        ImmunizationEvent MapToImmunizationEvent(PatientDataImmunizationRecord source);
     }
 }

--- a/Apps/Immunization/src/Services/ImmunizationMappingService.cs
+++ b/Apps/Immunization/src/Services/ImmunizationMappingService.cs
@@ -44,6 +44,16 @@ namespace HealthGateway.Immunization.Services
         }
 
         /// <inheritdoc/>
+        public ImmunizationEvent MapToImmunizationEvent(PatientDataImmunizationRecord source)
+        {
+            ImmunizationEvent dest = mapper.Map<PatientDataImmunizationRecord, ImmunizationEvent>(source);
+
+            dest.DateOfImmunization = DateFormatter.SpecifyTimeZone(dest.DateOfImmunization, this.LocalTimeZone);
+
+            return dest;
+        }
+
+        /// <inheritdoc/>
         public IList<ImmunizationRecommendation> MapToImmunizationRecommendations(IEnumerable<ImmunizationRecommendationResponse> source)
         {
             return source.SelectMany(s => s.Recommendations.Select(r => MapToImmunizationRecommendation(s, r))).ToList();
@@ -82,16 +92,6 @@ namespace HealthGateway.Immunization.Services
         public LoadStateModel MapToLoadStateModel(PhsaLoadState source)
         {
             return mapper.Map<PhsaLoadState, LoadStateModel>(source);
-        }
-
-        /// <inheritdoc/>
-        public ImmunizationEvent MapToImmunizationEvent(PatientDataImmunizationRecord source)
-        {
-            ImmunizationEvent dest = mapper.Map<PatientDataImmunizationRecord, ImmunizationEvent>(source);
-
-            dest.DateOfImmunization = DateFormatter.SpecifyTimeZone(dest.DateOfImmunization, this.LocalTimeZone);
-
-            return dest;
         }
     }
 }

--- a/Apps/Immunization/src/Services/ImmunizationService.cs
+++ b/Apps/Immunization/src/Services/ImmunizationService.cs
@@ -15,6 +15,7 @@
 //-------------------------------------------------------------------------
 namespace HealthGateway.Immunization.Services
 {
+    using System;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -62,25 +63,31 @@ namespace HealthGateway.Immunization.Services
 
             RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = await this.immunizationDelegate.GetImmunizationsAsync(hdid, ct);
 
-            return delegateResult.ResultStatus == ResultType.Success
-                ? new RequestResult<ImmunizationResult>
-                {
-                    ResultStatus = delegateResult.ResultStatus,
-                    ResourcePayload = new ImmunizationResult
-                    {
-                        LoadState = this.mappingService.MapToLoadStateModel(delegateResult.ResourcePayload!.LoadState),
-                        Immunizations = [.. delegateResult.ResourcePayload.Result!.ImmunizationViews.Select(this.mappingService.MapToImmunizationEvent)],
-                        Recommendations = this.mappingService.MapToImmunizationRecommendations(delegateResult.ResourcePayload.Result.Recommendations),
-                    },
-                    PageIndex = delegateResult.PageIndex,
-                    PageSize = delegateResult.PageSize,
-                    TotalResultCount = delegateResult.TotalResultCount,
-                }
-                : new RequestResult<ImmunizationResult>
+            if (delegateResult.ResultStatus != ResultType.Success)
+            {
+                return new RequestResult<ImmunizationResult>
                 {
                     ResultStatus = delegateResult.ResultStatus,
                     ResultError = delegateResult.ResultError,
                 };
+            }
+
+            PhsaResult<ImmunizationResponse> resourcePayload = delegateResult.ResourcePayload ?? throw new InvalidOperationException("A successful immunization response must include a resource payload.");
+            ImmunizationResponse result = resourcePayload.Result ?? throw new InvalidOperationException("A successful immunization response must include a result.");
+
+            return new RequestResult<ImmunizationResult>
+            {
+                ResultStatus = delegateResult.ResultStatus,
+                ResourcePayload = new ImmunizationResult
+                {
+                    LoadState = this.mappingService.MapToLoadStateModel(resourcePayload.LoadState),
+                    Immunizations = [.. result.ImmunizationViews.Select(this.mappingService.MapToImmunizationEvent)],
+                    Recommendations = this.mappingService.MapToImmunizationRecommendations(result.Recommendations),
+                },
+                PageIndex = delegateResult.PageIndex,
+                PageSize = delegateResult.PageSize,
+                TotalResultCount = delegateResult.TotalResultCount,
+            };
         }
     }
 }

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -223,6 +223,36 @@ namespace HealthGateway.ImmunizationTests.Services.Test
             actualResult.ShouldDeepEqual(expectedResult);
         }
 
+        /// <summary>
+        /// GetImmunizations - Successful response with missing data.
+        /// </summary>
+        /// <param name="hasResourcePayload">Whether the delegate response includes a resource payload.</param>
+        /// <param name="expectedMessage">The expected exception message.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData(false, "A successful immunization response must include a resource payload.")]
+        [InlineData(true, "A successful immunization response must include a result.")]
+        public async Task ValidateSuccessfulResponseWithMissingData(bool hasResourcePayload, string expectedMessage)
+        {
+            RequestResult<PhsaResult<ImmunizationResponse>> delegateResult = new()
+            {
+                ResultStatus = ResultType.Success,
+                ResourcePayload = hasResourcePayload ? new PhsaResult<ImmunizationResponse>() : null,
+            };
+
+            Mock<IImmunizationDelegate> mockDelegate = new();
+            mockDelegate.Setup(s => s.GetImmunizationsAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(delegateResult);
+
+            Mock<IPatientRepository> patientRepository = new();
+            patientRepository.Setup(p => p.CanAccessDataSourceAsync(It.IsAny<string>(), It.IsAny<DataSource>(), It.IsAny<CancellationToken>())).ReturnsAsync(true);
+
+            IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, MappingService);
+
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetImmunizationsAsync(It.IsAny<string>()));
+
+            Assert.Equal(expectedMessage, exception.Message);
+        }
+
         private static RequestResult<PhsaResult<ImmunizationResponse>> GetPhsaResult(ImmunizationRecommendationResponse immzRecommendationResponse)
         {
             return new RequestResult<PhsaResult<ImmunizationResponse>>

--- a/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
+++ b/Apps/Immunization/test/unit/Services.Test/ImmunizationServiceTests.cs
@@ -248,7 +248,7 @@ namespace HealthGateway.ImmunizationTests.Services.Test
 
             IImmunizationService service = new ImmunizationService(mockDelegate.Object, patientRepository.Object, MappingService);
 
-            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetImmunizationsAsync(It.IsAny<string>()));
+            InvalidOperationException exception = await Assert.ThrowsAsync<InvalidOperationException>(() => service.GetImmunizationsAsync("mock-hdid"));
 
             Assert.Equal(expectedMessage, exception.Message);
         }


### PR DESCRIPTION
# Fixes or Implements [AB#17110](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17110)

## Description

- Groups `MapToImmunizationEvent` overloads together.
- Replaces null-forgiving operators with validated response data.
- Adds tests for successful responses missing required data.

## Testing

- [x] Unit Tests Updated
- [ ] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
