### PR TITLE
Setup Aspire for the main HG App

### DIFF
--- a/Apps/Admin/Server/appsettings.Development.json
+++ b/Apps/Admin/Server/appsettings.Development.json
@@ -58,9 +58,5 @@
         "BlockedDataSources": {
             "Enabled": true
         }
-    },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
     }
 }

--- a/Apps/Admin/Server/appsettings.json
+++ b/Apps/Admin/Server/appsettings.json
@@ -145,7 +145,7 @@
         }
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "Admin",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/AspireHost/AspireHost.csproj
+++ b/Apps/AspireHost/AspireHost.csproj
@@ -1,0 +1,44 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Sdk Name="Aspire.AppHost.Sdk" Version="13.5.3" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>HealthGateway.AspireHost</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsAspireHost>true</IsAspireHost>
+    <!-- Shares the developer secrets used by the apps (GatewayConnection, RedisConnection). -->
+    <UserSecretsId>84e2fe9a-a1f5-4de7-bef6-4518a33fa8b9</UserSecretsId>
+    <!-- Local orchestration project only; solution-wide analyzers are not applied. -->
+    <AnalysisMode>None</AnalysisMode>
+    <EnforceCodeStyleInBuild>false</EnforceCodeStyleInBuild>
+    <!-- ASPIRE010: the Aspire CLI bundle is only needed for `aspire` CLI features; `dotnet run` works without it.
+         CA1506 (class coupling): an orchestration composition root wires many types by design. -->
+    <NoWarn>$(NoWarn);ASPIRE010;CA1506</NoWarn>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Remove="StyleCop.Analyzers" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.3" />
+    <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.5.3" />
+    <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ClinicalDocument\src\ClinicalDocument.csproj" />
+    <ProjectReference Include="..\Encounter\src\Encounter.csproj" />
+    <ProjectReference Include="..\GatewayApi\src\GatewayApi.csproj" />
+    <ProjectReference Include="..\Immunization\src\Immunization.csproj" />
+    <ProjectReference Include="..\JobScheduler\src\JobScheduler.csproj" />
+    <ProjectReference Include="..\Laboratory\src\Laboratory.csproj" />
+    <ProjectReference Include="..\Medication\src\Medication.csproj" />
+    <ProjectReference Include="..\Patient\src\Patient.csproj" />
+    <ProjectReference Include="..\WebClient\src\WebClient.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>

--- a/Apps/AspireHost/AspireHost.csproj
+++ b/Apps/AspireHost/AspireHost.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Admin\Server\Admin.Server.csproj" />
     <ProjectReference Include="..\ClinicalDocument\src\ClinicalDocument.csproj" />
     <ProjectReference Include="..\Encounter\src\Encounter.csproj" />
     <ProjectReference Include="..\GatewayApi\src\GatewayApi.csproj" />

--- a/Apps/AspireHost/AspireHost.csproj
+++ b/Apps/AspireHost/AspireHost.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Aspire.Hosting.Redis" Version="13.5.3" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <!-- Explicit because appsettings.json references its formatter type by assembly name. -->
+    <PackageReference Include="Serilog.Formatting.Compact" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Apps/AspireHost/Program.cs
+++ b/Apps/AspireHost/Program.cs
@@ -64,6 +64,7 @@ AddApp<Projects.Encounter>("Encounter");
 AddApp<Projects.ClinicalDocument>("ClinicalDocument");
 AddApp<Projects.JobScheduler>("JobScheduler");
 AddApp<Projects.WebClient>("WebClient");
+AddApp<Projects.Admin_Server>("Admin");
 
 builder.Build().Run();
 

