### PR TITLE
Fix cypress session reuse in registration tests AB#17114

### DIFF
--- a/Testing/functional/tests/cypress/integration/ui/pages/registration.js
+++ b/Testing/functional/tests/cypress/integration/ui/pages/registration.js
@@ -34,7 +34,9 @@ describe("Registration Page", () => {
             Cypress.env("keycloak.unregistered.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
-            homePath
+            homePath,
+            {},
+            "registration-validation-success"
         );
 
         cy.contains("#subject", "Registration").should("be.visible");
@@ -89,7 +91,9 @@ describe("Registration Page", () => {
             Cypress.env("keycloak.unregistered.username"),
             Cypress.env("keycloak.password"),
             AuthMethod.KeyCloak,
-            homePath
+            homePath,
+            {},
+            "registration-validation-failure"
         );
 
         cy.get("[data-testid=clientRegistryErrorText]").should("be.visible");

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -249,7 +249,8 @@ Cypress.Commands.add(
         password,
         authMethod = AuthMethod.BCSC,
         path = "/timeline",
-        initialDataWaitOptions = {}
+        initialDataWaitOptions = {},
+        sessionId = ""
     ) => {
         initialDataWaitOptions = getInitialDataWaitOptions(
             initialDataWaitOptions
@@ -278,7 +279,7 @@ Cypress.Commands.add(
                 } else {
                     setupStandardAliases();
                     cy.window().then((window) => {
-                        cy.session([username, authMethod], () => {
+                        cy.session([username, authMethod, sessionId], () => {
                             cy.readConfig().then((config) => {
                                 let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
                                 let codeVerifier = generateRandomString(96);

--- a/Testing/functional/tests/cypress/support/commands.js
+++ b/Testing/functional/tests/cypress/support/commands.js
@@ -22,13 +22,15 @@ function cloneConfig(config) {
 }
 
 function getInitialDataWaitOptions(initialDataWaitOptions) {
-    const normalizedSpecPath = Cypress.spec.relative.replaceAll("\\", "/");
-    const isUiSpec = /(^|\/)ui\//.test(normalizedSpecPath);
-
     return {
-        waitForInitialDataLoad: !isUiSpec,
+        waitForInitialDataLoad: !isUiSpec(),
         ...initialDataWaitOptions,
     };
+}
+
+function isUiSpec() {
+    const normalizedSpecPath = Cypress.spec.relative.replaceAll("\\", "/");
+    return /(^|\/)ui\//.test(normalizedSpecPath);
 }
 
 const { globalStorage } = require("./globalStorage");
@@ -279,105 +281,116 @@ Cypress.Commands.add(
                 } else {
                     setupStandardAliases();
                     cy.window().then((window) => {
-                        cy.session([username, authMethod, sessionId], () => {
-                            cy.readConfig().then((config) => {
-                                let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
-                                let codeVerifier = generateRandomString(96);
-                                cy.log(
-                                    `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
-                                );
-                                const loginCallback =
-                                    config.openIdConnect.callbacks?.Logon ||
-                                    `${Cypress.config().baseUrl}/loginCallback`;
-                                const stateStore = {
-                                    id: stateId,
-                                    created: new Date().getTime(),
-                                    request_type: "si:r",
-                                    code_verifier: codeVerifier,
-                                    redirect_uri: loginCallback,
-                                    authority: config.openIdConnect.authority,
-                                    client_id: config.openIdConnect.clientId,
-                                    response_mode: "query",
-                                    scope: config.openIdConnect.scope,
-                                    extraTokenParams: {},
-                                };
-                                cy.log(
-                                    "Creating OIDC StateStore in Local storage"
-                                );
-                                window.sessionStorage.setItem(
-                                    `oidc.${stateStore.id}`,
-                                    JSON.stringify(stateStore)
-                                );
-
-                                const escapedRedirectPath = encodeURI(path);
-                                const redirectUri = `${loginCallback}?redirect=${escapedRedirectPath}`;
-
-                                cy.log(
-                                    "Requesting Keycloak Authentication form"
-                                );
-                                cy.request({
-                                    url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
-                                    timeout: 60000,
-                                    followRedirect: false,
-                                    qs: {
-                                        scope: config.openIdConnect.scope,
-                                        response_type:
-                                            config.openIdConnect.responseType,
-                                        approval_prompt: "auto",
-                                        redirect_uri: redirectUri,
+                        cy.session(
+                            [username, authMethod, sessionId],
+                            () => {
+                                cy.readConfig().then((config) => {
+                                    let stateId = generateRandomString(32); //"d0b27ba424b64b358b65d40cfdbc040b"
+                                    let codeVerifier = generateRandomString(96);
+                                    cy.log(
+                                        `State Id:  ${stateId}, Generated Code Verifier: ${codeVerifier}`
+                                    );
+                                    const loginCallback =
+                                        config.openIdConnect.callbacks?.Logon ||
+                                        `${Cypress.config().baseUrl}/loginCallback`;
+                                    const stateStore = {
+                                        id: stateId,
+                                        created: new Date().getTime(),
+                                        request_type: "si:r",
+                                        code_verifier: codeVerifier,
+                                        redirect_uri: loginCallback,
+                                        authority:
+                                            config.openIdConnect.authority,
                                         client_id:
                                             config.openIdConnect.clientId,
                                         response_mode: "query",
-                                        state: stateStore.id,
-                                    },
-                                })
-                                    .then((response) => {
-                                        cy.log("Posting credentials");
-                                        const html =
-                                            document.createElement("html");
-                                        html.innerHTML = response.body;
-                                        const form =
-                                            html.getElementsByTagName(
-                                                "form"
-                                            )[0];
-                                        const url = form.action;
-                                        return cy.request({
-                                            method: "POST",
-                                            url,
-                                            timeout: 60000,
-                                            followRedirect: false,
-                                            form: true,
-                                            body: {
-                                                username: username,
-                                                password: password,
-                                            },
-                                        });
+                                        scope: config.openIdConnect.scope,
+                                        extraTokenParams: {},
+                                    };
+                                    cy.log(
+                                        "Creating OIDC StateStore in Local storage"
+                                    );
+                                    window.sessionStorage.setItem(
+                                        `oidc.${stateStore.id}`,
+                                        JSON.stringify(stateStore)
+                                    );
+
+                                    const escapedRedirectPath = encodeURI(path);
+                                    const redirectUri = `${loginCallback}?redirect=${escapedRedirectPath}`;
+
+                                    cy.log(
+                                        "Requesting Keycloak Authentication form"
+                                    );
+                                    cy.request({
+                                        url: `${config.openIdConnect.authority}/protocol/openid-connect/auth`,
+                                        timeout: 60000,
+                                        followRedirect: false,
+                                        qs: {
+                                            scope: config.openIdConnect.scope,
+                                            response_type:
+                                                config.openIdConnect
+                                                    .responseType,
+                                            approval_prompt: "auto",
+                                            redirect_uri: redirectUri,
+                                            client_id:
+                                                config.openIdConnect.clientId,
+                                            response_mode: "query",
+                                            state: stateStore.id,
+                                        },
                                     })
-                                    .then((response) => {
-                                        let callBackQS =
-                                            response.headers["location"];
-                                        const callbackURL = `${callBackQS}`;
-                                        cy.log(
-                                            `Visiting Callback ${callBackQS}`,
-                                            response
-                                        );
+                                        .then((response) => {
+                                            cy.log("Posting credentials");
+                                            const html =
+                                                document.createElement("html");
+                                            html.innerHTML = response.body;
+                                            const form =
+                                                html.getElementsByTagName(
+                                                    "form"
+                                                )[0];
+                                            const url = form.action;
+                                            return cy.request({
+                                                method: "POST",
+                                                url,
+                                                timeout: 60000,
+                                                followRedirect: false,
+                                                form: true,
+                                                body: {
+                                                    username: username,
+                                                    password: password,
+                                                },
+                                            });
+                                        })
+                                        .then((response) => {
+                                            let callBackQS =
+                                                response.headers["location"];
+                                            const callbackURL = `${callBackQS}`;
+                                            cy.log(
+                                                `Visiting Callback ${callBackQS}`,
+                                                response
+                                            );
 
-                                        cy.visit(callbackURL);
+                                            cy.visit(callbackURL);
 
-                                        // LoginCallbackView processes the OIDC response and retrieves the essential
-                                        // user data before ClientApp navigates to the appropriate destination.
-                                        // Do not save the Cypress session while still processing the callback.
-                                        cy.location("pathname", {
-                                            timeout: 60000,
-                                        }).should("not.eq", "/loginCallback");
+                                            // LoginCallbackView processes the OIDC response and retrieves the essential
+                                            // user data before ClientApp navigates to the appropriate destination.
+                                            // Do not save the Cypress session while still processing the callback.
+                                            cy.location("pathname", {
+                                                timeout: 60000,
+                                            }).should(
+                                                "not.eq",
+                                                "/loginCallback"
+                                            );
 
-                                        // Store authentication cookies only after login has completed.
-                                        cy.getCookies().then((cookies) => {
-                                            globalStorage.authCookies = cookies;
+                                            // Store authentication cookies only after login has completed.
+                                            cy.getCookies().then((cookies) => {
+                                                globalStorage.authCookies =
+                                                    cookies;
+                                            });
                                         });
-                                    });
-                            });
-                        });
+                                });
+                            },
+                            { cacheAcrossSpecs: isUiSpec() }
+                        );
 
                         // Register aliases for the post-session visit; login callback requests may
                         // have already consumed aliases registered before session initialization.

--- a/Testing/functional/tests/cypress/support/index.d.ts
+++ b/Testing/functional/tests/cypress/support/index.d.ts
@@ -19,7 +19,8 @@ declare namespace Cypress {
             password: string,
             authMethod?: string,
             path?: string,
-            initialDataWaitOptions?: InitialDataWaitOptions
+            initialDataWaitOptions?: InitialDataWaitOptions,
+            sessionId?: string
         ): void;
         getTokens(username: string, password: string): void;
         readConfig(): Chainable<any>;


### PR DESCRIPTION
# Fixes or Implements [AB#17114](https://dev.azure.com/qslvic/304a1f8c-dace-4f85-adf3-bf563d5b3a39/_workitems/edit/17114)

## Description

- Added an optional Cypress login session identifier.
- Assigned separate session identifiers to the registration success and client-registry-failure scenarios.
- Prevents the client-registry-failure scenario from restoring the successful-registration session and skipping its scenario-specific validation flow.

## Testing

- [ ] Unit Tests Updated
- [x] Functional Tests Updated
- [ ] Not Required

## UI Changes

None

## Notes



## Items to Review:

-   [General PR Guidelines](https://github.com/bcgov/healthgateway/wiki/PRguidance)
