### PR TITLE
Stabilize Cypress functional test workflows AB#17111

### DIFF
--- a/Testing/functional/tests/cypress/fixtures/LaboratoryService/laboratoryOrdersRefresh.json
+++ b/Testing/functional/tests/cypress/fixtures/LaboratoryService/laboratoryOrdersRefresh.json
@@ -71,7 +71,7 @@
     "totalResultCount": 1,
     "pageIndex": null,
     "pageSize": 25,
-    "resultStatus": 1,
+    "resultStatus": 2,
     "resultError": {
         "actionCode": "REFRESH"
     }

--- a/Testing/functional/tests/cypress/integration/e2e/user/acceptTermsOfService.js
+++ b/Testing/functional/tests/cypress/integration/e2e/user/acceptTermsOfService.js
@@ -30,7 +30,25 @@ describe("Need to accept terms of service", () => {
         cy.get("[data-testid=accept-tos-checkbox] input")
             .should("be.enabled")
             .check({ force: true });
+
+        cy.intercept(
+            "PUT",
+            "**/UserProfile/*/acceptedterms?api-version=2.0"
+        ).as("updateAcceptedTerms");
+        cy.intercept("GET", "**/UserProfile/*?api-version=2.0").as(
+            "getUpdatedUserProfile"
+        );
+
         cy.get("[data-testid=continue-btn]").should("be.enabled").click();
-        cy.url().should("include", "/home");
+        cy.wait("@updateAcceptedTerms", { timeout: defaultTimeout })
+            .its("response.statusCode")
+            .should("eq", 200);
+        cy.wait("@getUpdatedUserProfile", { timeout: defaultTimeout })
+            .its("response.statusCode")
+            .should("eq", 200);
+        cy.location("pathname", { timeout: defaultTimeout }).should(
+            "eq",
+            "/home"
+        );
     });
 });