--- a/Apps/AspireHost/Program.cs
+++ b/Apps/AspireHost/Program.cs
@@ -44,6 +44,10 @@ IResourceBuilder<RedisResource> redis = builder.AddRedis("gatewaycache", port: r
     .WithDataVolume("gatewaycache.local")
     .WithPersistence(TimeSpan.FromSeconds(60));
 
+// Secret parameters so the dashboard's Environment view masks the injected values.
+IResourceBuilder<ParameterResource> gatewayConnectionParam = builder.AddParameter("gateway-connection", gatewayConnection, secret: true);
+IResourceBuilder<ParameterResource> redisConnectionParam = builder.AddParameter("redis-connection", redisConnection, secret: true);
+
 // Requires the dotnet-ef global tool. The connection string is not passed on the command
 // line; DBMaintainer resolves GatewayConnection from the same shared user secrets.
 IResourceBuilder<ExecutableResource> migrations = builder
@@ -69,8 +73,8 @@ IResourceBuilder<ProjectResource> AddApp<TProject>(string name)
     // HealthGateway_-prefixed environment variables are loaded last by ProgramConfiguration,
     // so these override user secrets and appsettings.local.json in every app.
     return builder.AddProject<TProject>(name)
-        .WithEnvironment("HealthGateway_ConnectionStrings__GatewayConnection", gatewayConnection)
-        .WithEnvironment("HealthGateway_RedisConnection", redisConnection)
+        .WithEnvironment("HealthGateway_ConnectionStrings__GatewayConnection", gatewayConnectionParam)
+        .WithEnvironment("HealthGateway_RedisConnection", redisConnectionParam)
         .WaitFor(postgres)
         .WaitFor(redis)
         .WaitForCompletion(migrations);

--- a/Apps/AspireHost/Program.cs
+++ b/Apps/AspireHost/Program.cs
@@ -44,10 +44,11 @@ IResourceBuilder<RedisResource> redis = builder.AddRedis("gatewaycache", port: r
     .WithDataVolume("gatewaycache.local")
     .WithPersistence(TimeSpan.FromSeconds(60));
 
-// Requires the dotnet-ef global tool.
+// Requires the dotnet-ef global tool. The connection string is not passed on the command
+// line; DBMaintainer resolves GatewayConnection from the same shared user secrets.
 IResourceBuilder<ExecutableResource> migrations = builder
     .AddExecutable("db-migrations", "dotnet", "../DBMaintainer")
-    .WithArgs("ef", "database", "update", "--project", "../Database/src", "--connection", gatewayConnection)
+    .WithArgs("ef", "database", "update", "--project", "../Database/src")
     .WaitFor(postgres);
 
 AddApp<Projects.Patient>("patient");

--- a/Apps/AspireHost/Program.cs
+++ b/Apps/AspireHost/Program.cs
@@ -24,7 +24,7 @@ NpgsqlConnectionStringBuilder gatewayDb = new(gatewayConnection);
 
 IResourceBuilder<ParameterResource> postgresUser = builder.AddParameter("postgres-user", gatewayDb.Username!);
 IResourceBuilder<ParameterResource> postgresPassword = builder.AddParameter("postgres-password", gatewayDb.Password!, secret: true);
-IResourceBuilder<PostgresServerResource> postgres = builder.AddPostgres("gatewaydb", userName: postgresUser, password: postgresPassword, port: gatewayDb.Port)
+IResourceBuilder<PostgresServerResource> postgres = builder.AddPostgres("GatewayDb", userName: postgresUser, password: postgresPassword, port: gatewayDb.Port)
     .WithImageTag("15")
     .WithContainerName("GatewayDB")
     .WithArgs("-c", "max_connections=500")
@@ -37,7 +37,7 @@ int redisPort = redisEndpoint.Contains(':', StringComparison.Ordinal) ? int.Pars
 string? redisPasswordValue = redisConnection.Split(',')
     .Select(part => part.Trim())
     .FirstOrDefault(part => part.StartsWith("password=", StringComparison.OrdinalIgnoreCase))?["password=".Length..];
-IResourceBuilder<RedisResource> redis = builder.AddRedis("gatewaycache", port: redisPort)
+IResourceBuilder<RedisResource> redis = builder.AddRedis("GatewayCache", port: redisPort)
     .WithPassword(redisPasswordValue is null ? null : builder.AddParameter("redis-password", redisPasswordValue, secret: true))
     .WithImageTag("6.2")
     .WithContainerName("GatewayCache")
@@ -51,19 +51,19 @@ IResourceBuilder<ParameterResource> redisConnectionParam = builder.AddParameter(
 // Requires the dotnet-ef global tool. The connection string is not passed on the command
 // line; DBMaintainer resolves GatewayConnection from the same shared user secrets.
 IResourceBuilder<ExecutableResource> migrations = builder
-    .AddExecutable("db-migrations", "dotnet", "../DBMaintainer")
+    .AddExecutable("DbMigrations", "dotnet", "../DBMaintainer")
     .WithArgs("ef", "database", "update", "--project", "../Database/src")
     .WaitFor(postgres);
 
-AddApp<Projects.Patient>("patient");
-AddApp<Projects.GatewayApi>("gateway-api");
-AddApp<Projects.Immunization>("immunization");
-AddApp<Projects.Medication>("medication");
-AddApp<Projects.Laboratory>("laboratory");
-AddApp<Projects.Encounter>("encounter");
-AddApp<Projects.ClinicalDocument>("clinical-document");
-AddApp<Projects.JobScheduler>("job-scheduler");
-AddApp<Projects.WebClient>("web-client");
+AddApp<Projects.Patient>("Patient");
+AddApp<Projects.GatewayApi>("GatewayApi");
+AddApp<Projects.Immunization>("Immunization");
+AddApp<Projects.Medication>("Medication");
+AddApp<Projects.Laboratory>("Laboratory");
+AddApp<Projects.Encounter>("Encounter");
+AddApp<Projects.ClinicalDocument>("ClinicalDocument");
+AddApp<Projects.JobScheduler>("JobScheduler");
+AddApp<Projects.WebClient>("WebClient");
 
 builder.Build().Run();
 

--- a/Apps/AspireHost/Program.cs
+++ b/Apps/AspireHost/Program.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using Microsoft.Extensions.Configuration;
+using Npgsql;
+using Serilog;
+
+IDistributedApplicationBuilder builder = DistributedApplication.CreateBuilder(args);
+
+// Same Serilog defaults as the apps (see Observability.UseDefaultLogging), minus the
+// enrichers that only apply to HTTP request pipelines.
+builder.Services.AddSerilog(config => config
+    .Enrich.WithMachineName()
+    .Enrich.FromLogContext()
+    .Enrich.WithProperty("Application", "AspireHost")
+    .Enrich.WithEnvironmentName()
+    .ReadFrom.Configuration(builder.Configuration));
+
+// Connection strings come from the user secrets shared with the apps (UserSecretsId in the csproj).
+string gatewayConnection = builder.Configuration.GetConnectionString("GatewayConnection")
+    ?? throw new InvalidOperationException("The ConnectionStrings:GatewayConnection user secret is required.");
+string redisConnection = builder.Configuration["RedisConnection"]
+    ?? throw new InvalidOperationException("The RedisConnection user secret is required.");
+
+NpgsqlConnectionStringBuilder gatewayDb = new(gatewayConnection);
+
+IResourceBuilder<ParameterResource> postgresUser = builder.AddParameter("postgres-user", gatewayDb.Username!);
+IResourceBuilder<ParameterResource> postgresPassword = builder.AddParameter("postgres-password", gatewayDb.Password!, secret: true);
+IResourceBuilder<PostgresServerResource> postgres = builder.AddPostgres("gatewaydb", userName: postgresUser, password: postgresPassword, port: gatewayDb.Port)
+    .WithImageTag("15")
+    .WithContainerName("GatewayDB")
+    .WithArgs("-c", "max_connections=500")
+    .WithEnvironment("POSTGRES_DB", gatewayDb.Database)
+    .WithInitFiles("postgres-init")
+    .WithDataVolume("gatewaydb.local");
+
+string redisEndpoint = redisConnection.Split(',')[0];
+int redisPort = redisEndpoint.Contains(':', StringComparison.Ordinal) ? int.Parse(redisEndpoint.Split(':')[^1], CultureInfo.InvariantCulture) : 6379;
+string? redisPasswordValue = redisConnection.Split(',')
+    .Select(part => part.Trim())
+    .FirstOrDefault(part => part.StartsWith("password=", StringComparison.OrdinalIgnoreCase))?["password=".Length..];
+IResourceBuilder<RedisResource> redis = builder.AddRedis("gatewaycache", port: redisPort)
+    .WithPassword(redisPasswordValue is null ? null : builder.AddParameter("redis-password", redisPasswordValue, secret: true))
+    .WithImageTag("6.2")
+    .WithContainerName("GatewayCache")
+    .WithDataVolume("gatewaycache.local")
+    .WithPersistence(TimeSpan.FromSeconds(60));
+
+// Requires the dotnet-ef global tool.
+IResourceBuilder<ExecutableResource> migrations = builder
+    .AddExecutable("db-migrations", "dotnet", "../DBMaintainer")
+    .WithArgs("ef", "database", "update", "--project", "../Database/src", "--connection", gatewayConnection)
+    .WaitFor(postgres);
+
+AddApp<Projects.Patient>("patient");
+AddApp<Projects.GatewayApi>("gateway-api");
+AddApp<Projects.Immunization>("immunization");
+AddApp<Projects.Medication>("medication");
+AddApp<Projects.Laboratory>("laboratory");
+AddApp<Projects.Encounter>("encounter");
+AddApp<Projects.ClinicalDocument>("clinical-document");
+AddApp<Projects.JobScheduler>("job-scheduler");
+AddApp<Projects.WebClient>("web-client");
+
+builder.Build().Run();
+
+IResourceBuilder<ProjectResource> AddApp<TProject>(string name)
+    where TProject : IProjectMetadata, new()
+{
+    // HealthGateway_-prefixed environment variables are loaded last by ProgramConfiguration,
+    // so these override user secrets and appsettings.local.json in every app.
+    return builder.AddProject<TProject>(name)
+        .WithEnvironment("HealthGateway_ConnectionStrings__GatewayConnection", gatewayConnection)
+        .WithEnvironment("HealthGateway_RedisConnection", redisConnection)
+        .WaitFor(postgres)
+        .WaitFor(redis)
+        .WaitForCompletion(migrations);
+}

--- a/Apps/AspireHost/Properties/launchSettings.json
+++ b/Apps/AspireHost/Properties/launchSettings.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json.schemastore.org/launchsettings.json",
+    "profiles": {
+        "http": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "http://localhost:15100",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_ENVIRONMENT": "Development",
+                "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:21100",
+                "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:22100",
+                "ASPIRE_ALLOW_UNSECURED_TRANSPORT": "true"
+            }
+        },
+        "https": {
+            "commandName": "Project",
+            "dotnetRunMessages": true,
+            "launchBrowser": true,
+            "applicationUrl": "https://localhost:17100;http://localhost:15100",
+            "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development",
+                "DOTNET_ENVIRONMENT": "Development",
+                "ASPIRE_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21100",
+                "ASPIRE_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22100"
+            }
+        }
+    }
+}

