### PR TITLE
Fix(release): use consistent Cypress image for parallel agents AB#17113

### DIFF
--- a/Apps/Admin/Tests/Functional/cypress/support/functions/intercept.js
+++ b/Apps/Admin/Tests/Functional/cypress/support/functions/intercept.js
@@ -2,7 +2,7 @@ const defaultTimeout = 60000;
 
 export function setupStandardAliases(page) {
     cy.log("Setting up configuration alias.");
-    cy.intercept("GET", "**/Configuration/").as("getConfiguration");
+    cy.intercept("GET", "**/api/Configuration*").as("getConfiguration");
 
     switch (page) {
         case "/dashboard":

--- a/Tools/Pipelines/pipelines/FunctionalTests.yaml
+++ b/Tools/Pipelines/pipelines/FunctionalTests.yaml
@@ -173,7 +173,7 @@ jobs:
       - "Admin_Seed"
       - "Admin_Authentication_Tests"
     strategy:
-      parallel: 2
+      parallel: 3
     timeoutInMinutes: 15
     steps:
       - checkout: self

--- a/Tools/Pipelines/scripts/azp_waitForFunctionalTests.sh
+++ b/Tools/Pipelines/scripts/azp_waitForFunctionalTests.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+    echo "Usage: $0 <organization_url> <project> <pipeline_id> <branch_or_tag> <app_type>"
+    exit 1
+fi
+
+organizationUrl="${1%/}"
+project="$2"
+pipelineId="$3"
+branchOrTag="$4"
+appType="$5"
+
+if [ -z "${SYSTEM_ACCESSTOKEN:-}" ]; then
+    echo "ERROR: SYSTEM_ACCESSTOKEN is not set. Enable 'Allow scripts to access the OAuth token' and map \$(System.AccessToken) to this task's environment."
+    exit 1
+fi
+
+case "$appType" in
+    Admin|Both|WebClient)
+        ;;
+    *)
+        echo "ERROR: app_type must be Admin, Both, or WebClient."
+        exit 1
+        ;;
+esac
+
+if [ -z "$branchOrTag" ]; then
+    echo "ERROR: branch_or_tag must not be empty."
+    exit 1
+fi
+
+export AZURE_DEVOPS_EXT_PAT="$SYSTEM_ACCESSTOKEN"
+
+az devops configure --defaults organization="$organizationUrl" project="$project"
+
+runId="$(az pipelines run \
+    --id "$pipelineId" \
+    --branch "$branchOrTag" \
+    --parameters "appType=$appType" \
+    --query id \
+    --output tsv)"
+
+if [ -z "$runId" ]; then
+    echo "ERROR: Functional Tests pipeline did not return a run ID."
+    exit 1
+fi
+
+echo "Queued Functional Tests pipeline run $runId."
+echo "View it at: $organizationUrl/$project/_build/results?buildId=$runId"
+
+while true; do
+    runStatus="$(az pipelines runs show \
+        --id "$runId" \
+        --query status \
+        --output tsv)"
+
+    if [ "$runStatus" = "completed" ]; then
+        runResult="$(az pipelines runs show \
+            --id "$runId" \
+            --query result \
+            --output tsv)"
+
+        if [ "$runResult" = "succeeded" ]; then
+            echo "Functional Tests pipeline run $runId succeeded."
+            exit 0
+        fi
+
+        echo "ERROR: Functional Tests pipeline run $runId completed with result: ${runResult:-unknown}."
+        exit 1
+    fi
+
+    echo "Functional Tests pipeline run $runId is ${runStatus:-unknown}; checking again in 30 seconds."
+    sleep 30
+done


### PR DESCRIPTION
# Fixes or Implements [AB#17113](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17113)

## Description

## Functional Test Pipeline Orchestration

- Added `azp_waitForFunctionalTests.sh` for Classic Release use.
- The script queues the existing Cypress Tests YAML pipeline with the selected `appType` (`Admin`, `WebClient`, or `Both`).
- The script accepts the release artifact's branch or tag and queues the YAML pipeline against that ref instead of defaulting to `dev`.
- It waits for the queued pipeline to complete and fails the Classic Release when functional tests fail.
- This replaces Classic Release multi-agent Cypress execution, avoiding Cypress Cloud parallel-run failures caused by Azure hosted-agent rolling image updates.

## Other

- Increase Agents for Admin UI tests
- Fix configuration intercept defintion

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
