### PR TITLE
Split and stabilaze Admin functional test workflows for AB#17112

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/agentaccess-write.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/agentaccess-write.cy.js
@@ -2,9 +2,27 @@ import { removeUserIfExists } from "../../utilities/kcUtilities";
 
 const user = "FncTstUser1";
 const defaultTimeout = 60000;
+const rowSelector = "[data-testid=agent-table] tbody tr.mud-table-row";
+
+function createUser() {
+    cy.log("Create user.");
+    cy.get("[data-testid=create-btn]").click();
+    cy.get("[data-testid=provision-dialog-modal-text]").should("be.visible");
+    cy.get("[data-testid=username-input]").clear().type(user);
+    cy.get("[data-testid=identity-provider-select]").click({ force: true });
+    cy.get("[data-testid=identity-provider]").contains("IDIR").click();
+    cy.get("[data-testid=roles-select]").click();
+    cy.get("[data-testid=role]").contains("AdminUser").click();
+    cy.get("body").type("{esc}");
+    cy.intercept("POST", "**/AgentAccess/").as("postAgentAccess");
+    cy.get("[data-testid=save-btn]").click();
+    cy.wait("@postAgentAccess", { timeout: defaultTimeout });
+    cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
+}
 
 describe("Provision", () => {
     beforeEach(() => {
+        removeUserIfExists(user);
         cy.login(
             Cypress.env("keycloak_username"),
             Cypress.env("keycloak_password"),
@@ -12,28 +30,14 @@ describe("Provision", () => {
         );
     });
 
-    it("Create and Validate User", () => {
-        // Clean User
+    afterEach(() => {
         removeUserIfExists(user);
+    });
 
-        cy.log("Create user.");
-        cy.get("[data-testid=create-btn]").click();
-        cy.get("[data-testid=provision-dialog-modal-text]").should(
-            "be.visible"
-        );
-        cy.get("[data-testid=username-input]").clear().type(user);
-        cy.get("[data-testid=identity-provider-select]").click({ force: true });
-        cy.get("[data-testid=identity-provider]").contains("IDIR").click();
-        cy.get("[data-testid=roles-select]").click();
-        cy.get("[data-testid=role]").contains("AdminUser").click();
-        cy.get("body").type("{esc}");
-        cy.intercept("POST", "**/AgentAccess/").as("postAgentAccess");
-        cy.get("[data-testid=save-btn]").click();
-        cy.wait("@postAgentAccess", { timeout: defaultTimeout });
-        cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
+    it("Create, edit, and delete user", () => {
+        createUser();
 
         cy.log("Validate user was created.");
-        const rowSelector = "[data-testid=agent-table] tbody tr.mud-table-row";
         cy.get(rowSelector)
             .first()
             .within(() => {
@@ -47,30 +51,7 @@ describe("Provision", () => {
                     "AdminUser"
                 );
             });
-    });
 
-    it("Create Duplicate User", () => {
-        cy.get("[data-testid=create-btn]").click();
-        cy.get("[data-testid=provision-dialog-modal-text]").should(
-            "be.visible"
-        );
-        cy.get("[data-testid=username-input]").clear().type(user);
-        cy.get("[data-testid=identity-provider-select]").click({ force: true });
-        cy.get("[data-testid=identity-provider]").contains("IDIR").click();
-        cy.get("[data-testid=roles-select]").click();
-        cy.get("[data-testid=role]").contains("AdminUser").click();
-        cy.get("body").type("{esc}");
-        cy.intercept("POST", "**/AgentAccess/").as("postAgentAccess");
-        cy.get("[data-testid=save-btn]").click();
-        cy.wait("@postAgentAccess", { timeout: defaultTimeout });
-
-        cy.log("Validate duplicate user error.");
-        cy.get("[data-testid=add-error-alert]").should("exist");
-        cy.get("[data-testid=cancel-btn]").click();
-        cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
-    });
-
-    it("Edit User", () => {
         cy.intercept("GET", `**/AgentAccess/?query=${user}`).as("getUser");
         cy.get("[data-testid=query-input]").clear().type(user);
         cy.get("[data-testid=search-btn]").click();
@@ -102,7 +83,6 @@ describe("Provision", () => {
         cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
 
         cy.log("Validate user edit.");
-        const rowSelector = "[data-testid=agent-table] tbody tr.mud-table-row";
         cy.get(rowSelector)
             .first()
             .within(() => {
@@ -116,9 +96,7 @@ describe("Provision", () => {
                     "AdminAnalyst, AdminUser"
                 );
             });
-    });
 
-    it("Delete User", () => {
         cy.intercept("GET", `**/AgentAccess/?query=${user}`).as("getUser");
         cy.get("[data-testid=query-input]").clear().type(user);
         cy.get("[data-testid=search-btn]").click();
@@ -135,8 +113,32 @@ describe("Provision", () => {
         cy.get("[data-testid=confirm-delete-message]").should("not.exist");
 
         cy.log("Validate user delete.");
-        cy.contains("[data-testid=agent-table-username-]", user).should(
-            "not.exist"
+        cy.get("[data-testid=agent-table]").should(
+            "not.contain",
+            user.toLowerCase()
         );
+    });
+
+    it("Create duplicate user", () => {
+        createUser();
+
+        cy.get("[data-testid=create-btn]").click();
+        cy.get("[data-testid=provision-dialog-modal-text]").should(
+            "be.visible"
+        );
+        cy.get("[data-testid=username-input]").clear().type(user);
+        cy.get("[data-testid=identity-provider-select]").click({ force: true });
+        cy.get("[data-testid=identity-provider]").contains("IDIR").click();
+        cy.get("[data-testid=roles-select]").click();
+        cy.get("[data-testid=role]").contains("AdminUser").click();
+        cy.get("body").type("{esc}");
+        cy.intercept("POST", "**/AgentAccess/").as("postAgentAccess");
+        cy.get("[data-testid=save-btn]").click();
+        cy.wait("@postAgentAccess", { timeout: defaultTimeout });
+
+        cy.log("Validate duplicate user error.");
+        cy.get("[data-testid=add-error-alert]").should("exist");
+        cy.get("[data-testid=cancel-btn]").click();
+        cy.get("[data-testid=provision-dialog-modal-text]").should("not.exist");
     });
 });

--- a/Apps/Admin/Tests/Functional/cypress/integration/e2e/delegation-read.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/e2e/delegation-read.cy.js
@@ -106,7 +106,7 @@ describe("Delegation Search", () => {
         performSearch(dependentWithAudit);
 
         // Click delegation change header to show dependent audit
-        cy.get("[data-testid=delegation-changes-header")
+        cy.get("[data-testid=delegation-changes-header]")
             .should("be.visible")
             .click();
 
@@ -147,7 +147,7 @@ describe("Delegation Search", () => {
             });
 
         // Click delegation change header to not show dependent audit
-        cy.get("[data-testid=delegation-changes-header").click();
+        cy.get("[data-testid=delegation-changes-header]").click();
 
         cy.get("[data-testid=delegation-change-0]").should("not.be.visible");
         cy.get("[data-testid=delegation-change-1]").should("not.be.visible");

--- a/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
+++ b/Apps/Admin/Tests/Functional/cypress/integration/ui/patient-details.cy.js
@@ -204,7 +204,7 @@ describe("Patient details as admin", () => {
             .should("exist", "be.visible")
             .click();
 
-        cy.get("[data-testid=audit-reason-input")
+        cy.get("[data-testid=audit-reason-input]")
             .should("be.visible")
             .type(auditReasonInput);
 

--- a/Apps/Admin/Tests/Functional/cypress/support/commands.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/commands.js
@@ -134,7 +134,6 @@ Cypress.Commands.add("login", (username, password, path) => {
 
                 cy.log("Creating OIDC StateStore in local storage.");
                 cy.log(`State ID:  ${stateId}`);
-                cy.log(`Generated Code Verifier: ${codeVerifier}`);
                 window.sessionStorage.setItem(
                     `oidc.${stateStore.id}`,
                     JSON.stringify(stateStore)
@@ -216,11 +215,15 @@ Cypress.Commands.add("disableServiceWorker", () => {
     cy.log("Unregistering ServiceWorker.");
     cy.window().then((_win) => {
         if ("serviceWorker" in navigator) {
-            navigator.serviceWorker.getRegistrations().then((registrations) => {
-                registrations.forEach((registration) => {
-                    registration.unregister();
-                });
-            });
+            return navigator.serviceWorker
+                .getRegistrations()
+                .then((registrations) =>
+                    Promise.all(
+                        registrations.map((registration) =>
+                            registration.unregister()
+                        )
+                    )
+                );
         }
     });
 });

--- a/Tools/Pipelines/pipelines/FunctionalTests.yaml
+++ b/Tools/Pipelines/pipelines/FunctionalTests.yaml
@@ -25,7 +25,15 @@ variables:
     value: ${{ or(eq(parameters.appType, 'Admin'), eq(parameters.appType, 'Both')) }}
 
 jobs:
-  # Resolve latest once so every worker uses the same image during this run.
+  # Azure rolling image update issue.
+  #
+  # The first agent establishes the environment for the parallel Cypress run.
+  # All other agents must match its OS version, browser major version, and spec list.
+  # During an Azure image rollout, agents may receive different OS versions,
+  # causing Cypress to reject workers with a mismatched environment.
+  #
+  # Resolve cypress/browsers:latest to a digest once per pipeline run,
+  # so all Cypress workers use the same container OS and browser versions.
   - job: "Resolve_Cypress_Image"
     displayName: "Resolve Cypress browser image"
     pool:

--- a/Tools/Pipelines/pipelines/FunctionalTests.yaml
+++ b/Tools/Pipelines/pipelines/FunctionalTests.yaml
@@ -25,6 +25,35 @@ variables:
     value: ${{ or(eq(parameters.appType, 'Admin'), eq(parameters.appType, 'Both')) }}
 
 jobs:
+  # Resolve latest once so every worker uses the same image during this run.
+  - job: "Resolve_Cypress_Image"
+    displayName: "Resolve Cypress browser image"
+    pool:
+      vmImage: "ubuntu-latest"
+    timeoutInMinutes: 5
+    steps:
+      - checkout: none
+      - task: Bash@3
+        name: resolveImage
+        displayName: "Resolve current Linux AMD64 image digest"
+        inputs:
+          targetType: inline
+          script: |
+            set -euo pipefail
+            digest=$(curl --fail --silent --show-error --retry 3 \
+              --connect-timeout 15 --max-time 60 \
+              'https://hub.docker.com/v2/repositories/cypress/browsers/tags/latest' | \
+              jq -er '[.images[] | select(.os == "linux" and .architecture == "amd64") | .digest] | unique | if length == 1 then .[0] else error("Expected one Linux AMD64 image digest") end')
+
+            if [[ ! "$digest" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "##vso[task.logissue type=error]Invalid Cypress image digest."
+              exit 1
+            fi
+
+            image="cypress/browsers@$digest"
+            echo "Cypress image for this run: $image"
+            echo "##vso[task.setvariable variable=image;isOutput=true]$image"
+
   - job: "Admin_Seed"
     displayName: "Re-seed DB and PHSA data for Admin"
     pool:
@@ -48,8 +77,15 @@ jobs:
     displayName: "Admin Unauthorized Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
-    condition: and(succeeded(), eq(variables['Admin'], true))
-    dependsOn: "Admin_Seed"
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded(), eq(variables['Admin'], true))
+    dependsOn:
+      - "Resolve_Cypress_Image"
+      - "Admin_Seed"
     timeoutInMinutes: 10
     steps:
       - checkout: self
@@ -79,8 +115,14 @@ jobs:
     displayName: "Admin Authentication Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
-    condition: and(succeeded('Admin_Seed'), eq(variables['Admin'], true))
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('Admin_Seed'), eq(variables['Admin'], true))
     dependsOn:
+      - "Resolve_Cypress_Image"
       - "Admin_Seed"
       - "Admin_Unauthorized_Tests"
     timeoutInMinutes: 10
@@ -112,8 +154,14 @@ jobs:
     displayName: "Admin Ui Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
-    condition: and(succeeded('Admin_Seed'), eq(variables['Admin'], true))
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('Admin_Seed'), eq(variables['Admin'], true))
     dependsOn:
+      - "Resolve_Cypress_Image"
       - "Admin_Seed"
       - "Admin_Authentication_Tests"
     strategy:
@@ -148,8 +196,14 @@ jobs:
     displayName: "Admin Read Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
-    condition: and(succeeded('Admin_Seed'), eq(variables['Admin'], true))
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('Admin_Seed'), eq(variables['Admin'], true))
     dependsOn:
+      - "Resolve_Cypress_Image"
       - "Admin_Seed"
       - "Admin_Authentication_Tests"
     strategy:
@@ -184,8 +238,14 @@ jobs:
     displayName: "Admin Write Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
-    condition: and(succeeded('Admin_Seed'), eq(variables['Admin'], true))
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('Admin_Seed'), eq(variables['Admin'], true))
     dependsOn:
+      - "Resolve_Cypress_Image"
       - "Admin_Seed"
       - "Admin_Read_Tests"
     strategy:
@@ -241,8 +301,15 @@ jobs:
     displayName: "HG Auth Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
-    condition: and(succeeded('HG_Seed'), eq(variables['WebClient'], true))
-    dependsOn: "HG_Seed"
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('HG_Seed'), eq(variables['WebClient'], true))
+    dependsOn:
+      - "Resolve_Cypress_Image"
+      - "HG_Seed"
     timeoutInMinutes: 10
     steps:
       - checkout: self
@@ -278,10 +345,16 @@ jobs:
     displayName: "HG UI Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
     dependsOn:
+      - "Resolve_Cypress_Image"
       - "HG_Seed"
       - "HG_Auth_Functional_Tests"
-    condition: and(succeeded('HG_Seed'), eq(variables['WebClient'], true))
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('HG_Seed'), eq(variables['WebClient'], true))
     strategy:
       parallel: 6
     timeoutInMinutes: 15
@@ -319,10 +392,16 @@ jobs:
     displayName: "HG E2E Functional Tests"
     pool:
       vmImage: "ubuntu-latest"
+    variables:
+      cypressImage: $[ dependencies.Resolve_Cypress_Image.outputs['resolveImage.image'] ]
+    container:
+      image: $(cypressImage)
+      options: --shm-size=2g
     dependsOn:
+      - "Resolve_Cypress_Image"
       - "HG_Seed"
       - "HG_UI_Functional_Tests"
-    condition: and(succeeded('HG_Seed'), eq(variables['WebClient'], true))
+    condition: and(succeeded('Resolve_Cypress_Image'), succeeded('HG_Seed'), eq(variables['WebClient'], true))
     strategy:
       parallel: 6
     timeoutInMinutes: 15

--- a/Tools/Pipelines/pipelines/FunctionalTests.yaml
+++ b/Tools/Pipelines/pipelines/FunctionalTests.yaml
@@ -108,6 +108,42 @@ jobs:
           IDIR_PASSWORD: $(idir.password)
           KEYCLOAK_ADMIN_SECRET: $(keycloak.admin.secret)
           npm_config_cache: $(Pipeline.Workspace)/.npm
+  - job: "Admin_Ui_Tests"
+    displayName: "Admin Ui Functional Tests"
+    pool:
+      vmImage: "ubuntu-latest"
+    condition: and(succeeded('Admin_Seed'), eq(variables['Admin'], true))
+    dependsOn:
+      - "Admin_Seed"
+      - "Admin_Authentication_Tests"
+    strategy:
+      parallel: 2
+    timeoutInMinutes: 15
+    steps:
+      - checkout: self
+        fetchDepth: 1
+        clean: true
+      - task: Cache@2
+        displayName: Cache npm (Admin Ui Functional)
+        inputs:
+          key: 'npm | "$(Agent.OS)" | Apps/Admin/Tests/Functional/package-lock.json'
+          restoreKeys: |
+            npm | "$(Agent.OS)"
+          path: $(Pipeline.Workspace)/.npm
+      - task: Bash@3
+        displayName: "Run Admin Ui Functional Tests"
+        inputs:
+          targetType: filePath
+          filePath: "./Tools/Pipelines/scripts/azp_runAdminUiFunctionalTests.sh"
+          arguments: Apps/Admin/Tests/Functional $(Build.BuildNumber)-$(System.JobAttempt) "dev,$(Build.Reason)"
+        env: # Required environment settings and secrets for admin tests
+          TERM: xterm
+          CYPRESS_ADMIN_KEY: $(cypress.admin.key)
+          KEYCLOAK_PW: $(keycloak.pw)
+          IDIR_PASSWORD: $(idir.password)
+          KEYCLOAK_ADMIN_SECRET: $(keycloak.admin.secret)
+          npm_config_cache: $(Pipeline.Workspace)/.npm
+
   - job: "Admin_Read_Tests"
     displayName: "Admin Read Functional Tests"
     pool:
@@ -117,7 +153,7 @@ jobs:
       - "Admin_Seed"
       - "Admin_Authentication_Tests"
     strategy:
-      parallel: 9
+      parallel: 4
     timeoutInMinutes: 15
     steps:
       - checkout: self
@@ -153,7 +189,7 @@ jobs:
       - "Admin_Seed"
       - "Admin_Read_Tests"
     strategy:
-      parallel: 5
+      parallel: 4
     timeoutInMinutes: 15
     steps:
       - checkout: self

--- a/Tools/Pipelines/pipelines/FunctionalTests.yaml
+++ b/Tools/Pipelines/pipelines/FunctionalTests.yaml
@@ -205,7 +205,7 @@ jobs:
     dependsOn:
       - "Resolve_Cypress_Image"
       - "Admin_Seed"
-      - "Admin_Authentication_Tests"
+      - "Admin_Ui_Tests"
     strategy:
       parallel: 4
     timeoutInMinutes: 15

--- a/Tools/Pipelines/scripts/azp_runAdminUiFunctionalTests.sh
+++ b/Tools/Pipelines/scripts/azp_runAdminUiFunctionalTests.sh
@@ -40,10 +40,9 @@ pushd "$workDir"
 echo "Installing dependencies"
 npm ci
 
-echo "Running Cypress e2e Read Functional Tests"
-
-# Gather only `-read.cy.js` files in the `e2e` folder
-e2e_files=$(find cypress/integration/e2e -name '*-read.cy.js' | tr '\n' ',')
+echo "Running Cypress e2e UI Functional Tests"
+# Gather all test files in the `ui` folder
+ui_files=$(find cypress/integration/ui -name '*.cy.js' | tr '\n' ',')
 
 # Run Cypress with the combined spec list
 TZ=America/Vancouver npx cypress run \
@@ -51,10 +50,10 @@ TZ=America/Vancouver npx cypress run \
     --record \
     --key $CYPRESS_ADMIN_KEY \
     --parallel \
-    --ci-build-id "$buildId-AdminRead" \
-    --group "$buildId-AdminRead" \
+    --ci-build-id "$buildId-AdminUi" \
+    --group "$buildId-AdminUi" \
     --tag "$tags" \
-    --spec "${e2e_files%,}" \
+    --spec "${ui_files%,}" \
     --headless \
     --browser chrome
 popd


### PR DESCRIPTION
# Fixes or Implements [AB#17112](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17112)

## Description

Improves Admin functional-test reliability and pipeline execution by separating UI coverage from read-only E2E coverage.

## Changes

- Added a dedicated parallelized Admin UI Cypress job and runner script.
- Updated the Admin read runner to execute only `*-read.cy.js` specs.
- Adjusted Admin UI, read, and write job dependencies and parallel-agent counts.
- Consolidated agent provisioning create, edit, and delete validation into one lifecycle test, retaining duplicate-user validation separately.
- Added Keycloak test-user cleanup before and after provisioning tests.
- Fixed invalid selectors in delegation and patient-details Cypress tests.
- Removed PKCE code-verifier logging from Admin functional-test output.
- Improved service-worker cleanup handling during login.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