--- a/Apps/AspireHost/README.md
+++ b/Apps/AspireHost/README.md
@@ -1,0 +1,73 @@
+# AspireHost
+
+Aspire AppHost that orchestrates the full local Health Gateway development environment:
+
+- **PostgreSQL 15** (container `GatewayDB`) on `localhost:5432`, bootstrapped with the
+  credentials and database from the `ConnectionStrings:GatewayConnection` user secret.
+  When the data volume is first created, `postgres-init/00_CreateExtensions.sql` adds the
+  `uuid-ossp` extension (as `Tools/Dev/Postgres/init/00_SetupDevDB.sql` does), which the
+  audit trigger functions in the migrations depend on.
+- **db-migrations** — initializes/updates the schema by running
+  `dotnet ef database update --project ../Database/src` from the DBMaintainer directory
+  (DBMaintainer is the migrations startup project). This is the only database
+  initialization; all apps wait for it to finish before starting.
+- **Redis 6.2** (container `GatewayCache`) on `localhost:6379`, mirroring the
+  `RedisConnection` user secret (including its password, if one is set).
+- **Apps** — everything except Admin: Patient, GatewayApi, Immunization, Medication,
+  Laboratory, Encounter, ClinicalDocument, JobScheduler, and WebClient (SpaProxy launches
+  the Vite dev server). Each app keeps the port from its own launch profile (GatewayApi
+  3000, WebClient 3025, JobScheduler 5005, etc.), so existing inter-service URLs work
+  unchanged. Drug data loads via JobScheduler's recurring Hangfire jobs.
+
+The containers are removed when the AppHost stops; their data persists in the
+`gatewaydb.local` and `gatewaycache.local` Docker volumes — the same volumes used by
+`Tools/Dev/Postgres/docker-compose.yml`, so existing developers keep their data when
+switching between the two.
+
+The AppHost logs through Serilog with the same defaults as the WebClient (see the
+`Serilog` section in `appsettings.json`).
+
+## Configuration
+
+The AppHost shares the developer user secrets used by the apps (same `UserSecretsId`) and
+requires two of its keys — no credentials live in source:
+
+- `ConnectionStrings:GatewayConnection`
+- `RedisConnection`
+
+It injects those values into every app as `HealthGateway_`-prefixed environment variables,
+which `ProgramConfiguration` loads last, so they override user secrets and
+`appsettings.local.json`. All other configuration (Keycloak secrets, PHSA endpoints, etc.)
+still comes from user secrets as before.
+
+## Prerequisites
+
+- Docker Desktop running
+- `dotnet-ef` global tool (`dotnet tool install --global dotnet-ef`)
+- Stop the old compose stack first if it's running, since both use ports 5432/6379:
+  `docker compose -f Tools/Dev/Postgres/docker-compose.yml down`
+
+## Run and view the dashboard
+
+```console
+dotnet run --project Apps/AspireHost
+```
+
+The console prints a dashboard login link, e.g.
+
+```console
+Login to the dashboard at https://localhost:17100/login?t=<token>
+```
+
+Open that link (the token logs you in automatically). The dashboard at
+`https://localhost:17100` shows every resource with its state, endpoints, console logs,
+environment, and telemetry, and has start/stop/restart controls per resource. If you lose
+the link, the token is reprinted in the AppHost console output on each run.
+
+## Resetting local state
+
+```console
+docker volume rm gatewaydb.local gatewaycache.local
+```
+
+The next AppHost run re-creates the containers and re-runs the migrations from scratch.