--- a/Testing/functional/tests/cypress/integration/ui/timeline/dependent/main.js
+++ b/Testing/functional/tests/cypress/integration/ui/timeline/dependent/main.js
@@ -7,13 +7,36 @@ const formattedDependentName = "Sam T";
 const dependentsPath = "/dependents";
 
 function loginToDependentTimeline(dependentHdid) {
+    const waitForDependentFixture = prepareDependentFixtureWait();
+
     cy.login(
         Cypress.env("keycloak.username"),
         Cypress.env("keycloak.password"),
         AuthMethod.KeyCloak,
         `/dependents/${dependentHdid}/timeline`
     );
-    cy.wait("@getDependentFixture");
+
+    waitForDependentFixture();
+}
+
+function prepareDependentFixtureWait() {
+    let requestStarted = false;
+
+    cy.intercept("GET", "**/UserProfile/*/Dependent*", (req) => {
+        requestStarted = true;
+        req.reply({
+            fixture: "UserProfileService/dependent.json",
+        });
+    }).as("getDependentFixture");
+
+    return () =>
+        cy.then(() => {
+            if (requestStarted) {
+                return cy.wait("@getDependentFixture");
+            }
+
+            cy.log("Using previously loaded dependent data.");
+        });
 }
 
 describe("Dependent Timeline", () => {
@@ -28,9 +51,6 @@ describe("Dependent Timeline", () => {
             },
         });
         setupStandardFixtures();
-        cy.intercept("GET", "**/UserProfile/*/Dependent*", {
-            fixture: "UserProfileService/dependent.json",
-        }).as("getDependentFixture");
     });
 
     it("Redirects an unauthorized dependent timeline", () => {

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -259,128 +259,138 @@ Cypress.Commands.add(
             const baseWebClientUrl = Cypress.config("baseUrl");
 
             cy.log("Calling session storage");
-            const configSettingsString =
-                window.sessionStorage.getItem("configSettingsKey");
-            const configSettings = configSettingsString
-                ? JSON.parse(configSettingsString)
-                : undefined;
+            cy.window().then((currentWindow) => {
+                const configSettingsString =
+                    currentWindow.sessionStorage.getItem("configSettingsKey");
+                const configSettings = configSettingsString
+                    ? JSON.parse(configSettingsString)
+                    : undefined;
 
-            if (baseWebClientUrl == localDevUri) {
-                setupStandardAliases();
-                loginWithKeycloakUI(
-                    username,
-                    password,
-                    configSettings,
-                    path,
-                    initialDataWaitOptions
-                );
-            } else {
-                setupStandardAliases();
-                cy.window().then((window) => {
-                    cy.session([username, authMethod], () => {
-                        cy.readConfig().then((config) => {
-                            let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
-                            let codeVerifier = generateRandomString(96);
-                            cy.log(
-                                `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
-                            );
-                            const loginCallback =
-                                config.openIdConnect.callbacks?.Logon ||
-                                `${Cypress.config().baseUrl}/loginCallback`;
-                            const stateStore = {
-                                id: stateId,
-                                created: new Date().getTime(),
-                                request_type: "si:r",
-                                code_verifier: codeVerifier,
-                                redirect_uri: loginCallback,
-                                authority: config.openIdConnect.authority,
-                                client_id: config.openIdConnect.clientId,
-                                response_mode: "query",
-                                scope: config.openIdConnect.scope,
-                                extraTokenParams: {},
-                            };
-                            cy.log("Creating OIDC StateStore in Local storage");
-                            window.sessionStorage.setItem(
-                                `oidc.${stateStore.id}`,
-                                JSON.stringify(stateStore)
-                            );
-
-                            const escapedRedirectPath = encodeURI(path);
-                            const redirectUri = `${loginCallback}?redirect=${escapedRedirectPath}`;
-
-                            cy.log("Requesting Keycloak Authentication form");
-                            cy.request({
-                                url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
-                                timeout: 60000,
-                                followRedirect: false,
-                                qs: {
-                                    scope: config.openIdConnect.scope,
-                                    response_type:
-                                        config.openIdConnect.responseType,
-                                    approval_prompt: "auto",
-                                    redirect_uri: redirectUri,
-                                    client_id: config.openIdConnect.clientId,
-                                    response_mode: "query",
-                                    state: stateStore.id,
-                                },
-                            })
-                                .then((response) => {
-                                    cy.log("Posting credentials");
-                                    const html = document.createElement("html");
-                                    html.innerHTML = response.body;
-                                    const form =
-                                        html.getElementsByTagName("form")[0];
-                                    const url = form.action;
-                                    return cy.request({
-                                        method: "POST",
-                                        url,
-                                        timeout: 60000,
-                                        followRedirect: false,
-                                        form: true,
-                                        body: {
-                                            username: username,
-                                            password: password,
-                                        },
-                                    });
-                                })
-                                .then((response) => {
-                                    let callBackQS =
-                                        response.headers["location"];
-                                    const callbackURL = `${callBackQS}`;
-                                    cy.log(
-                                        `Visiting Callback ${callBackQS}`,
-                                        response
-                                    );
-
-                                    cy.visit(callbackURL);
-
-                                    // LoginCallbackView processes the OIDC response and retrieves the essential
-                                    // user data before ClientApp navigates to the appropriate destination.
-                                    // Do not save the Cypress session while still processing the callback.
-                                    cy.location("pathname", {
-                                        timeout: 60000,
-                                    }).should("not.eq", "/loginCallback");
-
-                                    // Store authentication cookies only after login has completed.
-                                    cy.getCookies().then((cookies) => {
-                                        globalStorage.authCookies = cookies;
-                                    });
-                                });
-                        });
-                    });
-
-                    // Register aliases for the post-session visit; login callback requests may
-                    // have already consumed aliases registered before session initialization.
+                if (baseWebClientUrl == localDevUri) {
                     setupStandardAliases();
-
-                    postLoginInitialization(
-                        configSettings,
+                    loginWithKeycloakUI(
                         username,
+                        password,
+                        configSettings,
                         path,
                         initialDataWaitOptions
                     );
-                });
-            }
+                } else {
+                    setupStandardAliases();
+                    cy.window().then((window) => {
+                        cy.session([username, authMethod], () => {
+                            cy.readConfig().then((config) => {
+                                let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
+                                let codeVerifier = generateRandomString(96);
+                                cy.log(
+                                    `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
+                                );
+                                const loginCallback =
+                                    config.openIdConnect.callbacks?.Logon ||
+                                    `${Cypress.config().baseUrl}/loginCallback`;
+                                const stateStore = {
+                                    id: stateId,
+                                    created: new Date().getTime(),
+                                    request_type: "si:r",
+                                    code_verifier: codeVerifier,
+                                    redirect_uri: loginCallback,
+                                    authority: config.openIdConnect.authority,
+                                    client_id: config.openIdConnect.clientId,
+                                    response_mode: "query",
+                                    scope: config.openIdConnect.scope,
+                                    extraTokenParams: {},
+                                };
+                                cy.log(
+                                    "Creating OIDC StateStore in Local storage"
+                                );
+                                window.sessionStorage.setItem(
+                                    `oidc.${stateStore.id}`,
+                                    JSON.stringify(stateStore)
+                                );
+
+                                const escapedRedirectPath = encodeURI(path);
+                                const redirectUri = `${loginCallback}?redirect=${escapedRedirectPath}`;
+
+                                cy.log(
+                                    "Requesting Keycloak Authentication form"
+                                );
+                                cy.request({
+                                    url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
+                                    timeout: 60000,
+                                    followRedirect: false,
+                                    qs: {
+                                        scope: config.openIdConnect.scope,
+                                        response_type:
+                                            config.openIdConnect.responseType,
+                                        approval_prompt: "auto",
+                                        redirect_uri: redirectUri,
+                                        client_id:
+                                            config.openIdConnect.clientId,
+                                        response_mode: "query",
+                                        state: stateStore.id,
+                                    },
+                                })
+                                    .then((response) => {
+                                        cy.log("Posting credentials");
+                                        const html =
+                                            document.createElement("html");
+                                        html.innerHTML = response.body;
+                                        const form =
+                                            html.getElementsByTagName(
+                                                "form"
+                                            )[0];
+                                        const url = form.action;
+                                        return cy.request({
+                                            method: "POST",
+                                            url,
+                                            timeout: 60000,
+                                            followRedirect: false,
+                                            form: true,
+                                            body: {
+                                                username: username,
+                                                password: password,
+                                            },
+                                        });
+                                    })
+                                    .then((response) => {
+                                        let callBackQS =
+                                            response.headers["location"];
+                                        const callbackURL = `${callBackQS}`;
+                                        cy.log(
+                                            `Visiting Callback ${callBackQS}`,
+                                            response
+                                        );
+
+                                        cy.visit(callbackURL);
+
+                                        // LoginCallbackView processes the OIDC response and retrieves the essential
+                                        // user data before ClientApp navigates to the appropriate destination.
+                                        // Do not save the Cypress session while still processing the callback.
+                                        cy.location("pathname", {
+                                            timeout: 60000,
+                                        }).should("not.eq", "/loginCallback");
+
+                                        // Store authentication cookies only after login has completed.
+                                        cy.getCookies().then((cookies) => {
+                                            globalStorage.authCookies = cookies;
+                                        });
+                                    });
+                            });
+                        });
+
+                        // Register aliases for the post-session visit; login callback requests may
+                        // have already consumed aliases registered before session initialization.
+                        setupStandardAliases();
+
+                        postLoginInitialization(
+                            configSettings,
+                            username,
+                            path,
+                            initialDataWaitOptions
+                        );
+                    });
+                }
+            });
         } else if (authMethod == AuthMethod.BCSC) {
             cy.log(
                 `Authenticating as BC Services Card user ${username} using the UI`


### PR DESCRIPTION
# Fixes or Implements [AB#17111](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17111)

## Description

Stabilizes Cypress functional tests by correcting configuration timing, cache-aware request waits, laboratory refresh fixtures, and Terms of Service workflow synchronization.
Changes

- Read configSettingsKey through Cypress’s command queue so login() uses the current test’s configured settings.
- Make dependent timeline fixture waits tolerate ClientApp’s valid cached-data behavior.
- Correct the laboratory refresh fixture to return ActionRequired with REFRESH, allowing the expected partial-results refresh flow.
- Wait for and verify the Terms of Service update and refreshed user profile before asserting navigation to /home.

**Cypress Runs:**

https://cloud.cypress.io/projects/ofnepc/runs/7479/overview/f06ef8b9-33c1-4fae-acaf-4928f569baff?roarHideRunsWithDiffGroupsAndTags=1

https://cloud.cypress.io/projects/ofnepc/runs/7478/overview?roarHideRunsWithDiffGroupsAndTags=1


## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