--- a/Apps/AspireHost/README.md
+++ b/Apps/AspireHost/README.md
@@ -14,11 +14,12 @@ Aspire AppHost that orchestrates the full local Health Gateway development envir
   initialization; all apps wait for it to finish before starting.
 - **Redis 6.2** (container `GatewayCache`), mirroring the `RedisConnection` user secret's
   port and password, if one is set (`localhost:6379` with the standard secret).
-- **Apps** — everything except Admin: Patient, GatewayApi, Immunization, Medication,
-  Laboratory, Encounter, ClinicalDocument, JobScheduler, and WebClient (SpaProxy launches
-  the Vite dev server). Each app keeps the port from its own launch profile (GatewayApi
-  3000, WebClient 3025, JobScheduler 5005, etc.), so existing inter-service URLs work
-  unchanged. Drug data loads via JobScheduler's recurring Hangfire jobs.
+- **Apps** — Patient, GatewayApi, Immunization, Medication, Laboratory, Encounter,
+  ClinicalDocument, JobScheduler, WebClient (SpaProxy launches the Vite dev server),
+  and Admin (Blazor WASM portal). Each app keeps the port from its own launch profile
+  (GatewayApi 3000, WebClient 3025, JobScheduler 5005, Admin 5027, etc.), so existing
+  inter-service URLs work unchanged. Drug data loads via JobScheduler's recurring
+  Hangfire jobs.
 
 The containers are removed when the AppHost stops; their data persists in the
 `gatewaydb.local` and `gatewaycache.local` Docker volumes — the same volumes used by

--- a/Apps/AspireHost/README.md
+++ b/Apps/AspireHost/README.md
@@ -8,7 +8,7 @@ Aspire AppHost that orchestrates the full local Health Gateway development envir
   When the data volume is first created, `postgres-init/00_CreateExtensions.sql` adds the
   `uuid-ossp` extension (as `Tools/Dev/Postgres/init/00_SetupDevDB.sql` does), which the
   audit trigger functions in the migrations depend on.
-- **db-migrations** — initializes/updates the schema by running
+- **DbMigrations** — initializes/updates the schema by running
   `dotnet ef database update --project ../Database/src` from the DBMaintainer directory
   (DBMaintainer is the migrations startup project). This is the only database
   initialization; all apps wait for it to finish before starting.

--- a/Apps/AspireHost/README.md
+++ b/Apps/AspireHost/README.md
@@ -2,8 +2,9 @@
 
 Aspire AppHost that orchestrates the full local Health Gateway development environment:
 
-- **PostgreSQL 15** (container `GatewayDB`) on `localhost:5432`, bootstrapped with the
-  credentials and database from the `ConnectionStrings:GatewayConnection` user secret.
+- **PostgreSQL 15** (container `GatewayDB`), bootstrapped with the credentials, database,
+  and port from the `ConnectionStrings:GatewayConnection` user secret (`localhost:5432`
+  with the standard secret).
   When the data volume is first created, `postgres-init/00_CreateExtensions.sql` adds the
   `uuid-ossp` extension (as `Tools/Dev/Postgres/init/00_SetupDevDB.sql` does), which the
   audit trigger functions in the migrations depend on.
@@ -11,8 +12,8 @@ Aspire AppHost that orchestrates the full local Health Gateway development envir
   `dotnet ef database update --project ../Database/src` from the DBMaintainer directory
   (DBMaintainer is the migrations startup project). This is the only database
   initialization; all apps wait for it to finish before starting.
-- **Redis 6.2** (container `GatewayCache`) on `localhost:6379`, mirroring the
-  `RedisConnection` user secret (including its password, if one is set).
+- **Redis 6.2** (container `GatewayCache`), mirroring the `RedisConnection` user secret's
+  port and password, if one is set (`localhost:6379` with the standard secret).
 - **Apps** — everything except Admin: Patient, GatewayApi, Immunization, Medication,
   Laboratory, Encounter, ClinicalDocument, JobScheduler, and WebClient (SpaProxy launches
   the Vite dev server). Each app keeps the port from its own launch profile (GatewayApi

--- a/Apps/AspireHost/appsettings.json
+++ b/Apps/AspireHost/appsettings.json
@@ -1,0 +1,28 @@
+{
+    "Serilog": {
+        "MinimumLevel": {
+            "Default": "Information",
+            "Override": {
+                "Microsoft.AspNetCore": "Warning",
+                "System.Net.Http.HttpClient": "Warning",
+                "Aspire.Hosting.Dcp": "Warning"
+            }
+        },
+        "WriteTo": [
+            {
+                "Name": "Async",
+                "Args": {
+                    "configure": [
+                        {
+                            "Name": "Console",
+                            "Args": {
+                                "theme": "Serilog.Sinks.SystemConsole.Themes.AnsiConsoleTheme::Code, Serilog.Sinks.Console",
+                                "formatter": "Serilog.Formatting.Compact.RenderedCompactJsonFormatter, Serilog.Formatting.Compact"
+                            }
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+}

--- a/Apps/AspireHost/postgres-init/00_CreateExtensions.sql
+++ b/Apps/AspireHost/postgres-init/00_CreateExtensions.sql
@@ -1,0 +1,4 @@
+-- Runs once when the Postgres data volume is first initialized, against the POSTGRES_DB
+-- database (hglocal). Mirrors Tools/Dev/Postgres/init/00_SetupDevDB.sql: provides
+-- uuid_generate_v4(), which the audit trigger functions in the EF migrations depend on.
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/Apps/ClinicalDocument/src/appsettings.Development.json
+++ b/Apps/ClinicalDocument/src/appsettings.Development.json
@@ -32,10 +32,6 @@
             }
         }
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"

--- a/Apps/ClinicalDocument/src/appsettings.json
+++ b/Apps/ClinicalDocument/src/appsettings.json
@@ -60,7 +60,7 @@
         "CacheTTL": 90
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "ClinicalDocumentService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/Common/src/AspNetConfiguration/Modules/Observability.cs
+++ b/Apps/Common/src/AspNetConfiguration/Modules/Observability.cs
@@ -47,6 +47,7 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
     /// Methods to configure observability dependencies and settings.
     /// </summary>
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Maintainability", "CA1506:Avoid excessive class coupling", Justification = "Central observability wiring necessarily touches many types")]
     public static class Observability
     {
         /// <summary>
@@ -120,9 +121,17 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
             services.AddOpenTelemetry()
                 .WithTracing(builder =>
                 {
+                    builder.SetSampler(new AlwaysOnSampler());
+
+                    // When a host such as the Aspire AppHost injects OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES,
+                    // the SDK's environment detectors must supply the service identity so telemetry is attributed
+                    // to that host's resource; overriding it here splits each service into two dashboard entries.
+                    if (!OtelServiceNameEnvironmentExists())
+                    {
+                        builder.ConfigureResource(resourceBuilder => resourceBuilder.AddService(otlpConfig.ServiceName, serviceVersion: otlpConfig.ServiceVersion));
+                    }
+
                     builder
-                        .SetSampler(new AlwaysOnSampler())
-                        .ConfigureResource(resourceBuilder => resourceBuilder.AddService(otlpConfig.ServiceName, serviceVersion: otlpConfig.ServiceVersion))
                         .AddHttpClientInstrumentation()
                         .AddAspNetCoreInstrumentation(options =>
                         {
@@ -158,9 +167,18 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                             config.Endpoint = otlpConfig.Endpoint;
                         });
                     }
+                    else if (OtlpEnvironmentEndpointExists())
+                    {
+                        builder.AddOtlpExporter();
+                    }
                 })
                 .WithMetrics(builder =>
                 {
+                    if (!OtelServiceNameEnvironmentExists())
+                    {
+                        builder.ConfigureResource(resourceBuilder => resourceBuilder.AddService(otlpConfig.ServiceName, serviceVersion: otlpConfig.ServiceVersion));
+                    }
+
                     builder
                         .AddHttpClientInstrumentation()
                         .AddAspNetCoreInstrumentation()
@@ -183,6 +201,10 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                             config.Protocol = otlpConfig.ExportProtocol;
                             config.Endpoint = otlpConfig.Endpoint;
                         });
+                    }
+                    else if (OtlpEnvironmentEndpointExists())
+                    {
+                        builder.AddOtlpExporter();
                     }
                 })
                 ;
@@ -215,6 +237,18 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                     await next();
                 });
             }
+        }
+
+        private static bool OtelServiceNameEnvironmentExists()
+        {
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_SERVICE_NAME"));
+        }
+
+        private static bool OtlpEnvironmentEndpointExists()
+        {
+            // Standard OTLP variable injected by hosts such as the Aspire AppHost; the parameterless
+            // exporter reads the OTEL_EXPORTER_OTLP_* variables (endpoint, protocol, headers) itself.
+            return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("OTEL_EXPORTER_OTLP_ENDPOINT"));
         }
 
         private static string GetRequestHdid(HttpContext context)
@@ -255,6 +289,14 @@ namespace HealthGateway.Common.AspNetConfiguration.Modules
                 .Enrich.WithClientIp()
                 .Enrich.WithSpan(new SpanOptions { IncludeBaggage = true, IncludeTags = true, IncludeOperationName = true, IncludeTraceFlags = true })
                 .ReadFrom.Configuration(configuration);
+
+            // Exports structured logs alongside traces and metrics when a host such as the Aspire AppHost
+            // injects the OTLP endpoint; the sink reads the OTEL_EXPORTER_OTLP_* and OTEL_RESOURCE_ATTRIBUTES
+            // variables itself, attributing entries to the same resource as the other signals.
+            if (OtlpEnvironmentEndpointExists())
+            {
+                loggerConfiguration.WriteTo.OpenTelemetry();
+            }
         }
 
         private static LogEventLevel ExcludePaths(HttpContext ctx, Exception? ex, string[] excludedPaths)

--- a/Apps/Common/src/Common.csproj
+++ b/Apps/Common/src/Common.csproj
@@ -40,6 +40,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="5.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="9.1.0" />
     <PackageReference Include="SerilogTraceListener" Version="3.2.0" />
     <PackageReference Include="StackExchange.Redis" Version="3.1.31" />

--- a/Apps/Database/src/Migrations/20260424213842_RemoveNotificationEmailBackfillRecurringJob.cs
+++ b/Apps/Database/src/Migrations/20260424213842_RemoveNotificationEmailBackfillRecurringJob.cs
@@ -27,14 +27,24 @@ namespace HealthGateway.Database.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            // The hangfire schema is created by Hangfire when the JobScheduler first starts,
+            // so it may not exist yet on a freshly initialized database.
             string schema = "hangfire";
             string sql = @$"
-            DELETE FROM {schema}.hash
-            WHERE key = 'recurring-job:NotificationBackfill-BcCancerScreening-Email';
+            DO $$
+            BEGIN
+                IF to_regclass('{schema}.hash') IS NOT NULL THEN
+                    DELETE FROM {schema}.hash
+                    WHERE key = 'recurring-job:NotificationBackfill-BcCancerScreening-Email';
+                END IF;
 
-            DELETE FROM {schema}.set
-            WHERE key = 'recurring-jobs'
-              AND value = 'NotificationBackfill-BcCancerScreening-Email';
+                IF to_regclass('{schema}.set') IS NOT NULL THEN
+                    DELETE FROM {schema}.set
+                    WHERE key = 'recurring-jobs'
+                      AND value = 'NotificationBackfill-BcCancerScreening-Email';
+                END IF;
+            END
+            $$;
             ";
 
             migrationBuilder.Sql(sql);

--- a/Apps/Encounter/src/appsettings.Development.json
+++ b/Apps/Encounter/src/appsettings.Development.json
@@ -37,10 +37,6 @@
             }
         }
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "PHSA": {
         "BaseUrl": "https://phsahealthgatewayapi-dev.azurewebsites.net"
     },

--- a/Apps/Encounter/src/appsettings.json
+++ b/Apps/Encounter/src/appsettings.json
@@ -78,7 +78,7 @@
         "CacheTTL": 90
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "EncounterService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/GatewayApi/src/appsettings.Development.json
+++ b/Apps/GatewayApi/src/appsettings.Development.json
@@ -35,10 +35,6 @@
             }
         }
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "CDOGS": {
         "BaseEndpoint": "https://dev-hgcdogs.apps.gold.devops.gov.bc.ca"
     },

--- a/Apps/GatewayApi/src/appsettings.json
+++ b/Apps/GatewayApi/src/appsettings.json
@@ -79,7 +79,7 @@
         "FrameAncestors": "'self' https://loginproxy.gov.bc.ca/"
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "GatewayApi",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/HealthGateway.sln
+++ b/Apps/HealthGateway.sln
@@ -85,6 +85,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountDataAccess", "Accoun
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountDataAccessTests", "AccountDataAccess\test\unit\AccountDataAccessTests.csproj", "{E4CD0A9C-196B-4CDD-97B8-4D3666BB582F}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireHost", "AspireHost\AspireHost.csproj", "{BE3C3E8A-6B14-4954-A6F8-C2209130D500}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -515,6 +517,18 @@ Global
 		{E4CD0A9C-196B-4CDD-97B8-4D3666BB582F}.Release|x64.Build.0 = Release|Any CPU
 		{E4CD0A9C-196B-4CDD-97B8-4D3666BB582F}.Release|x86.ActiveCfg = Release|Any CPU
 		{E4CD0A9C-196B-4CDD-97B8-4D3666BB582F}.Release|x86.Build.0 = Release|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Debug|x64.Build.0 = Debug|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Debug|x86.Build.0 = Debug|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Release|x64.ActiveCfg = Release|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Release|x64.Build.0 = Release|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Release|x86.ActiveCfg = Release|Any CPU
+		{BE3C3E8A-6B14-4954-A6F8-C2209130D500}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Apps/HealthGateway.sln
+++ b/Apps/HealthGateway.sln
@@ -85,7 +85,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountDataAccess", "Accoun
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AccountDataAccessTests", "AccountDataAccess\test\unit\AccountDataAccessTests.csproj", "{E4CD0A9C-196B-4CDD-97B8-4D3666BB582F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AspireHost", "AspireHost\AspireHost.csproj", "{BE3C3E8A-6B14-4954-A6F8-C2209130D500}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AspireHost", "AspireHost\AspireHost.csproj", "{BE3C3E8A-6B14-4954-A6F8-C2209130D500}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/Apps/Immunization/src/appsettings.Development.json
+++ b/Apps/Immunization/src/appsettings.Development.json
@@ -33,10 +33,6 @@
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "PatientService": {
         "ClientRegistry": {
             "ServiceUrl": "https://hiat1.hcim.ehealth.gov.bc.ca/HCIM.HIALServices.Portal/QUPA_AR101102.asmx",

--- a/Apps/Immunization/src/appsettings.json
+++ b/Apps/Immunization/src/appsettings.json
@@ -65,7 +65,7 @@
         "TokenCacheEnabled": true
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "ImmunizationService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/JobScheduler/src/appsettings.Development.json
+++ b/Apps/JobScheduler/src/appsettings.Development.json
@@ -24,10 +24,6 @@
     "ForwardProxies": {
         "Enabled": "false"
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "Host": "http://localhost:5000",
     "JobScheduler": {
         "AdminHome": "http://localhost:5027"

--- a/Apps/JobScheduler/src/appsettings.json
+++ b/Apps/JobScheduler/src/appsettings.json
@@ -58,7 +58,7 @@
         "IPs": []
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "JobScheduler",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/Laboratory/src/appsettings.Development.json
+++ b/Apps/Laboratory/src/appsettings.Development.json
@@ -42,9 +42,5 @@
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"
-    },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
     }
 }

--- a/Apps/Laboratory/src/appsettings.json
+++ b/Apps/Laboratory/src/appsettings.json
@@ -60,7 +60,7 @@
     },
     "LaboratoryDelegate": "HealthGateway.Laboratory.Delegates.RestLaboratoryDelegate",
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "LaboratoryService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/Medication/src/appsettings.Development.json
+++ b/Apps/Medication/src/appsettings.Development.json
@@ -33,10 +33,6 @@
         "DynamicServiceLookup": "false",
         "BaseEndpoint": "https://dev-odrproxy.apps.silver.devops.gov.bc.ca/"
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"

--- a/Apps/Medication/src/appsettings.json
+++ b/Apps/Medication/src/appsettings.json
@@ -87,7 +87,7 @@
         }
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "MedicationService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/Patient/src/appsettings.Development.json
+++ b/Apps/Patient/src/appsettings.Development.json
@@ -30,10 +30,6 @@
             }
         }
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "PhsaV2": {
         "TokenBaseUrl": "https://phsa-ccd-dev.azure-api.net/identity",
         "BaseUrl": "https://phsa-ccd-dev.azure-api.net/healthgateway"

--- a/Apps/Patient/src/appsettings.json
+++ b/Apps/Patient/src/appsettings.json
@@ -61,7 +61,7 @@
         "CacheTTL": 90
     },
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "PatientService",
         "TraceConsoleExporterEnabled": false,

--- a/Apps/WebClient/src/appsettings.Development.json
+++ b/Apps/WebClient/src/appsettings.Development.json
@@ -75,10 +75,6 @@
         "FrameSource": "'self' https://dev.loginproxy.gov.bc.ca/",
         "FrameAncestors": "'self' https://dev.loginproxy.gov.bc.ca/"
     },
-    "OpenTelemetry": {
-        "Enabled": true,
-        "TraceConsoleExporterEnabled": true
-    },
     "MobileConfiguration": {
         "BaseUrl": "https://localhost/",
         "Authentication": {

--- a/Apps/WebClient/src/appsettings.json
+++ b/Apps/WebClient/src/appsettings.json
@@ -110,7 +110,7 @@
     },
     "PermissionPolicy": "camera=(self)",
     "OpenTelemetry": {
-        "Enabled": false,
+        "Enabled": true,
         "Sources": ["HealthGateway.*"],
         "ServiceName": "WebClient",
         "TraceConsoleExporterEnabled": false,


### PR DESCRIPTION
# Fixes or Implements AB#nnnnn

## Description

Configure Aspire for Health Gateway
Enables telemetry and structured logs for local development
Corrects behaviour on a migration that cleans up JobScheduler before the schema exists
Updates app settings to enable telemetry in the base appsettings.json and remove it from each .Development.json 


